### PR TITLE
[Feature] DRC-724 Save onboarding state and sync with cloud

### DIFF
--- a/js/app/page.tsx
+++ b/js/app/page.tsx
@@ -18,6 +18,7 @@ import {
   Progress,
   HStack,
 } from "@chakra-ui/react";
+import React from "react";
 import { ReactNode, useLayoutEffect } from "react";
 import * as amplitude from "@amplitude/analytics-browser";
 import { QueryClientProvider, useQuery } from "@tanstack/react-query";

--- a/js/src/components/onboarding-guide/OnboardingGuide.tsx
+++ b/js/src/components/onboarding-guide/OnboardingGuide.tsx
@@ -1,21 +1,27 @@
 import { Button, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Image, List, ListItem, Stack, Divider } from "@chakra-ui/react";
 import React from "react";
 import { useEffect, useState } from "react";
+import { getServerFlag, markOnboardingCompleted } from "@/lib/api/flag";
 
 
 const OnboardingGuide = () => {
   const [isGuideOpen, setIsGuideOpen] = useState<boolean>(false);
 
   useEffect(() => {
-    const hasVisited = localStorage.getItem("hasVisited");
-    if (!hasVisited) {
-      setIsGuideOpen(true);
-      localStorage.setItem("hasVisited", "true");
-    }
+    getServerFlag().then((flags) => {
+      const showOnboardingGuide = flags.show_onboarding_guide;
+      const hasVisited = localStorage.getItem("hasVisited");
+      if (!hasVisited && showOnboardingGuide) {
+        setIsGuideOpen(true);
+        localStorage.setItem("hasVisited", "true");
+      }
+    });
+
   }, []);
 
   const closeGuide = () => {
     setIsGuideOpen(false);
+    markOnboardingCompleted();
   }
 
   return (

--- a/js/src/lib/api/flag.ts
+++ b/js/src/lib/api/flag.ts
@@ -1,0 +1,19 @@
+import { axiosClient } from "./axiosClient";
+
+export interface RecceServerFlags {
+  show_onboarding_guide: boolean;
+}
+
+export async function getServerFlag(): Promise<RecceServerFlags> {
+  const response = await axiosClient.get("/api/flag");
+  return response.data;
+}
+
+export async function markOnboardingCompleted(): Promise<void> {
+  try {
+    await axiosClient.post("/api/onboarding/completed");
+  }
+  catch (error) {
+    // skip any errors
+  }
+}

--- a/recce/core.py
+++ b/recce/core.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, Optional, List
 from recce.adapter.base import BaseAdapter
 from recce.models import Check, Run
 from recce.state import RecceState, RecceStateMetadata, GitRepoInfo, PullRequestInfo, RecceStateLoader
+from recce.util.recce_cloud import set_recce_cloud_onboarding_state
 
 logger = logging.getLogger('uvicorn')
 
@@ -224,6 +225,17 @@ class RecceContext:
             self.adapter.import_artifacts(import_state.artifacts)
 
         return import_runs, import_checks
+
+    def mark_onboarding_completed(self):
+        if self.state_loader.cloud_mode:
+            try:
+                token = self.state_loader.cloud_options.get('token')
+                set_recce_cloud_onboarding_state(token, 'completed')
+            except Exception as e:
+                logger.debug(f'Failed to mark onboarding completed in Recce Cloud. Reason: {str(e)}')
+        else:
+            # Skip the onboarding state for non-cloud mode
+            pass
 
 
 recce_context: Optional[RecceContext] = None

--- a/recce/server.py
+++ b/recce/server.py
@@ -166,6 +166,7 @@ async def config_flag():
 async def mark_onboarding_completed():
     context = default_context()
     context.mark_onboarding_completed()
+    app.state.flag['show_onboarding_guide'] = False
 
 
 @app.get("/api/info")

--- a/recce/server.py
+++ b/recce/server.py
@@ -33,6 +33,7 @@ logger = logging.getLogger('uvicorn')
 class AppState:
     state_loader: Optional[RecceStateLoader] = None
     kwargs: Optional[dict] = None
+    flag: Optional[dict] = None
 
 
 @asynccontextmanager
@@ -105,6 +106,7 @@ clients = set()
 
 origins = [
     "http://localhost:3000",
+    "http://localhost:3001",
 ]
 
 app.add_middleware(GZipMiddleware, minimum_size=1000)
@@ -151,6 +153,19 @@ async def disable_cache(request: Request, call_next):
 @app.get("/api/health")
 async def health_check(request: Request):
     return {"status": "ok"}
+
+
+@app.get("/api/flag")
+async def config_flag():
+    app_state: AppState = app.state
+    flag = app_state.flag
+    return flag
+
+
+@app.post("/api/onboarding/completed", status_code=204)
+async def mark_onboarding_completed():
+    context = default_context()
+    context.mark_onboarding_completed()
 
 
 @app.get("/api/info")

--- a/recce/state.py
+++ b/recce/state.py
@@ -308,7 +308,7 @@ class RecceStateLoader:
         file_path = file_path or self.state_file
         return RecceState.from_file(file_path) if file_path else None
 
-    def _load_state_from_cloud(self) -> Tuple[RecceState | None, str | None]:
+    def _load_state_from_cloud(self) -> Tuple[Optional[RecceState, None], Optional[str, None]]:
         '''
         Load the state from Recce Cloud.
 

--- a/recce/state.py
+++ b/recce/state.py
@@ -308,7 +308,7 @@ class RecceStateLoader:
         file_path = file_path or self.state_file
         return RecceState.from_file(file_path) if file_path else None
 
-    def _load_state_from_cloud(self) -> Tuple[RecceState, str]:
+    def _load_state_from_cloud(self) -> Tuple[RecceState | None, str | None]:
         '''
         Load the state from Recce Cloud.
 

--- a/recce/state.py
+++ b/recce/state.py
@@ -308,7 +308,7 @@ class RecceStateLoader:
         file_path = file_path or self.state_file
         return RecceState.from_file(file_path) if file_path else None
 
-    def _load_state_from_cloud(self) -> Tuple[Optional[RecceState, None], Optional[str, None]]:
+    def _load_state_from_cloud(self) -> Tuple[RecceState, str]:
         '''
         Load the state from Recce Cloud.
 

--- a/recce/util/recce_cloud.py
+++ b/recce/util/recce_cloud.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from typing import Dict
 
 import requests
 
@@ -102,3 +103,37 @@ class RecceCloud:
         except Exception as e:
             # We don't care the response of this request, so we don't need to raise any exception.
             logger.debug(f'Failed to update the GitHub PR check. Reason: {str(e)}')
+
+    def get_user_info(self) -> Dict:
+        api_url = f'{self.base_url}/users'
+        response = self._request('GET', api_url)
+        if response.status_code != 200:
+            raise RecceCloudException(
+                message='Failed to get user info from Recce Cloud.',
+                reason=response.text,
+                status_code=response.status_code
+            )
+        return response.json().get('user')
+
+    def set_onboarding_state(self, state: str):
+        api_url = f'{self.base_url}/users/onboarding-state'
+        response = self._request('PUT', api_url, data={'state': state})
+        if response.status_code != 200:
+            raise RecceCloudException(
+                message='Failed to update onboarding state in Recce Cloud.',
+                reason=response.text,
+                status_code=response.status_code
+            )
+
+
+def get_recce_cloud_onboarding_state(token: str) -> str:
+    recce_cloud = RecceCloud(token)
+    user_info = recce_cloud.get_user_info()
+    if user_info:
+        return user_info.get('onboarding_state')
+    return 'undefined'
+
+
+def set_recce_cloud_onboarding_state(token: str, new_state: str):
+    recce_cloud = RecceCloud(token)
+    recce_cloud.set_onboarding_state(new_state)

--- a/recce/util/recce_cloud.py
+++ b/recce/util/recce_cloud.py
@@ -127,10 +127,13 @@ class RecceCloud:
 
 
 def get_recce_cloud_onboarding_state(token: str) -> str:
-    recce_cloud = RecceCloud(token)
-    user_info = recce_cloud.get_user_info()
-    if user_info:
-        return user_info.get('onboarding_state')
+    try:
+        recce_cloud = RecceCloud(token)
+        user_info = recce_cloud.get_user_info()
+        if user_info:
+            return user_info.get('onboarding_state')
+    except Exception as e:
+        logger.debug(str(e))
     return 'undefined'
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,12 +39,14 @@ class TestCommandServer(TestCase):
         result = self.runner.invoke(cli_command_server, ['--cloud', '--password', 'unittest'])
         assert result.exit_code == 1
 
+    @patch('recce.util.recce_cloud.get_recce_cloud_onboarding_state')
     @patch('recce.cli.uvicorn.run')
     @patch('recce.cli.RecceStateLoader')
-    def test_cmd_server_with_cloud(self, mock_state_loader_class, mock_run):
+    def test_cmd_server_with_cloud(self, mock_state_loader_class, mock_run, mock_get_recce_cloud_onboarding_state):
         mock_state_loader = MagicMock(spec=RecceStateLoader)
         mock_state_loader.verify.return_value = True
         mock_state_loader.review_mode = True
+        mock_get_recce_cloud_onboarding_state.return_value = 'completed'
 
         mock_state_loader_class.return_value = mock_state_loader
         self.runner.invoke(cli_command_server, ['--cloud', '--password', 'unittest', '--cloud-token', 'unittest'])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- The onboarding guide will be shown based on the cloud user's `onboarding_state` when executing the' server' command with cloud mode. 
- Once user close the onboarding guide, will mark the cloud user's `onboarding_state` as `completed` 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
