### PR TITLE
[Bug] DRC-316 Artifact server observer does not work in windows

### DIFF
--- a/recce/server.py
+++ b/recce/server.py
@@ -53,7 +53,9 @@ app = FastAPI(lifespan=lifespan)
 
 
 def dbt_artifacts_updated_callback(file_changed_event: Any):
-    target_type, file_name = file_changed_event.src_path.split("/")[-2:]
+    src_path = Path(file_changed_event.src_path)
+    target_type = src_path.parent.name
+    file_name = src_path.name
     logger.info(
         f'Detect {target_type} file {file_changed_event.event_type}: {file_name}')
     ctx = load_dbt_context()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Use the Pathlib library to ensure dbt artifact changes are detectable on Windows.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE