### PR TITLE
[Bug] Fix histogram diff error if there is no min/max in the both side

### DIFF
--- a/tests/tasks/test_histogram.py
+++ b/tests/tasks/test_histogram.py
@@ -35,3 +35,74 @@ def test_histogram(dbt_test_helper):
     assert run_result['max'] == 50
     assert run_result['bin_edges'][0] == 25
     assert run_result['bin_edges'][-1] == 51
+
+
+def test_histogram_emtpy(dbt_test_helper):
+    csv_data = """
+    customer_id,name,age
+    1,Alice,30
+    2,Bob,25
+    3,Charlie,35
+    4,Dolly,50
+    """
+
+    csv_data_zero = """
+    customer_id,name,age
+    """
+
+    dbt_test_helper.create_model("customers", csv_data_zero, csv_data_zero)
+    dbt_test_helper.create_model("customers2", csv_data, csv_data_zero)
+    dbt_test_helper.create_model("customers3", csv_data_zero, csv_data)
+
+    params = {
+        "model": "customers",
+        "column_name": "age",
+        "column_type": "int"
+    }
+
+    task = HistogramDiffTask(params)
+    run_result = task.execute()
+
+    assert len(run_result['current']['counts']) == 0
+    assert run_result['current']['total'] == 0
+    assert run_result['min'] is None
+    assert run_result['max'] is None
+    assert len(run_result['bin_edges']) == 0
+
+    params = {
+        "model": "customers2",
+        "column_name": "age",
+        "column_type": "int"
+    }
+
+    task = HistogramDiffTask(params)
+    run_result = task.execute()
+    assert run_result['base']['counts'][0] == 1
+    assert run_result['base']['counts'][-1] == 1
+    assert run_result['base']['total'] == 4
+    assert run_result['current']['counts'][0] == 0
+    assert run_result['current']['counts'][-1] == 0
+    assert run_result['current']['total'] == 0
+    assert run_result['min'] == 25
+    assert run_result['max'] == 50
+    assert run_result['bin_edges'][0] == 25
+    assert run_result['bin_edges'][-1] == 51
+
+    params = {
+        "model": "customers3",
+        "column_name": "age",
+        "column_type": "int"
+    }
+
+    task = HistogramDiffTask(params)
+    run_result = task.execute()
+    assert run_result['base']['counts'][0] == 0
+    assert run_result['base']['counts'][-1] == 0
+    assert run_result['base']['total'] == 0
+    assert run_result['current']['counts'][0] == 1
+    assert run_result['current']['counts'][-1] == 1
+    assert run_result['current']['total'] == 4
+    assert run_result['min'] == 25
+    assert run_result['max'] == 50
+    assert run_result['bin_edges'][0] == 25
+    assert run_result['bin_edges'][-1] == 51


### PR DESCRIPTION
Fix #459 
If there is no min/max value for both side, the histogram would show 

```
in execute max_value = max(max_value, min_max_curr[0][1]) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ decimal.InvalidOperation: [<class 'decimal.InvalidOperation'>]
```

This PR fix this issue and add corresponding unittest

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
#459 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
