### PR TITLE
[Feature] rc-48 implement the summary page to demo the summary layout

### DIFF
--- a/js/app/page.tsx
+++ b/js/app/page.tsx
@@ -14,12 +14,13 @@ import { useParams } from "next/navigation";
 import { useEffect, useLayoutEffect, useState } from "react";
 import * as amplitude from "@amplitude/analytics-browser";
 import { QueryClientProvider } from "@tanstack/react-query";
+import RecceContextProvider from "@/lib/hooks/RecceContextProvider";
 import { reactQueryClient } from "@/lib/api/axiosClient";
 import { useVersionNumber } from "@/lib/api/version";
 import { setLocationHash, getLocationHash } from "@/lib/UrlHash";
-import { RecceQueryContextProvider } from "@/lib/hooks/RecceQueryContext";
 import { CheckPage } from "@/components/check/CheckPage";
 import { QueryPage } from "@/components/query/QueryPage";
+import SummaryView from "@/components/summary/SummaryView";
 
 function getCookie(key: string) {
   var b = document.cookie.match("(^|;)\\s*" + key + "\\s*=\\s*([^;]+)");
@@ -67,6 +68,8 @@ export default function Home() {
       setLocationHash("query");
     } else if (index === 2) {
       setLocationHash("checks");
+    } else if (index === 3) {
+      setLocationHash("summary");
     }
     setTabIndex(index);
   };
@@ -83,6 +86,8 @@ export default function Home() {
       setTabIndex(1);
     } else if (hash === "checks") {
       setTabIndex(2);
+    } else if (hash === 'summary') {
+      setTabIndex(3);
     } else {
       setTabIndex(0);
     }
@@ -92,13 +97,14 @@ export default function Home() {
 
   return (
     <ChakraProvider>
-      <RecceQueryContextProvider>
+      <RecceContextProvider>
         <QueryClientProvider client={reactQueryClient}>
           <Tabs index={tabIndex} onChange={handleTabsChange}>
             <TabList>
               <Tab>Lineage</Tab>
               <Tab>Query</Tab>
               <Tab>Checklist</Tab>
+              <Tab>Summary</Tab>
               <Box position="absolute" right="0" top="0" p="2" color="gray.500">
                 {version}
               </Box>
@@ -114,10 +120,13 @@ export default function Home() {
               <TabContainer pageHeight={pageHeight}>
                 <CheckPage />
               </TabContainer>
+              <TabContainer pageHeight={pageHeight}>
+                <SummaryView />
+              </TabContainer>
             </TabPanels>
           </Tabs>
         </QueryClientProvider>
-      </RecceQueryContextProvider>
+      </RecceContextProvider>
     </ChakraProvider>
   );
 }

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -13,6 +13,13 @@ import {
   Text,
   Spinner,
   useToast,
+  Modal,
+  useDisclosure,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
 } from "@chakra-ui/react";
 import axios, { AxiosError } from "axios";
 import React, { useCallback, useEffect, useState } from "react";
@@ -34,11 +41,12 @@ import "reactflow/dist/style.css";
 import { GraphNode } from "./GraphNode";
 import GraphEdge from "./GraphEdge";
 import { getIconForChangeStatus } from "./styles";
-import { FiDownloadCloud, FiRefreshCw } from "react-icons/fi";
+import { FiDownloadCloud, FiRefreshCw, FiList } from "react-icons/fi";
 import { NodeView } from "./NodeView";
 import { toPng } from "html-to-image";
 import path from "path";
 import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import SummaryView from "../summary/SummaryView";
 
 const layout = (nodes: Node[], edges: Edge[], direction = "LR") => {
   const dagreGraph = new dagre.graphlib.Graph();
@@ -130,6 +138,7 @@ function _LineageView() {
   const [lineageGraph, setLineageGraph] = useState<LineageGraph>();
   const [modifiedSet, setModifiedSet] = useState<string[]>();
   const { setLineageGraphSets } = useLineageGraphsContext();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
 
   const [loading, setLoading] = useState(false);
@@ -351,6 +360,9 @@ function _LineageView() {
             <ControlButton title="download image" onClick={onDownloadImage}>
               <Icon as={FiDownloadCloud} />
             </ControlButton>
+            <ControlButton title="summary" onClick={onOpen}>
+              <Icon as={FiList} />
+            </ControlButton>
           </Controls>
           <Panel position="bottom-left">
             <ChangeStatusLegend />
@@ -363,7 +375,15 @@ function _LineageView() {
           <MiniMap nodeColor={nodeColor} nodeStrokeWidth={3} />
         </ReactFlow>
       </Box>
-
+      <Modal isOpen={isOpen} onClose={onClose} size="6xl">
+        <ModalOverlay />
+        <ModalContent overflowY="auto" height="80%">
+          <ModalCloseButton />
+          <ModalBody>
+            <SummaryView />
+          </ModalBody>
+        </ModalContent>
+      </Modal>
       {selected && lineageGraph?.nodes[selected] && (
         <Box flex="0 0 500px" borderLeft="solid 1px lightgray" height="100%">
           <NodeView

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -37,8 +37,8 @@ import { getIconForChangeStatus } from "./styles";
 import { FiDownloadCloud, FiRefreshCw } from "react-icons/fi";
 import { NodeView } from "./NodeView";
 import { toPng } from "html-to-image";
-import { set } from "lodash";
 import path from "path";
+import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
 
 const layout = (nodes: Node[], edges: Edge[], direction = "LR") => {
   const dagreGraph = new dagre.graphlib.Graph();
@@ -129,6 +129,8 @@ function _LineageView() {
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [lineageGraph, setLineageGraph] = useState<LineageGraph>();
   const [modifiedSet, setModifiedSet] = useState<string[]>();
+  const { setLineageGraphSets } = useLineageGraphsContext();
+
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
@@ -165,6 +167,8 @@ function _LineageView() {
         responseBase.data,
         responseCurrent.data
       );
+      setLineageGraphSets(defaultLineageGraphs);
+
       const lineageGraph =
         viewMode === "changed_models"
           ? defaultLineageGraphs.changed
@@ -197,7 +201,7 @@ function _LineageView() {
     } finally {
       setLoading(false);
     }
-  }, [setNodes, setEdges, viewMode]);
+  }, [setNodes, setEdges, viewMode, setLineageGraphSets]);
 
   useEffect(() => {
     queryLineage();

--- a/js/src/components/lineage/MismatchSummary.tsx
+++ b/js/src/components/lineage/MismatchSummary.tsx
@@ -33,7 +33,7 @@ interface MismatchSummary {
 
 function extractColumnNames(node: LineageGraphNode) {
   function getNames(nodeData: NodeData) {
-    return nodeData.columns ? Object.values(nodeData.columns).map(column => column.name) : [];
+    return nodeData && nodeData.columns ? Object.values(nodeData.columns).map(column => column.name) : [];
   }
 
   const baseColumns = getNames(node.data.base!!);

--- a/js/src/components/summary/ChangeSummary.tsx
+++ b/js/src/components/summary/ChangeSummary.tsx
@@ -1,0 +1,226 @@
+import { Box, Grid, Icon, Tooltip, VStack, Text, Flex } from "@chakra-ui/react";
+import { ReactNode, use } from "react";
+import { FiInfo } from "react-icons/fi";
+import { IconAdded, IconChanged, IconModified, IconRemoved } from "../lineage/styles";
+import { DefaultLineageGraphSets, LineageGraph, NodeData } from "../lineage/lineage";
+
+export type ChangeStatus =
+  // node change
+  // code change (user edit)
+  | 'added'
+  | 'removed'
+  | 'modified'
+
+  // column change
+  | 'col_added'
+  | 'col_removed'
+  | 'col_changed'
+
+  // folder change
+  | 'folder_changed'
+  | null;
+
+export const NODE_CHANGE_STATUS_MSGS = {
+  added: ['Model Added', 'Added resource'],
+  removed: ['Model Removed', 'Removed resource'],
+  modified: ['Model Modified', 'Modified resource'],
+  col_added: ['Column Added', 'Added column'],
+  col_removed: ['Column Removed', 'Removed column'],
+  col_changed: ['Column Modified', 'Modified column'],
+  folder_changed: ['Modified', 'Modified folder'],
+};
+
+export function getIconForChangeStatus(
+  changeStatus?: ChangeStatus,
+): {
+  color: string;
+  icon: any; //IconType not provided
+} {
+  if (changeStatus === 'added') {
+    return { color: '#1dce00', icon: IconAdded };
+  } else if (changeStatus === 'removed') {
+    return { color: '#ff067e', icon: IconRemoved };
+  } else if (changeStatus === 'modified') {
+    return { color: '#ffa502', icon: IconModified };
+  } else if (changeStatus === 'col_added') {
+    return { color: '#1dce00', icon: IconAdded };
+  } else if (changeStatus === 'col_removed') {
+    return { color: '#ff067e', icon: IconRemoved };
+  } else if (changeStatus === 'col_changed') {
+    return { color: '#ffa502', icon: IconModified };
+  } else if (changeStatus === 'folder_changed') {
+    return { color: '#ffa502', icon: IconChanged };
+  }
+
+
+  return { color: 'inherit', icon: undefined };
+}
+
+function SummaryText({
+  name,
+  value,
+  tip,
+}: {
+  name: ReactNode;
+  value: ReactNode;
+  tip?: ReactNode;
+}) {
+  return (
+    <VStack alignItems="stretch">
+      <Text fontSize="sm" color="gray">
+        {name}
+        {tip && (
+          <Tooltip label={tip}>
+            <Box display="inline-block">
+              <Icon mx={'2px'} as={FiInfo} boxSize={3} />
+            </Box>
+          </Tooltip>
+        )}
+      </Text>
+      {value}
+    </VStack>
+  );
+}
+
+function ChangeStatusCountLabel({
+  changeStatus,
+  value,
+}: {
+  changeStatus: ChangeStatus;
+  value: number;
+}) {
+  const [label] = changeStatus ? NODE_CHANGE_STATUS_MSGS[changeStatus] : [''];
+  const { icon, color } = getIconForChangeStatus(changeStatus);
+
+  return (
+    <VStack alignItems="stretch">
+      <Flex alignItems="center" fontSize="sm" color="gray">
+        <Icon mr="5px" as={icon} color={color} />
+        {label}
+      </Flex>
+      <Text fontSize="sm">{value}</Text>
+    </VStack>
+  );
+}
+
+
+function calculateColumnChange(base: NodeData | undefined, current: NodeData | undefined) {
+  let adds = 0;
+  let removes = 0;
+  let modifies = 0;
+  if (!base && !current) return { adds, removes, modifies };
+
+  // Add columns
+  if (current) {
+    Object.keys(current.columns || {}).forEach((col) => {
+      if (!base || !base.columns || !base.columns[col]) adds++;
+    });
+  }
+
+  // Remove columns
+  if (base) {
+    Object.keys(base.columns || {}).forEach((col) => {
+      if (!current || !current.columns || !current.columns[col]) removes++;
+    });
+}
+
+  // Modify columns
+  if (current && base) {
+    Object.keys(current.columns || {}).forEach((col) => {
+      if (base.columns && current.columns && base.columns[col]) {
+        if (base.columns[col].type !== current.columns[col].type) modifies++;
+      }
+    });
+  }
+
+  return { adds, removes, modifies };
+}
+
+function calculateChangeSummary(lineageGraph: LineageGraph, modifiedSet: string[]) {
+  let adds = 0;
+  let removes = 0;
+  let modifies = 0;
+  let col_added = 0;
+  let col_removed = 0;
+  let col_changed = 0;
+
+  modifiedSet.forEach((nodeId) => {
+    if (lineageGraph.nodes[nodeId].changeStatus === 'added') adds++;
+    else if (lineageGraph.nodes[nodeId].changeStatus === 'removed') removes++;
+    else if (lineageGraph.nodes[nodeId].changeStatus === 'modified') modifies++;
+
+    const base = lineageGraph.nodes[nodeId].data.base;
+    const current = lineageGraph.nodes[nodeId].data.current;
+    const columnChange = calculateColumnChange(base, current);
+    col_added += columnChange.adds;
+    col_removed += columnChange.removes;
+    col_changed += columnChange.modifies;
+  });
+
+  return { adds, removes, modifies, col_added, col_removed, col_changed };
+}
+
+export interface Props {
+  lineageGraphSets: DefaultLineageGraphSets
+}
+
+
+export function ChangeSummary({ lineageGraphSets }: Props) {
+  const {
+    adds,
+    removes,
+    modifies,
+    col_added,
+    col_removed,
+    col_changed,
+  } = calculateChangeSummary(lineageGraphSets.all, lineageGraphSets.modifiedSet);
+
+  return (
+    <Grid templateColumns="1fr 1fr" mb="10px" borderTop="1px solid lightgray" padding={'2.5vw'}>
+      <Box borderColor='lightgray'>
+        <SummaryText
+          name="Code Changes"
+          value={
+            <>
+              <Grid templateColumns="1fr 1fr 1fr" width="100%">
+                <ChangeStatusCountLabel
+                  changeStatus="added"
+                  value={adds} />
+                <ChangeStatusCountLabel
+                  changeStatus="removed"
+                  value={removes}
+                />
+                <ChangeStatusCountLabel
+                  changeStatus="modified"
+                  value={modifies}
+                />
+              </Grid>
+            </>
+          }
+        />
+      </Box>
+      <Box borderLeft="1px" paddingLeft="12px" borderColor='lightgray'>
+        <SummaryText
+          name="Column Changes"
+          value={
+            <>
+              <Grid templateColumns="1fr 1fr 1fr" width="100%">
+                <ChangeStatusCountLabel
+                  changeStatus="col_added"
+                  value={col_added} />
+                <ChangeStatusCountLabel
+                  changeStatus="col_removed"
+                  value={col_removed}
+                />
+                <ChangeStatusCountLabel
+                  changeStatus="col_changed"
+                  value={col_changed}
+                />
+              </Grid>
+            </>
+          }
+        />
+      </Box>
+    </Grid>
+  );
+}

--- a/js/src/components/summary/SchemaSummary.tsx
+++ b/js/src/components/summary/SchemaSummary.tsx
@@ -1,0 +1,85 @@
+import { Card, CardProps, CardBody, CardHeader, Flex, Heading, SimpleGrid, Text } from "@chakra-ui/react";
+import { DefaultLineageGraphSets, LineageGraphNode } from "../lineage/lineage";
+import { SchemaView } from "../schema/SchemaView";
+import { mergeColumns } from "../schema/schema";
+import { mergeKeysWithStatus } from "@/lib/mergeKeys";
+import { useEffect, useState } from "react";
+
+interface SchemaDiffCardProps {
+  node: LineageGraphNode;
+}
+
+function SchemaDiffCard({
+  node,
+  ...props
+ }: CardProps & SchemaDiffCardProps) {
+  return (
+  <Card maxWidth={'500px'}>
+    <CardHeader>
+      <Heading fontSize={18}>{props.title}</Heading>
+      <Text fontSize={14} color={'gray'}>{node.resourceType}</Text>
+    </CardHeader>
+    <CardBody>
+      <Flex>
+        <SchemaView base={node.data.base} current={node.data.current} />
+      </Flex>
+    </CardBody>
+  </Card>
+  );
+}
+
+function listChangedNodes(lineageGraphSets: DefaultLineageGraphSets) {
+  const changedNodes: LineageGraphNode[] = [];
+  const allNodes = lineageGraphSets.all.nodes;
+  lineageGraphSets.modifiedSet.forEach((nodeId) => {
+    const node = allNodes[nodeId];
+    const columnDiffStatus = mergeKeysWithStatus( Object.keys(node.data.base?.columns || {}),  Object.keys(node.data.current?.columns || {}));
+    const isSchemaChanged = !Object.values(columnDiffStatus).every(el => el === undefined);
+
+    // We only want to show nodes that have schema changes
+    if (isSchemaChanged)
+      changedNodes.push(node);
+  })
+  return changedNodes;
+}
+
+export interface Props {
+  lineageGraphSets: DefaultLineageGraphSets
+}
+
+export function SchemaSummary({ lineageGraphSets }: Props) {
+  const [changedNodes, setChangedNodes] = useState<LineageGraphNode[]>([]);
+
+  useEffect(() => {
+    setChangedNodes(listChangedNodes(lineageGraphSets));
+  }, [lineageGraphSets]);
+
+  return (<>
+    <Flex w={'100%'} paddingBottom="10px" marginBottom="20px" marginTop="20px" >
+      <Heading fontSize={24}>Schema Summary</Heading>
+    </Flex>
+    <Flex w={'100%'} paddingBottom="10px" marginBottom="20px">
+    {(changedNodes.length === 0) ? (
+      <>
+        <Text fontSize={18} color={'gray'}>No schema changes detected.</Text>
+      </>
+    ):(
+      <>
+
+        <SimpleGrid
+          minChildWidth='500px'
+          spacing={'2vw'}
+          padding={'2.5vw'}
+          width={'100%'}
+          backgroundColor={'lightgray'}
+        >
+          {changedNodes.map((node) => {
+            return <SchemaDiffCard key={node.id} title={node.name} node={node} />;
+          })}
+        </SimpleGrid>
+
+      </>
+    )}
+    </Flex>
+  </>);
+}

--- a/js/src/components/summary/SummaryView.tsx
+++ b/js/src/components/summary/SummaryView.tsx
@@ -1,0 +1,23 @@
+import { Divider, Flex, Heading, Spacer, Text } from "@chakra-ui/react";
+import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { ChangeSummary } from "./ChangeSummary";
+import { SchemaSummary } from "./SchemaSummary";
+
+export default function SummaryView() {
+  const { lineageGraphSets } = useLineageGraphsContext();
+  return (
+    <>
+      <Flex direction="column" w={'100%'} minHeight="650px">
+        <Flex w={'100%'} paddingBottom="10px" marginBottom="20px">
+          <Heading fontSize={24}>Change Summary</Heading>
+        </Flex>
+        {lineageGraphSets &&<>
+          <ChangeSummary lineageGraphSets={lineageGraphSets}/>
+          <Divider />
+          <SchemaSummary lineageGraphSets={lineageGraphSets}/>
+        </>
+        }
+      </Flex>
+    </>
+  );
+}

--- a/js/src/lib/hooks/LineageGraphContext.tsx
+++ b/js/src/lib/hooks/LineageGraphContext.tsx
@@ -1,0 +1,29 @@
+import { DefaultLineageGraphSets } from '@/components/lineage/lineage';
+import React, { createContext, useContext } from 'react';
+
+export interface LineageGraphsContext {
+    lineageGraphSets?: DefaultLineageGraphSets;
+    setLineageGraphSets: (lineageGraphs: any) => void;
+}
+
+const defaultLineageGraphsContext: LineageGraphsContext = {
+    setLineageGraphSets: () => {},
+};
+
+const LineageGraphSets = createContext(defaultLineageGraphsContext);
+
+
+interface LineageGraphSetsProps {
+    children: React.ReactNode;
+}
+
+export function LineageGraphsContextProvider({ children }: LineageGraphSetsProps) {
+    const [lineageGraphSets, setLineageGraphSets] = React.useState<DefaultLineageGraphSets>();
+    return (
+        <LineageGraphSets.Provider value={{ setLineageGraphSets, lineageGraphSets }}>
+            {children}
+        </LineageGraphSets.Provider>
+    );
+}
+
+export const useLineageGraphsContext = () => useContext(LineageGraphSets);

--- a/js/src/lib/hooks/RecceContextProvider.tsx
+++ b/js/src/lib/hooks/RecceContextProvider.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { RecceQueryContextProvider } from './RecceQueryContext';
+import { LineageGraphsContextProvider } from './LineageGraphContext';
+
+interface RecceContextProps {
+  children: React.ReactNode;
+}
+
+export default function RecceContextProvider({ children }: RecceContextProps) {
+  return (
+    <>
+      <RecceQueryContextProvider>
+        <LineageGraphsContextProvider>
+          {children}
+        </LineageGraphsContextProvider>
+      </RecceQueryContextProvider>
+    </>
+  );
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- Add summary page to demo the layout of changed schemas summary
![CleanShot 2023-12-18 at 12 12 01](https://github.com/DataRecce/recce/assets/959606/dd45e5e2-5b68-42c5-aa67-2883fc2691ed)


**Which issue(s) this PR fixes**:
RC-48

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
