### PR TITLE
Profile diff should support bigquery array type

### DIFF
--- a/js/src/components/run/RunModal.tsx
+++ b/js/src/components/run/RunModal.tsx
@@ -230,7 +230,7 @@ export const RunModal = <PT, RT, VO>({
               </Button>
             )}
 
-            {hasResult && !RunForm && (
+            {(hasResult || hasError) && !RunForm && (
               <Button colorScheme="blue" onClick={handleRerun}>
                 Rerun
               </Button>


### PR DESCRIPTION
Fix #415 

1. Use separate sql for bigquery arrray. We show the min/max/avg/median of the the [ARRAY_LENGTH](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_length) of the array column
2. Show correct error message if there is any error from the profiling.
3. In the frontend, should show Rerun button if profile failed.




**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
