### PR TITLE
[Enhancement] Update the centering and fitting logic in the lineage view

### DIFF
--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -362,6 +362,8 @@ export function LineageView({ ...props }: LineageViewProps) {
       const selectedNode = nodes.find((node) => node.data.isSelected);
       if (selectedNode) {
         centerNode(selectedNode);
+      } else {
+        reactFlow.fitView({ nodes, duration: 200 });
       }
     }
   });
@@ -372,9 +374,9 @@ export function LineageView({ ...props }: LineageViewProps) {
     if (selectMode === "detail") {
       setDetailViewSelected(node.data);
       if (!isDetailViewShown) {
+        centerNode(node);
         setIsDetailViewShown(true);
       }
-      centerNode(node);
       setNodes(selectSingleNode(node.id, nodes));
     } else if (selectMode === "action_result") {
       if (node.data.action?.run?.run_id) {


### PR DESCRIPTION
1. When clicking a node, center the node only when the side pane is not shown
2. Center the selected node while resizing if one node is selected
3. Fit the lineage graph while no node is selected.

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
