### PR TITLE
[Bug] unable to run top k diff due to bigquery error

### DIFF
--- a/js/src/components/charts/TopKSummaryList.tsx
+++ b/js/src/components/charts/TopKSummaryList.tsx
@@ -16,6 +16,7 @@ import {
 } from "chart.js";
 import { Bar } from "react-chartjs-2";
 import { BASE_BAR_COLOR, CURRENT_BAR_COLOR, SquareIcon } from "./SquareIcon";
+import { is } from "date-fns/locale";
 
 export const INFO_VAL_COLOR = "#63B3ED";
 
@@ -31,6 +32,7 @@ interface Summary {
   displayCount: string;
   displayRatio: string;
   isLastItemOthers: boolean;
+  isSpecialLabel: boolean;
 }
 
 function prepareSummaryList(
@@ -47,9 +49,26 @@ function prepareSummaryList(
     const isLastItemOthers = index === counts.length;
     const count = isLastItemOthers ? remainingSumCount : counts[index];
 
+    let label: string;
+    let isSpecialLabel = false;
+
+    if (isLastItemOthers) {
+      label = "(others)";
+      isSpecialLabel = true;
+    } else if (v === undefined || v === null) {
+      label = "(null)";
+      isSpecialLabel = true;
+    } else if (typeof v === "string" && v.length === 0) {
+      label = "(empty)";
+      isSpecialLabel = true;
+    } else {
+      label = String(v);
+    }
+
     return {
       isLastItemOthers,
-      label: isLastItemOthers ? "(others)" : String(v) || "(empty)",
+      isSpecialLabel,
+      label,
       count: count,
       displayCount: formatAsAbbreviatedNumber(count),
       displayRatio: formatIntervalMinMax(count / topK.valids) || "N/A",
@@ -131,11 +150,7 @@ export function TopKSummaryBarChart({
                   noOfLines={1}
                   width={"10em"}
                   fontSize={"sm"}
-                  color={
-                    current.isLastItemOthers || current.label.length === 0
-                      ? "gray.400"
-                      : "inherit"
-                  }
+                  color={current.isSpecialLabel ? "gray.400" : "inherit"}
                 >
                   {current.label}
                 </Text>
@@ -215,7 +230,6 @@ export function TopKSummaryList({ topk, valids, isDisplayTopTen }: Props) {
         const isLastItemOthers = index === displayList.length;
         const topkCount = isLastItemOthers ? remainingSumCount : v;
         const catName = String(topk.values[index]);
-
         const topkLabel = isLastItemOthers ? "(others)" : catName || "(empty)";
         const displayTopkCount = formatAsAbbreviatedNumber(topkCount);
         const displayTopkRatio = formatIntervalMinMax(topkCount / valids);

--- a/js/src/components/charts/TopKSummaryList.tsx
+++ b/js/src/components/charts/TopKSummaryList.tsx
@@ -16,7 +16,6 @@ import {
 } from "chart.js";
 import { Bar } from "react-chartjs-2";
 import { BASE_BAR_COLOR, CURRENT_BAR_COLOR, SquareIcon } from "./SquareIcon";
-import { is } from "date-fns/locale";
 
 export const INFO_VAL_COLOR = "#63B3ED";
 

--- a/recce/dbt.py
+++ b/recce/dbt.py
@@ -521,7 +521,11 @@ class DBTContext:
             self.load_artifacts_from_state()
 
     def create_relation(self, model, base=False):
-        return self.adapter.Relation.create_from(self.runtime_config, self.find_node_by_name(model, base))
+        node = self.find_node_by_name(model, base)
+        if node is None:
+            return None
+
+        return self.adapter.Relation.create_from(self.runtime_config, node)
 
 
 dbt_context: Optional[DBTContext] = None

--- a/recce/tasks/top_k.py
+++ b/recce/tasks/top_k.py
@@ -34,14 +34,14 @@ class TopKDiffTask(Task, QueryMixin):
         WITH
         BASE_CAT as (
             select
-                coalesce(cast({{column}} as VARCHAR), '__null__') as category,
+                coalesce(cast({{column}} as {{ dbt.type_string() }}), '__null__') as category,
                 count(*) as c
             from {{base_relation}}
             group by category
         ),
         CURR_CAT as (
             select
-                coalesce(cast({{column}} as VARCHAR), '__null__') as category,
+                coalesce(cast({{column}} as {{ dbt.type_string() }}), '__null__') as category,
                 count(*) as c
             from {{cur_relation}}
             group by category


### PR DESCRIPTION
Fix #252 

In the bigquery, it does not support `unnest`

Solution:
Change to use JOIN on two sides and order by the counts of current enviornemtn

Note:

The reason why we use `__null__` in the CTE is because the outer join would not join the key is NULL for both side. So we use `__null__` to work around it.

https://stackoverflow.com/questions/72917878/snowflake-handling-of-nulls-in-a-join

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
