### PR TITLE
[Bug] Fix the private model query issue

### DIFF
--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -1,6 +1,0 @@
-from recce.dbt import _fake_node
-
-
-def test_fake_node():
-    # we must fake a node without exception
-    _fake_node('foobar_package', 'select 1', [])


### PR DESCRIPTION
Fix #171 

The root cause is that we use fake "model" node to generate the sql. However, it's not allowed to depends another private model. 

The solution is to use the SqlNode, which is used in `dbt show` and `dbt compile`

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
#171

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
