### PR TITLE
use wouter to routing

### DIFF
--- a/js/app/page.tsx
+++ b/js/app/page.tsx
@@ -1,52 +1,63 @@
 "use client";
 
 import LineageView from "@/components/lineage/LineageView";
-import {
-  Tabs,
-  TabList,
-  Tab,
-  TabPanels,
-  TabPanel,
-  ChakraProvider,
-  Box,
-} from "@chakra-ui/react";
-import { useParams } from "next/navigation";
-import { useEffect, useLayoutEffect, useState } from "react";
+import { Tabs, TabList, Tab, ChakraProvider, Box } from "@chakra-ui/react";
+import { useLayoutEffect } from "react";
 import * as amplitude from "@amplitude/analytics-browser";
 import { QueryClientProvider } from "@tanstack/react-query";
 import RecceContextProvider from "@/lib/hooks/RecceContextProvider";
 import { reactQueryClient } from "@/lib/api/axiosClient";
 import { useVersionNumber } from "@/lib/api/version";
-import { setLocationHash, getLocationHash } from "@/lib/UrlHash";
 import { CheckPage } from "@/components/check/CheckPage";
 import { QueryPage } from "@/components/query/QueryPage";
 import SummaryView from "@/components/summary/SummaryView";
+import { Route, Router, Switch, useLocation } from "wouter";
+
+import _ from "lodash";
+import { useHashLocation } from "@/lib/hooks/useHashLocation";
 
 function getCookie(key: string) {
   var b = document.cookie.match("(^|;)\\s*" + key + "\\s*=\\s*([^;]+)");
   return b ? b.pop() : "";
 }
 
-const TabContainer = ({
-  children,
-  pageHeight,
-}: {
-  children: React.ReactNode;
-  pageHeight: string;
-}) => {
+function NavBar() {
+  const [location, setLocation] = useLocation();
+  const version = useVersionNumber();
+
+  const tabs = [
+    ["Lineage", "/lineage"],
+    ["Query", "/query"],
+    ["Checklist", "/checks"],
+    ["Summary", "/summary"],
+  ];
+
+  const tabIndex = _.findIndex(tabs, ([, href]) => location.startsWith(href));
+
   return (
-    <TabPanel p={0} h={pageHeight} maxH={pageHeight} overflow="auto">
-      {children}
-    </TabPanel>
+    <Tabs index={tabIndex}>
+      <TabList>
+        {tabs.map(([name, href]) => {
+          return (
+            <Tab
+              onClick={() => {
+                setLocation(href);
+              }}
+            >
+              {name}
+            </Tab>
+          );
+        })}
+
+        <Box position="absolute" right="0" top="0" p="2" color="gray.500">
+          {version}
+        </Box>
+      </TabList>
+    </Tabs>
   );
-};
+}
 
 export default function Home() {
-  const version = useVersionNumber();
-  const params = useParams();
-  const [urlHash, setUrlHash] = useState(getLocationHash());
-  const [tabIndex, setTabIndex] = useState(0);
-
   useLayoutEffect(() => {
     const userId = getCookie("recce_user_id");
     if (userId && process.env.AMPLITUDE_API_KEY) {
@@ -61,70 +72,32 @@ export default function Home() {
     }
   }, []);
 
-  const handleTabsChange = (index: number) => {
-    if (index === 0) {
-      setLocationHash("lineage");
-    } else if (index === 1) {
-      setLocationHash("query");
-    } else if (index === 2) {
-      setLocationHash("checks");
-    } else if (index === 3) {
-      setLocationHash("summary");
-    }
-    setTabIndex(index);
-  };
-
-  useEffect(() => {
-    const hash = getLocationHash();
-    setUrlHash(hash);
-
-    if (hash !== urlHash) return;
-
-    if (hash === "lineage") {
-      setTabIndex(0);
-    } else if (hash === "query") {
-      setTabIndex(1);
-    } else if (hash === "checks") {
-      setTabIndex(2);
-    } else if (hash === 'summary') {
-      setTabIndex(3);
-    } else {
-      setTabIndex(0);
-    }
-  }, [params, urlHash]);
-
   const pageHeight = "calc(100vh - 42px)";
 
   return (
     <ChakraProvider>
       <RecceContextProvider>
         <QueryClientProvider client={reactQueryClient}>
-          <Tabs index={tabIndex} onChange={handleTabsChange}>
-            <TabList>
-              <Tab>Lineage</Tab>
-              <Tab>Query</Tab>
-              <Tab>Checklist</Tab>
-              <Tab>Summary</Tab>
-              <Box position="absolute" right="0" top="0" p="2" color="gray.500">
-                {version}
-              </Box>
-            </TabList>
+          <Router hook={useHashLocation}>
+            <NavBar />
 
-            <TabPanels>
-              <TabContainer pageHeight={pageHeight}>
-                <LineageView />
-              </TabContainer>
-              <TabContainer pageHeight={pageHeight}>
-                <QueryPage />
-              </TabContainer>
-              <TabContainer pageHeight={pageHeight}>
-                <CheckPage />
-              </TabContainer>
-              <TabContainer pageHeight={pageHeight}>
-                <SummaryView />
-              </TabContainer>
-            </TabPanels>
-          </Tabs>
+            <Box p={0} h={pageHeight} maxH={pageHeight} overflow="auto">
+              <Switch>
+                <Route path="/lineage">
+                  <LineageView />
+                </Route>
+                <Route path="/query">
+                  <QueryPage />
+                </Route>
+                <Route path="/checks/:slug*">
+                  <CheckPage />
+                </Route>
+                <Route path="/summary">
+                  <SummaryView />
+                </Route>
+              </Switch>
+            </Box>
+          </Router>
         </QueryClientProvider>
       </RecceContextProvider>
     </ChakraProvider>

--- a/js/package.json
+++ b/js/package.json
@@ -32,7 +32,8 @@
     "react-data-grid": "7.0.0-beta.40",
     "react-dom": "^18",
     "react-icons": "^4.11.0",
-    "reactflow": "^11.10.1"
+    "reactflow": "^11.10.1",
+    "wouter": "^2.12.1"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.3.3",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -62,6 +62,9 @@ dependencies:
   reactflow:
     specifier: ^11.10.1
     version: 11.10.1(@types/react@18.2.34)(react-dom@18.2.0)(react@18.2.0)
+  wouter:
+    specifier: ^2.12.1
+    version: 2.12.1(react@18.2.0)
 
 devDependencies:
   '@testing-library/dom':
@@ -7087,6 +7090,15 @@ packages:
     dependencies:
       isexe: 2.0.0
     dev: true
+
+  /wouter@2.12.1(react@18.2.0):
+    resolution: {integrity: sha512-G7a6JMSLSNcu6o8gdOfIzqxuo8Qx1qs+9rpVnlurH69angsSFPZP5gESNuVNeJct/MGpQg191pDo4HUjTx7IIQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+      use-sync-external-store: 1.2.0(react@18.2.0)
+    dev: false
 
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}

--- a/js/src/components/check/CheckBreadcrumb.tsx
+++ b/js/src/components/check/CheckBreadcrumb.tsx
@@ -68,32 +68,30 @@ export function CheckBreadcrumb({ name, setName }: CheckBreadcrumbProps) {
       separator={<ChevronRightIcon color="gray.500" />}
     >
       <BreadcrumbItem>
-        <BreadcrumbLink>Checks</BreadcrumbLink>
+        <Box>Checks</Box>
       </BreadcrumbItem>
-      <BreadcrumbItem flex="0 1">
-        <BreadcrumbLink href="#" isCurrentPage>
-          {isEditing ? (
-            <Input
-              ref={editInputRef}
-              value={editValue}
-              onChange={handleChange}
-              onKeyDown={handleKeyDown}
-              size="sm"
-              w="auto"
-              minW="100px"
-              maxW="600px"
-            />
-          ) : (
-            <Box
-              onClick={handleClick}
-              textOverflow="ellipsis"
-              whiteSpace="nowrap"
-              overflow="hidden"
-            >
-              {name}
-            </Box>
-          )}
-        </BreadcrumbLink>
+      <BreadcrumbItem flex="0 1" cursor="pointer">
+        {isEditing ? (
+          <Input
+            ref={editInputRef}
+            value={editValue}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            size="sm"
+            w="auto"
+            minW="100px"
+            maxW="600px"
+          />
+        ) : (
+          <Box
+            onClick={handleClick}
+            textOverflow="ellipsis"
+            whiteSpace="nowrap"
+            overflow="hidden"
+          >
+            {name}
+          </Box>
+        )}
       </BreadcrumbItem>
     </Breadcrumb>
   );

--- a/js/src/components/check/CheckDetail.tsx
+++ b/js/src/components/check/CheckDetail.tsx
@@ -32,9 +32,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { cacheKeys } from "@/lib/api/cacheKeys";
 import { Check, deleteCheck, getCheck, updateCheck } from "@/lib/api/checks";
 import { QueryDiffResult } from "@/lib/api/adhocQuery";
+import { useLocation } from "wouter";
 
 export const CheckDetail = ({ checkId }: CheckDetailProps) => {
   const queryClient = useQueryClient();
+  const [, setLocation] = useLocation();
+
   const {
     isLoading,
     error,
@@ -42,6 +45,8 @@ export const CheckDetail = ({ checkId }: CheckDetailProps) => {
   } = useQuery({
     queryKey: cacheKeys.check(checkId),
     queryFn: () => getCheck(checkId),
+    refetchOnMount: false,
+    staleTime: 5 * 60 * 1000,
   });
 
   const { mutate } = useMutation({
@@ -56,6 +61,7 @@ export const CheckDetail = ({ checkId }: CheckDetailProps) => {
     mutationFn: () => deleteCheck(checkId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: cacheKeys.checks() });
+      setLocation("/checks");
     },
   });
 

--- a/js/src/components/lineage/NodeView.tsx
+++ b/js/src/components/lineage/NodeView.tsx
@@ -21,13 +21,14 @@ import {
   ModalCloseButton,
 } from "@chakra-ui/react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+
 import { FaCode } from "react-icons/fa";
 import { LineageGraphNode } from "./lineage";
 import { SchemaView } from "../schema/SchemaView";
 import { useRecceQueryContext } from "@/lib/hooks/RecceQueryContext";
 import { SqlDiffView } from "../schema/SqlDiffView";
 import useMismatchSummaryModal from "./MismatchSummary";
+import { useLocation } from "wouter";
 
 interface NodeViewProps {
   node: LineageGraphNode;
@@ -35,7 +36,7 @@ interface NodeViewProps {
 }
 
 export function NodeView({ node, onCloseNode }: NodeViewProps) {
-  const router = useRouter();
+  const [, setLocation] = useLocation();
   const { setSqlQuery } = useRecceQueryContext();
   const withColumns =
     node.resourceType === "model" ||
@@ -43,7 +44,6 @@ export function NodeView({ node, onCloseNode }: NodeViewProps) {
     node.resourceType === "source";
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { MismatchSummaryModal } = useMismatchSummaryModal();
-
 
   return (
     <Grid height="100%" templateRows="auto 1fr">
@@ -104,7 +104,7 @@ export function NodeView({ node, onCloseNode }: NodeViewProps) {
             size="sm"
             onClick={() => {
               setSqlQuery(`select * from {{ ref("${node.name}") }}`);
-              router.push("#query");
+              setLocation("/query");
             }}
           >
             Query

--- a/js/src/components/query/QueryPage.tsx
+++ b/js/src/components/query/QueryPage.tsx
@@ -4,19 +4,19 @@ import SqlEditor from "./SqlEditor";
 import { useRecceQueryContext } from "@/lib/hooks/RecceQueryContext";
 import { submitQueryDiff } from "@/lib/api/runs";
 import { createCheckByRun, updateCheck } from "@/lib/api/checks";
-import { useRouter } from "next/navigation";
 import { QueryDiffDataGrid } from "./QueryDiffDataGrid";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { cacheKeys } from "@/lib/api/cacheKeys";
+import { useLocation, useRouter } from "wouter";
 
 export const QueryPage = () => {
   const { sqlQuery, setSqlQuery } = useRecceQueryContext();
   const [submittedQuery, setSubmittedQuery] = useState<string>();
 
-  const router = useRouter();
   const [primaryKeys, setPrimaryKeys] = useState<string[]>([]);
 
   const queryClient = useQueryClient();
+  const [, setLocation] = useLocation();
 
   const {
     data: queryResult,
@@ -44,8 +44,8 @@ export const QueryPage = () => {
     setSubmittedQuery(undefined);
 
     queryClient.invalidateQueries({ queryKey: cacheKeys.checks() });
-    router.push("#checks");
-  }, [queryResult?.run_id, router, primaryKeys, queryClient]);
+    setLocation(`/checks/${check.check_id}`);
+  }, [queryResult?.run_id, setLocation, primaryKeys, queryClient]);
 
   return (
     <Flex direction="column" height="100%">

--- a/js/src/lib/hooks/useHashLocation.ts
+++ b/js/src/lib/hooks/useHashLocation.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useCallback } from "react";
+
+function getWindow(): Window | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  return window;
+}
+
+function useHash(defaultValue?: string): [string, (location: string) => void] {
+  const _window = getWindow();
+  const [hash, setHash] = useState(defaultValue ?? "");
+
+  useEffect(() => {
+    if (!_window) {
+      return;
+    }
+
+    setHash(_window!.location.hash);
+    const handler = () => setHash(_window!.location.hash);
+    _window.addEventListener("hashchange", handler);
+
+    return () => window.removeEventListener("hashchange", handler);
+  }, [_window]);
+
+  const navigate = useCallback(
+    (to: string | null) => {
+      _window!.location.hash = `!${to}` || "";
+    },
+    [_window]
+  );
+
+  return [hash, navigate];
+}
+
+// This is used by wouter Router
+// <Router hook={useHashLocation}>
+export function useHashLocation() {
+  const [hash, setHash] = useHash("#!/ssr");
+
+  // replace '#!/path/to/resource?foo=bar' with '/path/to/resource'
+  let location = hash.replace(/^#!/, "") || "/";
+  if (location.includes("?")) {
+    location = location.split("?")[0];
+  }
+
+  return [location, setHash];
+}
+
+export function useHashParams() {
+  const [hash] = useHash();
+
+  if (hash.includes("?")) {
+    const [, search] = hash.split("?");
+    return new URLSearchParams(search);
+  } else {
+    return new URLSearchParams("");
+  }
+}

--- a/recce/apis/check_api.py
+++ b/recce/apis/check_api.py
@@ -12,8 +12,8 @@ check_router = APIRouter(tags=['check'])
 
 
 class CreateCheckIn(BaseModel):
-    name: Optional[str] = f"Check-{datetime.utcnow().isoformat()}"
-    description: Optional[str] = ''
+    name: Optional[str] = None
+    description: str = ''
     run_id: Optional[str] = None
 
 
@@ -27,6 +27,9 @@ class CreateCheckOut(BaseModel):
 
 
 def create_check_from_run(name, description, run_id):
+    if name is None:
+        name = f"Check {datetime.utcnow().isoformat()}"
+
     for run in runs_db:
         if run_id == str(run.run_id):
             check = Check(name=name, description=description, type=run.type, params=run.params)


### PR DESCRIPTION
Change to use wouter for global routing.

The reason why we don't use next route is 
- We use static site generation (SSG)
- We only generate one page, which is served by python fastapi
- Using hash as location is more suitable for our case

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed
