### PR TITLE
[Feature] Support node selector in schema check

### DIFF
--- a/js/src/components/check/CheckDescription.tsx
+++ b/js/src/components/check/CheckDescription.tsx
@@ -77,7 +77,6 @@ export function CheckDescription({ value, onChange }: CheckDescriptionProps) {
 
   return (
     <Text
-      maxHeight="400px"
       overflow="auto"
       fontSize="11pt"
       onClick={handleEdit}

--- a/js/src/components/check/CheckDescription.tsx
+++ b/js/src/components/check/CheckDescription.tsx
@@ -55,13 +55,13 @@ export function CheckDescription({ value, onChange }: CheckDescriptionProps) {
 
   if (editing) {
     return (
-      <Flex direction="column" align="flex-end">
+      <Flex direction="column" align="flex-end" height="100%">
         <Textarea
-          h="200px"
           value={tempValue}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           ref={textareaRef}
+          flex={1}
         ></Textarea>
         <Flex gap="12px" alignItems="flex-end">
           <Link onClick={handleCancel} colorScheme="blue">
@@ -81,7 +81,7 @@ export function CheckDescription({ value, onChange }: CheckDescriptionProps) {
       overflow="auto"
       fontSize="11pt"
       onClick={handleEdit}
-      whiteSpace="pre-line"
+      whiteSpace="pre"
       color={!value ? "lightgray" : "inherit"}
     >
       {!value ? "Add description here" : value}

--- a/js/src/components/check/CheckDetail.tsx
+++ b/js/src/components/check/CheckDetail.tsx
@@ -23,6 +23,11 @@ import {
   ModalHeader,
   ModalOverlay,
   Spacer,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
   Tag,
   TagLeftIcon,
   Tooltip,
@@ -229,8 +234,17 @@ export const CheckDetail = ({ checkId }: CheckDetailProps) => {
     : null;
 
   return (
-    <VSplit style={{ height: "100%", width: "100%", maxHeight: "100%" }}>
-      <Box style={{ contain: "size" }}>
+    <VSplit
+      minSize={200}
+      style={{ height: "100%", width: "100%", maxHeight: "100%" }}
+    >
+      {/* <Flex style={{ contain: "strict" }} flexDirection="column"> */}
+      <Box
+        style={{ contain: "strict" }}
+        display="flex"
+        flexDirection="column"
+        overflowY="auto"
+      >
         <Flex p="0px 16px" alignItems="center">
           <CheckBreadcrumb
             name={check?.name || ""}
@@ -318,57 +332,58 @@ export const CheckDetail = ({ checkId }: CheckDetailProps) => {
           </Tooltip>
         </Flex>
 
-        <Box p="8px 16px" minHeight="100px">
+        <Box flex="1" p="8px 16px" minHeight="100px">
           <CheckDescription
             key={check?.check_id}
             value={check?.description}
             onChange={handleUpdateDescription}
           />
         </Box>
-
-        {(check?.type === "query" || check?.type === "query_diff") && (
-          <Accordion defaultIndex={[]} allowToggle>
-            <AccordionItem>
-              <AccordionButton>
-                query
-                <AccordionIcon />
-              </AccordionButton>
-
-              <AccordionPanel>
-                <Box height="400px" width="100%" border="lightgray 1px solid ">
-                  <SqlEditor
-                    value={(check?.params as any)?.sql_template || ""}
-                    options={{ readOnly: true }}
-                  />
-                </Box>
-              </AccordionPanel>
-            </AccordionItem>
-          </Accordion>
-        )}
+        {/* </Flex> */}
       </Box>
 
-      <Box style={{ contain: "size" }}>
-        {runTypeEntry?.RunResultView && (
-          <RunView
-            isPending={rerunPending}
-            isAborting={abort}
-            isCheckDetail={true}
-            run={run}
-            error={rerunError}
-            progress={progress}
-            RunResultView={runTypeEntry.RunResultView}
-            viewOptions={check?.view_options}
-            onViewOptionsChanged={handelUpdateViewOptions}
-            onCancel={handleCancel}
-            onExecuteRun={handleRerun}
-          />
-        )}
-        {check && check.type === "schema_diff" && (
-          <SchemaDiffView check={check} />
-        )}
-        {check && check.type === "lineage_diff" && (
-          <LineageDiffView check={check} />
-        )}
+      <Box style={{ contain: "strict" }}>
+        <Tabs height="100%" display="flex" flexDirection="column">
+          <TabList>
+            <Tab fontSize="10pt">Result</Tab>
+            {(check?.type === "query" || check?.type === "query_diff") && (
+              <Tab fontSize="10pt">Query</Tab>
+            )}
+          </TabList>
+          <TabPanels height="100%" flex="1">
+            <TabPanel p={0} width="100%" height="100%">
+              {runTypeEntry?.RunResultView && (
+                <RunView
+                  isPending={rerunPending}
+                  isAborting={abort}
+                  isCheckDetail={true}
+                  run={run}
+                  error={rerunError}
+                  progress={progress}
+                  RunResultView={runTypeEntry.RunResultView}
+                  viewOptions={check?.view_options}
+                  onViewOptionsChanged={handelUpdateViewOptions}
+                  onCancel={handleCancel}
+                  onExecuteRun={handleRerun}
+                />
+              )}
+              {check && check.type === "schema_diff" && (
+                <SchemaDiffView check={check} />
+              )}
+              {check && check.type === "lineage_diff" && (
+                <LineageDiffView check={check} />
+              )}
+            </TabPanel>
+            {(check?.type === "query" || check?.type === "query_diff") && (
+              <TabPanel p={0} height="100%" width="100%">
+                <SqlEditor
+                  value={(check?.params as any)?.sql_template || ""}
+                  options={{ readOnly: true }}
+                />
+              </TabPanel>
+            )}
+          </TabPanels>
+        </Tabs>
       </Box>
       <Modal
         isOpen={isPresetCheckTemplateOpen}

--- a/js/src/components/check/CheckDetail.tsx
+++ b/js/src/components/check/CheckDetail.tsx
@@ -235,15 +235,15 @@ export const CheckDetail = ({ checkId }: CheckDetailProps) => {
 
   return (
     <VSplit
-      minSize={200}
+      minSize={100}
+      sizes={[30, 70]}
       style={{ height: "100%", width: "100%", maxHeight: "100%" }}
     >
-      {/* <Flex style={{ contain: "strict" }} flexDirection="column"> */}
       <Box
         style={{ contain: "strict" }}
         display="flex"
         flexDirection="column"
-        overflowY="auto"
+        overflow="auto"
       >
         <Flex p="0px 16px" alignItems="center">
           <CheckBreadcrumb
@@ -350,7 +350,7 @@ export const CheckDetail = ({ checkId }: CheckDetailProps) => {
               <Tab fontSize="10pt">Query</Tab>
             )}
           </TabList>
-          <TabPanels height="100%" flex="1">
+          <TabPanels height="100%" flex="1" style={{ contain: "strict" }}>
             <TabPanel p={0} width="100%" height="100%">
               {runTypeEntry?.RunResultView && (
                 <RunView

--- a/js/src/components/check/CheckDetail.tsx
+++ b/js/src/components/check/CheckDetail.tsx
@@ -57,6 +57,7 @@ import { formatDistanceToNow } from "date-fns";
 import { LineageDiffView } from "./LineageDiffView";
 import { findByRunType } from "../run/registry";
 import { PresetCheckTemplateView } from "./PresetCheckTemplateView";
+import { VSplit } from "../split/Split";
 
 interface CheckDetailProps {
   checkId: string;
@@ -228,123 +229,125 @@ export const CheckDetail = ({ checkId }: CheckDetailProps) => {
     : null;
 
   return (
-    <Flex height="100%" width="100%" maxHeight="100%" direction="column">
-      <Flex p="0px 16px" alignItems="center">
-        <CheckBreadcrumb
-          name={check?.name || ""}
-          setName={(name) => {
-            mutate({ name });
-          }}
-        />
-        <Spacer />
-        {isPresetCheck && (
-          <Tooltip label="Preset Check defined in recce config">
-            <Tag size="sm">
-              <TagLeftIcon boxSize={"14px"} as={CiBookmark} />
-              Preset
-            </Tag>
-          </Tooltip>
-        )}
-        <Menu>
-          <MenuButton
-            isRound={true}
-            as={IconButton}
-            icon={<Icon as={VscKebabVertical} />}
-            variant="ghost"
+    <VSplit style={{ height: "100%", width: "100%", maxHeight: "100%" }}>
+      <Box style={{ contain: "size" }}>
+        <Flex p="0px 16px" alignItems="center">
+          <CheckBreadcrumb
+            name={check?.name || ""}
+            setName={(name) => {
+              mutate({ name });
+            }}
           />
-          <MenuList>
-            <MenuItem
-              icon={<IoMdCodeWorking />}
-              onClick={() => {
-                setOverlay(<Overlay />);
-                onPresetCheckTemplateOpen();
-              }}
+          <Spacer />
+          {isPresetCheck && (
+            <Tooltip label="Preset Check defined in recce config">
+              <Tag size="sm">
+                <TagLeftIcon boxSize={"14px"} as={CiBookmark} />
+                Preset
+              </Tag>
+            </Tooltip>
+          )}
+          <Menu>
+            <MenuButton
+              isRound={true}
+              as={IconButton}
+              icon={<Icon as={VscKebabVertical} />}
+              variant="ghost"
+            />
+            <MenuList>
+              <MenuItem
+                icon={<IoMdCodeWorking />}
+                onClick={() => {
+                  setOverlay(<Overlay />);
+                  onPresetCheckTemplateOpen();
+                }}
+              >
+                Get Preset Check Template
+              </MenuItem>
+              <MenuItem icon={<DeleteIcon />} onClick={() => handleDelete()}>
+                Delete
+              </MenuItem>
+            </MenuList>
+          </Menu>
+
+          {relativeTime && (
+            <Box
+              textOverflow="ellipsis"
+              whiteSpace="nowrap"
+              overflow="hidden"
+              fontSize="10pt"
             >
-              Get Preset Check Template
-            </MenuItem>
-            <MenuItem icon={<DeleteIcon />} onClick={() => handleDelete()}>
-              Delete
-            </MenuItem>
-          </MenuList>
-        </Menu>
+              {relativeTime}
+            </Box>
+          )}
 
-        {relativeTime && (
-          <Box
-            textOverflow="ellipsis"
-            whiteSpace="nowrap"
-            overflow="hidden"
-            fontSize="10pt"
-          >
-            {relativeTime}
-          </Box>
-        )}
+          {runTypeEntry?.RunResultView && (
+            <Tooltip label="Rerun">
+              <IconButton
+                isRound={true}
+                isLoading={rerunPending}
+                variant="ghost"
+                aria-label="Rerun"
+                icon={<RepeatIcon />}
+                onClick={() => handleRerun()}
+              />
+            </Tooltip>
+          )}
 
-        {runTypeEntry?.RunResultView && (
-          <Tooltip label="Rerun">
+          <Tooltip label="Copy markdown">
             <IconButton
               isRound={true}
-              isLoading={rerunPending}
               variant="ghost"
-              aria-label="Rerun"
-              icon={<RepeatIcon />}
-              onClick={() => handleRerun()}
+              aria-label="Copy markdown"
+              icon={<CopyIcon />}
+              onClick={() => handleCopy()}
             />
           </Tooltip>
-        )}
 
-        <Tooltip label="Copy markdown">
-          <IconButton
-            isRound={true}
-            variant="ghost"
-            aria-label="Copy markdown"
-            icon={<CopyIcon />}
-            onClick={() => handleCopy()}
-          />
-        </Tooltip>
-
-        <Tooltip
-          label={check?.is_checked ? "Mark as unchecked" : "Mark as checked"}
-        >
-          <Button
-            size="sm"
-            colorScheme={check?.is_checked ? "green" : "gray"}
-            leftIcon={<CheckCircleIcon />}
-            onClick={() => handleCheck()}
+          <Tooltip
+            label={check?.is_checked ? "Mark as unchecked" : "Mark as checked"}
           >
-            {check?.is_checked ? "Checked" : "Unchecked"}
-          </Button>
-        </Tooltip>
-      </Flex>
+            <Button
+              size="sm"
+              colorScheme={check?.is_checked ? "green" : "gray"}
+              leftIcon={<CheckCircleIcon />}
+              onClick={() => handleCheck()}
+            >
+              {check?.is_checked ? "Checked" : "Unchecked"}
+            </Button>
+          </Tooltip>
+        </Flex>
 
-      <Box p="8px 16px" minHeight="100px">
-        <CheckDescription
-          key={check?.check_id}
-          value={check?.description}
-          onChange={handleUpdateDescription}
-        />
+        <Box p="8px 16px" minHeight="100px">
+          <CheckDescription
+            key={check?.check_id}
+            value={check?.description}
+            onChange={handleUpdateDescription}
+          />
+        </Box>
+
+        {(check?.type === "query" || check?.type === "query_diff") && (
+          <Accordion defaultIndex={[]} allowToggle>
+            <AccordionItem>
+              <AccordionButton>
+                query
+                <AccordionIcon />
+              </AccordionButton>
+
+              <AccordionPanel>
+                <Box height="400px" width="100%" border="lightgray 1px solid ">
+                  <SqlEditor
+                    value={(check?.params as any)?.sql_template || ""}
+                    options={{ readOnly: true }}
+                  />
+                </Box>
+              </AccordionPanel>
+            </AccordionItem>
+          </Accordion>
+        )}
       </Box>
 
-      {(check?.type === "query" || check?.type === "query_diff") && (
-        <Accordion defaultIndex={[]} allowToggle>
-          <AccordionItem>
-            <AccordionButton>
-              query
-              <AccordionIcon />
-            </AccordionButton>
-
-            <AccordionPanel>
-              <Box height="400px" width="100%" border="lightgray 1px solid ">
-                <SqlEditor
-                  value={(check?.params as any)?.sql_template || ""}
-                  options={{ readOnly: true }}
-                />
-              </Box>
-            </AccordionPanel>
-          </AccordionItem>
-        </Accordion>
-      )}
-
-      <Box style={{ contain: "size" }} flex="1 1 0%">
+      <Box style={{ contain: "size" }}>
         {runTypeEntry?.RunResultView && (
           <RunView
             isPending={rerunPending}
@@ -398,7 +401,7 @@ export const CheckDetail = ({ checkId }: CheckDetailProps) => {
           </ModalBody>
         </ModalContent>
       </Modal>
-    </Flex>
+    </VSplit>
   );
 };
 

--- a/js/src/components/check/CheckList.tsx
+++ b/js/src/components/check/CheckList.tsx
@@ -97,6 +97,7 @@ export const CheckList = ({
             w="full"
             spacing="0"
             flex="1"
+            overflow={"auto"}
           >
             {checks.map((check, index) => (
               <Draggable

--- a/js/src/components/check/CheckPage.tsx
+++ b/js/src/components/check/CheckPage.tsx
@@ -114,13 +114,18 @@ export const CheckPage = () => {
   }
 
   return (
-    <HSplit style={{ height: "100%" }} minSize={300} sizes={[10, 90]}>
+    <HSplit style={{ height: "100%" }} minSize={50} sizes={[20, 80]}>
       <Box
         borderRight="lightgray solid 1px"
         height="100%"
         style={{ contain: "size" }}
       >
-        <VStack spacing={0} align="flex-end" h="100%">
+        <VStack
+          spacing={0}
+          align="flex-end"
+          h="100%"
+          style={{ contain: "strict" }}
+        >
           <Tooltip label="Copy checklist to the clipboard">
             <IconButton
               mr="10px"

--- a/js/src/components/check/SchemaDiffView.tsx
+++ b/js/src/components/check/SchemaDiffView.tsx
@@ -148,13 +148,13 @@ export function SchemaDiffView({ check }: SchemaDiffViewProps) {
   } else if (selected < nodes.length) {
     const node = nodes[selected];
     return (
-      <HSplit sizes={[80, 20]} minSize={200} style={{ height: "100%" }}>
+      <HSplit sizes={[80, 20]} minSize={30} style={{ height: "100%" }}>
         <SchemaView
           base={node.data.base}
           current={node.data.current}
           enableScreenshot={true}
         />
-        <List>
+        <List overflow="auto">
           {nodes.map((node, i) => (
             <NodelistItem
               key={i}

--- a/js/src/components/check/SchemaDiffView.tsx
+++ b/js/src/components/check/SchemaDiffView.tsx
@@ -1,29 +1,119 @@
 import { Check } from "@/lib/api/checks";
 import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 import { SchemaView } from "../schema/SchemaView";
+import { useQuery } from "@tanstack/react-query";
+import { cacheKeys } from "@/lib/api/cacheKeys";
+import { select } from "@/lib/api/select";
+import { HSplit } from "../split/Split";
+import { Box, Flex, List, ListItem } from "@chakra-ui/react";
+import { LineageGraphNode } from "../lineage/lineage";
+import { useState } from "react";
 
 interface SchemaDiffViewProps {
   check: Check;
 }
 
 export interface SchemaDiffParams {
-  node_id: string;
+  node_id?: string;
+  select?: string;
+  exclude?: string;
 }
+
+const NodelistItem = ({
+  node,
+  selected,
+  onSelect,
+}: {
+  node: LineageGraphNode;
+  selected: boolean;
+  onSelect: (nodeId: string) => void;
+}) => {
+  // const icon: IconType = findByRunType(check.type)?.icon || TbChecklist;
+
+  return (
+    <Flex
+      width="100%"
+      fontSize="10pt"
+      p="5px 8px"
+      cursor="pointer"
+      _hover={{ bg: "gray.200" }}
+      bg={selected ? "gray.100" : "inherit"}
+      onClick={() => onSelect(node.id)}
+      alignItems="center"
+      gap="2px"
+    >
+      {/* <Icon as={icon} /> */}
+      <Box
+        flex="1"
+        textOverflow="ellipsis"
+        whiteSpace="nowrap"
+        overflow="hidden"
+      >
+        {node.name}
+      </Box>
+
+      {/* {check.is_checked && <Icon color="green" as={FaCheckCircle} />} */}
+    </Flex>
+  );
+};
 
 export function SchemaDiffView({ check }: SchemaDiffViewProps) {
   const { lineageGraph } = useLineageGraphContext();
   const params = check.params as SchemaDiffParams;
-  const id = params.node_id;
-  const node = id ? lineageGraph?.nodes[id] : undefined;
-  if (node) {
+
+  const queryKey = [...cacheKeys.check(check.check_id), "select"];
+
+  const { isLoading, error, refetch, data } = useQuery({
+    queryKey,
+    queryFn: async () =>
+      select({ select: params.select, exclude: params.exclude }),
+    refetchOnMount: true,
+    enabled: !params.node_id,
+  });
+
+  let nodes: LineageGraphNode[] = [];
+  const [selected, setSelected] = useState<number>(0);
+
+  if (params.node_id) {
+    const node = lineageGraph?.nodes[params.node_id];
+    if (node) {
+      nodes.push(node);
+    }
+  } else {
+    for (const nodeId of data?.nodes || []) {
+      const node = lineageGraph?.nodes[nodeId];
+      if (node) {
+        nodes.push(node);
+      }
+    }
+  }
+
+  if (selected < nodes.length) {
+    const node = nodes[selected];
     return (
-      <SchemaView
-        base={node.data.base}
-        current={node.data.current}
-        enableScreenshot={true}
-      />
+      <HSplit sizes={[80, 20]} minSize={200} style={{ height: "100%" }}>
+        <SchemaView
+          base={node.data.base}
+          current={node.data.current}
+          enableScreenshot={true}
+        />
+        <List>
+          {nodes.map((node, i) => (
+            <NodelistItem
+              key={i}
+              node={node}
+              selected={i === selected}
+              onSelect={() => {
+                const index = i;
+                setSelected(index);
+              }}
+            />
+          ))}
+        </List>
+      </HSplit>
     );
   }
+
   // TODO: handle the edge case where the node is not found
   return <></>;
 }

--- a/js/src/components/check/SchemaDiffView.tsx
+++ b/js/src/components/check/SchemaDiffView.tsx
@@ -103,7 +103,16 @@ export function SchemaDiffView({ check }: SchemaDiffViewProps) {
       }
     }
 
-    for (const node of selectedNodes) {
+    // filter that the resourec_type is mode,seed, source, or snapshot
+    const filteredNodes = selectedNodes.filter(
+      (node) =>
+        node.resourceType === "model" ||
+        node.resourceType === "seed" ||
+        node.resourceType === "source" ||
+        node.resourceType === "snapshot"
+    );
+
+    for (const node of filteredNodes) {
       if (
         isSchemaChanged(node.data.base?.columns, node.data.current?.columns)
       ) {
@@ -112,7 +121,7 @@ export function SchemaDiffView({ check }: SchemaDiffViewProps) {
     }
 
     //sort the selectedNodes from schemaChange and node name
-    selectedNodes.sort((a, b) => {
+    filteredNodes.sort((a, b) => {
       if (changedNodes.includes(a.id) && !changedNodes.includes(b.id)) {
         return -1;
       }
@@ -122,7 +131,7 @@ export function SchemaDiffView({ check }: SchemaDiffViewProps) {
       return a.name.localeCompare(b.name);
     });
 
-    return [selectedNodes, changedNodes];
+    return [filteredNodes, changedNodes];
   }, [params?.node_id, data?.nodes, lineageGraph]);
 
   const [selected, setSelected] = useState<number>(0);

--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -13,39 +13,10 @@ import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 import { MdFormatListNumberedRtl, MdSchema } from "react-icons/md";
 import { NodeColumnData } from "@/lib/api/info";
 import { findByRunType } from "../run/registry";
+import { isSchemaChanged } from "../schema/schemaDiff";
 
 interface GraphNodeProps extends NodeProps<LineageGraphNode> {}
 
-function isSchemaChanged(
-  baseSchema: { [key: string]: NodeColumnData } | undefined,
-  currSchema: { [key: string]: NodeColumnData } | undefined
-) {
-  if (!baseSchema || !currSchema) {
-    return undefined;
-  }
-  const baseKeys = Object.keys(baseSchema);
-  const currKeys = Object.keys(currSchema);
-
-  // added, removed
-  if (baseKeys.length !== currKeys.length) {
-    return true;
-  }
-
-  // reordered
-  for (let i = 0; i < baseKeys.length; i++) {
-    if (baseKeys[i] !== currKeys[i]) {
-      return true;
-    }
-  }
-
-  // modified
-  for (const key of currKeys) {
-    if (!baseSchema[key] || baseSchema[key].type !== currSchema[key].type) {
-      return true;
-    }
-  }
-  return false;
-}
 
 const NodeRunsAggregated = ({ id }: { id: string }) => {
   const { lineageGraph, runsAggregated } = useLineageGraphContext();

--- a/js/src/components/query/QueryResultView.tsx
+++ b/js/src/components/query/QueryResultView.tsx
@@ -83,7 +83,7 @@ function toDataGrid(result: DataFrame, options: QueryDataGridOptions) {
   columns.push({
     key: "_index",
     name: "",
-    width: 10,
+    width: 50,
     cellClass: "index-column",
   });
 

--- a/js/src/components/query/querydiff.tsx
+++ b/js/src/components/query/querydiff.tsx
@@ -398,6 +398,8 @@ export function toDataDiffGrid(
   if (primaryKeys.length === 0) {
     columns.push({
       key: "_index",
+      width: 50,
+      maxWidth: 100,
       name: "",
       cellClass: "index-column",
     });

--- a/js/src/components/schema/schemaDiff.ts
+++ b/js/src/components/schema/schemaDiff.ts
@@ -1,0 +1,32 @@
+import { NodeColumnData } from "@/lib/api/info";
+
+export function isSchemaChanged(
+  baseSchema: { [key: string]: NodeColumnData } | undefined,
+  currSchema: { [key: string]: NodeColumnData } | undefined
+) {
+  if (!baseSchema || !currSchema) {
+    return undefined;
+  }
+  const baseKeys = Object.keys(baseSchema);
+  const currKeys = Object.keys(currSchema);
+
+  // added, removed
+  if (baseKeys.length !== currKeys.length) {
+    return true;
+  }
+
+  // reordered
+  for (let i = 0; i < baseKeys.length; i++) {
+    if (baseKeys[i] !== currKeys[i]) {
+      return true;
+    }
+  }
+
+  // modified
+  for (const key of currKeys) {
+    if (!baseSchema[key] || baseSchema[key].type !== currSchema[key].type) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/js/src/components/valuediff/ValueDiffResultView.tsx
+++ b/js/src/components/valuediff/ValueDiffResultView.tsx
@@ -124,6 +124,7 @@ export function ValueDiffResultView({ run }: ValueDiffResultViewProp) {
     {
       key: "__is_pk__",
       name: "",
+      width: 30,
       maxWidth: 30,
       renderCell: ({ row }) => {
         return (

--- a/js/src/lib/api/select.ts
+++ b/js/src/lib/api/select.ts
@@ -1,0 +1,15 @@
+import { axiosClient } from "./axiosClient";
+
+interface SelectInput {
+  select?: string;
+  exclude?: string;
+}
+
+interface SelectOutput {
+  nodes: string[];
+}
+
+export async function select(input: SelectInput): Promise<SelectOutput> {
+  const response = await axiosClient.post(`/api/select`, input);
+  return response.data;
+}


### PR DESCRIPTION
Support the schema diff by dbt selector. Currently, it can only be added in the preset check. 

```yaml
# recce.yml
checks:
  - name: Schema diff (modified+)
    type: schema_diff
    params:
      select: 'state:modified+'
  - name: Schema diff (modified+, exclude snapshot)
    type: schema_diff
    params:
      select: 'state:modified+'      
      exclude: 'resource_type:snapshot'
  - name: Schema diff for all nodes
    type: schema_diff
    params:
  - name: schema by node id
    type: schema_diff
    params:
      node_id: model.jaffle_shop.orders
```



**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
