### PR TITLE
[Enhancement] Recce run: Only run the row count diff on table models

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -183,7 +183,7 @@ def run(output, **kwargs):
 
     from .server import AppState
     state = AppState(state_file=output)
-    load_default_state(state.state_file)
+    load_default_state()
     asyncio.run(archive_artifacts(state.state_file, **kwargs))
     pass
 

--- a/recce/dbt.py
+++ b/recce/dbt.py
@@ -358,6 +358,7 @@ class DBTContext:
                 'name': node['name'],
                 'resource_type': node['resource_type'],
                 'package_name': node['package_name'],
+                'config': node['config'],
                 'checksum': node['checksum'],
                 'raw_code': node['raw_code'],
             }
@@ -407,6 +408,7 @@ class DBTContext:
                 'name': source['name'],
                 'resource_type': source['resource_type'],
                 'package_name': source['package_name'],
+                'config': source['config'],
             }
 
             if catalog is not None and unique_id in catalog.sources:
@@ -418,6 +420,7 @@ class DBTContext:
                 'name': exposure['name'],
                 'resource_type': exposure['resource_type'],
                 'package_name': exposure['package_name'],
+                'config': exposure['config'],
             }
         for metric in manifest_dict['metrics'].values():
             nodes[metric['unique_id']] = {
@@ -425,6 +428,7 @@ class DBTContext:
                 'name': metric['name'],
                 'resource_type': metric['resource_type'],
                 'package_name': metric['package_name'],
+                'config': metric['config'],
             }
 
         if 'semantic_models' in manifest_dict:
@@ -434,6 +438,7 @@ class DBTContext:
                     'name': semantic_models['name'],
                     'resource_type': semantic_models['resource_type'],
                     'package_name': semantic_models['package_name'],
+                    'config': semantic_models['config'],
                 }
 
         metadata = dict(

--- a/recce/run.py
+++ b/recce/run.py
@@ -1,15 +1,16 @@
 import os
+import time
 
 from rich.console import Console
 
 from recce.apis.run_func import submit_run
+from recce.dbt import DBTContext
 from recce.models.lineage import LineageDAO
 from recce.models.state import default_recce_state
 from recce.models.types import Lineage, RunType
 
 
 def check_github_ci_env(**kwargs):
-    github_pull_request_url = None
     """Check if the environment is GitHub CI"""
     if 'GITHUB_ACTIONS' not in os.environ:
         return False, None
@@ -23,17 +24,76 @@ def check_github_ci_env(**kwargs):
     return True, github_pull_request_url
 
 
+async def execute_default_runs(context: DBTContext):
+    """
+    Execute the default runs. It includes
+
+    1. Run 'row_count_diff' for all the modified table models
+    """
+
+    try:
+        # Query the row count of all the nodes in the lineage
+        node_ids = []
+
+        for node in context.curr_manifest.nodes.values():
+            if node.resource_type != 'model':
+                continue
+
+            materialized = node.config.materialized
+            if materialized != 'table' and materialized != 'incremental':
+                continue
+
+            base_node = context.base_manifest.nodes.get(node.unique_id)
+            if not base_node:
+                continue
+
+            if not node.checksum or not base_node.checksum or node.checksum.checksum == base_node.checksum.checksum:
+                continue
+
+            node_ids.append(node.unique_id)
+
+        print(f"Querying row count diff for the modified table models. [{len(node_ids)} node(s)]")
+        if len(node_ids) == 0:
+            print("Skipped")
+            return
+
+        start = time.time()
+        run, future = submit_run(RunType.ROW_COUNT_DIFF, params={
+            'node_ids': node_ids
+        })
+        await future
+        end = time.time()
+        print(f"Completed in {end - start:.2f} seconds")
+    except Exception as e:
+        print("Failed to run queries")
+        raise e
+
+
 async def archive_artifacts(state_file: str, **kwargs):
-    console = Console()
     """Archive the artifacts"""
+    console = Console()
+
     from recce.dbt import load_dbt_context
     ctx = load_dbt_context()
     is_skip_query = kwargs.get('skip_query', False)
 
     # Prepare the artifact by collecting the lineage
-    console.rule("Collecting the lineage")
+    console.rule("DBT Artifacts")
+    print(f"Base:")
+    print(f"    Manifest: {ctx.base_manifest.metadata.generated_at}")
+    print(f"    Catalog:  {ctx.base_catalog.metadata.generated_at if ctx.base_catalog else 'N/A'}")
+
+    print(f"Current:")
+    print(f"    Manifest: {ctx.curr_manifest.metadata.generated_at}")
+    print(f"    Catalog:  {ctx.curr_catalog.metadata.generated_at if ctx.curr_catalog else 'N/A'}")
     base = ctx.get_lineage(base=True)
     current = ctx.get_lineage(base=False)
+    lineage = Lineage(
+        base=base,
+        current=current,
+    )
+    LineageDAO().set(lineage)
+
     # patch the metadata
     if 'git_current_branch' in kwargs:
         current['metadata']['git_branch'] = kwargs.get('git_current_branch')
@@ -42,32 +102,15 @@ async def archive_artifacts(state_file: str, **kwargs):
     if 'github_pull_request_url' in kwargs:
         current['metadata']['pr_url'] = kwargs.get('github_pull_request_url')
 
-    lineage = Lineage(
-        base=base,
-        current=current,
-    )
-    LineageDAO().set(lineage)
-
-    if is_skip_query:
-        print("Skip querying row count for nodes in the lineage")
+    # Execute the default runs
+    console.rule("Default queries")
+    if not is_skip_query:
+        await execute_default_runs(ctx)
     else:
-        try:
-            # Query the row count of all the nodes in the lineage
-            print("Querying row count for nodes in the lineage")
-            base_nodes = list(base.get('nodes', []).keys())
-            current_nodes = list(current.get('nodes', []).keys())
-            node_ids = list(set(base_nodes + current_nodes))
-            print(f"Total nodes: {len(node_ids)}")
+        print("Skip querying row counts")
 
-            run, future = submit_run(RunType.ROW_COUNT_DIFF, params={
-                'node_ids': node_ids
-            })
-            print(f"Run is submitted: {run.run_id}")
-            await future
-        except Exception as e:
-            print(f"Failed to submit run: {e}")
-
-    # Patch metadata
+    # Store the state
+    console.rule("Output the state file")
     default_recce_state().store(state_file, **kwargs)
-    print(f'State is stored as {state_file}')
+    print(f'The state file is stored at [{state_file}]')
     pass

--- a/recce/run.py
+++ b/recce/run.py
@@ -79,11 +79,11 @@ async def archive_artifacts(state_file: str, **kwargs):
 
     # Prepare the artifact by collecting the lineage
     console.rule("DBT Artifacts")
-    print(f"Base:")
+    print("Base:")
     print(f"    Manifest: {ctx.base_manifest.metadata.generated_at}")
     print(f"    Catalog:  {ctx.base_catalog.metadata.generated_at if ctx.base_catalog else 'N/A'}")
 
-    print(f"Current:")
+    print("Current:")
     print(f"    Manifest: {ctx.curr_manifest.metadata.generated_at}")
     print(f"    Catalog:  {ctx.curr_catalog.metadata.generated_at if ctx.curr_catalog else 'N/A'}")
     base = ctx.get_lineage(base=True)


### PR DESCRIPTION
Improve
-  run only the modified table model (including table and materialized)
- add the query time for the row count diff

Fix
- the state file is loaded if the file `recce_state.json` exists. It will let the keep the previous run results.

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
