### PR TITLE
[Enhancement] support merge local and cloud state

### DIFF
--- a/js/app/page.tsx
+++ b/js/app/page.tsx
@@ -168,7 +168,8 @@ interface TabProps {
 }
 
 function NavBar() {
-  const { isDemoSite, cloudMode, isLoading } = useLineageGraphContext();
+  const { isDemoSite, cloudMode, fileMode, isLoading } =
+    useLineageGraphContext();
   const [location, setLocation] = useLocation();
 
   const tabs: TabProps[] = [
@@ -195,13 +196,13 @@ function NavBar() {
           );
         })}
         <Spacer />
-        { !isLoading &&
-          (<>
-            {cloudMode && <StateSynchronizer />}
-            {(!isDemoSite && !cloudMode) && <StateImporter />}
+        {!isLoading && (
+          <>
+            {(cloudMode || fileMode) && <StateSynchronizer />}
+            {!isDemoSite && !cloudMode && <StateImporter />}
             <StateExporter />
-          </>)
-        }
+          </>
+        )}
         <EnvInfo />
       </TabList>
     </Tabs>

--- a/js/app/page.tsx
+++ b/js/app/page.tsx
@@ -168,8 +168,7 @@ interface TabProps {
 }
 
 function NavBar() {
-  const { isDemoSite, cloudMode, fileMode, isLoading } =
-    useLineageGraphContext();
+  const { isDemoSite, cloudMode, isLoading } = useLineageGraphContext();
   const [location, setLocation] = useLocation();
 
   const tabs: TabProps[] = [
@@ -198,7 +197,7 @@ function NavBar() {
         <Spacer />
         {!isLoading && (
           <>
-            {(cloudMode || fileMode) && <StateSynchronizer />}
+            {cloudMode && <StateSynchronizer />}
             {!isDemoSite && !cloudMode && <StateImporter />}
             <StateExporter />
           </>

--- a/js/src/components/check/StateSynchronizer.tsx
+++ b/js/src/components/check/StateSynchronizer.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Icon,
   IconButton,
@@ -22,6 +23,7 @@ import { syncState, isStateSyncing, SyncStateInput } from "@/lib/api/state";
 import { useQueryClient } from "@tanstack/react-query";
 import { cacheKeys } from "@/lib/api/cacheKeys";
 import { useLocation } from "wouter";
+import { InfoIcon, InfoOutlineIcon } from "@chakra-ui/icons";
 
 function isCheckDetailPage(href: string): boolean {
   const pattern =
@@ -51,23 +53,16 @@ export function StateSynchronizer() {
     if (await isStateSyncing()) {
       return;
     }
-    if (syncOption === "merge") {
-      toast({
-        title: "Merge Completed",
-        position: "bottom-right",
-        description: (
-          <>
-            The following information updated
-            <ul>
-              <li>artifacts/base/manifest</li>
-            </ul>
-          </>
-        ),
-        status: "success",
-        duration: 10000,
-        isClosable: true,
-      });
-    }
+
+    toast({
+      description: "Sync Completed",
+      status: "success",
+      variant: "left-accent",
+      position: "bottom",
+      duration: 5000,
+      isClosable: true,
+    });
+
     setSyncing(false);
     setSyncOption("");
 
@@ -123,15 +118,49 @@ export function StateSynchronizer() {
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Select Sync Option</ModalHeader>
+          <ModalHeader fontSize="lg" fontWeight="bold">
+            Sync with Cloud
+          </ModalHeader>
           <ModalBody>
-            <RadioGroup onChange={setSyncOption} value={syncOption}>
-              <Stack direction="column">
-                <Radio value="overwrite">Overwrite</Radio>
-                <Radio value="revert">Revert</Radio>
-                <Radio value="merge">Merge</Radio>
-              </Stack>
-            </RadioGroup>
+            <Box>
+              New changes have been detected in the cloud. Please choose a
+              method to sync your state
+            </Box>
+            <Box mt="5px">
+              <RadioGroup onChange={setSyncOption} value={syncOption}>
+                <Stack direction="column">
+                  {/* Merge */}
+                  <Radio value="merge">
+                    Merge
+                    <Tooltip label="This will merge the local and remote states.">
+                      <span>
+                        <Icon as={InfoOutlineIcon} ml={2} cursor="pointer" />
+                      </span>
+                    </Tooltip>
+                  </Radio>
+
+                  {/* Overwrite */}
+                  <Radio value="overwrite">
+                    Overwrite
+                    <Tooltip label="This will overwrite the remote state file with the local state.">
+                      <span>
+                        <Icon as={InfoOutlineIcon} ml={2} cursor="pointer" />
+                      </span>
+                    </Tooltip>
+                  </Radio>
+
+                  {/* Revert */}
+                  <Radio value="revert">
+                    Revert
+                    <Tooltip label="This will discard local changes and revert to the cloud state.">
+                      <span>
+                        <Icon as={InfoOutlineIcon} ml={2} cursor="pointer" />
+                      </span>
+                    </Tooltip>
+                  </Radio>
+                </Stack>
+              </RadioGroup>
+            </Box>
           </ModalBody>
           <ModalFooter>
             <Button onClick={onClose} mr={3}>
@@ -142,7 +171,7 @@ export function StateSynchronizer() {
               onClick={() => requestSyncStatus({ method: syncOption as any })}
               isDisabled={!syncOption} // Disable button until an option is selected
             >
-              Confirm
+              Sync
             </Button>
           </ModalFooter>
         </ModalContent>

--- a/js/src/components/check/StateSynchronizer.tsx
+++ b/js/src/components/check/StateSynchronizer.tsx
@@ -69,7 +69,7 @@ export function StateSynchronizer() {
     // Refresh the lineage graph and checks
     queryClient.invalidateQueries({ queryKey: cacheKeys.lineage() });
     queryClient.invalidateQueries({ queryKey: cacheKeys.checks() });
-  }, [setSyncing, queryClient, toast, syncOption]);
+  }, [setSyncing, queryClient, toast]);
 
   useEffect(() => {
     let intervalId: NodeJS.Timeout | null = null;

--- a/js/src/components/check/StateSynchronizer.tsx
+++ b/js/src/components/check/StateSynchronizer.tsx
@@ -1,28 +1,49 @@
-import { Button, Icon, IconButton, Spinner, Tooltip } from "@chakra-ui/react";
+import {
+  Button,
+  Icon,
+  IconButton,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Radio,
+  RadioGroup,
+  Spinner,
+  Stack,
+  Tooltip,
+  useDisclosure,
+} from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 import { TfiCloudDown, TfiCloudUp, TfiReload } from "react-icons/tfi";
-import { syncState, isStateSyncing } from "@/lib/api/state";
+import { syncState, isStateSyncing, SyncStateInput } from "@/lib/api/state";
 import { useQueryClient } from "@tanstack/react-query";
 import { cacheKeys } from "@/lib/api/cacheKeys";
 import { useLocation } from "wouter";
 
 function isCheckDetailPage(href: string): boolean {
-  const pattern = /^\/checks\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/;
+  const pattern =
+    /^\/checks\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/;
   return pattern.test(href);
 }
 
 export function StateSpinner() {
-  return (<Tooltip label="Loading">
-    <Button pt="6px" variant='unstyled'  boxSize={"1.2em"} >
-      <Spinner/>
-    </Button>
-  </Tooltip>);
+  return (
+    <Tooltip label="Loading">
+      <Button pt="6px" variant="unstyled" boxSize={"1.2em"}>
+        <Spinner />
+      </Button>
+    </Tooltip>
+  );
 }
 
 export function StateSynchronizer() {
   const [isSyncing, setSyncing] = useState(false);
   const queryClient = useQueryClient();
   const [location, setLocation] = useLocation();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [syncOption, setSyncOption] = useState("");
 
   const checkSyncStatus = useCallback(async () => {
     if (await isStateSyncing()) {
@@ -49,46 +70,88 @@ export function StateSynchronizer() {
         clearInterval(intervalId);
       }
     };
-  }, [isSyncing, checkSyncStatus, setLocation, location])
+  }, [isSyncing, checkSyncStatus, setLocation, location]);
 
+  const requestSyncStatus = useCallback(
+    async (input: SyncStateInput) => {
+      onClose();
+      if ((await isStateSyncing()) === false) {
+        const response = await syncState(input);
+        if (response.status === "conflict") {
+          onOpen();
+        } else {
+          setSyncing(true);
+        }
+      }
+    },
+    [onClose, onOpen, setSyncing]
+  );
 
-  const requestSyncStatus = useCallback(async () => {
-    if (await isStateSyncing() === false) {
-      await syncState();
-    }
-    setSyncing(true);
-  }, [setSyncing]);
-
-  if (isSyncing) return <StateSpinner/>;
-  return (<Tooltip label="Sync with Cloud">
-    <IconButton
-      pt="6px"
-      variant="unstyled"
-      aria-label="Sync state"
-      onClick={requestSyncStatus}
-      icon={<Icon as={TfiReload} boxSize={"1.2em"} />}
-    />
-  </Tooltip>);
+  if (isSyncing) return <StateSpinner />;
+  return (
+    <>
+      <Tooltip label="Sync with Cloud">
+        <IconButton
+          pt="6px"
+          variant="unstyled"
+          aria-label="Sync state"
+          onClick={() => requestSyncStatus({})}
+          icon={<Icon as={TfiReload} boxSize={"1.2em"} />}
+        />
+      </Tooltip>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Select Sync Option</ModalHeader>
+          <ModalBody>
+            <RadioGroup onChange={setSyncOption} value={syncOption}>
+              <Stack direction="column">
+                <Radio value="overwrite">Overwrite</Radio>
+                <Radio value="revert">Revert</Radio>
+                <Radio value="merge">Merge</Radio>
+              </Stack>
+            </RadioGroup>
+          </ModalBody>
+          <ModalFooter>
+            <Button onClick={onClose} mr={3}>
+              Cancel
+            </Button>
+            <Button
+              colorScheme="blue"
+              onClick={() => requestSyncStatus({ method: syncOption as any })}
+              isDisabled={!syncOption} // Disable button until an option is selected
+            >
+              Confirm
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
 }
 
 export function StateCloudUploader() {
-  return (<Tooltip label="Upload to Cloud">
-    <IconButton
-      pt="6px"
-      variant="unstyled"
-      aria-label="Upload state"
-      icon={<Icon as={TfiCloudUp} boxSize={"1.2em"} />}
-    />
-  </Tooltip>);
+  return (
+    <Tooltip label="Upload to Cloud">
+      <IconButton
+        pt="6px"
+        variant="unstyled"
+        aria-label="Upload state"
+        icon={<Icon as={TfiCloudUp} boxSize={"1.2em"} />}
+      />
+    </Tooltip>
+  );
 }
 
 export function StateCloudDownloader() {
-  return (<Tooltip label="Download from Cloud">
-    <IconButton
-      pt="6px"
-      variant="unstyled"
-      aria-label="Download state"
-      icon={<Icon as={TfiCloudDown} boxSize={"1.2em"} />}
-    />
-  </Tooltip>);
+  return (
+    <Tooltip label="Download from Cloud">
+      <IconButton
+        pt="6px"
+        variant="unstyled"
+        aria-label="Download state"
+        icon={<Icon as={TfiCloudDown} boxSize={"1.2em"} />}
+      />
+    </Tooltip>
+  );
 }

--- a/js/src/lib/api/info.ts
+++ b/js/src/lib/api/info.ts
@@ -125,6 +125,7 @@ export interface ServerInfoResult {
   adapter_type: string;
   review_mode: boolean;
   cloud_mode: boolean;
+  file_mode: boolean;
   git?: gitInfo;
   pull_request?: pullRequestInfo;
   sqlmesh?: SQLMeshInfo;

--- a/js/src/lib/hooks/LineageGraphContext.tsx
+++ b/js/src/lib/hooks/LineageGraphContext.tsx
@@ -36,6 +36,7 @@ export interface LineageGraphContextType {
   envInfo?: EnvInfo;
   reviewMode?: boolean;
   cloudMode?: boolean;
+  fileMode?: boolean;
   isDemoSite?: boolean;
   isLoading?: boolean;
   error?: string;
@@ -127,6 +128,7 @@ export function LineageGraphContextProvider({ children }: LineageGraphProps) {
   const isDemoSite = data?.demo;
   const reviewMode = data?.review_mode;
   const cloudMode = data?.cloud_mode;
+  const fileMode = data?.file_mode;
   const adapterType = data?.adapter_type;
   const git = data?.git;
   const pullRequest = data?.pull_request;
@@ -156,6 +158,7 @@ export function LineageGraphContextProvider({ children }: LineageGraphProps) {
           envInfo,
           reviewMode,
           cloudMode,
+          fileMode,
           isDemoSite,
           error: errorMessage,
           isLoading,

--- a/recce/adapter/base.py
+++ b/recce/adapter/base.py
@@ -38,7 +38,7 @@ class BaseAdapter(ABC):
     def export_artifacts(self) -> ArtifactsRoot:
         return ArtifactsRoot(base={}, current={})
 
-    def import_artifacts(self, artifacts: ArtifactsRoot):
+    def import_artifacts(self, artifacts: ArtifactsRoot, merge: bool = False):
         pass
 
     def find_node_by_name(self, node_name, base=False):

--- a/recce/apis/check_api.py
+++ b/recce/apis/check_api.py
@@ -75,7 +75,7 @@ async def create_check(check_in: CreateCheckIn, background_tasks: BackgroundTask
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    # background_tasks.add_task(export_persistent_state)
+    background_tasks.add_task(export_persistent_state)
     return CheckOut.from_check(check)
 
 

--- a/recce/apis/check_api.py
+++ b/recce/apis/check_api.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
 
@@ -74,7 +75,7 @@ async def create_check(check_in: CreateCheckIn, background_tasks: BackgroundTask
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    background_tasks.add_task(export_persistent_state)
+    # background_tasks.add_task(export_persistent_state)
     return CheckOut.from_check(check)
 
 
@@ -155,6 +156,7 @@ async def update_check_handler(check_id: UUID, patch: PatchCheckIn, background_t
         check.view_options = patch.view_options
     if patch.is_checked is not None:
         check.is_checked = patch.is_checked
+    check.updated_at = datetime.now(timezone.utc).replace(microsecond=0)
 
     background_tasks.add_task(export_persistent_state)
     return CheckOut.from_check(check)

--- a/recce/apis/check_func.py
+++ b/recce/apis/check_func.py
@@ -136,4 +136,10 @@ def purge_preset_checks():
 
 def export_persistent_state():
     ctx = default_context()
-    ctx.state_loader.export(ctx.export_state())
+    state_loader = ctx.state_loader
+    if state_loader:
+        is_conflict = state_loader.check_conflict()
+        if is_conflict:
+            ctx.sync_state('merge')
+        else:
+            ctx.sync_state('overwrite')

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -229,20 +229,20 @@ def server(host, port, state_file=None, **kwargs):
             'password': kwargs.get('password'),
         }
 
-    recce_state = create_state_loader(is_review, is_cloud, state_file, cloud_options)
+    state_loader = create_state_loader(is_review, is_cloud, state_file, cloud_options)
 
-    if not recce_state.verify():
-        error, hint = recce_state.error_and_hint
+    if not state_loader.verify():
+        error, hint = state_loader.error_and_hint
         console.print(f"[[red]Error[/red]] {error}")
         console.print(f"{hint}")
         exit(1)
 
-    if recce_state.review_mode is True:
+    if state_loader.review_mode is True:
         console.rule("Recce Server : Review Mode")
     else:
         console.rule("Recce Server")
 
-    state = AppState(recce_state=recce_state, kwargs=kwargs)
+    state = AppState(state_loader=state_loader, kwargs=kwargs)
     app.state = state
 
     uvicorn.run(app, host=host, port=port, lifespan='on')
@@ -303,11 +303,11 @@ def run(output, **kwargs):
         'password': kwargs.get('password'),
     } if cloud_mode else None
 
-    recce_state = create_state_loader(review_mode=False, cloud_mode=cloud_mode, state_file=state_file,
-                                      cloud_options=cloud_options)
+    state_loader = create_state_loader(review_mode=False, cloud_mode=cloud_mode, state_file=state_file,
+                                       cloud_options=cloud_options)
 
-    if not recce_state.verify():
-        error, hint = recce_state.error_and_hint
+    if not state_loader.verify():
+        error, hint = state_loader.error_and_hint
         console.print(f"[[red]Error[/red]] {error}")
         console.print(f"{hint}")
         exit(1)
@@ -332,7 +332,7 @@ def run(output, **kwargs):
         console.print(f"Reason: {e}")
         exit(1)
 
-    return asyncio.run(cli_run(output, recce_state=recce_state, **kwargs))
+    return asyncio.run(cli_run(output, state_loader=state_loader, **kwargs))
 
 
 @cli.command(cls=TrackCommand)
@@ -358,17 +358,17 @@ def summary(state_file, **kwargs):
         'password': kwargs.get('password'),
     } if cloud_mode else None
 
-    recce_state = create_state_loader(review_mode=True, cloud_mode=cloud_mode, state_file=state_file,
-                                      cloud_options=cloud_options)
+    state_loader = create_state_loader(review_mode=True, cloud_mode=cloud_mode, state_file=state_file,
+                                       cloud_options=cloud_options)
 
-    if not recce_state.verify():
-        error, hint = recce_state.error_and_hint
+    if not state_loader.verify():
+        error, hint = state_loader.error_and_hint
         console.print(f"[[red]Error[/red]] {error}")
         console.print(f"{hint}")
         exit(1)
     try:
         # Load context in review mode, won't need to check dbt_project.yml file.
-        ctx = load_context(**kwargs, recce_state=recce_state, review=True)
+        ctx = load_context(**kwargs, state_loader=state_loader, review=True)
     except Exception as e:
         console.print("[[red]Error[/red]] Failed to generate summary")
         console.print(f"{e}")

--- a/recce/models/check.py
+++ b/recce/models/check.py
@@ -3,56 +3,54 @@ from typing import Optional, List
 from recce.exceptions import RecceException
 from .types import Check
 
-_checks: List[Check] = []
-
 
 class CheckDAO:
     """
     Data Access Object for Check. Currently, we store runs in memory, in the future, we can store them in a database.
     """
 
+    @property
+    def _checks(self):
+        from recce.core import default_context
+        return default_context().checks
+
     def create(self, check) -> None:
-        _checks.append(check)
+        self._checks.append(check)
 
     def find_check_by_id(self, check_id) -> Optional[Check]:
-        for check in _checks:
+        for check in self._checks:
             if str(check_id) == str(check.check_id):
                 return check
 
         return None
 
     def delete(self, check_id) -> bool:
-        for check in _checks:
+        for check in self._checks:
             if str(check_id) == str(check.check_id):
-                _checks.remove(check)
+                self._checks.remove(check)
                 return True
 
         return False
 
     def list(self) -> List[Check]:
-        return list(_checks)
+        return list(self._checks)
 
     def reorder(self, source: int, destination: int):
 
-        if source < 0 or source >= len(_checks):
+        if source < 0 or source >= len(self._checks):
             raise RecceException('Failed to reorder checks. Source index out of range')
 
-        if destination < 0 or destination >= len(_checks):
+        if destination < 0 or destination >= len(self._checks):
             raise RecceException('Failed to reorder checks. Destination index out of range')
 
-        check_to_move = _checks.pop(source)
-        _checks.insert(destination, check_to_move)
+        check_to_move = self._checks.pop(source)
+        self._checks.insert(destination, check_to_move)
 
     def clear(self):
-        _checks.clear()
+        self._checks.clear()
 
     def status(self):
         return {
-            'total': len(_checks),
-            'approved': len([c for c in _checks if c.is_checked])
+            'total': len(self._checks),
+            'approved': len([c for c in self._checks if c.is_checked])
         }
-
-
-def load_checks(checks: List[Check]):
-    global _checks
-    _checks = checks

--- a/recce/models/run.py
+++ b/recce/models/run.py
@@ -1,8 +1,4 @@
-from typing import List
-
 from .types import Run, RunType
-
-_runs: List[Run] = []
 
 
 class RunDAO:
@@ -10,11 +6,16 @@ class RunDAO:
     Data Access Object for Run. Currently, we store runs in memory, in the future, we can store them in a database.
     """
 
+    @property
+    def _runs(self):
+        from recce.core import default_context
+        return default_context().runs
+
     def create(self, run: Run):
-        _runs.append(run)
+        self._runs.append(run)
 
     def find_run_by_id(self, run_id):
-        for run in _runs:
+        for run in self._runs:
             if str(run_id) == str(run.run_id):
                 return run
 
@@ -22,28 +23,23 @@ class RunDAO:
 
     def list(self, type_filter: RunType = None):
         if type_filter:
-            return list(filter(lambda run: run.type == type_filter, _runs))
-        return list(_runs)
+            return list(filter(lambda run: run.type == type_filter, self._runs))
+        return list(self._runs)
 
     def list_by_check_id(self, check_id):
         runs = []
-        for run in _runs:
+        for run in self._runs:
             if str(check_id) == str(run.check_id):
                 runs.append(run)
         return runs
 
     def delete(self, run_id):
-        for run in _runs:
+        for run in self._runs:
             if str(run_id) == str(run.run_id):
-                _runs.remove(run)
+                self._runs.remove(run)
                 return True
 
         return False
 
     def clear(self):
-        _runs.clear()
-
-
-def load_runs(runs: List[Run]):
-    global _runs
-    _runs = runs
+        self._runs.clear()

--- a/recce/models/types.py
+++ b/recce/models/types.py
@@ -36,7 +36,7 @@ class Run(BaseModel):
     error: Optional[str] = None
     progress: Optional[RunProgress] = None
     run_id: UUID4 = Field(default_factory=uuid.uuid4)
-    run_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).replace(microsecond=0))
+    run_at: str = Field(default_factory=lambda: datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"))
 
 
 class Check(BaseModel):

--- a/recce/models/types.py
+++ b/recce/models/types.py
@@ -49,6 +49,17 @@ class Check(BaseModel):
     is_checked: bool = False
     is_preset: bool = False
 
+    def merge(self, other):
+        if self.check_id != other.check_id:
+            raise ValueError("Check ID mismatch")
+        self.name = other.name
+        self.description = other.description
+        self.type = other.type
+        self.params = other.params
+        self.view_options = other.view_options
+        self.is_checked = other.is_checked
+        self.is_preset = other.is_preset
+
 
 class Lineage(BaseModel):
     base: dict

--- a/recce/models/types.py
+++ b/recce/models/types.py
@@ -51,12 +51,12 @@ class Check(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc).replace(microsecond=0))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc).replace(microsecond=0))
 
-    def merge(self, other):
+    def merge(self, other) -> bool:
         if not self.is_preset and not other.is_preset and self.check_id != other.check_id:
             raise ValueError(f"check_id mismatch: {self.check_id} != {other.check_id}")
 
         if self.updated_at and other.updated_at and self.updated_at >= other.updated_at:
-            return
+            return False
 
         self.name = other.name
         self.description = other.description
@@ -66,6 +66,7 @@ class Check(BaseModel):
         self.is_checked = other.is_checked
         self.is_preset = other.is_preset
         self.updated_at = other.updated_at
+        return True
 
 
 class Lineage(BaseModel):

--- a/recce/run.py
+++ b/recce/run.py
@@ -140,7 +140,7 @@ async def execute_state_checks(checks: list) -> (int, List[dict]):
         check_params = check.params if check.params else {}
         if check.is_checked:
             check.is_checked = False
-            check.updated_at = datetime.utc(tz=timezone.utc).replace(microsecond=0)
+            check.updated_at = datetime.now(tz=timezone.utc).replace(microsecond=0)
 
         try:
             # verify the check

--- a/recce/run.py
+++ b/recce/run.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+from datetime import datetime, timezone
 from typing import List
 
 from rich import box
@@ -137,7 +138,9 @@ async def execute_state_checks(checks: list) -> (int, List[dict]):
         check_type = check.type.value
         check_description = check.description
         check_params = check.params if check.params else {}
-        check.is_checked = False
+        if check.is_checked:
+            check.is_checked = False
+            check.updated_at = datetime.utc(tz=timezone.utc).replace(microsecond=0)
 
         try:
             # verify the check

--- a/recce/server.py
+++ b/recce/server.py
@@ -264,12 +264,13 @@ async def sync_handler(input: SyncStateInput, response: Response, background_tas
     # Sync the state file
     context = default_context()
     state_loader = context.state_loader
-    print(input)
+    method = input.method
 
-    if not input.method:
+    if not method:
         is_conflict = state_loader.check_conflict()
         if is_conflict:
             raise HTTPException(status_code=409, detail='Conflict detected')
+        method = 'overwrite'
 
     is_syncing = state_loader.state_lock.locked()
     if is_syncing:
@@ -278,7 +279,7 @@ async def sync_handler(input: SyncStateInput, response: Response, background_tas
 
     def reload_state():
         ctx = default_context()
-        ctx.sync_state()
+        ctx.sync_state(method)
 
     background_tasks.add_task(reload_state)
     response.status_code = 202

--- a/recce/server.py
+++ b/recce/server.py
@@ -278,7 +278,7 @@ async def sync_handler(input: SyncStateInput, response: Response, background_tas
 
     def reload_state():
         ctx = default_context()
-        ctx.refresh_state()
+        ctx.sync_state()
 
     background_tasks.add_task(reload_state)
     response.status_code = 202

--- a/recce/server.py
+++ b/recce/server.py
@@ -31,7 +31,7 @@ logger = logging.getLogger('uvicorn')
 
 @dataclass
 class AppState:
-    recce_state: Optional[RecceStateLoader] = None
+    state_loader: Optional[RecceStateLoader] = None
     kwargs: Optional[dict] = None
 
 
@@ -42,14 +42,14 @@ async def lifespan(fastapi: FastAPI):
 
     console = Console()
     app_state: AppState = app.state
-    recce_state = app_state.recce_state
+    state_loader = app_state.state_loader
     kwargs = app_state.kwargs
-    ctx = load_context(**kwargs, recce_state=recce_state)
+    ctx = load_context(**kwargs, state_loader=state_loader)
     ctx.start_monitor_artifacts(callback=dbt_artifacts_updated_callback)
 
     # Initialize Recce Config
     config = RecceConfig(config_file=kwargs.get('config'))
-    if not recce_state:
+    if not state_loader:
         preset_checks = config.get('checks', [])
         if preset_checks and len(preset_checks) > 0:
             console.rule("Loading Preset Checks")
@@ -60,7 +60,7 @@ async def lifespan(fastapi: FastAPI):
 
     yield
 
-    recce_state.export(ctx.export_state())
+    state_loader.export(ctx.export_state())
 
     ctx.stop_monitor_artifacts()
 

--- a/recce/state.py
+++ b/recce/state.py
@@ -221,9 +221,7 @@ class RecceStateLoader:
         self.state_lock.acquire()
         try:
             if self.cloud_mode:
-                print("sync start")
                 self.state, self.state_etag = self._load_state_from_cloud()
-                print("sync complete")
             elif self.state_file:
                 self.state = self._load_state_from_file()
         finally:
@@ -331,7 +329,6 @@ class RecceStateLoader:
                 return None
             state_etag = metadata.get('etag')
             if self.state_etag and state_etag == self.state_etag:
-                print("use cache state")
                 return self.state, self.state_etag
 
             return self._load_state_from_recce_cloud(), state_etag

--- a/recce/state.py
+++ b/recce/state.py
@@ -267,7 +267,6 @@ class RecceStateLoader:
             return False
 
         state_etag = metadata.get('etag')
-        print(state_etag, self.state_etag)
         return state_etag != self.state_etag
 
     def info(self):

--- a/recce/state.py
+++ b/recce/state.py
@@ -326,7 +326,7 @@ class RecceStateLoader:
             logger.debug('Fetching state from Recce Cloud...')
             metadata = self._get_metadata_from_recce_cloud()
             if metadata is None:
-                return None
+                return None, None
             state_etag = metadata.get('etag')
             if self.state_etag and state_etag == self.state_etag:
                 return self.state, self.state_etag

--- a/recce/util/recce_cloud.py
+++ b/recce/util/recce_cloud.py
@@ -61,6 +61,8 @@ class RecceCloud:
     def get_artifact_metadata(self, pr_info: PullRequestInfo) -> dict:
         api_url = f'{self.base_url}/{pr_info.repository}/pulls/{pr_info.id}/metadata'
         response = self._request('GET', api_url)
+        if response.status_code == 204:
+            return None
         if response.status_code != 200:
             raise RecceCloudException(
                 message='Failed to get artifact metadata from Recce Cloud.',

--- a/recce/util/recce_cloud.py
+++ b/recce/util/recce_cloud.py
@@ -58,8 +58,8 @@ class RecceCloud:
         presigned_url = response.json().get('presigned_url')
         return presigned_url
 
-    def get_artifact_metadata(self, pr_info: PullRequestInfo, artifact_name: str) -> dict:
-        api_url = f'{self.base_url}/{pr_info.repository}/pulls/{pr_info.id}/artifacts/{artifact_name}/metadata'
+    def get_artifact_metadata(self, pr_info: PullRequestInfo) -> dict:
+        api_url = f'{self.base_url}/{pr_info.repository}/pulls/{pr_info.id}/metadata'
         response = self._request('GET', api_url)
         if response.status_code != 200:
             raise RecceCloudException(

--- a/tests/adapter/dbt_adapter/dbt_test_helper.py
+++ b/tests/adapter/dbt_adapter/dbt_test_helper.py
@@ -33,14 +33,21 @@ class DbtTestHelper:
         context.schema_prefix = schema_prefix
         self.adapter = dbt_adapter
         self.context = context
-        writable_manifest = load_manifest(manifest_path)
-        self.curr_manifest = as_manifest(writable_manifest)
-        self.base_manifest = as_manifest(writable_manifest)
+        curr_writable_manifest = load_manifest(manifest_path)
+        base_writable_manifest = load_manifest(manifest_path)
+
+        self.curr_manifest = as_manifest(curr_writable_manifest)
+        self.base_manifest = as_manifest(base_writable_manifest)
         self.context = context
 
         self.adapter.execute(f"CREATE schema IF NOT EXISTS {self.base_schema}")
         self.adapter.execute(f"CREATE schema IF NOT EXISTS {self.curr_schema}")
-        self.adapter.set_artifacts(writable_manifest, writable_manifest, self.curr_manifest, self.base_manifest)
+        self.adapter.set_artifacts(
+            base_writable_manifest,
+            curr_writable_manifest,
+            self.curr_manifest,
+            self.base_manifest
+        )
 
     def create_model(self, model_name, base_csv=None, curr_csv=None, depends_on=[], disabled=False):
         package_name = "recce_test"

--- a/tests/adapter/dbt_adapter/dbt_test_helper.py
+++ b/tests/adapter/dbt_adapter/dbt_test_helper.py
@@ -33,13 +33,14 @@ class DbtTestHelper:
         context.schema_prefix = schema_prefix
         self.adapter = dbt_adapter
         self.context = context
-        self.curr_manifest = as_manifest(load_manifest(manifest_path))
-        self.base_manifest = as_manifest(load_manifest(manifest_path))
+        writable_manifest = load_manifest(manifest_path)
+        self.curr_manifest = as_manifest(writable_manifest)
+        self.base_manifest = as_manifest(writable_manifest)
         self.context = context
 
         self.adapter.execute(f"CREATE schema IF NOT EXISTS {self.base_schema}")
         self.adapter.execute(f"CREATE schema IF NOT EXISTS {self.curr_schema}")
-        self.adapter.set_artifacts(self.base_manifest, self.curr_manifest)
+        self.adapter.set_artifacts(writable_manifest, writable_manifest, self.curr_manifest, self.base_manifest)
 
     def create_model(self, model_name, base_csv=None, curr_csv=None, depends_on=[], disabled=False):
         package_name = "recce_test"
@@ -101,7 +102,11 @@ class DbtTestHelper:
                 _add_model_to_manifest(False, curr_csv)
                 df_curr = pd.read_csv(StringIO(curr_csv))
                 dbt_adapter.execute(f"CREATE TABLE {self.curr_schema}.{model_name} AS SELECT * FROM df_curr")
-        self.adapter.set_artifacts(self.base_manifest, self.curr_manifest)
+        self.adapter.set_artifacts(
+            self.base_manifest.writable_manifest(),
+            self.curr_manifest.writable_manifest(),
+            self.curr_manifest,
+            self.base_manifest)
 
     def remove_model(self, model_name):
         dbt_adapter = self.adapter
@@ -171,7 +176,11 @@ class DbtTestHelper:
         with dbt_adapter.connection_named('create model'):
             dbt_adapter.execute(f"CREATE TABLE {self.base_schema}.{sanpshot_name} AS SELECT * FROM df_base")
             dbt_adapter.execute(f"CREATE TABLE {self.curr_schema}.{sanpshot_name} AS SELECT * FROM df_curr")
-        self.adapter.set_artifacts(self.base_manifest, self.curr_manifest)
+        self.adapter.set_artifacts(
+            self.base_manifest.writable_manifest(),
+            self.curr_manifest.writable_manifest(),
+            self.curr_manifest,
+            self.base_manifest)
 
     def remove_snapshot(self, snapshot_name):
         dbt_adapter = self.adapter

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,75 @@
+# add the RecceState test case
+import os
+import unittest
+
+from recce.models import Check, Run
+from recce.state import RecceState, ArtifactsRoot
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestRecceState(unittest.TestCase):
+    def test_merge_check(self):
+        check1 = Check(name='test1', description='', type='query')
+        check2 = Check(name='test2', description='', type='query')
+        check2_2 = Check(name='test2_2', description='', type='query', check_id=check2.check_id)
+        check3 = Check(name='test3', description='', type='query')
+
+        state = RecceState(checks=[])
+        state._merge_check(check1)
+        self.assertEqual(len(state.checks), 1)
+        self.assertEqual(state.checks[0].check_id, check1.check_id)
+
+        state = RecceState(checks=[check1, check2])
+        state._merge_check(check2_2)
+        state._merge_check(check3)
+        self.assertEqual(len(state.checks), 3)
+        self.assertEqual(state.checks[1].check_id, check2.check_id)
+        self.assertEqual(state.checks[1].name, check2_2.name)
+
+    def test_merge_run(self):
+        run1 = Run(type='query')
+        run2 = Run(type='query')
+        run3 = Run(type='query')
+
+        state = RecceState(runs=[])
+        state._merge_run(run1)
+        self.assertEqual(len(state.runs), 1)
+
+        state = RecceState(runs=[run1, run2])
+        state._merge_run(run2)
+        state._merge_run(run3)
+        self.assertEqual(len(state.runs), 3)
+
+    def test_merge_artifacts(self):
+        import json
+        import os
+        # load json from ./manifest.json
+
+        with open(os.path.join(current_dir, 'manifest.json'), 'r') as f:
+            manifest = json.load(f)
+        with open(os.path.join(current_dir, 'catalog.json'), 'r') as f:
+            catalog = json.load(f)
+
+        artifacts1 = ArtifactsRoot(
+            base=dict(
+                manifest=manifest,
+                catalog=catalog,
+            )
+        )
+        artifacts2 = ArtifactsRoot(
+            current=dict(
+                manifest=manifest,
+                catalog=catalog,
+            )
+        )
+
+        artifacts1.merge(artifacts2)
+        self.assertEqual(artifacts1.base['manifest'], manifest)
+        self.assertEqual(artifacts1.base['catalog'], catalog)
+        self.assertEqual(artifacts1.current['manifest'], manifest)
+        self.assertEqual(artifacts1.current['catalog'], catalog)
+
+
+
+

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -11,13 +11,6 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 
 class TestRecceState(unittest.TestCase):
     def test_merge_checks(self):
-        context = RecceContext()
-        check1 = Check(name='test1', description='', type='query')
-        state = RecceState(checks=[check1], runs=[])
-        context.import_state(state)
-        assert len(context.checks) == 1
-
-    def test_merge_check(self):
         check1 = Check(name='test1', description='', type='query')
         check2 = Check(name='test2', description='', type='query')
         check2_2 = Check(name='test2_2', description='', type='query', check_id=check2.check_id)
@@ -30,12 +23,12 @@ class TestRecceState(unittest.TestCase):
         self.assertEqual(context.checks[0].name, check1.name)
 
         context = RecceContext(checks=[check1, check2])
-        state = RecceState(checks=[check2_2, check3], runs=[])
+        state = RecceState(checks=[check1, check2_2, check3], runs=[])
         context.import_state(state)
         self.assertEqual(len(context.checks), 3)
         self.assertEqual(context.checks[1].name, check2_2.name)
 
-    def test_merge_run(self):
+    def test_merge_runs(self):
         run1 = Run(type='query')
         run2 = Run(type='query')
         run3 = Run(type='query')

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -44,11 +44,11 @@ class TestRecceState(unittest.TestCase):
         self.assertEqual(1, len(context.checks))
         self.assertEqual(check2.name, context.checks[0].name)
 
-        # context = RecceContext(checks=[check2])
-        # state = RecceState(checks=[check1], runs=[])
-        # context.import_state(state)
-        # self.assertEqual(1, len(context.checks))
-        # self.assertEqual(check2.name, context.checks[0].name)
+        context = RecceContext(checks=[check2])
+        state = RecceState(checks=[check1], runs=[])
+        context.import_state(state)
+        self.assertEqual(1, len(context.checks))
+        self.assertEqual(check2.name, context.checks[0].name)
 
     def test_revert_checks(self):
         check1 = Check(name='test1', description='', type='query')

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ basepython = python3.10
 deps =
     pytest
     pandas
+    duckdb<1.1
     dbt1.5: dbt-duckdb==1.5.*
     dbt1.6: dbt-duckdb==1.6.*
     dbt1.7: dbt-duckdb==1.7.*


### PR DESCRIPTION
When running recce server in the cloud mode, the syncing behavior is
1. When launching, it load the state from the cloud
2. When editing check, it upload(overwrite) state to the cloud
3. When clicking check, it download(import) runs and checks from the cloud. 
4. When termingating, it upload(overwrite) state to the cloud

### Problme
However, there is a case we did not cover.
When run the recce server in the cloud mode. If the ci trigger the `recce run --cloud` and update the dbt artifacts to the code.  There is no way to sync the dbt artifacts in the recce server

### Solution
In this PR, we implement the merge operation. In the 2,3,4 case, it changes to merge instance of one-way upload/download. Instead, it download the state(if necessary), merge the state, and upload back to the cloud.

In addition, if user click the sync button. It would detect if there is a new state in the cloud
1. If yes. just upload local state to remote
2. If no, it will prompt three option to sync (merge, revert, overwrite). User can have the options to decide which way to sync with the cloud.



**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature/Enhacenemnt

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
