### PR TITLE
Add telemetry for creating check/run and number preset check

### DIFF
--- a/recce/apis/run_api.py
+++ b/recce/apis/run_api.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from recce.apis.run_func import submit_run, cancel_run, materialize_run_results
+from recce.event import log_api_event
 from recce.exceptions import RecceException
 from recce.models import RunDAO
 
@@ -21,6 +22,10 @@ class CreateRunIn(BaseModel):
 
 @run_router.post("/runs", status_code=201)
 async def create_run_handler(input: CreateRunIn):
+    log_api_event('create_run', dict(
+        type=input.type,
+        params=input.params,
+    ))
     try:
         run, future = submit_run(input.type, input.params)
     except RecceException as e:

--- a/recce/event/__init__.py
+++ b/recce/event/__init__.py
@@ -154,7 +154,7 @@ def log_api_event(endpoint_name, prop):
         endpoint_name=endpoint_name,
     )
     log_event(prop, 'api_event')
-    _schedule_flush()
+    _collector.schedule_flush()
 
 
 def capture_exception(e):
@@ -172,26 +172,3 @@ def flush_exceptions():
 
 def set_exception_tag(key, value):
     sentry_sdk.set_tag(key, value)
-
-
-flush_timer = None
-
-
-def _auto_flush():
-    global flush_timer
-    _collector.send_events()
-    flush_timer = None
-
-
-def _schedule_flush():
-    import asyncio
-    global flush_timer
-    try:
-        loop = asyncio.get_running_loop()
-        if loop.is_running():
-            flush_timer = loop.call_later(1, _auto_flush)
-
-    except RuntimeError:
-        # Not in an event loop, use threading.Timer instead
-        flush_timer = threading.Timer(1, _auto_flush)
-        flush_timer.start()

--- a/recce/event/__init__.py
+++ b/recce/event/__init__.py
@@ -157,6 +157,28 @@ def log_api_event(endpoint_name, prop):
     _collector.schedule_flush()
 
 
+def log_load_state(command='server'):
+    from recce.models import CheckDAO
+
+    checks = 0
+    preset_checks = 0
+
+    for check in CheckDAO().list():
+        checks += 1
+        if check.is_preset:
+            preset_checks += 1
+
+    prop = dict(
+        command=command,
+        checks=checks,
+        preset_checks=preset_checks,
+    )
+
+    log_event(prop, 'load_state')
+    if command == 'server':
+        _collector.schedule_flush()
+
+
 def capture_exception(e):
     user_id = load_user_profile().get('user_id')
     if is_ci_env() is True:

--- a/recce/event/__init__.py
+++ b/recce/event/__init__.py
@@ -154,6 +154,7 @@ def log_api_event(endpoint_name, prop):
         endpoint_name=endpoint_name,
     )
     log_event(prop, 'api_event')
+    _schedule_flush()
 
 
 def capture_exception(e):
@@ -171,3 +172,26 @@ def flush_exceptions():
 
 def set_exception_tag(key, value):
     sentry_sdk.set_tag(key, value)
+
+
+flush_timer = None
+
+
+def _auto_flush():
+    global flush_timer
+    _collector.send_events()
+    flush_timer = None
+
+
+def _schedule_flush():
+    import asyncio
+    global flush_timer
+    try:
+        loop = asyncio.get_running_loop()
+        if loop.is_running():
+            flush_timer = loop.call_later(1, _auto_flush)
+
+    except RuntimeError:
+        # Not in an event loop, use threading.Timer instead
+        flush_timer = threading.Timer(1, _auto_flush)
+        flush_timer.start()

--- a/recce/event/__init__.py
+++ b/recce/event/__init__.py
@@ -148,6 +148,14 @@ def log_event(prop, event_type, **kwargs):
     _collector.log_event(payload, event_type)
 
 
+def log_api_event(endpoint_name, prop):
+    prop = dict(
+        **prop,
+        endpoint_name=endpoint_name,
+    )
+    log_event(prop, 'api_event')
+
+
 def capture_exception(e):
     user_id = load_user_profile().get('user_id')
     if is_ci_env() is True:

--- a/recce/event/collector.py
+++ b/recce/event/collector.py
@@ -23,6 +23,23 @@ class Collector:
         self._delete_threshold = 1000
         self._upload_threshold = 10
         self._is_ci: bool = is_ci_env()
+        self._flush_timer = None
+
+    def schedule_flush(self):
+        def _callback():
+            self._flush_timer = None
+            self.send_events()
+
+        # send async thread
+        import threading
+        if self._flush_timer:
+            try:
+                self._flush_timer.cancel()
+            except Exception:
+                # do nothing
+                pass
+        self._flush_timer = threading.Timer(1, _callback)
+        self._flush_timer.start()
 
     def is_ready(self):
         if self._api_key is None or self._user_id is None:

--- a/recce/run.py
+++ b/recce/run.py
@@ -172,6 +172,9 @@ async def cli_run(output_state_file: str, **kwargs):
         if rc != 0 and failed_checks:
             process_failed_checks(failed_checks, error_log)
 
+    from recce.event import log_load_state
+    log_load_state(command='run')
+
     # Export the state
     console.rule("Export state")
     state: RecceState = ctx.export_state()

--- a/recce/server.py
+++ b/recce/server.py
@@ -55,6 +55,9 @@ async def lifespan(fastapi: FastAPI):
             console.rule("Loading Preset Checks")
             load_preset_checks(preset_checks)
 
+    from recce.event import log_load_state
+    log_load_state(command='server')
+
     yield
 
     recce_state.export(ctx.export_state())


### PR DESCRIPTION
Telemtry for two new events

- `api_event`: it would contain the api endpoint name and params. Currently, we have two endpoint `create_run`, `create_check`, `rerun_check`
- `load_state`: it would contains the `command`, `preset_checks`, and `checks`

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
