### PR TITLE
[Bug] Cannot launch recce server in file mode when file does not exist

### DIFF
--- a/recce/state.py
+++ b/recce/state.py
@@ -121,7 +121,7 @@ class RecceState(BaseModel):
 
         logger.debug(f"Load state file from: '{file_path}'")
         if not Path(file_path).is_file():
-            raise FileNotFoundError(f"State file not found: {file_path}")
+            return None
 
         io = file_io_factory(file_type)
         json_content = io.read(file_path)


### PR DESCRIPTION
Fix: cannot launch recce server in file mode if the file does not exist.
```
recce server myfile.json
```

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
