### PR TITLE
[Enhancement] Show refetch information if recce server is down

### DIFF
--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -139,8 +139,13 @@ function _LineageView({ ...props }: LineageViewProps) {
     props.viewOptions || {}
   );
 
-  const { lineageGraph, isLoading, error, refetchRunsAggregated } =
-    useLineageGraphContext();
+  const {
+    lineageGraph,
+    retchLineageGraph,
+    isLoading,
+    error,
+    refetchRunsAggregated,
+  } = useLineageGraphContext();
 
   /**
    * View mode
@@ -356,7 +361,25 @@ function _LineageView({ ...props }: LineageViewProps) {
   };
 
   if (error) {
-    return <>Fail to load lineage data: {error}</>;
+    return (
+      <Center h="100%">
+        <VStack>
+          <Box>
+            Failed to load lineage data. This could be because the server has
+            been terminated or there is a network error.
+          </Box>
+          <Box>[Reason: {error}]</Box>
+          <Button
+            colorScheme="blue"
+            onClick={() => {
+              retchLineageGraph && retchLineageGraph();
+            }}
+          >
+            Retry
+          </Button>
+        </VStack>
+      </Center>
+    );
   }
 
   if (viewMode === "changed_models" && !lineageGraph?.modifiedSet?.length) {

--- a/js/src/lib/hooks/LineageGraphContext.tsx
+++ b/js/src/lib/hooks/LineageGraphContext.tsx
@@ -24,6 +24,7 @@ export interface LineageGraphContextType {
   isDemoSite?: boolean;
   isLoading?: boolean;
   error?: string;
+  retchLineageGraph?: () => void;
 
   runsAggregated?: RunsAggregated;
   refetchRunsAggregated?: () => void;
@@ -114,6 +115,9 @@ export function LineageGraphContextProvider({ children }: LineageGraphProps) {
       <LineageGraphContext.Provider
         value={{
           lineageGraph,
+          retchLineageGraph: () => {
+            refetch();
+          },
           metadata: data?.current?.metadata,
           isDemoSite: !!data?.current?.metadata.pr_url,
           error: errorMessage,


### PR DESCRIPTION
<img width="1170" alt="image" src="https://github.com/DataRecce/recce/assets/860633/d6593a06-7977-4e04-9168-2b5eb81f113e">

Show refetch information if recce server is down

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed
