### PR TITLE
[Feature] Reload manifest and catalog files when they changed

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -115,7 +115,7 @@ def server(host, port, **kwargs):
     from .server import load_dbt_context, app
 
     load_dbt_context(**kwargs)
-    uvicorn.run(app, host=host, port=port)
+    uvicorn.run(app, host=host, port=port, lifespan='on')
 
 
 if __name__ == "__main__":

--- a/recce/server.py
+++ b/recce/server.py
@@ -15,16 +15,19 @@ from .dbt import DBTContext
 dbt_context: DBTContext = None
 
 
-def load_dbt_context(**kwargs):
+def load_dbt_context(**kwargs) -> DBTContext:
     global dbt_context
     if dbt_context is None:
         dbt_context = DBTContext.load(**kwargs)
+    return dbt_context
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    load_dbt_context()
+    ctx = load_dbt_context()
+    ctx.start_monitor_artifacts()
     yield
+    ctx.stop_monitor_artifacts()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/recce/server.py
+++ b/recce/server.py
@@ -1,18 +1,23 @@
+import asyncio
+import json
+import logging
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Any
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.websockets import WebSocketDisconnect
 
 from . import __version__, event
 from .dbt import DBTContext
 
-dbt_context: DBTContext = None
+logger = logging.getLogger('uvicorn')
+dbt_context: DBTContext | None = None
 
 
 def load_dbt_context(**kwargs) -> DBTContext:
@@ -23,14 +28,32 @@ def load_dbt_context(**kwargs) -> DBTContext:
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(fastapi_app: FastAPI):
     ctx = load_dbt_context()
-    ctx.start_monitor_artifacts()
+    ctx.start_monitor_artifacts(callback=dbt_artifacts_updated_callback)
     yield
     ctx.stop_monitor_artifacts()
 
 
+def dbt_artifacts_updated_callback(file_changed_event: Any):
+    target_type, file_name = file_changed_event.src_path.split("/")[-2:]
+    logger.info(
+        f'Detect {target_type} file {file_changed_event.event_type}: {file_name}')
+    ctx = load_dbt_context()
+    ctx.refresh(file_changed_event.src_path)
+    broadcast_command = {
+        'command': 'refresh',
+        'event': {
+            'eventType': file_changed_event.event_type,
+            'srcPath': file_changed_event.src_path
+        }
+    }
+    payload = json.dumps(broadcast_command)
+    asyncio.run(broadcast(payload))
+
+
 app = FastAPI(lifespan=lifespan)
+clients = set()
 
 origins = [
     "http://localhost:3000",
@@ -106,6 +129,24 @@ async def version():
         return __version__
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@app.websocket("/api/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    clients.add(websocket)
+    try:
+        while True:
+            data = await websocket.receive_text()
+            if data == 'ping':
+                await websocket.send_text('pong')
+    except WebSocketDisconnect:
+        clients.remove(websocket)
+
+
+async def broadcast(data: str):
+    for client in clients:
+        await client.send_text(data)
 
 
 static_folder_path = Path(__file__).parent / 'data'

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name='recce',
           'requests>=2.28.1',
           'rich>=12.0.0',
           'sentry-sdk',
+          'watchdog',
       ],
       tests_require=['pytest'],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(name='recce',
           'rich>=12.0.0',
           'sentry-sdk',
           'watchdog',
+          'websockets',
       ],
       tests_require=['pytest'],
       extras_require={


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- Monitor the manifest and catalog files changed
- Reload the dbt context once we detect `manifest.json` or `catalog.json` files changed
- User websocket to brocast all the clients browser to reload lineage graph if we detected files changed.

**Which issue(s) this PR fixes**:
RC-50

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
