### PR TITLE
[Feature] Allows to show histogram and top k in the schema column

### DIFF
--- a/js/src/components/histogram/HistogramDiffForm.tsx
+++ b/js/src/components/histogram/HistogramDiffForm.tsx
@@ -53,6 +53,10 @@ function isDateTimeType(columnType: string) {
 
 interface HistogramDiffEditProps extends RunFormProps<HistogramDiffParams> {}
 
+export function supportsHistogramDiff(columnType: string) {
+  return !isStringDataType(columnType) && !isDateTimeType(columnType);
+}
+
 export function HistogramDiffForm({
   params,
   onParamsChanged,

--- a/js/src/components/schema/ColumnNameCell.tsx
+++ b/js/src/components/schema/ColumnNameCell.tsx
@@ -1,0 +1,86 @@
+import { useRecceActionContext } from "@/lib/hooks/RecceActionContext";
+import {
+  Flex,
+  Box,
+  Spacer,
+  Menu,
+  MenuButton,
+  IconButton,
+  Icon,
+  Portal,
+  MenuList,
+  MenuGroup,
+  MenuItem,
+} from "@chakra-ui/react";
+import { VscKebabVertical } from "react-icons/vsc";
+
+export function ColumnNameCell({
+  model,
+  columnName,
+  columnType,
+}: //   containerRef,
+{
+  model: string;
+  columnName: string;
+  columnType: string;
+  //   containerRef: React.RefObject<any>;
+}) {
+  const { runAction } = useRecceActionContext();
+
+  const handleHistogramDiff = () => {
+    runAction(
+      "histogram_diff",
+      { model, column_name: columnName, column_type: columnType },
+      { showForm: false }
+    );
+  };
+
+  const handleTopkDiff = () => {
+    runAction(
+      "top_k_diff",
+      { model, column_name: columnName, k: 50 },
+      { showForm: false }
+    );
+  };
+
+  return (
+    <Flex>
+      <Box overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
+        {columnName}
+      </Box>
+      <Spacer />
+
+      <Menu>
+        {({ isOpen }) => (
+          <>
+            <MenuButton
+              className="row-context-menu"
+              visibility={isOpen ? "visible" : "hidden"}
+              width={isOpen ? "auto" : "0px"}
+              minWidth={isOpen ? "auto" : "0px"}
+              as={IconButton}
+              icon={<Icon as={VscKebabVertical} />}
+              variant="unstyled"
+              size={"sm"}
+            />
+
+            <Portal
+            // containerRef={containerRef}
+            >
+              <MenuList lineHeight="20px">
+                <MenuGroup title="Diff" m="0" p="4px 12px">
+                  <MenuItem fontSize="10pt" onClick={handleHistogramDiff}>
+                    Histogram Diff
+                  </MenuItem>
+                  <MenuItem fontSize="10pt" onClick={handleTopkDiff}>
+                    Top-k Diff
+                  </MenuItem>
+                </MenuGroup>
+              </MenuList>
+            </Portal>
+          </>
+        )}
+      </Menu>
+    </Flex>
+  );
+}

--- a/js/src/components/schema/ColumnNameCell.tsx
+++ b/js/src/components/schema/ColumnNameCell.tsx
@@ -13,24 +13,26 @@ import {
   MenuItem,
 } from "@chakra-ui/react";
 import { VscKebabVertical } from "react-icons/vsc";
+import { supportsHistogramDiff } from "../histogram/HistogramDiffForm";
 
 export function ColumnNameCell({
   model,
-  columnName,
-  columnType,
-}: //   containerRef,
-{
+  name,
+  baseType,
+  currentType,
+}: {
   model: string;
-  columnName: string;
-  columnType: string;
-  //   containerRef: React.RefObject<any>;
+  name: string;
+  baseType?: string;
+  currentType?: string;
 }) {
   const { runAction } = useRecceActionContext();
+  const columnType = currentType || baseType;
 
   const handleHistogramDiff = () => {
     runAction(
       "histogram_diff",
-      { model, column_name: columnName, column_type: columnType },
+      { model, column_name: name, column_type: columnType },
       { showForm: false }
     );
   };
@@ -38,15 +40,16 @@ export function ColumnNameCell({
   const handleTopkDiff = () => {
     runAction(
       "top_k_diff",
-      { model, column_name: columnName, k: 50 },
+      { model, column_name: name, k: 50 },
       { showForm: false }
     );
   };
+  const addedOrRemoved = !baseType || !currentType;
 
   return (
     <Flex>
       <Box overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
-        {columnName}
+        {name}
       </Box>
       <Spacer />
 
@@ -64,15 +67,24 @@ export function ColumnNameCell({
               size={"sm"}
             />
 
-            <Portal
-            // containerRef={containerRef}
-            >
+            <Portal>
               <MenuList lineHeight="20px">
                 <MenuGroup title="Diff" m="0" p="4px 12px">
-                  <MenuItem fontSize="10pt" onClick={handleHistogramDiff}>
+                  <MenuItem
+                    fontSize="10pt"
+                    onClick={handleHistogramDiff}
+                    isDisabled={
+                      addedOrRemoved ||
+                      (columnType ? !supportsHistogramDiff(columnType) : true)
+                    }
+                  >
                     Histogram Diff
                   </MenuItem>
-                  <MenuItem fontSize="10pt" onClick={handleTopkDiff}>
+                  <MenuItem
+                    fontSize="10pt"
+                    onClick={handleTopkDiff}
+                    isDisabled={addedOrRemoved}
+                  >
                     Top-k Diff
                   </MenuItem>
                 </MenuGroup>

--- a/js/src/components/schema/SchemaView.tsx
+++ b/js/src/components/schema/SchemaView.tsx
@@ -21,14 +21,15 @@ export function SchemaView({
   current,
   enableScreenshot = false,
 }: SchemaViewProps) {
-  const { columns, rows } = useMemo(
-    () =>
-      toDataGrid(
-        current?.name || base?.name,
-        mergeColumns(base?.columns, current?.columns)
-      ),
-    [base, current]
-  );
+  const { columns, rows } = useMemo(() => {
+    const schemaDiff = mergeColumns(base?.columns, current?.columns);
+    const resourceType = current?.resource_type || base?.resource_type;
+    if (resourceType && ["model", "seed", "snapshot"].includes(resourceType)) {
+      return toDataGrid(schemaDiff, current?.name || base?.name);
+    } else {
+      return toDataGrid(schemaDiff);
+    }
+  }, [base, current]);
 
   const { lineageGraph } = useLineageGraphContext();
   const noCatalogBase = !lineageGraph?.catalogMetadata.base;

--- a/js/src/components/schema/SchemaView.tsx
+++ b/js/src/components/schema/SchemaView.tsx
@@ -22,7 +22,11 @@ export function SchemaView({
   enableScreenshot = false,
 }: SchemaViewProps) {
   const { columns, rows } = useMemo(
-    () => toDataGrid(mergeColumns(base?.columns, current?.columns)),
+    () =>
+      toDataGrid(
+        current?.name || base?.name,
+        mergeColumns(base?.columns, current?.columns)
+      ),
     [base, current]
   );
 

--- a/js/src/components/schema/schema.tsx
+++ b/js/src/components/schema/schema.tsx
@@ -49,7 +49,7 @@ export function mergeColumns(
   return result;
 }
 
-export function toDataGrid(name: string | undefined, schemaDiff: SchemaDiff) {
+export function toDataGrid(schemaDiff: SchemaDiff, nodeName?: string) {
   function columnIndexCellClass(row: SchemaDiffRow) {
     if (row.baseIndex === undefined) {
       return "column-index-added";
@@ -113,9 +113,9 @@ export function toDataGrid(name: string | undefined, schemaDiff: SchemaDiff) {
       name: "Name",
       resizable: true,
       renderCell: ({ row, column }) => {
-        return name ? (
+        return nodeName ? (
           <ColumnNameCell
-            model={name}
+            model={nodeName}
             name={row["name"]}
             baseType={row["baseType"]}
             currentType={row["currentType"]}

--- a/js/src/components/schema/schema.tsx
+++ b/js/src/components/schema/schema.tsx
@@ -116,9 +116,9 @@ export function toDataGrid(name: string | undefined, schemaDiff: SchemaDiff) {
         return name ? (
           <ColumnNameCell
             model={name}
-            columnName={row["name"] || ""}
-            columnType={row["currentType"] || ""}
-            // containerRef={containerRef}
+            name={row["name"]}
+            baseType={row["baseType"]}
+            currentType={row["currentType"]}
           />
         ) : (
           row["name"]

--- a/js/src/components/schema/schema.tsx
+++ b/js/src/components/schema/schema.tsx
@@ -4,6 +4,7 @@ import { ColumnOrColumnGroup } from "react-data-grid";
 
 import "./style.css";
 import { NodeData } from "@/lib/api/info";
+import { ColumnNameCell } from "./ColumnNameCell";
 
 interface SchemaDiffRow {
   name: string;
@@ -48,7 +49,7 @@ export function mergeColumns(
   return result;
 }
 
-export function toDataGrid(schemaDiff: SchemaDiff) {
+export function toDataGrid(name: string | undefined, schemaDiff: SchemaDiff) {
   function columnIndexCellClass(row: SchemaDiffRow) {
     if (row.baseIndex === undefined) {
       return "column-index-added";
@@ -111,6 +112,18 @@ export function toDataGrid(schemaDiff: SchemaDiff) {
       key: "name",
       name: "Name",
       resizable: true,
+      renderCell: ({ row, column }) => {
+        return name ? (
+          <ColumnNameCell
+            model={name}
+            columnName={row["name"] || ""}
+            columnType={row["currentType"] || ""}
+            // containerRef={containerRef}
+          />
+        ) : (
+          row["name"]
+        );
+      },
       cellClass: columnNameCellClass,
     },
     {


### PR DESCRIPTION
###  Problem to solve
There are too many steps to navigate a node to run histogram/topk diff
1. click the “Explore Changes” button
2. Select histogram
3. Find the column i want to run
4. Click Execute button

### Solution
Provide additional ‘…’ button on the column name,  The steps would be

1. Scroll to the column
2. Click the “…” button
3. Select the “Historam” (or Top-K”

![image](https://github.com/user-attachments/assets/6e4177bf-228e-4547-a95c-492d0b16bb17)


**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
