### PR TITLE
[Feature] Query diff view allows to filter out unchanged rows or columns

### DIFF
--- a/js/src/components/check/QueryDiffView.tsx
+++ b/js/src/components/check/QueryDiffView.tsx
@@ -41,6 +41,9 @@ export function QueryDiffView({ check }: QueryDiffViewProp) {
           <QueryDiffDataGrid
             run={check?.last_run}
             primaryKeys={(check?.params as QueryDiffResult)?.primary_keys || []}
+            changedOnly={
+              (check?.params as QueryDiffResult)?.changed_only || false
+            }
           />
         )}
       </Box>

--- a/js/src/components/query/QueryDiffDataGrid.tsx
+++ b/js/src/components/query/QueryDiffDataGrid.tsx
@@ -95,9 +95,13 @@ export const QueryDiffDataGrid = ({
     return <Center height="100%">No data</Center>;
   }
 
+  if (changedOnly && gridData.rows.length === 0) {
+    return <Center height="100%">No change</Center>;
+  }
+
   return (
     <DataGrid
-      style={{ flex: 1 }}
+      style={{ blockSize: "100%" }}
       columns={gridData.columns}
       rows={gridData.rows}
       defaultColumnOptions={{ resizable: true, maxWidth: 800, width: 100 }}

--- a/js/src/components/query/QueryDiffDataGrid.tsx
+++ b/js/src/components/query/QueryDiffDataGrid.tsx
@@ -22,6 +22,7 @@ interface QueryDiffDataGridProps {
   isFetching?: boolean;
   run?: Run<QueryDiffParams, QueryDiffResult>;
   error?: Error | null; // error from submit
+  changedOnly?: boolean;
   primaryKeys: string[];
   setPrimaryKeys?: (primaryKeys: string[]) => void;
   onCancel?: () => void;
@@ -31,6 +32,7 @@ export const QueryDiffDataGrid = ({
   isFetching,
   run,
   error,
+  changedOnly,
   primaryKeys,
   setPrimaryKeys,
   onCancel,
@@ -41,13 +43,12 @@ export const QueryDiffDataGrid = ({
       return { rows: [], columns: [] };
     }
 
-    return toDataDiffGrid(
-      run?.result?.base,
-      run?.result?.current,
+    return toDataDiffGrid(run?.result?.base, run?.result?.current, {
+      changedOnly,
       primaryKeys,
-      setPrimaryKeys
-    );
-  }, [run, isFetching, primaryKeys, setPrimaryKeys]);
+      onPrimaryKeyChange: setPrimaryKeys,
+    });
+  }, [run, isFetching, primaryKeys, setPrimaryKeys, changedOnly]);
 
   const handleCancel = () => {
     setAborting(true);
@@ -96,7 +97,7 @@ export const QueryDiffDataGrid = ({
 
   return (
     <DataGrid
-      style={{ blockSize: "100%" }}
+      style={{ flex: 1 }}
       columns={gridData.columns}
       rows={gridData.rows}
       defaultColumnOptions={{ resizable: true, maxWidth: 800, width: 100 }}

--- a/js/src/components/query/querydiff.test.ts
+++ b/js/src/components/query/querydiff.test.ts
@@ -91,7 +91,7 @@ test("query diff", () => {
     ],
   };
 
-  const result = toDataDiffGrid(base, current, [], () => {});
+  const result = toDataDiffGrid(base, current);
 
   expect(result?.rows).toStrictEqual([
     {

--- a/js/src/components/query/querydiff.test.ts
+++ b/js/src/components/query/querydiff.test.ts
@@ -96,6 +96,7 @@ test("query diff", () => {
   expect(result?.rows).toStrictEqual([
     {
       index: 0,
+      status: "modified",
       base__id: 1,
       base__name: "Alice",
       base__value: 100,
@@ -105,6 +106,7 @@ test("query diff", () => {
     },
     {
       index: 1,
+      status: "modified",
       base__id: 2,
       base__name: "Bob",
       base__value: 200,
@@ -114,6 +116,7 @@ test("query diff", () => {
     },
     {
       index: 2,
+      status: "modified",
       base__id: 3,
       base__name: "Charlie",
       base__value: 300,

--- a/js/src/components/query/styles.css
+++ b/js/src/components/query/styles.css
@@ -2,9 +2,31 @@
   color: rgb(128, 128, 128);
   text-align: right;
 }
-.diff-cell {
+
+
+.diff-header-added {
+  background-color: #3aa53a;
+  color: white;
+}
+
+.diff-cell-added {
+  background-color: #cefece;
+  color: black;
+}
+
+.diff-header-removed {
   background-color: #ff6666;
   color: white;
+}
+
+.diff-cell-removed {
+  background-color: #ffc5c5;
+  color: black;
+}
+
+.diff-cell-modified {
+  background-color: #ffc5c5;
+  color: black;
 }
 
 .rdg-cell {

--- a/js/src/lib/api/adhocQuery.ts
+++ b/js/src/lib/api/adhocQuery.ts
@@ -17,6 +17,7 @@ export interface QueryDiffParams {
 
 export interface QueryDiffResult {
   primary_keys?: string[];
+  changed_only?: boolean;
   base?: DataFrame;
   current?: DataFrame;
   base_error?: string;


### PR DESCRIPTION
In the query diff view, we support to show only the changed one.
- We add the “Changed only” toggle, the default value is false, because if it set to true, we cannot select the primary key.
- Add the color of added/removed columns
- Add the color of added/removed rows (according to the PK settings)
- Change the color of cell value changed.
- Move the “Add to check” to be close to the query result.

![image](https://github.com/DataRecce/recce/assets/860633/3632606d-f2c1-42b6-86ad-da581eda9be8)
![image](https://github.com/DataRecce/recce/assets/860633/59ec8b5b-00d8-4025-9353-f306ed3ebf70)

## PR Checklist

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed


