### PR TITLE
[Chore] Refactor LineageGraph interface

### DIFF
--- a/js/app/page.tsx
+++ b/js/app/page.tsx
@@ -24,7 +24,7 @@ import { Redirect, Route, Router, Switch, useLocation, useRoute } from "wouter";
 import _ from "lodash";
 import { useHashLocation } from "@/lib/hooks/useHashLocation";
 import { ThemeProvider, createTheme } from "@mui/material";
-import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 import { InfoIcon } from "@chakra-ui/icons";
 import { RunPage } from "@/components/run/RunPage";
 import { ErrorBoundary } from "@/components/errorboundary/ErrorBoundary";
@@ -50,7 +50,7 @@ const RouteAlwaysMount = ({
 };
 
 function TopBar() {
-  const { metadata } = useLineageGraphsContext();
+  const { metadata } = useLineageGraphContext();
   const prURL = metadata?.pr_url;
 
   if (!prURL || prURL === null) {

--- a/js/src/components/check/CheckPage.tsx
+++ b/js/src/components/check/CheckPage.tsx
@@ -29,10 +29,10 @@ import { buildDescription, buildTitle } from "./check";
 import { stripIndent } from "common-tags";
 import { CheckListInitLoader, CheckListLoader } from "./CheckListLoader";
 import { CheckListExporter } from "./CheckListExporter";
-import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 
 export const CheckPage = () => {
-  const { isDemoSite } = useLineageGraphsContext();
+  const { isDemoSite } = useLineageGraphContext();
   const [, setLocation] = useLocation();
   const [, params] = useRoute("/checks/:checkId");
   const queryClient = useQueryClient();

--- a/js/src/components/check/SchemaDiffView.tsx
+++ b/js/src/components/check/SchemaDiffView.tsx
@@ -11,10 +11,10 @@ export interface SchemaDiffParams {
 }
 
 export function SchemaDiffView({ check }: SchemaDiffViewProps) {
-  const { lineageGraphSets } = useLineageGraphsContext();
+  const { lineageGraph } = useLineageGraphsContext();
   const params = check.params as SchemaDiffParams;
   const id = params.node_id;
-  const node = id ? lineageGraphSets?.all.nodes[id] : undefined;
+  const node = id ? lineageGraph?.nodes[id] : undefined;
   if (node) {
     return (
       <SchemaView

--- a/js/src/components/check/SchemaDiffView.tsx
+++ b/js/src/components/check/SchemaDiffView.tsx
@@ -1,5 +1,5 @@
 import { Check } from "@/lib/api/checks";
-import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 import { SchemaView } from "../schema/SchemaView";
 
 interface SchemaDiffViewProps {
@@ -11,7 +11,7 @@ export interface SchemaDiffParams {
 }
 
 export function SchemaDiffView({ check }: SchemaDiffViewProps) {
-  const { lineageGraph } = useLineageGraphsContext();
+  const { lineageGraph } = useLineageGraphContext();
   const params = check.params as SchemaDiffParams;
   const id = params.node_id;
   const node = id ? lineageGraph?.nodes[id] : undefined;

--- a/js/src/components/histogram/HistogramDiffForm.tsx
+++ b/js/src/components/histogram/HistogramDiffForm.tsx
@@ -1,6 +1,6 @@
 import { HistogramDiffParams } from "@/lib/api/profile";
 import { RunFormProps } from "../run/types";
-import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 import _ from "lodash";
 import { extractColumns } from "../valuediff/ValueDiffForm";
 import { Box, FormControl, FormLabel, Select } from "@chakra-ui/react";
@@ -60,7 +60,7 @@ export function HistogramDiffForm({
   onParamsChanged,
   setIsReadyToExecute,
 }: HistogramDiffEditProps) {
-  const { lineageGraph } = useLineageGraphsContext();
+  const { lineageGraph } = useLineageGraphContext();
   const node = _.find(lineageGraph?.nodes, {
     name: params?.model,
   });

--- a/js/src/components/histogram/HistogramDiffForm.tsx
+++ b/js/src/components/histogram/HistogramDiffForm.tsx
@@ -60,8 +60,8 @@ export function HistogramDiffForm({
   onParamsChanged,
   setIsReadyToExecute,
 }: HistogramDiffEditProps) {
-  const lineageGraph = useLineageGraphsContext();
-  const node = _.find(lineageGraph.lineageGraphSets?.all.nodes, {
+  const { lineageGraph } = useLineageGraphsContext();
+  const node = _.find(lineageGraph?.nodes, {
     name: params?.model,
   });
   const columns = node

--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -8,14 +8,14 @@ import { getIconForChangeStatus, getIconForResourceType } from "./styles";
 import "./styles.css";
 
 import { ActionTag } from "./ActionTag";
-import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 
 import { FiAlignLeft } from "react-icons/fi";
 
 interface GraphNodeProps extends NodeProps<LineageGraphNode> {}
 
 const NodeRunsAggregated = ({ id }: { id: string }) => {
-  const { runsAggregated } = useLineageGraphsContext();
+  const { runsAggregated } = useLineageGraphContext();
   const runs = runsAggregated?.[id];
   if (!runs) {
     return <></>;

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -18,7 +18,6 @@ import {
   Tooltip,
   Text,
   Spinner,
-  useDisclosure,
   HStack,
   Button,
   VStack,
@@ -27,6 +26,10 @@ import {
   MenuItem,
   Center,
   SlideFade,
+  MenuButton,
+  MenuDivider,
+  MenuItemOption,
+  MenuOptionGroup,
 } from "@chakra-ui/react";
 import React, { useCallback, useEffect, useState } from "react";
 import ReactFlow, {
@@ -66,6 +69,7 @@ import {
 } from "@/lib/hooks/ScreenShot";
 import { useClipBoardToast } from "@/lib/hooks/useClipBoardToast";
 import { NodeRunView } from "./NodeRunView";
+import { PackageMenu } from "./PackageMenu";
 
 export interface LineageViewProps {
   viewMode?: "changed_models" | "all";
@@ -200,9 +204,10 @@ function _LineageView({ ...props }: LineageViewProps) {
   });
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
-  const [lineageGraph, setLineageGraph] = useState<LineageGraph>();
+  // const [lineageGraph, setLineageGraph] = useState<LineageGraph>();
+  const setLineageGraph = (s: any) => {};
   const [modifiedSet, setModifiedSet] = useState<string[]>();
-  const { lineageGraphSets, isLoading, error, refetchRunsAggregated } =
+  const { lineageGraph, isLoading, error, refetchRunsAggregated } =
     useLineageGraphsContext();
 
   /**
@@ -229,15 +234,15 @@ function _LineageView({ ...props }: LineageViewProps) {
   }>({ x: 0, y: 0 });
 
   useEffect(() => {
-    if (!lineageGraphSets) {
+    if (!lineageGraph) {
       return;
     }
 
-    const lineageGraph =
-      viewMode === "changed_models"
-        ? { ...lineageGraphSets.changed }
-        : { ...lineageGraphSets.all };
-    const modifiedSet = lineageGraphSets.modifiedSet;
+    // const lineageGraph =
+    //   viewMode === "changed_models"
+    //     ? { ...lineageGraphSets.changed }
+    //     : { ...lineageGraphSets.all };
+    const modifiedSet = lineageGraph.modifiedSet;
 
     if (typeof props.filterNodes === "function") {
       const filterFn = props.filterNodes ? props.filterNodes : () => true;
@@ -248,23 +253,19 @@ function _LineageView({ ...props }: LineageViewProps) {
       );
     }
 
-    const [nodes, edges] = toReactflow(
-      lineageGraph,
-      lineageGraphSets.modifiedSet
-    );
+    const [nodes, edges] = toReactflow(lineageGraph);
 
     layout(nodes, edges);
     setLineageGraph(lineageGraph);
     setModifiedSet(modifiedSet);
     setNodes(nodes);
     setEdges(edges);
-  }, [setNodes, setEdges, viewMode, lineageGraphSets, props.filterNodes]);
+  }, [setNodes, setEdges, viewMode, lineageGraph, props.filterNodes]);
 
   const onNodeMouseEnter = (event: React.MouseEvent, node: Node) => {
     if (lineageGraph && modifiedSet !== undefined) {
       const [newNodes, newEdges] = highlightPath(
         lineageGraph,
-        modifiedSet,
         nodes,
         edges,
         node.id
@@ -279,7 +280,6 @@ function _LineageView({ ...props }: LineageViewProps) {
     if (lineageGraph && modifiedSet !== undefined) {
       const [newNodes, newEdges] = highlightPath(
         lineageGraph,
-        modifiedSet,
         nodes,
         edges,
         null

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -58,7 +58,7 @@ import {
 } from "react-icons/bi";
 import { NodeView } from "./NodeView";
 import { toBlob } from "html-to-image";
-import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 import SummaryView from "../summary/SummaryView";
 import { AddLineageDiffCheckButton, NodeSelector } from "./NodeSelector";
 import {
@@ -69,7 +69,7 @@ import {
 } from "@/lib/hooks/ScreenShot";
 import { useClipBoardToast } from "@/lib/hooks/useClipBoardToast";
 import { NodeRunView } from "./NodeRunView";
-import { PackageMenu } from "./PackageMenu";
+
 import { union } from "./graph";
 
 export interface LineageViewProps {
@@ -207,7 +207,7 @@ function _LineageView({ ...props }: LineageViewProps) {
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
   const { lineageGraph, isLoading, error, refetchRunsAggregated } =
-    useLineageGraphsContext();
+    useLineageGraphContext();
   const modifiedSet = lineageGraph?.modifiedSet;
 
   /**

--- a/js/src/components/lineage/NodeTag.tsx
+++ b/js/src/components/lineage/NodeTag.tsx
@@ -23,7 +23,7 @@ import { cacheKeys } from "@/lib/api/cacheKeys";
 import { LineageGraphNode } from "./lineage";
 import { useQuery } from "@tanstack/react-query";
 import { RiArrowDownSFill, RiArrowUpSFill, RiSwapLine } from "react-icons/ri";
-import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 import { deltaPercentageString } from "../rowcount/delta";
 
 import { RepeatIcon } from "@chakra-ui/icons";
@@ -119,7 +119,7 @@ export function RowCountTag({
   node,
   isInteractive,
 }: RowCountTagProps) {
-  const { runsAggregated, refetchRunsAggregated } = useLineageGraphsContext();
+  const { runsAggregated, refetchRunsAggregated } = useLineageGraphContext();
   const lastRowCount: RowCount | undefined =
     runsAggregated?.[node.id]?.["row_count_diff"]?.result;
 

--- a/js/src/components/lineage/graph.ts
+++ b/js/src/components/lineage/graph.ts
@@ -30,3 +30,15 @@ export function getNeighborSet(
 
   return neighborSet;
 }
+
+export function union(...sets: Set<string>[]) {
+  const unionSet = new Set<string>();
+
+  sets.forEach((set) => {
+    set.forEach((key) => {
+      unionSet.add(key);
+    });
+  });
+
+  return unionSet;
+}

--- a/js/src/components/lineage/lineage.test.ts
+++ b/js/src/components/lineage/lineage.test.ts
@@ -3,12 +3,15 @@ import {
   LineageGraphEdge,
   LineageGraphNode,
   buildLineageGraph,
-  highlightPath,
+  highlightNodes,
+  selectDownstream,
+  selectUpstream,
   toReactflow,
 } from "./lineage";
 import { Node, Edge } from "reactflow";
 
 import { find } from "lodash";
+import { union } from "./graph";
 
 test("lineage diff", () => {
   const base = {
@@ -123,8 +126,19 @@ test("hightlight", () => {
   };
 
   const lineageGraph = buildLineageGraph(base, current);
-  const [nodes, edges] = toReactflow(lineageGraph);
-  const [nodes2, edges2] = highlightPath(lineageGraph, nodes, edges, "a");
+  const [nodes, edges] = toReactflow(
+    Object.values(lineageGraph.nodes),
+    Object.values(lineageGraph.edges)
+  );
+  const relatedNodes = union(
+    selectUpstream(lineageGraph, ["a"]),
+    selectDownstream(lineageGraph, ["a"])
+  );
+  const [nodes2, edges2] = highlightNodes(
+    Array.from(relatedNodes),
+    nodes,
+    edges
+  );
 
   expect(nodes.length).toBe(nodes2.length);
   expect(edges.length).toBe(edges2.length);

--- a/js/src/components/lineage/lineage.test.ts
+++ b/js/src/components/lineage/lineage.test.ts
@@ -2,7 +2,7 @@ import {
   LineageData,
   LineageGraphEdge,
   LineageGraphNode,
-  buildDefaultLineageGraphSets,
+  buildLineageGraph,
   highlightPath,
   toReactflow,
 } from "./lineage";
@@ -19,6 +19,7 @@ test("lineage diff", () => {
       c: ["a"],
       d: ["b"],
     },
+    catalog_metadata: null,
   };
 
   const current = {
@@ -29,11 +30,10 @@ test("lineage diff", () => {
       c: ["a"],
       d: ["b", "c"],
     },
+    catalog_metadata: null,
   };
 
-  const { all } = buildDefaultLineageGraphSets(base, current);
-  const nodes = all.nodes;
-  const edges = all.edges;
+  const { nodes, edges } = buildLineageGraph(base, current);
 
   expect(Object.keys(nodes).length).toBe(4);
   expect(Object.keys(edges).length).toBe(4);
@@ -61,6 +61,7 @@ test("lineage diff 2", () => {
       c: ["b"],
       d: ["c"],
     },
+    catalog_metadata: null,
   };
 
   const current: LineageData = {
@@ -80,11 +81,10 @@ test("lineage diff 2", () => {
       c: ["b"],
       d: ["c"],
     },
+    catalog_metadata: null,
   };
 
-  const { all } = buildDefaultLineageGraphSets(base, current);
-  const nodes = all.nodes;
-  const edges = all.edges;
+  const { nodes, edges } = buildLineageGraph(base, current);
 
   expect(Object.keys(nodes).length).toBe(5);
   expect(Object.keys(edges).length).toBe(4);
@@ -108,6 +108,7 @@ test("hightlight", () => {
       c: ["b"],
       d: ["c"],
     },
+    catalog_metadata: null,
   };
 
   const current: LineageData = {
@@ -118,11 +119,12 @@ test("hightlight", () => {
       c: ["b"],
       d: ["c"],
     },
+    catalog_metadata: null,
   };
 
-  const { all, modifiedSet } = buildDefaultLineageGraphSets(base, current);
-  const [nodes, edges] = toReactflow(all, modifiedSet);
-  const [nodes2, edges2] = highlightPath(all, modifiedSet, nodes, edges, "a");
+  const lineageGraph = buildLineageGraph(base, current);
+  const [nodes, edges] = toReactflow(lineageGraph);
+  const [nodes2, edges2] = highlightPath(lineageGraph, nodes, edges, "a");
 
   expect(nodes.length).toBe(nodes2.length);
   expect(edges.length).toBe(edges2.length);

--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -95,6 +95,8 @@ export interface LineageGraph {
   edges: {
     [key: string]: LineageGraphEdge;
   };
+  modifiedSet: string[];
+  catalogExistence: CatalogExistence;
 }
 
 export interface CatalogExistence {
@@ -102,149 +104,134 @@ export interface CatalogExistence {
   current: boolean;
 }
 
-export interface DefaultLineageGraphSets {
-  all: LineageGraph;
-  changed: LineageGraph;
-  modifiedSet: string[];
-  catalogExistence: CatalogExistence;
-}
+// function buildChangedOnlyLineageGraph(
+//   all: LineageGraph,
+//   modifiedSet: string[]
+// ): LineageGraph {
+//   const nodes: { [key: string]: LineageGraphNode } = {};
+//   const edges: { [key: string]: LineageGraphEdge } = {};
+//   function union(...sets: Set<string>[]) {
+//     const unionSet = new Set<string>();
 
-export function buildDefaultLineageGraphSets(
+//     sets.forEach((set) => {
+//       set.forEach((key) => {
+//         unionSet.add(key);
+//       });
+//     });
+//     return unionSet;
+//   }
+
+//   // Select all downstream sets of modified nodes
+//   const downstreamSet = selectDownstream(all, modifiedSet);
+
+//   // Select a single upstream layer of modified nodes
+//   const upstreamSet = selectUpstream(all, modifiedSet, 1);
+
+//   // Union of upstream and downstream nodes
+//   const modifiedSets = union(downstreamSet, upstreamSet);
+
+//   Object.entries(all.nodes).forEach(([key, node]) => {
+//     if (modifiedSets.has(key)) {
+//       nodes[key] = node;
+//     }
+//   });
+
+//   Object.entries(all.edges).forEach(([key, edge]) => {
+//     if (modifiedSets.has(edge.parent.id) && modifiedSets.has(edge.child.id)) {
+//       edges[key] = edge;
+//     }
+//   });
+
+//   return { nodes, edges };
+// }
+
+export function buildLineageGraph(
   base: LineageData,
   current: LineageData
-): DefaultLineageGraphSets {
-  function buildAllLineageGraph(
-    base: LineageData,
-    current: LineageData
-  ): LineageGraph {
-    const nodes: { [key: string]: LineageGraphNode } = {};
-    const edges: { [key: string]: LineageGraphEdge } = {};
-    const buildNode = (
-      key: string,
-      from: "base" | "current"
-    ): LineageGraphNode => {
-      return {
-        id: key,
-        name: key,
-        data: {},
-        from,
-        parents: {},
-        children: {},
-        isSelected: false,
-      };
+): LineageGraph {
+  const nodes: { [key: string]: LineageGraphNode } = {};
+  const edges: { [key: string]: LineageGraphEdge } = {};
+  const buildNode = (
+    key: string,
+    from: "base" | "current"
+  ): LineageGraphNode => {
+    return {
+      id: key,
+      name: key,
+      data: {},
+      from,
+      parents: {},
+      children: {},
+      isSelected: false,
     };
+  };
 
-    for (const [key, parents] of Object.entries(base.parent_map)) {
-      nodes[key] = buildNode(key, "base");
-      const nodeData = base.nodes && base.nodes[key];
-      if (nodeData) {
-        nodes[key].data.base = nodeData;
-        nodes[key].name = nodeData?.name;
-        nodes[key].resourceType = nodeData?.resource_type;
-        nodes[key].packageName = nodeData?.package_name;
-      }
+  for (const [key, parents] of Object.entries(base.parent_map)) {
+    nodes[key] = buildNode(key, "base");
+    const nodeData = base.nodes && base.nodes[key];
+    if (nodeData) {
+      nodes[key].data.base = nodeData;
+      nodes[key].name = nodeData?.name;
+      nodes[key].resourceType = nodeData?.resource_type;
+      nodes[key].packageName = nodeData?.package_name;
     }
+  }
 
-    for (const [key, parents] of Object.entries(current.parent_map)) {
-      if (nodes[key]) {
-        nodes[key].from = "both";
+  for (const [key, parents] of Object.entries(current.parent_map)) {
+    if (nodes[key]) {
+      nodes[key].from = "both";
+    } else {
+      nodes[key] = buildNode(key, "current");
+    }
+    const nodeData = current.nodes && current.nodes[key];
+    if (nodeData) {
+      nodes[key].data.current = current.nodes && current.nodes[key];
+      nodes[key].name = nodeData?.name;
+      nodes[key].resourceType = nodeData?.resource_type;
+      nodes[key].packageName = nodeData?.package_name;
+    }
+  }
+
+  for (const [child, parents] of Object.entries(base.parent_map)) {
+    for (const parent of parents) {
+      const childNode = nodes[child];
+      const parentNode = nodes[parent];
+      const id = `${parent}_${child}`;
+      edges[id] = {
+        id,
+        from: "base",
+        parent: parentNode,
+        child: childNode,
+      };
+      const edge = edges[id];
+
+      childNode.parents[parent] = edge;
+      parentNode.children[child] = edge;
+    }
+  }
+
+  for (const [child, parents] of Object.entries(current.parent_map)) {
+    for (const parent of parents) {
+      const childNode = nodes[child];
+      const parentNode = nodes[parent];
+      const id = `${parent}_${child}`;
+
+      if (edges[id]) {
+        edges[id].from = "both";
       } else {
-        nodes[key] = buildNode(key, "current");
-      }
-      const nodeData = current.nodes && current.nodes[key];
-      if (nodeData) {
-        nodes[key].data.current = current.nodes && current.nodes[key];
-        nodes[key].name = nodeData?.name;
-        nodes[key].resourceType = nodeData?.resource_type;
-        nodes[key].packageName = nodeData?.package_name;
-      }
-    }
-
-    for (const [child, parents] of Object.entries(base.parent_map)) {
-      for (const parent of parents) {
-        const childNode = nodes[child];
-        const parentNode = nodes[parent];
-        const id = `${parent}_${child}`;
         edges[id] = {
           id,
-          from: "base",
+          from: "current",
           parent: parentNode,
           child: childNode,
         };
-        const edge = edges[id];
-
-        childNode.parents[parent] = edge;
-        parentNode.children[child] = edge;
       }
+      const edge = edges[id];
+
+      childNode.parents[parent] = edge;
+      parentNode.children[child] = edge;
     }
-
-    for (const [child, parents] of Object.entries(current.parent_map)) {
-      for (const parent of parents) {
-        const childNode = nodes[child];
-        const parentNode = nodes[parent];
-        const id = `${parent}_${child}`;
-
-        if (edges[id]) {
-          edges[id].from = "both";
-        } else {
-          edges[id] = {
-            id,
-            from: "current",
-            parent: parentNode,
-            child: childNode,
-          };
-        }
-        const edge = edges[id];
-
-        childNode.parents[parent] = edge;
-        parentNode.children[child] = edge;
-      }
-    }
-
-    return { edges, nodes };
   }
-  function buildChangedOnlyLineageGraph(
-    all: LineageGraph,
-    modifiedSet: string[]
-  ): LineageGraph {
-    const nodes: { [key: string]: LineageGraphNode } = {};
-    const edges: { [key: string]: LineageGraphEdge } = {};
-    function union(...sets: Set<string>[]) {
-      const unionSet = new Set<string>();
-
-      sets.forEach((set) => {
-        set.forEach((key) => {
-          unionSet.add(key);
-        });
-      });
-      return unionSet;
-    }
-
-    // Select all downstream sets of modified nodes
-    const downstreamSet = selectDownstream(all, modifiedSet);
-
-    // Select a single upstream layer of modified nodes
-    const upstreamSet = selectUpstream(all, modifiedSet, 1);
-
-    // Union of upstream and downstream nodes
-    const modifiedSets = union(downstreamSet, upstreamSet);
-
-    Object.entries(all.nodes).forEach(([key, node]) => {
-      if (modifiedSets.has(key)) {
-        nodes[key] = node;
-      }
-    });
-
-    Object.entries(all.edges).forEach(([key, edge]) => {
-      if (modifiedSets.has(edge.parent.id) && modifiedSets.has(edge.child.id)) {
-        edges[key] = edge;
-      }
-    });
-
-    return { nodes, edges };
-  }
-
-  const { nodes, edges } = buildAllLineageGraph(base, current);
 
   const modifiedSet: string[] = [];
   for (const [key, node] of Object.entries(nodes)) {
@@ -274,11 +261,8 @@ export function buildDefaultLineageGraphSets(
   }
 
   return {
-    all: {
-      nodes,
-      edges,
-    },
-    changed: buildChangedOnlyLineageGraph({ nodes, edges }, modifiedSet),
+    nodes,
+    edges,
     modifiedSet,
     catalogExistence: {
       base: !!base.catalog_metadata,
@@ -321,10 +305,8 @@ export function selectDownstream(
   );
 }
 
-export function toReactflow(
-  lineageGraph: LineageGraph,
-  modifiedSet: string[]
-): [Node[], Edge[]] {
+export function toReactflow(lineageGraph: LineageGraph): [Node[], Edge[]] {
+  const modifiedSet = lineageGraph.modifiedSet;
   const nodes: Node[] = [];
   const edges: Edge[] = [];
   const backgroundColorMap = {
@@ -358,16 +340,16 @@ export function toReactflow(
     });
   }
 
-  return highlightPath(lineageGraph, modifiedSet, nodes, edges, null);
+  return highlightPath(lineageGraph, nodes, edges, null);
 }
 
 export function highlightPath(
   lineageGraph: LineageGraph,
-  modifiedSet: string[],
   nodes: Node<LineageGraphNode>[],
   edges: Edge[],
   id: string | null
 ): [Node<LineageGraphNode>[], Edge[]] {
+  const modifiedSet = lineageGraph.modifiedSet;
   function union(...sets: Set<string>[]) {
     const unionSet = new Set<string>();
 

--- a/js/src/components/schema/SchemaView.tsx
+++ b/js/src/components/schema/SchemaView.tsx
@@ -25,9 +25,9 @@ export function SchemaView({
     [base, current]
   );
 
-  const { lineageGraphSets } = useLineageGraphsContext();
-  const noCatalogBase = lineageGraphSets?.catalogExistence.base === false;
-  const noCatalogCurrent = lineageGraphSets?.catalogExistence.current === false;
+  const { lineageGraph } = useLineageGraphsContext();
+  const noCatalogBase = lineageGraph?.catalogExistence.base === false;
+  const noCatalogCurrent = lineageGraph?.catalogExistence.current === false;
   let catalogMissingMessage = undefined;
   if (noCatalogBase && noCatalogCurrent) {
     catalogMissingMessage =

--- a/js/src/components/schema/SchemaView.tsx
+++ b/js/src/components/schema/SchemaView.tsx
@@ -7,7 +7,7 @@ import {
   EmptyRowsRenderer,
   ScreenshotDataGrid,
 } from "../data-grid/ScreenshotDataGrid";
-import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 
 interface SchemaViewProps {
   base?: NodeData;
@@ -25,7 +25,7 @@ export function SchemaView({
     [base, current]
   );
 
-  const { lineageGraph } = useLineageGraphsContext();
+  const { lineageGraph } = useLineageGraphContext();
   const noCatalogBase = lineageGraph?.catalogExistence.base === false;
   const noCatalogCurrent = lineageGraph?.catalogExistence.current === false;
   let catalogMissingMessage = undefined;

--- a/js/src/components/summary/ChangeSummary.tsx
+++ b/js/src/components/summary/ChangeSummary.tsx
@@ -1,59 +1,61 @@
 import { Box, Grid, Icon, Tooltip, VStack, Text, Flex } from "@chakra-ui/react";
 import { ReactNode, use } from "react";
 import { FiInfo } from "react-icons/fi";
-import { IconAdded, IconChanged, IconModified, IconRemoved } from "../lineage/styles";
-import { DefaultLineageGraphSets, LineageGraph, NodeData } from "../lineage/lineage";
+import {
+  IconAdded,
+  IconChanged,
+  IconModified,
+  IconRemoved,
+} from "../lineage/styles";
+import { LineageGraph, NodeData } from "../lineage/lineage";
 
 export type ChangeStatus =
   // node change
   // code change (user edit)
-  | 'added'
-  | 'removed'
-  | 'modified'
+  | "added"
+  | "removed"
+  | "modified"
 
   // column change
-  | 'col_added'
-  | 'col_removed'
-  | 'col_changed'
+  | "col_added"
+  | "col_removed"
+  | "col_changed"
 
   // folder change
-  | 'folder_changed'
+  | "folder_changed"
   | null;
 
 export const NODE_CHANGE_STATUS_MSGS = {
-  added: ['Model Added', 'Added resource'],
-  removed: ['Model Removed', 'Removed resource'],
-  modified: ['Model Modified', 'Modified resource'],
-  col_added: ['Column Added', 'Added column'],
-  col_removed: ['Column Removed', 'Removed column'],
-  col_changed: ['Column Modified', 'Modified column'],
-  folder_changed: ['Modified', 'Modified folder'],
+  added: ["Model Added", "Added resource"],
+  removed: ["Model Removed", "Removed resource"],
+  modified: ["Model Modified", "Modified resource"],
+  col_added: ["Column Added", "Added column"],
+  col_removed: ["Column Removed", "Removed column"],
+  col_changed: ["Column Modified", "Modified column"],
+  folder_changed: ["Modified", "Modified folder"],
 };
 
-export function getIconForChangeStatus(
-  changeStatus?: ChangeStatus,
-): {
+export function getIconForChangeStatus(changeStatus?: ChangeStatus): {
   color: string;
   icon: any; //IconType not provided
 } {
-  if (changeStatus === 'added') {
-    return { color: '#1dce00', icon: IconAdded };
-  } else if (changeStatus === 'removed') {
-    return { color: '#ff067e', icon: IconRemoved };
-  } else if (changeStatus === 'modified') {
-    return { color: '#ffa502', icon: IconModified };
-  } else if (changeStatus === 'col_added') {
-    return { color: '#1dce00', icon: IconAdded };
-  } else if (changeStatus === 'col_removed') {
-    return { color: '#ff067e', icon: IconRemoved };
-  } else if (changeStatus === 'col_changed') {
-    return { color: '#ffa502', icon: IconModified };
-  } else if (changeStatus === 'folder_changed') {
-    return { color: '#ffa502', icon: IconChanged };
+  if (changeStatus === "added") {
+    return { color: "#1dce00", icon: IconAdded };
+  } else if (changeStatus === "removed") {
+    return { color: "#ff067e", icon: IconRemoved };
+  } else if (changeStatus === "modified") {
+    return { color: "#ffa502", icon: IconModified };
+  } else if (changeStatus === "col_added") {
+    return { color: "#1dce00", icon: IconAdded };
+  } else if (changeStatus === "col_removed") {
+    return { color: "#ff067e", icon: IconRemoved };
+  } else if (changeStatus === "col_changed") {
+    return { color: "#ffa502", icon: IconModified };
+  } else if (changeStatus === "folder_changed") {
+    return { color: "#ffa502", icon: IconChanged };
   }
 
-
-  return { color: 'inherit', icon: undefined };
+  return { color: "inherit", icon: undefined };
 }
 
 function SummaryText({
@@ -72,7 +74,7 @@ function SummaryText({
         {tip && (
           <Tooltip label={tip}>
             <Box display="inline-block">
-              <Icon mx={'2px'} as={FiInfo} boxSize={3} />
+              <Icon mx={"2px"} as={FiInfo} boxSize={3} />
             </Box>
           </Tooltip>
         )}
@@ -89,7 +91,7 @@ function ChangeStatusCountLabel({
   changeStatus: ChangeStatus;
   value: number;
 }) {
-  const [label] = changeStatus ? NODE_CHANGE_STATUS_MSGS[changeStatus] : [''];
+  const [label] = changeStatus ? NODE_CHANGE_STATUS_MSGS[changeStatus] : [""];
   const { icon, color } = getIconForChangeStatus(changeStatus);
 
   return (
@@ -103,8 +105,10 @@ function ChangeStatusCountLabel({
   );
 }
 
-
-function calculateColumnChange(base: NodeData | undefined, current: NodeData | undefined) {
+function calculateColumnChange(
+  base: NodeData | undefined,
+  current: NodeData | undefined
+) {
   let adds = 0;
   let removes = 0;
   let modifies = 0;
@@ -122,7 +126,7 @@ function calculateColumnChange(base: NodeData | undefined, current: NodeData | u
     Object.keys(base.columns || {}).forEach((col) => {
       if (!current || !current.columns || !current.columns[col]) removes++;
     });
-}
+  }
 
   // Modify columns
   if (current && base) {
@@ -136,7 +140,8 @@ function calculateColumnChange(base: NodeData | undefined, current: NodeData | u
   return { adds, removes, modifies };
 }
 
-function calculateChangeSummary(lineageGraph: LineageGraph, modifiedSet: string[]) {
+function calculateChangeSummary(lineageGraph: LineageGraph) {
+  const modifiedSet = lineageGraph.modifiedSet;
   let adds = 0;
   let removes = 0;
   let modifies = 0;
@@ -145,9 +150,9 @@ function calculateChangeSummary(lineageGraph: LineageGraph, modifiedSet: string[
   let col_changed = 0;
 
   modifiedSet.forEach((nodeId) => {
-    if (lineageGraph.nodes[nodeId].changeStatus === 'added') adds++;
-    else if (lineageGraph.nodes[nodeId].changeStatus === 'removed') removes++;
-    else if (lineageGraph.nodes[nodeId].changeStatus === 'modified') modifies++;
+    if (lineageGraph.nodes[nodeId].changeStatus === "added") adds++;
+    else if (lineageGraph.nodes[nodeId].changeStatus === "removed") removes++;
+    else if (lineageGraph.nodes[nodeId].changeStatus === "modified") modifies++;
 
     const base = lineageGraph.nodes[nodeId].data.base;
     const current = lineageGraph.nodes[nodeId].data.current;
@@ -161,31 +166,27 @@ function calculateChangeSummary(lineageGraph: LineageGraph, modifiedSet: string[
 }
 
 export interface Props {
-  lineageGraphSets: DefaultLineageGraphSets
+  lineageGraph: LineageGraph;
 }
 
-
-export function ChangeSummary({ lineageGraphSets }: Props) {
-  const {
-    adds,
-    removes,
-    modifies,
-    col_added,
-    col_removed,
-    col_changed,
-  } = calculateChangeSummary(lineageGraphSets.all, lineageGraphSets.modifiedSet);
+export function ChangeSummary({ lineageGraph }: Props) {
+  const { adds, removes, modifies, col_added, col_removed, col_changed } =
+    calculateChangeSummary(lineageGraph);
 
   return (
-    <Grid templateColumns="1fr 1fr" mb="10px" borderTop="1px solid lightgray" padding={'2.5vw'}>
-      <Box borderColor='lightgray'>
+    <Grid
+      templateColumns="1fr 1fr"
+      mb="10px"
+      borderTop="1px solid lightgray"
+      padding={"2.5vw"}
+    >
+      <Box borderColor="lightgray">
         <SummaryText
           name="Code Changes"
           value={
             <>
               <Grid templateColumns="1fr 1fr 1fr" width="100%">
-                <ChangeStatusCountLabel
-                  changeStatus="added"
-                  value={adds} />
+                <ChangeStatusCountLabel changeStatus="added" value={adds} />
                 <ChangeStatusCountLabel
                   changeStatus="removed"
                   value={removes}
@@ -199,7 +200,7 @@ export function ChangeSummary({ lineageGraphSets }: Props) {
           }
         />
       </Box>
-      <Box borderLeft="1px" paddingLeft="12px" borderColor='lightgray'>
+      <Box borderLeft="1px" paddingLeft="12px" borderColor="lightgray">
         <SummaryText
           name="Column Changes"
           value={
@@ -207,7 +208,8 @@ export function ChangeSummary({ lineageGraphSets }: Props) {
               <Grid templateColumns="1fr 1fr 1fr" width="100%">
                 <ChangeStatusCountLabel
                   changeStatus="col_added"
-                  value={col_added} />
+                  value={col_added}
+                />
                 <ChangeStatusCountLabel
                   changeStatus="col_removed"
                   value={col_removed}

--- a/js/src/components/summary/SchemaSummary.tsx
+++ b/js/src/components/summary/SchemaSummary.tsx
@@ -14,7 +14,7 @@ import {
   TagLabel,
   SkeletonText,
 } from "@chakra-ui/react";
-import { DefaultLineageGraphSets, LineageGraphNode } from "../lineage/lineage";
+import { LineageGraph, LineageGraphNode } from "../lineage/lineage";
 import { SchemaView } from "../schema/SchemaView";
 import { mergeColumns } from "../schema/schema";
 import { mergeKeysWithStatus } from "@/lib/mergeKeys";
@@ -44,10 +44,10 @@ function SchemaDiffCard({ node, ...props }: CardProps & SchemaDiffCardProps) {
   );
 }
 
-function listChangedNodes(lineageGraphSets: DefaultLineageGraphSets) {
+function listChangedNodes(lineageGraph: LineageGraph) {
   const changedNodes: LineageGraphNode[] = [];
-  const allNodes = lineageGraphSets.all.nodes;
-  lineageGraphSets.modifiedSet.forEach((nodeId) => {
+  const allNodes = lineageGraph.nodes;
+  lineageGraph.modifiedSet.forEach((nodeId) => {
     const node = allNodes[nodeId];
     const columnDiffStatus = mergeKeysWithStatus(
       Object.keys(node.data.base?.columns || {}),
@@ -65,15 +65,15 @@ function listChangedNodes(lineageGraphSets: DefaultLineageGraphSets) {
 }
 
 export interface Props {
-  lineageGraphSets: DefaultLineageGraphSets;
+  lineageGraph: LineageGraph;
 }
 
-export function SchemaSummary({ lineageGraphSets }: Props) {
+export function SchemaSummary({ lineageGraph }: Props) {
   const [changedNodes, setChangedNodes] = useState<LineageGraphNode[]>([]);
 
   useEffect(() => {
-    setChangedNodes(listChangedNodes(lineageGraphSets));
-  }, [lineageGraphSets]);
+    setChangedNodes(listChangedNodes(lineageGraph));
+  }, [lineageGraph]);
 
   return (
     <>

--- a/js/src/components/summary/SummaryView.tsx
+++ b/js/src/components/summary/SummaryView.tsx
@@ -1,10 +1,10 @@
 import { Divider, Flex, Heading, Spacer, Text } from "@chakra-ui/react";
-import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 import { ChangeSummary } from "./ChangeSummary";
 import { SchemaSummary } from "./SchemaSummary";
 
 export default function SummaryView() {
-  const { lineageGraph } = useLineageGraphsContext();
+  const { lineageGraph } = useLineageGraphContext();
   return (
     <>
       <Flex direction="column" w={"100%"} minHeight="650px">

--- a/js/src/components/summary/SummaryView.tsx
+++ b/js/src/components/summary/SummaryView.tsx
@@ -4,19 +4,20 @@ import { ChangeSummary } from "./ChangeSummary";
 import { SchemaSummary } from "./SchemaSummary";
 
 export default function SummaryView() {
-  const { lineageGraphSets } = useLineageGraphsContext();
+  const { lineageGraph } = useLineageGraphsContext();
   return (
     <>
-      <Flex direction="column" w={'100%'} minHeight="650px">
-        <Flex w={'100%'} paddingBottom="10px" marginBottom="20px">
+      <Flex direction="column" w={"100%"} minHeight="650px">
+        <Flex w={"100%"} paddingBottom="10px" marginBottom="20px">
           <Heading fontSize={24}>Change Summary</Heading>
         </Flex>
-        {lineageGraphSets &&<>
-          <ChangeSummary lineageGraphSets={lineageGraphSets}/>
-          <Divider />
-          <SchemaSummary lineageGraphSets={lineageGraphSets}/>
-        </>
-        }
+        {lineageGraph && (
+          <>
+            <ChangeSummary lineageGraph={lineageGraph} />
+            <Divider />
+            <SchemaSummary lineageGraph={lineageGraph} />
+          </>
+        )}
       </Flex>
     </>
   );

--- a/js/src/components/top-k/TopKDiffForm.tsx
+++ b/js/src/components/top-k/TopKDiffForm.tsx
@@ -1,6 +1,6 @@
 import { TopKDiffParams } from "@/lib/api/profile";
 import { RunFormProps } from "../run/types";
-import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 import _ from "lodash";
 import { Box, FormControl, FormLabel, Select } from "@chakra-ui/react";
 import { extractColumnNames } from "../valuediff/ValueDiffForm";
@@ -13,7 +13,7 @@ export function TopKDiffForm({
   onParamsChanged,
   setIsReadyToExecute,
 }: TopKDiffFormProps) {
-  const { lineageGraph } = useLineageGraphsContext();
+  const { lineageGraph } = useLineageGraphContext();
   const node = _.find(lineageGraph?.nodes, {
     name: params?.model,
   });

--- a/js/src/components/top-k/TopKDiffForm.tsx
+++ b/js/src/components/top-k/TopKDiffForm.tsx
@@ -13,8 +13,8 @@ export function TopKDiffForm({
   onParamsChanged,
   setIsReadyToExecute,
 }: TopKDiffFormProps) {
-  const lineageGraph = useLineageGraphsContext();
-  const node = _.find(lineageGraph.lineageGraphSets?.all.nodes, {
+  const { lineageGraph } = useLineageGraphsContext();
+  const node = _.find(lineageGraph?.nodes, {
     name: params?.model,
   });
   const columns = node ? extractColumnNames(node) : [];

--- a/js/src/components/valuediff/ValueDiffForm.tsx
+++ b/js/src/components/valuediff/ValueDiffForm.tsx
@@ -70,14 +70,14 @@ export function ValueDiffForm({
   onParamsChanged,
   setIsReadyToExecute,
 }: ValueDiffFormProp) {
-  const lineageGraph = useLineageGraphsContext();
+  const { lineageGraph } = useLineageGraphsContext();
   const [allColumns, setAllColumns] = useState<boolean>(
     !params.columns || params.columns.length === 0
   );
 
   const model = params?.model;
   const primaryKey = params?.primary_key;
-  const node = _.find(lineageGraph.lineageGraphSets?.all.nodes, {
+  const node = _.find(lineageGraph?.nodes, {
     name: params?.model,
   });
   const nodePrimaryKey = node?.data.current?.primary_key;

--- a/js/src/components/valuediff/ValueDiffForm.tsx
+++ b/js/src/components/valuediff/ValueDiffForm.tsx
@@ -9,7 +9,7 @@ import {
 } from "@chakra-ui/react";
 
 import { Select } from "chakra-react-select";
-import { useLineageGraphsContext } from "@/lib/hooks/LineageGraphContext";
+import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 import { LineageGraphNode, NodeColumnData, NodeData } from "../lineage/lineage";
 import _ from "lodash";
 import { useEffect, useState } from "react";
@@ -70,7 +70,7 @@ export function ValueDiffForm({
   onParamsChanged,
   setIsReadyToExecute,
 }: ValueDiffFormProp) {
-  const { lineageGraph } = useLineageGraphsContext();
+  const { lineageGraph } = useLineageGraphContext();
   const [allColumns, setAllColumns] = useState<boolean>(
     !params.columns || params.columns.length === 0
   );

--- a/js/src/lib/hooks/LineageGraphContext.tsx
+++ b/js/src/lib/hooks/LineageGraphContext.tsx
@@ -1,7 +1,4 @@
-import {
-  DefaultLineageGraphSets,
-  buildDefaultLineageGraphSets,
-} from "@/components/lineage/lineage";
+import { LineageGraph, buildLineageGraph } from "@/components/lineage/lineage";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import React, {
   createContext,
@@ -23,7 +20,8 @@ interface EnvMetadata {
 }
 
 export interface LineageGraphsContext {
-  lineageGraphSets?: DefaultLineageGraphSets;
+  // lineageGraphSets?: DefaultLineageGraphSets;
+  lineageGraph?: LineageGraph;
   metadata?: EnvMetadata;
   isDemoSite?: boolean;
   isLoading?: boolean;
@@ -103,12 +101,12 @@ export function LineageGraphsContextProvider({
     queryFn: aggregateRuns,
   });
 
-  const lineageGraphSets = useMemo(() => {
+  const lineageGraph = useMemo(() => {
     if (!data) {
       return undefined;
     }
 
-    return buildDefaultLineageGraphSets(data.base, data.current);
+    return buildLineageGraph(data.base, data.current);
   }, [data]);
 
   const errorMessage =
@@ -119,7 +117,7 @@ export function LineageGraphsContextProvider({
       <LineageWatcher refetch={refetch} />
       <LineageGraphSets.Provider
         value={{
-          lineageGraphSets: lineageGraphSets,
+          lineageGraph,
           metadata: data?.current.metadata,
           isDemoSite: !!data?.current.metadata.pr_url,
           error: errorMessage,

--- a/js/src/lib/hooks/LineageGraphContext.tsx
+++ b/js/src/lib/hooks/LineageGraphContext.tsx
@@ -130,10 +130,10 @@ export function LineageGraphContextProvider({ children }: LineageGraphProps) {
   );
 }
 
-export const useLineageGraphsContext = () => useContext(LineageGraphContext);
+export const useLineageGraphContext = () => useContext(LineageGraphContext);
 
 export const useRunsAggregated = () => {
-  const { runsAggregated, refetchRunsAggregated } = useLineageGraphsContext();
+  const { runsAggregated, refetchRunsAggregated } = useLineageGraphContext();
   return [runsAggregated, refetchRunsAggregated] as [
     RunsAggregated | undefined,
     () => void

--- a/js/src/lib/hooks/LineageGraphContext.tsx
+++ b/js/src/lib/hooks/LineageGraphContext.tsx
@@ -2,7 +2,6 @@ import { LineageGraph, buildLineageGraph } from "@/components/lineage/lineage";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import React, {
   createContext,
-  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -19,8 +18,7 @@ interface EnvMetadata {
   pr_url: string | null;
 }
 
-export interface LineageGraphsContext {
-  // lineageGraphSets?: DefaultLineageGraphSets;
+export interface LineageGraphContextType {
   lineageGraph?: LineageGraph;
   metadata?: EnvMetadata;
   isDemoSite?: boolean;
@@ -31,11 +29,11 @@ export interface LineageGraphsContext {
   refetchRunsAggregated?: () => void;
 }
 
-const defaultLineageGraphsContext: LineageGraphsContext = {};
+const defaultLineageGraphsContext: LineageGraphContextType = {};
 
-const LineageGraphSets = createContext(defaultLineageGraphsContext);
+const LineageGraphContext = createContext(defaultLineageGraphsContext);
 
-interface LineageGraphSetsProps {
+interface LineageGraphProps {
   children: React.ReactNode;
 }
 
@@ -88,9 +86,7 @@ function LineageWatcher({ refetch }: { refetch: () => void }) {
   return <></>;
 }
 
-export function LineageGraphsContextProvider({
-  children,
-}: LineageGraphSetsProps) {
+export function LineageGraphContextProvider({ children }: LineageGraphProps) {
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: cacheKeys.lineage(),
     queryFn: getLineageDiff,
@@ -115,7 +111,7 @@ export function LineageGraphsContextProvider({
   return (
     <>
       <LineageWatcher refetch={refetch} />
-      <LineageGraphSets.Provider
+      <LineageGraphContext.Provider
         value={{
           lineageGraph,
           metadata: data?.current.metadata,
@@ -129,12 +125,12 @@ export function LineageGraphsContextProvider({
         }}
       >
         {children}
-      </LineageGraphSets.Provider>
+      </LineageGraphContext.Provider>
     </>
   );
 }
 
-export const useLineageGraphsContext = () => useContext(LineageGraphSets);
+export const useLineageGraphsContext = () => useContext(LineageGraphContext);
 
 export const useRunsAggregated = () => {
   const { runsAggregated, refetchRunsAggregated } = useLineageGraphsContext();

--- a/js/src/lib/hooks/RecceContextProvider.tsx
+++ b/js/src/lib/hooks/RecceContextProvider.tsx
@@ -4,7 +4,7 @@ import {
   RecceQueryContextProvider,
   RowCountStateContextProvider,
 } from "./RecceQueryContext";
-import { LineageGraphsContextProvider } from "./LineageGraphContext";
+import { LineageGraphContextProvider } from "./LineageGraphContext";
 import { RecceActionContextProvider } from "./RecceActionContext";
 
 interface RecceContextProps {
@@ -15,11 +15,11 @@ export default function RecceContextProvider({ children }: RecceContextProps) {
   return (
     <>
       <RecceQueryContextProvider>
-        <LineageGraphsContextProvider>
+        <LineageGraphContextProvider>
           <RowCountStateContextProvider>
             <RecceActionContextProvider>{children}</RecceActionContextProvider>
           </RowCountStateContextProvider>
-        </LineageGraphsContextProvider>
+        </LineageGraphContextProvider>
       </RecceQueryContextProvider>
     </>
   );


### PR DESCRIPTION
Because we may have different way to show the subset of nodes in the LineageView component, it does not make sense to keep the changed only and all. So

1. Only keep one linage graph, which is the fetched version.
2. The consumer of the LineageGraph should clone and filtered to their own and transform the the format ReactFlow uses.


**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Refactory

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
