### PR TITLE
[Fix] DRC-535 Add dbt related options in `summary` command

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -305,6 +305,7 @@ def run(output, **kwargs):
 @click.option('--format', '-f', help='Output format. Currently only markdown is supported.',
               type=click.Choice(['markdown', 'mermaid', 'check'], case_sensitive=False),
               default='markdown', show_default=True, hidden=True)
+@add_options(dbt_related_options)
 @add_options(recce_options)
 @add_options(recce_cloud_options)
 def summary(state_file, **kwargs):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
When executing `recce summary` outside the DBT project folder, the Recce will throw the error message `No dbt_project.yml.` However, the recce summary doesn't provide any options to let users assign the DBT project directory.
- Add dbt-related options in the `recce summary` command. 

**Which issue(s) this PR fixes**:
#372 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
