### PR TITLE
[Bug] DRC-577 Handle the updated artifact file is not updated completely

### DIFF
--- a/recce/server.py
+++ b/recce/server.py
@@ -68,10 +68,24 @@ async def lifespan(fastapi: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 
+def verify_json_file(file_path: str) -> bool:
+    try:
+        with open(file_path, 'r') as f:
+            json.load(f)
+    except Exception:
+        return False
+    return True
+
+
 def dbt_artifacts_updated_callback(file_changed_event: Any):
     src_path = Path(file_changed_event.src_path)
     target_type = src_path.parent.name
     file_name = src_path.name
+
+    if not verify_json_file(file_changed_event.src_path):
+        logger.debug('Skip to refresh the artifacts because the file is not updated completely.')
+        return
+
     logger.info(
         f'Detect {target_type} file {file_changed_event.event_type}: {file_name}')
     ctx = load_context()


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
 - When the 3rd party procress try to update the manifest files, the file updated event could be triggered before the manifest file is updated completely.
 - Check the json format before refresh the manifest files. If the file content is not valid json, skip the event and wait until the next updated event.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
