### PR TITLE
[Fix] DRC-527 Support dbt version below 1.6

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -665,11 +665,17 @@ class DbtAdapter(BaseAdapter):
         self.curr_catalog = load_catalog(data=artifacts.current.get('catalog'))
 
         self.manifest = as_manifest(self.curr_manifest)
-        self.previous_state = PreviousState(
-            Path('target-base'),
-            Path(self.runtime_config.target_path),
-            Path(self.runtime_config.project_root)
-        )
+        if dbt_version < 'v1.6':
+            self.previous_state = PreviousState(
+                Path('target-base'),
+                Path(self.runtime_config.target_path),
+            )
+        else:
+            self.previous_state = PreviousState(
+                Path('target-base'),
+                Path(self.runtime_config.target_path),
+                Path(self.runtime_config.project_root)
+            )
         self.previous_state.manifest = as_manifest(self.base_manifest)
 
         # The dependencies of the review mode is derived from manifests.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
When dbt version is < 1.6, The `PreviousState` class only supports 2 arguments

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
