### PR TITLE
Materialize the last run result for row count diff

### DIFF
--- a/js/src/components/check/CheckDetail.tsx
+++ b/js/src/components/check/CheckDetail.tsx
@@ -33,7 +33,7 @@ import { ValueDiffResultView } from "@/components/valuediff/ValueDiffResultView"
 import { SchemaDiffView } from "./SchemaDiffView";
 import { useLocation } from "wouter";
 import { CheckDescription } from "./CheckDescription";
-import { RowCountDiffResultView } from "../rowcount/RowCountDiffView";
+import { RowCountDiffResultView } from "../rowcount/RowCountDiffResultView";
 import { ProfileDiffResultView } from "../profile/ProfileDiffResultView";
 import { stripIndent } from "common-tags";
 import { useClipBoardToast } from "@/lib/hooks/useClipBoardToast";

--- a/js/src/components/check/CheckListLoader.tsx
+++ b/js/src/components/check/CheckListLoader.tsx
@@ -21,12 +21,14 @@ import { InfoIcon } from "@chakra-ui/icons";
 import { loadChecks } from "@/lib/api/checks";
 import { IoFolderOpenOutline } from "react-icons/io5";
 import { useLocation } from "wouter";
+import { useRunsAggregated } from "@/lib/hooks/LineageGraphContext";
 
 export function CheckListInitLoader() {
   const toast = useToast();
   const queryClient = useQueryClient();
   const hiddenFileInput = useRef<HTMLInputElement>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [, refetchRunsAggregated] = useRunsAggregated();
 
   const handleLoad = useCallback(async () => {
     if (!selectedFile) {
@@ -35,6 +37,7 @@ export function CheckListInitLoader() {
 
     try {
       const { checks } = await loadChecks(selectedFile);
+      refetchRunsAggregated();
       queryClient.invalidateQueries({ queryKey: cacheKeys.checks() });
       toast({
         description: `${checks} checks loaded successfully`,
@@ -56,7 +59,7 @@ export function CheckListInitLoader() {
         isClosable: true,
       });
     }
-  }, [queryClient, toast, selectedFile]);
+  }, [queryClient, toast, selectedFile, refetchRunsAggregated]);
 
   useEffect(() => {
     if (selectedFile) {
@@ -97,6 +100,7 @@ export function CheckListLoader() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [, setLocation] = useLocation();
+  const [, refetchRunsAggregated] = useRunsAggregated();
 
   const handleLoad = useCallback(async () => {
     if (!selectedFile) {
@@ -105,6 +109,7 @@ export function CheckListLoader() {
 
     try {
       const { checks } = await loadChecks(selectedFile);
+      refetchRunsAggregated();
       await queryClient.invalidateQueries({ queryKey: cacheKeys.checks() });
       setLocation("/checks");
       toast({
@@ -129,7 +134,14 @@ export function CheckListLoader() {
     }
 
     onClose();
-  }, [queryClient, selectedFile, toast, onClose, setLocation]);
+  }, [
+    queryClient,
+    selectedFile,
+    toast,
+    onClose,
+    setLocation,
+    refetchRunsAggregated,
+  ]);
 
   const handleClick = () => {
     if (hiddenFileInput.current) {

--- a/js/src/components/lineage/ActionTag.tsx
+++ b/js/src/components/lineage/ActionTag.tsx
@@ -13,7 +13,7 @@ import {
 } from "@chakra-ui/react";
 import { LineageGraphNode } from "./lineage";
 import { RowCountDiffResult } from "@/lib/api/rowcount";
-import { ModelRowCount } from "./NodeTag";
+import { ModelRowCount, RowCountTag } from "./NodeTag";
 
 interface ActionTagProps {
   node: LineageGraphNode;
@@ -101,11 +101,11 @@ export const ActionTag = ({ node, action }: ActionTagProps) => {
   if (run.type === "row_count_diff") {
     const result = run.result as RowCountDiffResult;
     return (
-      <Tag>
-        <TagLabel>
-          <ModelRowCount rowCount={result[node.name]} />
-        </TagLabel>
-      </Tag>
+      <RowCountTag
+        rowCount={result[node.name]}
+        node={node}
+        isInteractive={false}
+      />
     );
   }
 

--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -164,7 +164,6 @@ export function GraphNode({ data }: GraphNodeProps) {
                   <></>
                 )
               ) : data.resourceType === "model" ? (
-                // <RowCountTag node={data} isInteractive={false} />
                 <NodeRunsAggregated id={data.id} />
               ) : (
                 <></>

--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -1,24 +1,15 @@
-import {
-  Box,
-  Flex,
-  HStack,
-  Icon,
-  Spacer,
-  Text,
-  Tooltip,
-} from "@chakra-ui/react";
-import React, { useContext } from "react";
+import { Box, Flex, HStack, Icon, Spacer, Tooltip } from "@chakra-ui/react";
+import React from "react";
 
 import { Handle, NodeProps, Position, useStore } from "reactflow";
 import { LineageGraphNode } from "./lineage";
 import { getIconForChangeStatus, getIconForResourceType } from "./styles";
 
 import "./styles.css";
-import { RowCountTag } from "./NodeTag";
+
 import { ActionTag } from "./ActionTag";
 import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
-import { RowCountDiffResult } from "@/lib/api/rowcount";
-import { MdOutlineQuestionMark } from "react-icons/md";
+
 import { FiAlignLeft } from "react-icons/fi";
 
 interface GraphNodeProps extends NodeProps<LineageGraphNode> {}

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -18,12 +18,7 @@ import {
   Tooltip,
   Text,
   Spinner,
-  Modal,
   useDisclosure,
-  ModalOverlay,
-  ModalContent,
-  ModalCloseButton,
-  ModalBody,
   HStack,
   Button,
   VStack,
@@ -209,7 +204,6 @@ function _LineageView({ ...props }: LineageViewProps) {
   const [modifiedSet, setModifiedSet] = useState<string[]>();
   const { lineageGraphSets, isLoading, error, refetchRunsAggregated } =
     useLineageGraphsContext();
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
   /**
    * Select mode: the behavior of clicking on nodes
@@ -473,10 +467,6 @@ function _LineageView({ ...props }: LineageViewProps) {
                 >
                   <Icon as={FiRefreshCw} />
                 </ControlButton>
-
-                {/* <ControlButton title="summary" onClick={onOpen}>
-                  <Icon as={FiList} />
-                </ControlButton> */}
               </>
             )}
             <ControlButton
@@ -568,15 +558,6 @@ function _LineageView({ ...props }: LineageViewProps) {
           <MiniMap nodeColor={nodeColor} nodeStrokeWidth={3} />
         </ReactFlow>
       </Box>
-      {/* <Modal isOpen={isOpen} onClose={onClose} size="6xl">
-        <ModalOverlay />
-        <ModalContent overflowY="auto" height="80%">
-          <ModalCloseButton />
-          <ModalBody>
-            <SummaryView />
-          </ModalBody>
-        </ModalContent>
-      </Modal> */}
       {selectMode === "detail" && detailViewSelected && (
         <Box flex="0 0 500px" borderLeft="solid 1px lightgray" height="100%">
           <NodeView

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -2,7 +2,7 @@ import { PUBLIC_API_URL } from "../../lib/const";
 import {
   LineageGraph,
   LineageGraphNode,
-  cleanUpSelectedNodes,
+  cleanUpNodes,
   highlightPath,
   selectDownstream,
   selectNode,
@@ -207,7 +207,8 @@ function _LineageView({ ...props }: LineageViewProps) {
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [lineageGraph, setLineageGraph] = useState<LineageGraph>();
   const [modifiedSet, setModifiedSet] = useState<string[]>();
-  const { lineageGraphSets, isLoading, error } = useLineageGraphsContext();
+  const { lineageGraphSets, isLoading, error, refetchRunsAggregated } =
+    useLineageGraphsContext();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   /**
@@ -466,7 +467,7 @@ function _LineageView({ ...props }: LineageViewProps) {
                   title="switch mode"
                   onClick={() => {
                     setViewMode(viewMode === "all" ? "changed_models" : "all");
-                    const newNodes = cleanUpSelectedNodes(nodes);
+                    const newNodes = cleanUpNodes(nodes);
                     setNodes(newNodes);
                   }}
                 >
@@ -512,7 +513,10 @@ function _LineageView({ ...props }: LineageViewProps) {
                           selectMode === "detail" ? "action" : "detail";
                         setDetailViewSelected(undefined);
                         setIsDetailViewShown(false);
-                        const newNodes = cleanUpSelectedNodes(nodes);
+                        const newNodes = cleanUpNodes(
+                          nodes,
+                          newMode === "action"
+                        );
                         setNodes(newNodes);
                         setSelectMode(newMode);
                       }}
@@ -547,10 +551,11 @@ function _LineageView({ ...props }: LineageViewProps) {
                   .filter((node) => node.isSelected)}
                 onClose={() => {
                   setSelectMode("detail");
-                  const newNodes = cleanUpSelectedNodes(nodes);
+                  const newNodes = cleanUpNodes(nodes);
                   setDetailViewSelected(undefined);
                   setIsDetailViewShown(false);
                   setNodes(newNodes);
+                  refetchRunsAggregated?.();
                 }}
                 onActionStarted={() => {
                   setSelectMode("action_result");
@@ -579,7 +584,7 @@ function _LineageView({ ...props }: LineageViewProps) {
             onCloseNode={() => {
               setDetailViewSelected(undefined);
               setIsDetailViewShown(false);
-              setNodes(cleanUpSelectedNodes(nodes));
+              setNodes(cleanUpNodes(nodes));
             }}
           />
         </Box>

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -474,9 +474,9 @@ function _LineageView({ ...props }: LineageViewProps) {
                   <Icon as={FiRefreshCw} />
                 </ControlButton>
 
-                <ControlButton title="summary" onClick={onOpen}>
+                {/* <ControlButton title="summary" onClick={onOpen}>
                   <Icon as={FiList} />
-                </ControlButton>
+                </ControlButton> */}
               </>
             )}
             <ControlButton
@@ -568,7 +568,7 @@ function _LineageView({ ...props }: LineageViewProps) {
           <MiniMap nodeColor={nodeColor} nodeStrokeWidth={3} />
         </ReactFlow>
       </Box>
-      <Modal isOpen={isOpen} onClose={onClose} size="6xl">
+      {/* <Modal isOpen={isOpen} onClose={onClose} size="6xl">
         <ModalOverlay />
         <ModalContent overflowY="auto" height="80%">
           <ModalCloseButton />
@@ -576,7 +576,7 @@ function _LineageView({ ...props }: LineageViewProps) {
             <SummaryView />
           </ModalBody>
         </ModalContent>
-      </Modal>
+      </Modal> */}
       {selectMode === "detail" && detailViewSelected && (
         <Box flex="0 0 500px" borderLeft="solid 1px lightgray" height="100%">
           <NodeView

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -312,16 +312,16 @@ function _LineageView({ ...props }: LineageViewProps) {
       setDetailViewSelected(node.data);
       if (!isDetailViewShown) {
         setIsDetailViewShown(true);
+        centerNode(node);
       }
       setNodes(selectSingleNode(node.id, nodes));
-      centerNode(node);
     } else if (selectMode === "action_result") {
       setDetailViewSelected(node.data);
       if (!isDetailViewShown) {
         setIsDetailViewShown(true);
+        centerNode(node);
       }
       setNodes(selectSingleNode(node.id, nodes));
-      centerNode(node);
     } else {
       setNodes(selectNode(node.id, nodes));
     }

--- a/js/src/components/lineage/NodeRunView.tsx
+++ b/js/src/components/lineage/NodeRunView.tsx
@@ -23,7 +23,7 @@ import { useLocation } from "wouter";
 import { useQueryClient } from "@tanstack/react-query";
 import { cacheKeys } from "@/lib/api/cacheKeys";
 import { createCheckByRun } from "@/lib/api/checks";
-import { RowCountDiffResultView } from "../rowcount/RowCountDiffView";
+import { RowCountDiffResultView } from "../rowcount/RowCountDiffResultView";
 
 interface NodeRunViewProps {
   node: LineageGraphNode;

--- a/js/src/components/lineage/NodeRunView.tsx
+++ b/js/src/components/lineage/NodeRunView.tsx
@@ -15,7 +15,7 @@ import {
 } from "@chakra-ui/react";
 
 import { LineageGraphNode } from "./lineage";
-import { ResourceTypeTag } from "./NodeTag";
+import { ResourceTypeTag, RowCountTag } from "./NodeTag";
 import { RunView } from "../run/RunView";
 import { ValueDiffResultView } from "../valuediff/ValueDiffResultView";
 import { useCallback, useState } from "react";
@@ -68,6 +68,9 @@ export function NodeRunView({ node, onCloseNode }: NodeRunViewProps) {
       <Box color="gray" paddingLeft={"16px"}>
         <HStack spacing={"8px"}>
           <ResourceTypeTag node={node} />
+          {run?.type === "row_count_diff" && run.result?.[node.name] && (
+            <RowCountTag rowCount={run.result[node.name] as any} node={node} />
+          )}
         </HStack>
       </Box>
 

--- a/js/src/components/lineage/NodeSelector.tsx
+++ b/js/src/components/lineage/NodeSelector.tsx
@@ -3,11 +3,9 @@ import {
   Box,
   Button,
   ButtonGroup,
-  CircularProgress,
   HStack,
   Icon,
   IconButton,
-  SlideFade,
   StackDivider,
   useUnmountEffect,
 } from "@chakra-ui/react";
@@ -21,7 +19,6 @@ import {
 } from "@/lib/api/checks";
 import { useLocation } from "wouter";
 import { FiAlignLeft } from "react-icons/fi";
-import { useRowCountQueries } from "@/lib/api/models";
 import { TbBrandStackshare } from "react-icons/tb";
 import { ValueDiffParams } from "@/lib/api/valuediff";
 import { useCallback, useState } from "react";
@@ -39,35 +36,6 @@ export interface NodeSelectorProps {
   onActionStarted: () => void;
   onActionNodeUpdated: (node: LineageGraphNode) => void;
   onActionCompleted: () => void;
-}
-
-export function FetchSelectedNodesRowCountButton({
-  nodes,
-  onFinish,
-}: {
-  nodes: LineageGraphNode[];
-  onFinish?: () => void;
-}) {
-  const { isLoading, fetchFn } = useRowCountQueries(
-    nodes.map((node) => node.name)
-  );
-  return (
-    <Button
-      isLoading={isLoading}
-      loadingText="Querying"
-      size="xs"
-      variant="outline"
-      title="Query Row Counts"
-      onClick={async () => {
-        await fetchFn();
-        onFinish && onFinish();
-      }}
-      isDisabled={nodes.length === 0}
-    >
-      <Icon as={MdQueryStats} mr={1} />
-      Query Row Counts
-    </Button>
-  );
 }
 
 function AddSchemaChangesCheckButton({
@@ -106,42 +74,6 @@ function AddSchemaChangesCheckButton({
     >
       <Icon as={MdOutlineSchema} />
       Add schema check
-    </Button>
-  );
-}
-
-function AddRowCountCheckButton({
-  nodes,
-  onFinish,
-}: {
-  nodes: LineageGraphNode[];
-  onFinish: () => void;
-}) {
-  const [, setLocation] = useLocation();
-  const { isLoading, fetchFn: fetchRowCountFn } = useRowCountQueries(
-    nodes.map((node) => node.name)
-  );
-
-  return (
-    <Button
-      size="xs"
-      isLoading={isLoading}
-      loadingText="Querying"
-      variant="outline"
-      isDisabled={nodes.length === 0}
-      onClick={async () => {
-        const runId = await fetchRowCountFn({ skipCache: true });
-        const check = await createCheckByRun(runId);
-        if (check) {
-          setLocation(`/checks/${check.check_id}`);
-        } else {
-          setLocation(`/checks`);
-        }
-        onFinish();
-      }}
-    >
-      <Icon as={FiAlignLeft} />
-      Add row count check
     </Button>
   );
 }
@@ -472,12 +404,8 @@ export function NodeSelector({
             />
           </ButtonGroup>
           <HStack>
-            {/* <FetchSelectedNodesRowCountButton
-              nodes={nodes}
-              onFinish={onClose}
-            /> */}
             <AddSchemaChangesCheckButton nodes={nodes} onFinish={onClose} />
-            {/* <AddRowCountCheckButton nodes={nodes} onFinish={onClose} /> */}
+
             <AddLineageDiffCheckButton
               viewMode={viewMode}
               nodes={nodes}

--- a/js/src/components/lineage/NodeTag.tsx
+++ b/js/src/components/lineage/NodeTag.tsx
@@ -124,11 +124,9 @@ export function RowCountTag({
     runsAggregated?.[node.id]?.["row_count_diff"]?.result;
 
   const {
-    isLoading,
     data: fetchedRowCount,
-    error,
     refetch: invokeRowCountQuery,
-    isFetched,
+    isFetching,
   } = useQuery({
     queryKey: cacheKeys.rowCount(node.name),
     queryFn: () => queryModelRowCount(node.name),
@@ -156,9 +154,9 @@ export function RowCountTag({
         <TagLeftIcon as={FiAlignLeft} />
 
         <TagLabel>
-          {rowCount || isLoading ? (
+          {rowCount || isFetching ? (
             <SkeletonText
-              isLoaded={!isLoading}
+              isLoaded={!isFetching}
               noOfLines={1}
               skeletonHeight={2}
               minWidth={"30px"}
@@ -172,7 +170,7 @@ export function RowCountTag({
         {isInteractive && (
           <TagRightIcon
             as={IconButton}
-            isLoading={isLoading}
+            isLoading={isFetching}
             aria-label="Query Row Count"
             icon={<RepeatIcon />}
             size="xs"

--- a/js/src/components/lineage/NodeTag.tsx
+++ b/js/src/components/lineage/NodeTag.tsx
@@ -26,6 +26,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useRowCountStateContext } from "@/lib/hooks/RecceQueryContext";
 import { RiArrowDownSFill, RiArrowUpSFill, RiSwapLine } from "react-icons/ri";
 import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { deltaPercentageString } from "../rowcount/delta";
 
 interface ModelRowCountProps {
   rowCount?: RowCount;
@@ -84,9 +85,7 @@ function RowCountWiteRate({ rowCount }: { rowCount: RowCount }) {
       <HStack>
         <Text>{current} rows</Text>
         <Icon as={RiArrowUpSFill} color="green.500" />
-        <Text color="green.500">
-          + {Math.round(((current - base) / base) * 100)}%
-        </Text>
+        <Text color="green.500">{deltaPercentageString(base, current)}</Text>
       </HStack>
     );
   } else {
@@ -94,9 +93,7 @@ function RowCountWiteRate({ rowCount }: { rowCount: RowCount }) {
       <HStack>
         <Text>{current} rows</Text>
         <Icon as={RiArrowDownSFill} color="red.500" />
-        <Text color="red.500">
-          - {Math.round(((base - current) / base) * 100)}%
-        </Text>
+        <Text color="red.500">{deltaPercentageString(base, current)}</Text>
       </HStack>
     );
   }

--- a/js/src/components/lineage/NodeView.tsx
+++ b/js/src/components/lineage/NodeView.tsx
@@ -34,7 +34,6 @@ import { useLocation } from "wouter";
 import { ResourceTypeTag, RowCountTag } from "./NodeTag";
 import { useCallback } from "react";
 import { createCheckByNodeSchema, createCheckByRun } from "@/lib/api/checks";
-import { useRowCountQueries } from "@/lib/api/models";
 import { useRecceActionContext } from "@/lib/hooks/RecceActionContext";
 
 interface NodeViewProps {
@@ -45,7 +44,6 @@ interface NodeViewProps {
 export function NodeView({ node, onCloseNode }: NodeViewProps) {
   const [, setLocation] = useLocation();
   const { setSqlQuery } = useRecceQueryContext();
-  const { fetchFn: fetchRowCountFn } = useRowCountQueries([node.name]);
   const withColumns =
     node.resourceType === "model" ||
     node.resourceType === "seed" ||
@@ -62,13 +60,6 @@ export function NodeView({ node, onCloseNode }: NodeViewProps) {
     const check = await createCheckByNodeSchema(nodeId);
     setLocation(`/checks/${check.check_id}`);
   }, [node, setLocation]);
-
-  const addRowCountCheck = useCallback(async () => {
-    const runId = await fetchRowCountFn({ skipCache: true });
-    const check = await createCheckByRun(runId);
-
-    setLocation(`/checks/${check.check_id}`);
-  }, [setLocation, fetchRowCountFn]);
 
   return (
     <Grid height="100%" templateRows="auto auto 1fr">
@@ -133,7 +124,6 @@ export function NodeView({ node, onCloseNode }: NodeViewProps) {
               </MenuButton>
               <MenuList>
                 <MenuItem onClick={addSchemaCheck}>Schema Check</MenuItem>
-                <MenuItem onClick={addRowCountCheck}>Row Count Check</MenuItem>
               </MenuList>
             </Menu>
             <Spacer />

--- a/js/src/components/lineage/NodeView.tsx
+++ b/js/src/components/lineage/NodeView.tsx
@@ -36,8 +36,6 @@ import { useCallback } from "react";
 import { createCheckByNodeSchema, createCheckByRun } from "@/lib/api/checks";
 import { useRowCountQueries } from "@/lib/api/models";
 import { useRecceActionContext } from "@/lib/hooks/RecceActionContext";
-import { RunView } from "../run/RunView";
-import { ValueDiffResultView } from "../valuediff/ValueDiffResultView";
 
 interface NodeViewProps {
   node: LineageGraphNode;

--- a/js/src/components/lineage/NodeView.tsx
+++ b/js/src/components/lineage/NodeView.tsx
@@ -109,7 +109,9 @@ export function NodeView({ node, onCloseNode }: NodeViewProps) {
       <Box color="gray" paddingLeft={"16px"}>
         <HStack spacing={"8px"}>
           <ResourceTypeTag node={node} />
-          {node.resourceType === "model" && <RowCountTag node={node} />}
+          {node.resourceType === "model" && (
+            <RowCountTag node={node} isInteractive />
+          )}
         </HStack>
       </Box>
       {withColumns && (

--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -69,6 +69,7 @@ export interface LineageGraphNode {
   /**
    * The action status for the node which is trigger by action for multiple nodes
    */
+  isActionMode?: boolean;
   action?: {
     mode: "per_node" | "multi_nodes";
     status?: "pending" | "running" | "success" | "failure" | "skipped";
@@ -468,13 +469,17 @@ export function selectNodes(
   return newNodes;
 }
 
-export function cleanUpSelectedNodes(nodes: Node<LineageGraphNode>[]) {
+export function cleanUpNodes(
+  nodes: Node<LineageGraphNode>[],
+  isActionMode?: boolean
+) {
   const newNodes = nodes.map((n) => {
     return {
       ...n,
       data: {
         ...n.data,
         isSelected: false,
+        isActionMode,
         action: undefined,
       },
     };

--- a/js/src/components/rowcount/RowCountDiffResultView.tsx
+++ b/js/src/components/rowcount/RowCountDiffResultView.tsx
@@ -6,6 +6,7 @@ import {
 
 import { RunResultViewProps } from "../run/types";
 import { RowCountDiffParams, RowCountDiffResult } from "@/lib/api/rowcount";
+import { deltaPercentageString } from "./delta";
 
 interface RowCountDiffResultViewProp
   extends RunResultViewProps<RowCountDiffParams, RowCountDiffResult> {}
@@ -44,13 +45,8 @@ export function RowCountDiffResultView({ run }: RowCountDiffResultViewProp) {
     let delta = "No Change";
 
     if (base !== null && current !== null) {
-      if (base < current) {
-        delta = `+ ${Math.round(((current - base) / base) * 100)}%`;
-      } else if (base > current) {
-        delta = `- ${Math.round(((base - current) / base) * 100)}%`;
-      } else {
-        delta = "No Change";
-      }
+      delta =
+        base !== current ? deltaPercentageString(base, current) : "No Change";
     } else {
       if (base === current) {
         delta = "N/A";

--- a/js/src/components/rowcount/delta.ts
+++ b/js/src/components/rowcount/delta.ts
@@ -1,0 +1,11 @@
+export function deltaPercentageString(base: number, current: number) {
+  if (base < current) {
+    const p = ((current - base) / base) * 100;
+    return `+${p >= 0.1 ? p.toFixed(1) : " <0.1 "}%`;
+  } else if (base > current) {
+    const p = ((base - current) / base) * 100;
+    return `-${p >= 0.1 ? p.toFixed(1) : " <0.1 "}%`;
+  } else {
+    return "0 %";
+  }
+}

--- a/js/src/components/summary/SchemaSummary.tsx
+++ b/js/src/components/summary/SchemaSummary.tsx
@@ -1,4 +1,19 @@
-import { Card, CardProps, CardBody, CardHeader, Flex, Heading, SimpleGrid, Text, HStack, Tooltip, Tag, TagLeftIcon, TagLabel, SkeletonText } from "@chakra-ui/react";
+import {
+  Card,
+  CardProps,
+  CardBody,
+  CardHeader,
+  Flex,
+  Heading,
+  SimpleGrid,
+  Text,
+  HStack,
+  Tooltip,
+  Tag,
+  TagLeftIcon,
+  TagLabel,
+  SkeletonText,
+} from "@chakra-ui/react";
 import { DefaultLineageGraphSets, LineageGraphNode } from "../lineage/lineage";
 import { SchemaView } from "../schema/SchemaView";
 import { mergeColumns } from "../schema/schema";
@@ -10,28 +25,22 @@ interface SchemaDiffCardProps {
   node: LineageGraphNode;
 }
 
-function SchemaDiffCard({
-  node,
-  ...props
- }: CardProps & SchemaDiffCardProps) {
-
+function SchemaDiffCard({ node, ...props }: CardProps & SchemaDiffCardProps) {
   return (
-  <Card maxWidth={'500px'}>
-    <CardHeader>
-      <Heading fontSize={18}>{props.title}</Heading>
-      <HStack spacing={"8px"} p={"16px"}>
-        <ResourceTypeTag node={node} />
-        {node.resourceType === "model" && (
-          <RowCountTag node={node} isAutoFetching={true}/>
-        )}
-      </HStack>
-    </CardHeader>
-    <CardBody>
-      <Flex>
-        <SchemaView base={node.data.base} current={node.data.current} />
-      </Flex>
-    </CardBody>
-  </Card>
+    <Card maxWidth={"500px"}>
+      <CardHeader>
+        <Heading fontSize={18}>{props.title}</Heading>
+        <HStack spacing={"8px"} p={"16px"}>
+          <ResourceTypeTag node={node} />
+          {node.resourceType === "model" && <RowCountTag node={node} />}
+        </HStack>
+      </CardHeader>
+      <CardBody>
+        <Flex>
+          <SchemaView base={node.data.base} current={node.data.current} />
+        </Flex>
+      </CardBody>
+    </Card>
   );
 }
 
@@ -40,18 +49,23 @@ function listChangedNodes(lineageGraphSets: DefaultLineageGraphSets) {
   const allNodes = lineageGraphSets.all.nodes;
   lineageGraphSets.modifiedSet.forEach((nodeId) => {
     const node = allNodes[nodeId];
-    const columnDiffStatus = mergeKeysWithStatus( Object.keys(node.data.base?.columns || {}),  Object.keys(node.data.current?.columns || {}));
-    const isSchemaChanged = !Object.values(columnDiffStatus).every(el => el === undefined);
+    const columnDiffStatus = mergeKeysWithStatus(
+      Object.keys(node.data.base?.columns || {}),
+      Object.keys(node.data.current?.columns || {})
+    );
+    const isSchemaChanged = !Object.values(columnDiffStatus).every(
+      (el) => el === undefined
+    );
     // We only want to show nodes that have real schema changes.
     // It doesn't include added or deleted model.
     if (isSchemaChanged && node.data.base && node.data.current)
       changedNodes.push(node);
-  })
+  });
   return changedNodes;
 }
 
 export interface Props {
-  lineageGraphSets: DefaultLineageGraphSets
+  lineageGraphSets: DefaultLineageGraphSets;
 }
 
 export function SchemaSummary({ lineageGraphSets }: Props) {
@@ -61,32 +75,41 @@ export function SchemaSummary({ lineageGraphSets }: Props) {
     setChangedNodes(listChangedNodes(lineageGraphSets));
   }, [lineageGraphSets]);
 
-  return (<>
-    <Flex w={'100%'} paddingBottom="10px" marginBottom="20px" marginTop="20px" >
-      <Heading fontSize={24}>Schema Summary</Heading>
-    </Flex>
-    <Flex w={'100%'} paddingBottom="10px" marginBottom="20px">
-    {(changedNodes.length === 0) ? (
-      <>
-        <Text fontSize={18} color={'gray'}>No schema changes detected.</Text>
-      </>
-    ):(
-      <>
-
-        <SimpleGrid
-          minChildWidth='400px'
-          spacing={'2vw'}
-          padding={'2.5vw'}
-          width={'100%'}
-          backgroundColor={'lightgray'}
-        >
-          {changedNodes.map((node) => {
-            return <SchemaDiffCard key={node.id} title={node.name} node={node} />;
-          })}
-        </SimpleGrid>
-
-      </>
-    )}
-    </Flex>
-  </>);
+  return (
+    <>
+      <Flex
+        w={"100%"}
+        paddingBottom="10px"
+        marginBottom="20px"
+        marginTop="20px"
+      >
+        <Heading fontSize={24}>Schema Summary</Heading>
+      </Flex>
+      <Flex w={"100%"} paddingBottom="10px" marginBottom="20px">
+        {changedNodes.length === 0 ? (
+          <>
+            <Text fontSize={18} color={"gray"}>
+              No schema changes detected.
+            </Text>
+          </>
+        ) : (
+          <>
+            <SimpleGrid
+              minChildWidth="400px"
+              spacing={"2vw"}
+              padding={"2.5vw"}
+              width={"100%"}
+              backgroundColor={"lightgray"}
+            >
+              {changedNodes.map((node) => {
+                return (
+                  <SchemaDiffCard key={node.id} title={node.name} node={node} />
+                );
+              })}
+            </SimpleGrid>
+          </>
+        )}
+      </Flex>
+    </>
+  );
 }

--- a/js/src/lib/api/cacheKeys.ts
+++ b/js/src/lib/api/cacheKeys.ts
@@ -5,4 +5,5 @@ export const cacheKeys = {
   checks: () => ["checks", "list"],
   check: (checkId: string) => ["checks", checkId],
   run: (runId: string) => ["runs", runId],
+  runsAggregated: () => ["runs_aggregated"],
 };

--- a/js/src/lib/api/cacheKeys.ts
+++ b/js/src/lib/api/cacheKeys.ts
@@ -1,5 +1,4 @@
 export const cacheKeys = {
-  allRowCount: () => ["row_count"],
   rowCount: (model: string) => ["row_count", model],
   lineage: () => ["lineage"],
   checks: () => ["checks", "list"],

--- a/js/src/lib/api/models.ts
+++ b/js/src/lib/api/models.ts
@@ -1,10 +1,6 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { RowCountDiffResult, submitRowCountDiff } from "./rowcount";
 import { axiosClient } from "./axiosClient";
 import { waitRun } from "./runs";
-import { cacheKeys } from "./cacheKeys";
-import { useState } from "react";
-import { useRowCountStateContext } from "../hooks/RecceQueryContext";
 
 export interface RowCount {
   name?: string;
@@ -43,60 +39,5 @@ export async function queryRowCount(
   return {
     runId: run_id,
     result: run.result,
-  };
-}
-
-export function useRowCountQueries(modelNames: string[]) {
-  const [isLoading, setIsLoading] = useState(false);
-  const queryClient = useQueryClient();
-  const { setIsNodesFetching } = useRowCountStateContext();
-  const cachedRowCounts = queryClient
-    .getQueriesData<RowCount[]>({
-      queryKey: cacheKeys.allRowCount(),
-    })
-    .filter((cachedData) => {
-      const [queryKey, data] = cachedData;
-      const [key, modelName] = queryKey;
-      return modelNames.includes(modelName as string);
-    })
-    .map((cachedData) => {
-      const [queryKey, data] = cachedData;
-      const [key, modelName] = queryKey;
-      return { modelName, data };
-    });
-
-  const fetchCandidates: string[] = [];
-  modelNames.forEach((modelName) => {
-    const { data } = cachedRowCounts.find(
-      (cachedData) => cachedData.modelName === modelName
-    ) || { data: undefined, modelName: modelName };
-    if (data === undefined) {
-      fetchCandidates.push(modelName);
-    }
-  });
-
-  async function fetchModelsRowCount(options: { skipCache?: boolean } = {}) {
-    const fetchNodes =
-      options && options.skipCache ? modelNames : fetchCandidates;
-    setIsLoading(true);
-    setIsNodesFetching(fetchNodes);
-
-    const { runId, result: queryResponses } = await queryRowCount(fetchNodes);
-    Object.keys(queryResponses).forEach((name) => {
-      const modelName = name as string;
-      const queryResponse = queryResponses[modelName];
-      queryClient.setQueryData<RowCount>(cacheKeys.rowCount(modelName), {
-        base: queryResponse.base,
-        curr: queryResponse.curr,
-      });
-    });
-    setIsLoading(false);
-    setIsNodesFetching([]);
-    return runId;
-  }
-
-  return {
-    isLoading,
-    fetchFn: fetchModelsRowCount,
   };
 }

--- a/js/src/lib/api/runs.ts
+++ b/js/src/lib/api/runs.ts
@@ -60,16 +60,26 @@ export async function submitRunFromCheck<PT = any, RT = any>(
   return run;
 }
 
-export async function searchRuns(
-  type: string,
-  params: any,
-  limit?: number,
-) {
+export async function searchRuns(type: string, params: any, limit?: number) {
   const response = await axiosClient.post(`/api/runs/search`, {
     type,
     params,
-    limit
+    limit,
   });
+
+  return response.data;
+}
+
+export interface RunsAggregated {
+  [unique_id: string]: {
+    [run_type: string]: {
+      run_id: string;
+      result: any;
+    };
+  };
+}
+export async function aggregateRuns(): Promise<RunsAggregated> {
+  const response = await axiosClient.post(`/api/runs/aggregate`, {});
 
   return response.data;
 }

--- a/recce/apis/run_func.py
+++ b/recce/apis/run_func.py
@@ -94,7 +94,7 @@ def cancel_run(run_id):
     task.cancel()
 
 
-def materialize_run_results(runs: List[Run]):
+def materialize_run_results(runs: List[Run], nodes: List[str] = None):
     '''
     Materialize the run results for nodes. It walks through all runs and get the last results for primary run types.
 
@@ -127,6 +127,11 @@ def materialize_run_results(runs: List[Run]):
         if run.type == RunType.ROW_COUNT_DIFF:
             for model_name, node_run_result in run.result.items():
                 key = mame_to_unique_id.get(model_name, model_name)
+
+                if nodes:
+                    if key not in nodes:
+                        continue
+
                 if model_name not in result:
                     node_result = result[key] = {}
                 else:

--- a/recce/dbt.py
+++ b/recce/dbt.py
@@ -381,6 +381,16 @@ class DBTContext:
             }
         return None
 
+    def build_name_to_unique_id_index(self) -> Dict[str, str]:
+        curr_manifest = self.get_manifest(base=False)
+        base_manifest = self.get_manifest(base=True)
+        name_to_unique_id = {}
+        for unique_id, node in base_manifest.nodes.items():
+            name_to_unique_id[node.name] = unique_id
+        for unique_id, node in curr_manifest.nodes.items():
+            name_to_unique_id[node.name] = unique_id
+        return name_to_unique_id
+
     def start_monitor_artifacts(self, callback: Callable = None):
         event_handler = ArtifactsEventHandler(self.artifacts_files, callback=callback)
         self.artifacts_observer.schedule(event_handler, self.target_path, recursive=False)

--- a/recce/dbt.py
+++ b/recce/dbt.py
@@ -133,7 +133,6 @@ class DBTContext:
     base_catalog: CatalogArtifact = None
     artifacts_observer = Observer()
     artifacts_files = []
-    row_count_cache = LRUCache(32)
 
     @classmethod
     def load(cls, **kwargs):
@@ -404,9 +403,6 @@ class DBTContext:
         logger.info('Stop monitoring artifacts')
 
     def refresh(self, refresh_file_path: str = None):
-        # clear the cache
-        self.row_count_cache.clear()
-
         # Refresh the artifacts
         if refresh_file_path is None:
             return self.load_artifacts()

--- a/recce/tasks/rowcount.py
+++ b/recce/tasks/rowcount.py
@@ -25,11 +25,7 @@ class RowCountDiffTask(Task, QueryMixin):
         query_candidates = []
         nodes = self.params.get('node_names')
         for node in nodes:
-            cached_row_count = dbt_context.row_count_cache.get(node)
-            if cached_row_count is not None:
-                result[node] = cached_row_count
-            else:
-                query_candidates.append(node)
+            query_candidates.append(node)
 
         # Query row count for nodes that are not cached
         with adapter.connection_named("query"):
@@ -58,7 +54,6 @@ class RowCountDiffTask(Task, QueryMixin):
 
                 # Cache the row_count result
                 row_count = dict(base=base_row_count, curr=curr_row_count)
-                dbt_context.row_count_cache.put(node, row_count)
                 result[node] = row_count
 
         return result

--- a/tests/apis/row_count_diff.json
+++ b/tests/apis/row_count_diff.json
@@ -1,0 +1,59 @@
+{
+  "metadata": null,
+  "runs": [
+    {
+      "type": "row_count_diff",
+      "params": {
+        "node_names": [
+          "customers",
+          "customer_segments"
+        ]
+      },
+      "check_id": null,
+      "result": {
+        "customers": {
+          "base": 1856,
+          "curr": 1856
+        },
+        "customer_segments": {
+          "base": 1856,
+          "curr": 1856
+        }
+      },
+      "error": null,
+      "progress": null,
+      "run_id": "92f31d63-0758-46af-a674-0e969208ec96",
+      "run_at": "2024-03-11T07:20:31Z"
+    },
+    {
+      "type": "row_count_diff",
+      "params": {
+        "node_names": [
+          "customer_order_pattern"
+        ]
+      },
+      "check_id": null,
+      "result": {
+        "customer_order_pattern": {
+          "base": 1856,
+          "curr": 1856
+        }
+      },
+      "error": null,
+      "progress": null,
+      "run_id": "ecef5ebd-f820-453d-9daf-f4f2f1b06d2e",
+      "run_at": "2024-03-11T07:20:41Z"
+    }
+  ],
+  "checks": [
+    {
+      "name": "Check - 11 Mar 2024",
+      "description": "",
+      "type": "simple",
+      "params": null,
+      "view_options": null,
+      "check_id": "7187e630-f64f-4b14-b1c5-b2e157ab721d",
+      "is_checked": false
+    }
+  ]
+}

--- a/tests/apis/test_run_func.py
+++ b/tests/apis/test_run_func.py
@@ -8,8 +8,8 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_materialize_run_results():
-    os.path.join(os.path.join(current_dir, "row_count_diff.json"))
-    state = RecceState.load("row_count_diff.json")
+    path = os.path.join(os.path.join(current_dir, "row_count_diff.json"))
+    state = RecceState.load(path)
     result = materialize_run_results(state.runs)
 
     node_result = result['customers']['row_count_diff']

--- a/tests/apis/test_run_func.py
+++ b/tests/apis/test_run_func.py
@@ -1,0 +1,18 @@
+import os
+
+from recce.apis.run_func import materialize_run_results
+from recce.models.state import RecceState
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_something():
+    os.path.join(os.path.join(current_dir, "row_count_diff.json"))
+    state = RecceState.load("row_count_diff.json")
+    result = materialize_run_results(state.runs)
+
+    node_result = result['customers']['row_count_diff']
+
+    node_result['run_id'] == '92f31d63-0758-46af-a674-0e969208ec96'
+    node_result['result']['base'] == 1856
+    node_result['result']['curr'] == 1856

--- a/tests/apis/test_run_func.py
+++ b/tests/apis/test_run_func.py
@@ -1,4 +1,5 @@
 import os
+from uuid import UUID
 
 from recce.apis.run_func import materialize_run_results
 from recce.models.state import RecceState
@@ -6,13 +7,15 @@ from recce.models.state import RecceState
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-def test_something():
+def test_materialize_run_results():
     os.path.join(os.path.join(current_dir, "row_count_diff.json"))
     state = RecceState.load("row_count_diff.json")
     result = materialize_run_results(state.runs)
 
     node_result = result['customers']['row_count_diff']
+    assert node_result['run_id'] == UUID('92f31d63-0758-46af-a674-0e969208ec96')
+    assert node_result['result']['base'] == 1856
+    assert node_result['result']['curr'] == 1856
 
-    node_result['run_id'] == '92f31d63-0758-46af-a674-0e969208ec96'
-    node_result['result']['base'] == 1856
-    node_result['result']['curr'] == 1856
+    result = materialize_run_results(state.runs, nodes=['xyz'])
+    assert result == {}


### PR DESCRIPTION
The row count result would be materialized from all the previous row count runs.

Before
- When the browser restart, the row count information is lost.

Now
- The browser reload the row count information is still available
- If load from a recce state file, it will present the last row count queried by this state file.

In the lineage view, it shows the row count diff icon 
![image](https://github.com/DataRecce/recce/assets/860633/d05cff8f-f19f-401f-9e2d-1505898c60ab)

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
