### PR TITLE
[Feature] RC-87 add a query row count button in lineage view

### DIFF
--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Icon, Text, Tooltip } from "@chakra-ui/react";
+import { Box, Flex, HStack, Icon, Spacer, Text, Tooltip } from "@chakra-ui/react";
 import React from "react";
 
 import { Handle, NodeProps, Position, useStore } from "reactflow";
@@ -6,6 +6,7 @@ import { LineageGraphNode } from "./lineage";
 import { getIconForChangeStatus, getIconForResourceType } from "./styles";
 
 import "./styles.css";
+import { RowCountTag } from "./NodeTag";
 
 interface GraphNodeProps extends NodeProps<LineageGraphNode> {}
 
@@ -102,6 +103,14 @@ export function GraphNode({ data }: GraphNodeProps) {
               </Flex>
             )}
           </Flex>
+          {data.resourceType === "model" && (
+          <Flex flex='1 0 auto' mx="1" direction="column" paddingBottom="1">
+            <HStack spacing={"8px"}>
+              <Spacer />
+              <RowCountTag node={data} isInteractive={false}/>
+            </HStack>
+          </Flex>
+          )}
         </Flex>
 
         {Object.keys(data?.parents ?? {}).length > 0 && (

--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -104,7 +104,12 @@ export function GraphNode({ data }: GraphNodeProps) {
             )}
           </Flex>
           {data.resourceType === "model" && (
-          <Flex flex='1 0 auto' mx="1" direction="column" paddingBottom="1">
+          <Flex
+            flex='1 0 auto'
+            mx="1" direction="column"
+            paddingBottom="1"
+            visibility={showContent ? "inherit" : "hidden"}
+          >
             <HStack spacing={"8px"}>
               <Spacer />
               <RowCountTag node={data} isInteractive={false}/>

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -13,14 +13,9 @@ import {
   ModalContent,
   ModalCloseButton,
   ModalBody,
-  Button,
   HStack,
-  Menu,
-  MenuButton,
-  MenuList,
-  MenuItem,
 } from "@chakra-ui/react";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import ReactFlow, {
   Node,
   Edge,
@@ -32,7 +27,6 @@ import ReactFlow, {
   Background,
   ReactFlowProvider,
   ControlButton,
-  useReactFlow,
 } from "reactflow";
 import dagre from "dagre";
 import "reactflow/dist/style.css";
@@ -40,14 +34,11 @@ import { GraphNode } from "./GraphNode";
 import GraphEdge from "./GraphEdge";
 import { getIconForChangeStatus } from "./styles";
 import { FiDownloadCloud, FiRefreshCw, FiList } from "react-icons/fi";
-import { MdQueryStats } from "react-icons/md";
 import { NodeView } from "./NodeView";
 import { toPng } from "html-to-image";
 import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
 import SummaryView from "../summary/SummaryView";
-import { ChevronUpIcon } from "@chakra-ui/icons";
-import { FetchRowCountsButton, fetchRowCountsByNodes } from "./NodeTag";
-import { useQueries } from "@tanstack/react-query";
+import { FetchRowCountsButton } from "./NodeTag";
 
 const layout = (nodes: Node[], edges: Edge[], direction = "LR") => {
   const dagreGraph = new dagre.graphlib.Graph();
@@ -132,60 +123,6 @@ function ChangeStatusLegend() {
   );
 }
 
-const statNames : {
-  [key: string]: string
-} = {
-  '': 'No Stat',
-  row_count: 'Row Count',
-}
-
-function StatMenu({ stat, setStat }: { stat: string, setStat: (stat: string) => void }) {
-  const statName = statNames[stat] || 'No Stat';
-  return (
-    <Box p={2} flex="0 1 160px" fontSize="14px">
-      <Text color="gray" mb="2px">
-        Stat
-      </Text>
-      <Menu >
-        <MenuButton as={Box}>
-          <Flex alignItems="center" fontSize="sm" gap={2}>
-            {statName}
-            <ChevronUpIcon />
-          </Flex>
-        </MenuButton>
-        <MenuList>
-          {Object.entries(statNames).map(([key, name]) => {
-            return (
-              <MenuItem key={key}>{name}</MenuItem>
-            );
-          })}
-        </MenuList>
-      </Menu>
-    </Box>
-  );
-}
-
-// function FetchRowCountsButton({ onClick }: {onClick: () => void }) {
-//   const [enabled, setEnabled] = useState<boolean>(false);
-//   const [index, setIndex] = useState<number>(0);
-
-//   return (
-//     <Box p={2} flex="0 1 160px" fontSize="14px">
-//       <Text color="gray" mb="2px">
-//         Actions
-//       </Text>
-//       <Button
-//         size="xs"
-//         variant="outline"
-//         title="Query Row Counts"
-//         onClick={onClick}
-//       >
-//         <Icon as={MdQueryStats} mr={1} />
-//         Row Counts
-//       </Button>
-//     </Box>);
-// }
-
 function _LineageView() {
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
@@ -198,9 +135,6 @@ function _LineageView() {
   const [viewMode, setViewMode] = useState<"changed_models" | "all">(
     "changed_models"
   );
-  const [stat, setStat] = useState<string>('' as string);
-
-  const { getViewport } = useReactFlow();
 
   useEffect(() => {
     if (!lineageGraphSets) {
@@ -222,11 +156,6 @@ function _LineageView() {
     setNodes(nodes);
     setEdges(edges);
   }, [setNodes, setEdges, viewMode, lineageGraphSets]);
-
-  const fetchAllRowCounts = useCallback(async () => {
-    fetchRowCountsByNodes(nodes.map((node) => node.data));
-  },[nodes]);
-
 
   const onNodeMouseEnter = (event: React.MouseEvent, node: Node) => {
     if (lineageGraph && modifiedSet !== undefined) {
@@ -339,11 +268,11 @@ function _LineageView() {
           <Panel position="bottom-left" >
             <HStack>
               <ChangeStatusLegend />
-              {/* <StatMenu stat={stat} setStat={setStat}/> */}
               { nodes.length > 0 && (
               <FetchRowCountsButton
                 nodes={nodes.map((node) => node.data)}
-              />)}
+              />)
+              }
             </HStack>
           </Panel>
           <Panel position="top-left">

--- a/js/src/components/lineage/NodeTag.tsx
+++ b/js/src/components/lineage/NodeTag.tsx
@@ -1,0 +1,181 @@
+import { HStack, SkeletonText, Tag, TagLabel, TagLeftIcon, Tooltip, Text, Icon, IconButton, Box, Button } from "@chakra-ui/react";
+import { getIconForResourceType } from "./styles";
+import { FiAlignLeft, FiFrown, FiTrendingDown, FiTrendingUp } from "react-icons/fi";
+import { MdQueryStats, MdOutlineQuestionMark } from "react-icons/md";
+import { fetchModelRowCount } from "@/lib/api/models";
+import { cacheKeys } from "@/lib/api/cacheKeys";
+import { LineageGraphNode } from "./lineage";
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+
+interface ModelRowCount {
+  base: number | null;
+  curr: number | null;
+}
+
+interface ModelRowCountProps {
+  rowCount?: ModelRowCount;
+}
+
+export function ModelRowCount({ rowCount }: ModelRowCountProps ) {
+  if (!rowCount) {
+    return (
+      <HStack>
+        <Text>Failed to load</Text>
+        <Icon as={FiFrown} color="red.500" />
+      </HStack>
+    )
+  }
+  const base = rowCount.base === null ? -1 : rowCount.base;
+  const current = rowCount.curr === null ? -1 : rowCount.curr;
+  const baseLabel = base === -1 ? "N/A" : base;
+  const currentLabel = current === -1 ? "N/A" : current;
+
+
+  if (base === current) {
+    return <Text>{base}</Text>;
+  } else if (base < current) {
+    return (
+      <HStack>
+        <Text>{baseLabel}</Text>
+        <Icon as={FiTrendingUp} color="green.500" />
+        <Text>{currentLabel}</Text>
+      </HStack>
+    );
+  } else {
+    return (
+      <HStack>
+        <Text>{baseLabel}</Text>
+        <Icon as={FiTrendingDown} color="red.500" />
+        <Text>{currentLabel}</Text>
+      </HStack>
+    );
+  }
+}
+
+export function ResourceTypeTag({ node }: { node: LineageGraphNode }) {
+  const { icon: resourceTypeIcon } = getIconForResourceType(node.resourceType);
+  return (
+    <Tooltip hasArrow label="Type of resource">
+      <Tag>
+        <TagLeftIcon as={resourceTypeIcon} />
+        <TagLabel>{node.resourceType}</TagLabel>
+      </Tag>
+    </Tooltip>
+  );
+}
+
+export interface RowCountTagProps {
+  node: LineageGraphNode;
+  isAutoFetching?: boolean; // if true, automatically fetches row count on mount
+  isInteractive?: boolean; // if true, allows user to manually fetch row count
+}
+
+export function RowCountTag(
+  {
+    node,
+    isAutoFetching = false,
+    isInteractive = true,
+  }: RowCountTagProps) {
+  const { isLoading, data: rowCount, refetch: invokeRowCountQuery , isFetched, isFetching } = useQuery({
+    queryKey: cacheKeys.rowCount(node.name),
+    queryFn:  () => fetchModelRowCount(node.name),
+    enabled: node.resourceType === "model" && isAutoFetching,
+  });
+
+  function ProcessedRowCountTag(
+    { isLoading, rowCount }: {isLoading: boolean, rowCount: ModelRowCount}) {
+    return (<TagLabel>
+              <SkeletonText isLoaded={!isLoading} noOfLines={1} skeletonHeight={2} minWidth={'30px'}>
+                <ModelRowCount rowCount={rowCount} />
+              </SkeletonText>
+            </TagLabel>);
+  }
+
+  function UnprocessedRowCountTag(
+    { isInteractive, invokeFunction }: {isInteractive:boolean,invokeFunction: () => void}) {
+      if (isInteractive) {
+        return (
+          <IconButton
+            aria-label="Query Row Count"
+            icon={<MdQueryStats />}
+            size="xs"
+            onClick={() => {invokeFunction()}}
+            />
+        );
+      }
+
+      return <Icon
+        as={MdOutlineQuestionMark}
+        />;
+  }
+
+  return (
+    <Tooltip hasArrow label={isFetched || isFetching || !isInteractive ?"Number of row":"Query the number of row"}>
+      <Tag>
+        <TagLeftIcon as={FiAlignLeft} />
+        {isFetched || isFetching ? (
+          <ProcessedRowCountTag
+            isLoading={isLoading}
+            rowCount={rowCount}
+          />
+        ) : (
+          <UnprocessedRowCountTag
+            isInteractive={isInteractive}
+            invokeFunction={invokeRowCountQuery}
+          />
+        )}
+      </Tag>
+    </Tooltip>
+  );
+}
+
+export async function fetchRowCountsByNodes(nodes: LineageGraphNode[]) {
+  nodes.forEach((node) => {
+    if (node.resourceType === "model") {
+      console.log("Name", node.name);
+    }
+  });
+}
+
+export function FetchRowCountsButton({ nodes }: { nodes: LineageGraphNode[] }) {
+  const [enabled, setEnabled] = useState<boolean>(false);
+  const [index, setIndex] = useState<number>(0);
+  const name = (index < nodes.length) ? nodes[index].name : "";
+  const { isLoading, isFetched } = useQuery({
+    queryKey: cacheKeys.rowCount(name),
+    queryFn:  () => fetchModelRowCount(name),
+    enabled: enabled,
+  });
+
+  useEffect(() => {
+    if (isFetched) {
+      if (index + 1 < nodes.length) {
+        // TODO: Use BFS to walk though all the changed nodes first.
+        setIndex(index + 1);
+      } else{
+        setEnabled(false);
+      }
+    }
+  }, [isFetched, index, nodes]);
+
+
+
+  return (
+    <Box p={2} flex="0 1 160px" fontSize="14px">
+      <Text color="gray" mb="2px">
+        Actions
+      </Text>
+      <Button
+        size="xs"
+        variant="outline"
+        title= "Query Row Counts"
+        onClick={() => {setIndex(0); setEnabled(true);}}
+        isDisabled={isLoading}
+      >
+        <Icon as={MdQueryStats} mr={1} />
+        {isLoading ? "Loading" : "Row Counts"}
+      </Button>
+    </Box>);
+}

--- a/js/src/components/lineage/NodeTag.tsx
+++ b/js/src/components/lineage/NodeTag.tsx
@@ -111,6 +111,12 @@ export function RowCountTag(
         />;
   }
 
+  if (isInteractive === false && isFetched === false && isFetching === false) {
+    // Don't show anything if the row count is not fetched and is not interactive.
+    return null;
+  }
+
+
   return (
     <Tooltip hasArrow label={isFetched || isFetching || !isInteractive ?"Number of row":"Query the number of row"}>
       <Tag>

--- a/js/src/components/lineage/NodeTag.tsx
+++ b/js/src/components/lineage/NodeTag.tsx
@@ -118,7 +118,12 @@ export function RowCountTag(
 
 
   return (
-    <Tooltip hasArrow label={isFetched || isFetching || !isInteractive ?"Number of row":"Query the number of row"}>
+    <Tooltip
+      hasArrow
+      label={isFetched || isFetching || !isInteractive ?"Number of row":"Query the number of row"}
+      openDelay={500}
+      closeDelay={200}
+    >
       <Tag>
         <TagLeftIcon as={FiAlignLeft} />
         {isFetched || isFetching ? (

--- a/js/src/components/lineage/NodeView.tsx
+++ b/js/src/components/lineage/NodeView.tsx
@@ -9,11 +9,9 @@ import {
   TabPanel,
   TabPanels,
   Tabs,
-  Text,
   HStack,
   Button,
   Spacer,
-  SkeletonText,
   useDisclosure,
   Modal,
   ModalOverlay,
@@ -21,78 +19,18 @@ import {
   ModalHeader,
   ModalBody,
   ModalCloseButton,
-  Tooltip,
-  Tag,
-  TagLeftIcon,
-  TagLabel,
-  Icon,
-  IconButton,
 } from "@chakra-ui/react";
 
 import { FaCode } from "react-icons/fa";
-import {
-  FiAlignLeft,
-  FiTrendingUp,
-  FiTrendingDown,
-  FiFrown,
-} from "react-icons/fi";
-import { MdQueryStats } from "react-icons/md";
 import { LineageGraphNode } from "./lineage";
 import { SchemaView } from "../schema/SchemaView";
 import { useRecceQueryContext } from "@/lib/hooks/RecceQueryContext";
 import { SqlDiffView } from "../schema/SqlDiffView";
 import useMismatchSummaryModal from "./MismatchSummary";
 import { useLocation } from "wouter";
-import { getIconForResourceType } from "./styles";
-import { useQuery } from "@tanstack/react-query";
-import { cacheKeys } from "@/lib/api/cacheKeys";
-import { fetchModelRowCount } from "@/lib/api/models";
+import { ResourceTypeTag, RowCountTag } from "./NodeTag";
 import { useCallback } from "react";
 import { createCheckByNodeSchema } from "@/lib/api/checks";
-
-interface ModelRowCount {
-  base: number | null;
-  curr: number | null;
-}
-
-interface ModelRowCountProps {
-  rowCount?: ModelRowCount;
-}
-
-export function ModelRowCount({ rowCount }: ModelRowCountProps) {
-  if (!rowCount) {
-    return (
-      <HStack>
-        <Text>Failed to load</Text>
-        <Icon as={FiFrown} color="red.500" />
-      </HStack>
-    );
-  }
-  const base = rowCount.base === null ? -1 : rowCount.base;
-  const current = rowCount.curr === null ? -1 : rowCount.curr;
-  const baseLabel = base === -1 ? "N/A" : base;
-  const currentLabel = current === -1 ? "N/A" : current;
-
-  if (base === current) {
-    return <Text>{base}</Text>;
-  } else if (base < current) {
-    return (
-      <HStack>
-        <Text>{baseLabel}</Text>
-        <Icon as={FiTrendingUp} color="green.500" />
-        <Text>{currentLabel}</Text>
-      </HStack>
-    );
-  } else {
-    return (
-      <HStack>
-        <Text>{baseLabel}</Text>
-        <Icon as={FiTrendingDown} color="red.500" />
-        <Text>{currentLabel}</Text>
-      </HStack>
-    );
-  }
-}
 
 interface NodeViewProps {
   node: LineageGraphNode;
@@ -108,19 +46,6 @@ export function NodeView({ node, onCloseNode }: NodeViewProps) {
     node.resourceType === "source";
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { MismatchSummaryModal } = useMismatchSummaryModal();
-  const { icon: resourceTypeIcon } = getIconForResourceType(node.resourceType);
-  const {
-    isLoading,
-    data: rowCount,
-    refetch: invokeRowCountQuery,
-    isFetched,
-    isFetching,
-  } = useQuery({
-    queryKey: cacheKeys.rowCount(node.name),
-    queryFn: () => fetchModelRowCount(node.name),
-    enabled: false,
-  });
-
   const addToChecklist = useCallback(async () => {
     const nodeID = node.id;
     const check = await createCheckByNodeSchema(nodeID);
@@ -165,46 +90,9 @@ export function NodeView({ node, onCloseNode }: NodeViewProps) {
       </HStack>
       <Box color="gray" paddingLeft={"16px"}>
         <HStack spacing={"8px"}>
-          <Tooltip hasArrow label="Type of resource">
-            <Tag>
-              <TagLeftIcon as={resourceTypeIcon} />
-              <TagLabel>{node.resourceType}</TagLabel>
-            </Tag>
-          </Tooltip>
+          <ResourceTypeTag node={node} />
           {node.resourceType === "model" && (
-            <Tooltip
-              hasArrow
-              label={
-                isFetched || isFetching
-                  ? "Number of row"
-                  : "Query the number of row"
-              }
-            >
-              <Tag>
-                <TagLeftIcon as={FiAlignLeft} />
-                {isFetched || isFetching ? (
-                  <TagLabel>
-                    <SkeletonText
-                      isLoaded={!isLoading}
-                      noOfLines={1}
-                      skeletonHeight={2}
-                      minWidth={"30px"}
-                    >
-                      <ModelRowCount rowCount={rowCount} />
-                    </SkeletonText>
-                  </TagLabel>
-                ) : (
-                  <IconButton
-                    aria-label="Query Row Count"
-                    icon={<MdQueryStats />}
-                    size="xs"
-                    onClick={() => {
-                      invokeRowCountQuery();
-                    }}
-                  />
-                )}
-              </Tag>
-            </Tooltip>
+            <RowCountTag node={node} />
           )}
         </HStack>
       </Box>

--- a/js/src/components/summary/SchemaSummary.tsx
+++ b/js/src/components/summary/SchemaSummary.tsx
@@ -4,12 +4,7 @@ import { SchemaView } from "../schema/SchemaView";
 import { mergeColumns } from "../schema/schema";
 import { mergeKeysWithStatus } from "@/lib/mergeKeys";
 import { useEffect, useState } from "react";
-import { getIconForResourceType } from "../lineage/styles";
-import { FiAlignLeft } from "react-icons/fi";
-import { cacheKeys } from "@/lib/api/cacheKeys";
-import { fetchModelRowCount } from "@/lib/api/models";
-import { useQuery } from "@tanstack/react-query";
-import { ModelRowCount } from "../lineage/NodeView";
+import { ResourceTypeTag, RowCountTag } from "../lineage/NodeTag";
 
 interface SchemaDiffCardProps {
   node: LineageGraphNode;
@@ -19,36 +14,16 @@ function SchemaDiffCard({
   node,
   ...props
  }: CardProps & SchemaDiffCardProps) {
-  const { icon: resourceTypeIcon } = getIconForResourceType(node.resourceType);
-  const { isLoading, data: rowCount } = useQuery({
-    queryKey: cacheKeys.rowCount(node.name),
-    queryFn: () => fetchModelRowCount(node.name),
-    enabled: node.resourceType === "model",
-  });
 
   return (
   <Card maxWidth={'500px'}>
     <CardHeader>
       <Heading fontSize={18}>{props.title}</Heading>
       <HStack spacing={"8px"} p={"16px"}>
-        <Tooltip hasArrow label="Type of resource">
-          <Tag>
-            <TagLeftIcon as={resourceTypeIcon} />
-            <TagLabel>{node.resourceType}</TagLabel>
-          </Tag>
-        </Tooltip>
+        <ResourceTypeTag node={node} />
         {node.resourceType === "model" && (
-            <Tooltip hasArrow label="Number of row">
-              <Tag>
-                <TagLeftIcon as={FiAlignLeft} />
-                <TagLabel>
-                  <SkeletonText isLoaded={!isLoading} noOfLines={1} skeletonHeight={2} minWidth={'30px'}>
-                    <ModelRowCount rowCount={rowCount} />
-                  </SkeletonText>
-                </TagLabel>
-              </Tag>
-            </Tooltip>
-          )}
+          <RowCountTag node={node} />
+        )}
       </HStack>
     </CardHeader>
     <CardBody>

--- a/js/src/components/summary/SchemaSummary.tsx
+++ b/js/src/components/summary/SchemaSummary.tsx
@@ -22,7 +22,7 @@ function SchemaDiffCard({
       <HStack spacing={"8px"} p={"16px"}>
         <ResourceTypeTag node={node} />
         {node.resourceType === "model" && (
-          <RowCountTag node={node} />
+          <RowCountTag node={node} isAutoFetching={true}/>
         )}
       </HStack>
     </CardHeader>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- Add `Query Row Count` button on the Lineage View page
  ![CleanShot 2023-12-26 at 15 02 26](https://github.com/DataRecce/recce/assets/959606/708b5fb8-cf9c-498d-a15c-8c257047b124)

- When users click that button, we will query all the row counts of showing models individually.
  ![CleanShot 2023-12-26 at 15 03 07](https://github.com/DataRecce/recce/assets/959606/7bd048e9-ac4a-479e-92b6-a30647d91554)

- Refactor row count tag component

**Which issue(s) this PR fixes**:
RC-87

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
