### PR TITLE
[Bug] Should get the repository name from the ci event object

### DIFF
--- a/recce/pull_request.py
+++ b/recce/pull_request.py
@@ -18,6 +18,7 @@ def fetch_pr_metadata(**kwargs):
         pr_info.id = metadata.get('github_pr_id')
         pr_info.url = metadata.get('github_pr_url')
         pr_info.title = metadata.get('github_pr_title')
+        pr_info.repository = metadata.get('github_repository')
     else:
         repo = hosting_repo()
         pr = recce_pr_information(github_token=kwargs.get('github_token'))
@@ -53,8 +54,9 @@ def fetch_pr_metadata_from_event_path() -> Optional[dict]:
         Example:
         {
             "github_pr_id": 1,
-            "github_pr_url": "https://github.com/xyz/abc/pull/1
-            "github_pr_title": "Update README.md"
+            "github_pr_url": "https://github.com/xyz/abc/pull/1,
+            "github_pr_title": "Update README.md",
+            "github_repository": "xyz/abc"
         }
 
         :return: dict
@@ -62,6 +64,7 @@ def fetch_pr_metadata_from_event_path() -> Optional[dict]:
 
     # get the event json from the path in GITHUB_EVENT_PATH
     event_path = os.getenv("GITHUB_EVENT_PATH")
+    github_repository = os.getenv("GITHUB_REPOSITORY")
     if event_path:
         try:
             with open(event_path, "r") as event_file:
@@ -73,7 +76,10 @@ def fetch_pr_metadata_from_event_path() -> Optional[dict]:
                 pr_url = pull_request_data["_links"]["html"]["href"]
                 pr_api = pull_request_data["_links"]["self"]["href"]
                 pr_title = _fetch_pr_title(pr_api)
-                return dict(github_pr_id=pr_id, github_pr_url=pr_url, github_pr_title=pr_title)
+                return dict(github_pr_id=pr_id,
+                            github_pr_url=pr_url,
+                            github_pr_title=pr_title,
+                            github_repository=github_repository)
             else:
                 print("Not a pull request event, skip.")
         except Exception as e:

--- a/tests/test_pull_request.py
+++ b/tests/test_pull_request.py
@@ -23,6 +23,7 @@ def mock_github_event(tmp_path, monkeypatch):
         json.dump(event_data, f)
 
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "abc/xyz")
 
 
 @pytest.fixture
@@ -62,6 +63,7 @@ def test_fetch_pr_metadata(mock_github_event, mock_github_token, mock_get_reques
     assert result["github_pr_id"] == 1
     assert result["github_pr_url"] == "https://github.com/xyz/abc/pull/1"
     assert result["github_pr_title"] == "Update README.md"
+    assert result["github_repository"] == "abc/xyz"
 
 
 def test_fetch_pr_metadata_no_event(mock_get_request_success, monkeypatch):


### PR DESCRIPTION
Run `recce run --cloud` in the github action, we cannot get the github pr information succesfully

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
