### PR TITLE
[Bug] DRC-260 Fix linage view edges will disapper in copy image

### DIFF
--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -101,6 +101,7 @@ function _LineageView({ ...props }: LineageViewProps) {
     ImageBoardModal,
   } = useImageBoardModal();
   const { toImage, ref } = useToBlob({
+    renderLibrary: "html-to-image",
     imageType: "png",
     shadowEffect: true,
     backgroundColor: "white",

--- a/js/src/components/lineage/styles.css
+++ b/js/src/components/lineage/styles.css
@@ -1,5 +1,5 @@
 .node-unhighlight {
-  filter: opacity(0.2) grayscale(50%)
+  filter: opacity(0.2) grayscale(50%);
 }
 
 .node-highlight {

--- a/js/src/components/query/styles.css
+++ b/js/src/components/query/styles.css
@@ -3,7 +3,6 @@
   text-align: right;
 }
 
-
 .diff-header-added {
   background-color: #3aa53a;
   color: white;
@@ -47,7 +46,7 @@
   border-color: var(--rdg-border-color);
 }
 
-.rdg-row:hover .row-context-menu {  
+.rdg-row:hover .row-context-menu {
   visibility: visible;
   width: auto;
 }

--- a/js/src/lib/hooks/ScreenShot.tsx
+++ b/js/src/lib/hooks/ScreenShot.tsx
@@ -14,6 +14,7 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import html2canvas from "html2canvas";
+import { toCanvas } from "html-to-image";
 import { RefObject, useEffect, useRef, useState } from "react";
 import { useClipBoardToast } from "./useClipBoardToast";
 import { format } from "date-fns";
@@ -25,6 +26,7 @@ export const highlightBoxShadow =
   "rgba(0, 0, 0, 0.25) 0px 54px 55px, rgba(0, 0, 0, 0.12) 0px -12px 30px, rgba(0, 0, 0, 0.12) 0px 4px 6px, rgba(0, 0, 0, 0.17) 0px 12px 13px, rgba(0, 0, 0, 0.09) 0px -3px 5px";
 
 export interface HookOptions {
+  renderLibrary?: "html2canvas" | "html-to-image";
   imageType?: "png" | "jpeg";
   backgroundColor?: string | null;
   boardEffect?: boolean;
@@ -47,6 +49,7 @@ export interface BlobHookReturn {
 }
 
 export function useToBlob({
+  renderLibrary = "html2canvas",
   imageType = "png",
   backgroundColor = null,
   boardEffect = true,
@@ -85,7 +88,7 @@ export function useToBlob({
     }
 
     try {
-      nodeToUse.style.overflow = "hidden";
+      nodeToUse.style.overflow = "visible";
       nodeToUse.style.border = boardEffect ? borderStyle : "";
       nodeToUse.style.borderRadius = boardEffect ? borderRadius : "";
       nodeToUse.style.backgroundColor = backgroundColor || "";
@@ -97,13 +100,22 @@ export function useToBlob({
       style.sheet?.insertRule(
         "body > div:last-child img { display: inline-block; }"
       );
+      const filter = ignoreElements
+        ? (n: HTMLElement) => !ignoreElements(n)
+        : undefined;
 
       setStatus("loading");
-      const canvas = await html2canvas(nodeToUse, {
-        logging: false,
-        backgroundColor: null,
-        ignoreElements: ignoreElements,
-      });
+      const canvas =
+        renderLibrary === "html2canvas"
+          ? await html2canvas(nodeToUse, {
+              logging: false,
+              backgroundColor: null,
+              ignoreElements: ignoreElements,
+            })
+          : await toCanvas(nodeToUse, {
+              filter: filter,
+            }); // Use html-to-image for copy reactflow graph
+
       style.remove();
       const outputCanvas = shadowEffect
         ? document.createElement("canvas")

--- a/js/src/lib/hooks/ScreenShot.tsx
+++ b/js/src/lib/hooks/ScreenShot.tsx
@@ -88,7 +88,7 @@ export function useToBlob({
     }
 
     try {
-      nodeToUse.style.overflow = "visible";
+      nodeToUse.style.overflow = "hidden";
       nodeToUse.style.border = boardEffect ? borderStyle : "";
       nodeToUse.style.borderRadius = boardEffect ? borderRadius : "";
       nodeToUse.style.backgroundColor = backgroundColor || "";


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
- Fix the issue when copying the lineage graph. Some of the edges will disappear
- When copy the lineage graph image, change to use `html-to-image` library instead of using `html2canvas`

***Before***
![image](https://github.com/DataRecce/recce/assets/959606/cc206186-0d83-495e-b917-80a4d0a10cda)

***After***
![image](https://github.com/DataRecce/recce/assets/959606/cfd8d1f4-21ff-4bc5-a24d-c4715c5938e5)

***Ref***
https://github.com/xyflow/xyflow/issues/2118

**Which issue(s) this PR fixes**:
DRC-260

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
