### PR TITLE
[Bug] Fix the naming of the value diff detail

### DIFF
--- a/recce/apis/run_func.py
+++ b/recce/apis/run_func.py
@@ -63,9 +63,12 @@ def generate_run_name(run):
         if ref:
             return f"query diff of {ref}".capitalize()
         return f"{'query diff'.capitalize()} - {now}"
-    elif run_type == RunType.VALUE_DIFF or run_type == RunType.VALUE_DIFF_DETAIL:
+    elif run_type == RunType.VALUE_DIFF:
         model = params.get('model')
         return f"value diff of {model}".capitalize()
+    elif run_type == RunType.VALUE_DIFF_DETAIL:
+        model = params.get('model')
+        return f"value diff detail of {model}".capitalize()
     elif run_type == RunType.PROFILE_DIFF:
         model = params.get('model')
         return f"profile diff of {model}".capitalize()


### PR DESCRIPTION
If the run type is value diff detail, we should show correct run type name

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

