### PR TITLE
[Feature] sc-32616 Default show changed only nodes in Lineage View

### DIFF
--- a/js/src/components/lineage/lineage.test.ts
+++ b/js/src/components/lineage/lineage.test.ts
@@ -2,7 +2,7 @@ import {
   LineageData,
   LineageGraphEdge,
   LineageGraphNode,
-  buildLineageGraph,
+  buildDefaultLineageGraphSets,
   highlightPath,
   toReactflow,
 } from "./lineage";
@@ -31,7 +31,9 @@ test("lineage diff", () => {
     },
   };
 
-  const { nodes, edges } = buildLineageGraph(base, current);
+  const { all } = buildDefaultLineageGraphSets(base, current);
+  const nodes = all.nodes;
+  const edges = all.edges;
 
   expect(Object.keys(nodes).length).toBe(4);
   expect(Object.keys(edges).length).toBe(4);
@@ -80,7 +82,9 @@ test("lineage diff 2", () => {
     },
   };
 
-  const { nodes, edges } = buildLineageGraph(base, current);
+  const { all } = buildDefaultLineageGraphSets(base, current);
+  const nodes = all.nodes;
+  const edges = all.edges;
 
   expect(Object.keys(nodes).length).toBe(5);
   expect(Object.keys(edges).length).toBe(4);
@@ -116,9 +120,9 @@ test("hightlight", () => {
     },
   };
 
-  const g = buildLineageGraph(base, current);
-  const [nodes, edges] = toReactflow(g);
-  const [nodes2, edges2] = highlightPath(g, nodes, edges, "a");
+  const { all, modifiedSet } = buildDefaultLineageGraphSets(base, current);
+  const [nodes, edges] = toReactflow(all, modifiedSet);
+  const [nodes2, edges2] = highlightPath(all, modifiedSet, nodes, edges, "a");
 
   expect(nodes.length).toBe(nodes2.length);
   expect(edges.length).toBe(edges2.length);

--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -188,8 +188,8 @@ export function buildDefaultLineageGraphSets(
     // Select all downstream sets of modified nodes
     const downstreamSet = selectDownstream(all, modifiedSet);
 
-    // Select all upstream sets of modified nodes
-    const upstreamSet = selectUpstream(all, modifiedSet);
+    // Select a single upstream layer of modified nodes
+    const upstreamSet = selectUpstream(all, modifiedSet, 1);
 
     // Union of upstream and downstream nodes
     const modifiedSets = union(downstreamSet, upstreamSet);
@@ -251,24 +251,22 @@ export function buildDefaultLineageGraphSets(
 
 }
 
-export function selectUpstream(lineageGraph: LineageGraph, nodeIds: string[]) {
+export function selectUpstream(lineageGraph: LineageGraph, nodeIds: string[], degree: number = 1000) {
   return getNeighborSet(nodeIds, (key) => {
       if (lineageGraph.nodes[key] === undefined) {
         return [];
       }
       return Object.keys(lineageGraph.nodes[key].parents);
-    }
-  );
+    }, degree);
 }
 
