### PR TITLE
Resetting invocation_context on generate_sql function when dbt_version > 1.8

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -406,7 +406,7 @@ class DbtAdapter(BaseAdapter):
         if dbt_version >= dbt_version.parse('v1.8'):
             from dbt_common.context import set_invocation_context
             set_invocation_context({})
-            
+
         node_id = str("generated_" + uuid.uuid4().hex)
         node = parser.parse_remote(sql_template, node_id)
         process_node(self.runtime_config, manifest, node)

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -403,6 +403,10 @@ class DbtAdapter(BaseAdapter):
         manifest = as_manifest(self.get_manifest(base))
         parser = SqlBlockParser(self.runtime_config, manifest, self.runtime_config)
 
+        if dbt_version >= dbt_version.parse('v1.8'):
+            from dbt_common.context import set_invocation_context
+            set_invocation_context({})
+            
         node_id = str("generated_" + uuid.uuid4().hex)
         node = parser.parse_remote(sql_template, node_id)
         process_node(self.runtime_config, manifest, node)


### PR DESCRIPTION
Fix [405](https://github.com/DataRecce/recce/issues/405)

On new dbt 1.8 version there is error  LookupError: <ContextVar name='DBT_INVOCATION_CONTEXT_VAR' at 0x10c4889f0>   when using function "Run query" or "Run diff". This happens because class DbtAdapter sets the invocation context with function set_invocation_context({}) when dbt version is 1.8, but on tasks/query.py file the default_context is regenererated before calling function generate_sql from DbtAdapter.


![image](https://github.com/user-attachments/assets/3120f853-cf60-46f8-8596-8aaa17c86d79)
![image](https://github.com/user-attachments/assets/a992e212-cd6e-4c85-80f5-a1a084d4ea47)


To fix this, added a new call of set_invocation_context({}) on start of function generate_sql if dbt version is greater or equal than 1.8.

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug fix

**What this PR does / why we need it**:
Added a new call of set_invocation_context({}) on start of function generate_sql if dbt version is greater or equal than 1.8 to fix the issue described below.

With the fix, `Run Diff` works fine with dbt version 1.8:

![image](https://github.com/user-attachments/assets/453cbc9d-cf59-4a3d-a62d-7b9faa1376ed)

Tests:
![image](https://github.com/user-attachments/assets/5b494ce9-d618-4855-b588-a275e4a3dc2f)


**Which issue(s) this PR fixes**:
Fix [405](https://github.com/DataRecce/recce/issues/405)
When using new dbt 1.8 version, `Run Diff` feature will throw error `LookupError: <ContextVar name='DBT_INVOCATION_CONTEXT_VAR' at 0x10c4889f0>`

This happens because class DbtAdapter sets the invocation context with function set_invocation_context({}) when dbt version is 1.8, but on tasks/query.py file the default_context is regenererated before calling function generate_sql from DbtAdapter.

![image](https://github.com/user-attachments/assets/f73c25ed-c493-4d1c-b5f5-c0203598f458)


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
"NONE"