### PR TITLE
[Bug] The dbt deps should not be required in the review mode

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -598,6 +598,16 @@ class DbtAdapter(BaseAdapter):
 
         self.manifest = as_manifest(self.curr_manifest)
 
+        # The dependencies of the review mode is derived from manifests.
+        # It is a workaround solution to use macro dispatch
+        # see: https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch
+        dependencies = {}
+        for macro in self.manifest.macros.values():
+            if macro.package_name not in dependencies:
+                dependencies[macro.package_name] = self.runtime_config
+
+        self.runtime_config.dependencies = dependencies
+
         if not self.curr_manifest or not self.base_manifest:
             raise Exception(
                 'No enough dbt artifacts in the state file. Please use the latest recce to generate the recce state')


### PR DESCRIPTION
In the recce server review, it should not be necessary to run `dbt deps` beforehand. Because the macros should from the manifests in the state file.

```
recce server --review <state_file>
```

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