-export function selectDownstream(lineageGraph: LineageGraph, nodeIds: string[]) {
+export function selectDownstream(lineageGraph: LineageGraph, nodeIds: string[], degree: number = 1000) {
   return getNeighborSet(nodeIds, (key) => {
       if (lineageGraph.nodes[key] === undefined) {
         return [];
       }
       return Object.keys(lineageGraph.nodes[key].children)
-    }
-  );
+    }, degree);
 }
 
 export function toReactflow(lineageGraph: LineageGraph, modifiedSet: string[]): [Node[], Edge[]] {

--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -193,7 +193,6 @@ export function buildDefaultLineageGraphSets(
 
     // Union of upstream and downstream nodes
     const modifiedSets = union(downstreamSet, upstreamSet);
-    console.log("modifiedSets", modifiedSets);
 
     Object.entries(all.nodes).forEach(([key, node]) => {
       if (modifiedSets.has(key)) {

--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { Node, Edge, Position } from "reactflow";
 import { getNeighborSet } from "./graph";
 
@@ -73,96 +72,145 @@ export interface LineageGraph {
   edges: {
     [key: string]: LineageGraphEdge;
   };
+}
 
+export interface DefaultLineageGraphSets {
+  all: LineageGraph;
+  changed: LineageGraph;
   modifiedSet: string[];
 }
 
-export function buildLineageGraph(
+export function buildDefaultLineageGraphSets(
   base: LineageData,
   current: LineageData
-): LineageGraph {
-  const nodes: { [key: string]: LineageGraphNode } = {};
-  const edges: { [key: string]: LineageGraphEdge } = {};
-  const buildNode = (
-    key: string,
-    from: "base" | "current"
-  ): LineageGraphNode => {
-    return {
-      id: key,
-      name: key,
-      data: {},
-      from,
-      parents: {},
-      children: {},
-    };
-  };
-
-  for (const [key, parents] of Object.entries(base.parent_map)) {
-    nodes[key] = buildNode(key, "base");
-    const nodeData = base.nodes && base.nodes[key];
-    if (nodeData) {
-      nodes[key].data.base = nodeData;
-      nodes[key].name = nodeData?.name;
-      nodes[key].resourceType = nodeData?.resource_type;
-      nodes[key].packageName = nodeData?.package_name;
-    }
-  }
-
-  for (const [key, parents] of Object.entries(current.parent_map)) {
-    if (nodes[key]) {
-      nodes[key].from = "both";
-    } else {
-      nodes[key] = buildNode(key, "current");
-    }
-    const nodeData = current.nodes && current.nodes[key];
-    if (nodeData) {
-      nodes[key].data.current = current.nodes && current.nodes[key];
-      nodes[key].name = nodeData?.name;
-      nodes[key].resourceType = nodeData?.resource_type;
-      nodes[key].packageName = nodeData?.package_name;
-    }
-  }
-
-  for (const [child, parents] of Object.entries(base.parent_map)) {
-    for (const parent of parents) {
-      const childNode = nodes[child];
-      const parentNode = nodes[parent];
-      const id = `${parent}_${child}`;
-      edges[id] = {
-        id,
-        from: "base",
-        parent: parentNode,
-        child: childNode,
+): DefaultLineageGraphSets {
+  function buildAllLineageGraph(base: LineageData, current: LineageData): LineageGraph {
+    const nodes: { [key: string]: LineageGraphNode } = {};
+    const edges: { [key: string]: LineageGraphEdge } = {};
+    const buildNode = (
+      key: string,
+      from: "base" | "current"
+    ): LineageGraphNode => {
+      return {
+        id: key,
+        name: key,
+        data: {},
+        from,
+        parents: {},
+        children: {},
       };
-      const edge = edges[id];
+    };
 
-      childNode.parents[parent] = edge;
-      parentNode.children[child] = edge;
+    for (const [key, parents] of Object.entries(base.parent_map)) {
+      nodes[key] = buildNode(key, "base");
+      const nodeData = base.nodes && base.nodes[key];
+      if (nodeData) {
+        nodes[key].data.base = nodeData;
+        nodes[key].name = nodeData?.name;
+        nodes[key].resourceType = nodeData?.resource_type;
+        nodes[key].packageName = nodeData?.package_name;
+      }
     }
-  }
 
-  for (const [child, parents] of Object.entries(current.parent_map)) {
-    for (const parent of parents) {
-      const childNode = nodes[child];
-      const parentNode = nodes[parent];
-      const id = `${parent}_${child}`;
-
-      if (edges[id]) {
-        edges[id].from = "both";
+    for (const [key, parents] of Object.entries(current.parent_map)) {
+      if (nodes[key]) {
+        nodes[key].from = "both";
       } else {
+        nodes[key] = buildNode(key, "current");
+      }
+      const nodeData = current.nodes && current.nodes[key];
+      if (nodeData) {
+        nodes[key].data.current = current.nodes && current.nodes[key];
+        nodes[key].name = nodeData?.name;
+        nodes[key].resourceType = nodeData?.resource_type;
+        nodes[key].packageName = nodeData?.package_name;
+      }
+    }
+
+    for (const [child, parents] of Object.entries(base.parent_map)) {
+      for (const parent of parents) {
+        const childNode = nodes[child];
+        const parentNode = nodes[parent];
+        const id = `${parent}_${child}`;
         edges[id] = {
           id,
-          from: "current",
+          from: "base",
           parent: parentNode,
           child: childNode,
         };
-      }
-      const edge = edges[id];
+        const edge = edges[id];
 
-      childNode.parents[parent] = edge;
-      parentNode.children[child] = edge;
+        childNode.parents[parent] = edge;
+        parentNode.children[child] = edge;
+      }
     }
+
+    for (const [child, parents] of Object.entries(current.parent_map)) {
+      for (const parent of parents) {
+        const childNode = nodes[child];
+        const parentNode = nodes[parent];
+        const id = `${parent}_${child}`;
+
+        if (edges[id]) {
+          edges[id].from = "both";
+        } else {
+          edges[id] = {
+            id,
+            from: "current",
+            parent: parentNode,
+            child: childNode,
+          };
+        }
+        const edge = edges[id];
+
+        childNode.parents[parent] = edge;
+        parentNode.children[child] = edge;
+      }
+    }
+
+    return { edges, nodes };
   }
+  function buildChangedOnlyLineageGraph(all: LineageGraph, modifiedSet: string[]): LineageGraph {
+    const nodes: { [key: string]: LineageGraphNode } = {};
+    const edges: { [key: string]: LineageGraphEdge } = {};
+    function union(...sets: Set<string>[]) {
+      const unionSet = new Set<string>();
+
+      sets.forEach((set) => {
+        set.forEach((key) => {
+          unionSet.add(key);
+        });
+      });
+      return unionSet;
+    }
+
+
+    // Select all downstream sets of modified nodes
+    const downstreamSet = selectDownstream(all, modifiedSet);
+
+    // Select all upstream sets of modified nodes
+    const upstreamSet = selectUpstream(all, modifiedSet);
+
+    // Union of upstream and downstream nodes
+    const modifiedSets = union(downstreamSet, upstreamSet);
+    console.log("modifiedSets", modifiedSets);
+
+    Object.entries(all.nodes).forEach(([key, node]) => {
+      if (modifiedSets.has(key)) {
+        nodes[key] = node;
+      }
+    });
+
+    Object.entries(all.edges).forEach(([key, edge]) => {
+      if (modifiedSets.has(edge.parent.id) && modifiedSets.has(edge.child.id)) {
+        edges[key] = edge;
+      }
+    });
+
+    return { nodes, edges }
+  }
+
+  const { nodes, edges } = buildAllLineageGraph(base, current);
 
   const modifiedSet: string[] = [];
   for (const [key, node] of Object.entries(nodes)) {
@@ -192,13 +240,38 @@ export function buildLineageGraph(
   }
 
   return {
-    nodes,
-    edges,
+    all: {
+      nodes,
+      edges,
+    },
+    changed: buildChangedOnlyLineageGraph({ nodes, edges }, modifiedSet),
     modifiedSet,
   };
+
+
 }
 
-export function toReactflow(lineageGraph: LineageGraph): [Node[], Edge[]] {
+export function selectUpstream(lineageGraph: LineageGraph, nodeIds: string[]) {
+  return getNeighborSet(nodeIds, (key) => {
+      if (lineageGraph.nodes[key] === undefined) {
+        return [];
+      }
+      return Object.keys(lineageGraph.nodes[key].parents);
+    }
+  );
+}
+
+export function selectDownstream(lineageGraph: LineageGraph, nodeIds: string[]) {
+  return getNeighborSet(nodeIds, (key) => {
+      if (lineageGraph.nodes[key] === undefined) {
+        return [];
+      }
+      return Object.keys(lineageGraph.nodes[key].children)
+    }
+  );
+}
+
+export function toReactflow(lineageGraph: LineageGraph, modifiedSet: string[]): [Node[], Edge[]] {
   const nodes: Node[] = [];
   const edges: Edge[] = [];
   const backgroundColorMap = {
@@ -232,14 +305,15 @@ export function toReactflow(lineageGraph: LineageGraph): [Node[], Edge[]] {
     });
   }
 
-  return highlightPath(lineageGraph, nodes, edges, null);
+  return highlightPath(lineageGraph, modifiedSet, nodes, edges, null);
 }
 
 export function highlightPath(
   lineageGraph: LineageGraph,
+  modifiedSet: string[],
   nodes: Node<LineageGraphNode>[],
   edges: Edge[],
-  id: string | null
+  id: string | null,
 ): [Node<LineageGraphNode>[], Edge[]] {
   function union(...sets: Set<string>[]) {
     const unionSet = new Set<string>();
@@ -256,15 +330,13 @@ export function highlightPath(
   const relatedNodes =
     id !== null
       ? union(
-          getNeighborSet([id], (key) =>
-            Object.keys(lineageGraph.nodes[key].parents)
-          ),
-          getNeighborSet([id], (key) =>
-            Object.keys(lineageGraph.nodes[key].children)
-          )
+          selectUpstream(lineageGraph, [id]),
+          selectDownstream(lineageGraph, [id]),
         )
-      : getNeighborSet(lineageGraph.modifiedSet, (key) =>
-          Object.keys(lineageGraph.nodes[key].children)
+      : getNeighborSet(modifiedSet, (key) => {
+          if (lineageGraph.nodes[key] === undefined) return [];
+          return Object.keys(lineageGraph.nodes[key].children)
+        }
         );
 
   const relatedEdges = new Set(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- Default shows Changed Only mode 
- Add a new ControllButton `Switch View` on the ReactFlow controls
![CleanShot 2023-12-04 at 16 58 46](https://github.com/DataRecce/recce/assets/959606/8c53d7d9-9fe3-476b-9575-b6a66725c9f1)
- Show current View Mode on the top-left of Lineage View
![CleanShot 2023-12-04 at 16 58 33](https://github.com/DataRecce/recce/assets/959606/9ec8fc84-7d87-40b3-816a-cf7ad3020c92)
![CleanShot 2023-12-05 at 10 33 41](https://github.com/DataRecce/recce/assets/959606/e4e43e96-5512-4f56-9067-cf76890bbdc2)


**Which issue(s) this PR fixes**:
sc-32616

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
