### PR TITLE
[Bug] DRC-883 Workaround when the query result is Decimal(NaN)

### DIFF
--- a/recce/tasks/dataframe.py
+++ b/recce/tasks/dataframe.py
@@ -1,5 +1,6 @@
 import json
 import typing as t
+from decimal import Decimal
 from enum import Enum
 
 if t.TYPE_CHECKING:
@@ -62,7 +63,12 @@ class DataFrame(BaseModel):
             else:
                 col_type = DataFrameColumnType.UNKNOWN
             columns.append(DataFrameColumn(name=col_name, type=col_type))
-        data = [row.values() for row in table.rows]
+
+        def _row_values(row):
+            # If the value is Decimal, check if it's finite. If not, convert it to float(xxx) (GitHub issue #476)
+            return tuple([float(v) if isinstance(v, Decimal) and not v.is_finite() else v for v in row.values()])
+
+        data = [_row_values(row) for row in table.rows]
         df = DataFrame(
             columns=columns,
             data=data,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
- The average value will be Decimal type when executing the profile diff. When the value is Decimal('NaN'), it will cause the fastAPI's jsno encoder to fail. To prevent this edge case, convert it to float('NaN') as a workaround before the FastAPI fix this issue.

**Which issue(s) this PR fixes**:
#476 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
