### PR TITLE
[Bug] The recce summary would raise exception if node is excluded

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -392,8 +392,6 @@ class DbtAdapter(BaseAdapter):
 
         manifest_dict = manifest.to_dict()
 
-        parent_map = {k: v for k, v in manifest_dict['parent_map'].items() if not k.startswith('test.')}
-
         nodes = {}
 
         for node in manifest_dict['nodes'].values():
@@ -492,6 +490,8 @@ class DbtAdapter(BaseAdapter):
                     'config': semantic_models['config'],
                 }
 
+        nodeIds = nodes.keys()
+        parent_map = {k: v for k, v in manifest_dict['parent_map'].items() if k in nodeIds}
         return dict(
             parent_map=parent_map,
             nodes=nodes,

--- a/recce/summary.py
+++ b/recce/summary.py
@@ -1,3 +1,4 @@
+import sys
 from typing import List, Dict, Set, Union, Type, Optional
 from uuid import UUID
 
@@ -16,6 +17,11 @@ from recce.tasks.valuediff import ValueDiffTaskResultDiffer, ValueDiffDetailTask
 ADD_COLOR = '#1dce00'
 MODIFIED_COLOR = '#ffa502'
 REMOVE_COLOR = '#ff067e'
+
+
+def _warn(msg):
+    # print to stderr
+    print(f"warning: {msg}", file=sys.stderr)
 
 
 class Node:
@@ -219,9 +225,11 @@ class LineageGraph:
 
     def create_edge(self, parent_id: str, child_id: str, edge_from: str = 'base'):
         if parent_id not in self.nodes:
-            raise ValueError(f'Parent node {parent_id} not found in graph')
+            _warn(f'Parent node {parent_id} not found in graph')
+            return
         if child_id not in self.nodes:
-            raise ValueError(f'Child node {child_id} not found in graph')
+            _warn(f'Child node {child_id} not found in graph')
+            return
 
         edge_id = f'{parent_id}-->{child_id}'
         if edge_id in self.edges:


### PR DESCRIPTION
Fix #336 
Root cause
The node type 'snapshot' is not handled correctly.

Solution
When building the lineage graph object, dont put the the excluded node to the `parent_map` dict


**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
