### PR TITLE
[Fix] DRC-511 build the nodes by `nodes` instead of `parent_map`

### DIFF
--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -98,9 +98,8 @@ export function buildLineageGraph(
     };
   };
 
-  for (const [key, parents] of Object.entries(base.parent_map)) {
+  for (const [key, nodeData] of Object.entries(base.nodes)) {
     nodes[key] = buildNode(key, "base");
-    const nodeData = base.nodes && base.nodes[key];
     if (nodeData) {
       nodes[key].data.base = nodeData;
       nodes[key].name = nodeData?.name;
@@ -109,13 +108,12 @@ export function buildLineageGraph(
     }
   }
 
-  for (const [key, parents] of Object.entries(current.parent_map)) {
+  for (const [key, nodeData] of Object.entries(current.nodes)) {
     if (nodes[key]) {
       nodes[key].from = "both";
     } else {
       nodes[key] = buildNode(key, "current");
     }
-    const nodeData = current.nodes && current.nodes[key];
     if (nodeData) {
       nodes[key].data.current = current.nodes && current.nodes[key];
       nodes[key].name = nodeData?.name;
@@ -129,6 +127,11 @@ export function buildLineageGraph(
       const childNode = nodes[child];
       const parentNode = nodes[parent];
       const id = `${parent}_${child}`;
+
+      if (!childNode || !parentNode) {
+        // Skip the edge if the node is not found
+        continue;
+      }
       edges[id] = {
         id,
         from: "base",
@@ -148,6 +151,10 @@ export function buildLineageGraph(
       const parentNode = nodes[parent];
       const id = `${parent}_${child}`;
 
+      if (!childNode || !parentNode) {
+        // Skip the edge if the node is not found
+        continue;
+      }
       if (edges[id]) {
         edges[id].from = "both";
       } else {

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -491,7 +491,12 @@ class DbtAdapter(BaseAdapter):
                 }
 
         nodeIds = nodes.keys()
-        parent_map = {k: v for k, v in manifest_dict['parent_map'].items() if k in nodeIds}
+        parent_map = {}
+        for k, parents in manifest_dict['parent_map'].items():
+            if k not in nodeIds:
+                continue
+            parent_map[k] = [parent for parent in parents if parent in nodeIds]
+
         return dict(
             parent_map=parent_map,
             nodes=nodes,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
Build the node based on dbt manifest's `nodes` instead of `parent_map`

**Which issue(s) this PR fixes**:
#344 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
