### PR TITLE
[Bug] Fix recce run failed if no state file exists

### DIFF
--- a/recce/dbt.py
+++ b/recce/dbt.py
@@ -178,7 +178,7 @@ class DBTContext:
         profile_name = kwargs.get('profile')
         project_dir = kwargs.get('project_dir')
         profiles_dir = kwargs.get('profiles_dir')
-        state_file = kwargs.get('state_file', 'recce_state.json')
+        state_file = kwargs.get('state_file')
         is_review_mode = kwargs.get('review', False)
 
         # We need to run the dbt parse command because

--- a/recce/run.py
+++ b/recce/run.py
@@ -73,7 +73,7 @@ async def cli_run(state_file: str, **kwargs):
     console = Console()
 
     from recce.dbt import load_dbt_context
-    ctx = load_dbt_context()
+    ctx = load_dbt_context(**kwargs)
     is_skip_query = kwargs.get('skip_query', False)
 
     # Prepare the artifact by collecting the lineage


### PR DESCRIPTION
```
$ recce run
```
It raise error that `recce_state.json` not found

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug