### PR TITLE
[Bug] Fix recce run behavior by checking state existence

### DIFF
--- a/recce/run.py
+++ b/recce/run.py
@@ -224,7 +224,7 @@ async def cli_run(output_state_file: str, **kwargs):
 
     # Execute the preset checks
     rc = 0
-    if ctx.state_loader.state_file is None:
+    if ctx.state_loader.state is None:
         preset_checks = RecceConfig().get('checks')
         if is_skip_query or preset_checks is None or len(preset_checks) == 0:
             # Skip the preset checks


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:
- In cloud mode, recce run should not load preset checks when the recce state was given.

**Which issue(s) this PR fixes**:
DRC-578

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE