### PR TITLE
[Bug] API endpoint /api/lineage not found

### DIFF
--- a/recce/core.py
+++ b/recce/core.py
@@ -182,6 +182,5 @@ def load_context(**kwargs) -> RecceContext:
 
 
 def default_context() -> RecceContext:
-    logger.info("deprecated. Use default_context() instead")
     global recce_context
     return recce_context

--- a/recce/server.py
+++ b/recce/server.py
@@ -102,6 +102,17 @@ async def set_context_by_cookie(request: Request, call_next):
     return response
 
 
+@app.middleware("http")
+async def disable_cache(request: Request, call_next):
+    response = await call_next(request)
+
+    # disable cache for '/' and '/index.html'
+    if request.url.path in ['/', '/index.html']:
+        response.headers['Cache-Control'] = 'no-cache'
+
+    return response
+
+
 @app.get("/api/health")
 async def health_check(request: Request):
     return {"status": "ok"}


### PR DESCRIPTION
## Root cause
The root endpoint is cached. So the client and server code is not in sync.

## Solution
Disable cache for the root endpoint