### PR TITLE
[Enhacnemtn] simplify right click menu by removing initial node selection

### DIFF
--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -130,15 +130,6 @@ export function GraphNode({ data }: GraphNodeProps) {
 
   const name = data?.name;
 
-  const highlightClassName =
-    isHighlighted === true
-      ? "node-highlight"
-      : isSelected === true
-      ? "node-highlight"
-      : isHighlighted === false
-      ? "node-unhighlight"
-      : undefined;
-
   return (
     <Tooltip
       label={resourceType === "model" ? name : `${name} (${resourceType})`}
@@ -175,7 +166,9 @@ export function GraphNode({ data }: GraphNodeProps) {
           if (selectMode === "action_result") {
             return !!data?.action ? "none" : "opacity(0.2) grayscale(50%)";
           } else {
-            return isHighlighted ? "none" : "opacity(0.2) grayscale(50%)";
+            return isHighlighted || isSelected
+              ? "none"
+              : "opacity(0.2) grayscale(50%)";
           }
         })()}
         onMouseEnter={() => setIsHovered(true)}

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -25,6 +25,7 @@ import {
   Center,
   StackDivider,
   useToast,
+  MenuDivider,
 } from "@chakra-ui/react";
 import React, {
   Ref,
@@ -493,32 +494,40 @@ export function _LineageView(
     );
   }
 
-  const selectParentNodes = () => {
+  const selectParentNodes = (degree = 1000) => {
     const selectedNode = contextMenuPosition.selectedNode;
     if (
-      selectMode !== "multi" ||
+      selectMode === "action_result" ||
       selectedNode === undefined ||
       lineageGraph === undefined
     )
       return;
 
+    if (selectMode === "single") {
+      setSelectMode("multi");
+    }
+
     const selectedNodeId = selectedNode.id;
-    const upstream = selectUpstream(lineageGraph, [selectedNodeId]);
+    const upstream = selectUpstream(lineageGraph, [selectedNodeId], degree);
     const newNodes = selectNodes([...upstream], nodes);
     setNodes(newNodes);
   };
 
-  const selectChildNodes = () => {
+  const selectChildNodes = (degree = 1000) => {
     const selectedNode = contextMenuPosition.selectedNode;
     if (
-      selectMode !== "multi" ||
+      selectMode === "action_result" ||
       selectedNode === undefined ||
       lineageGraph === undefined
     )
       return;
 
+    if (selectMode === "single") {
+      setSelectMode("multi");
+    }
+
     const selectedNodeId = selectedNode.id;
-    const downstream = selectDownstream(lineageGraph, [selectedNodeId]);
+    const downstream = selectDownstream(lineageGraph, [selectedNodeId], degree);
     const newNodes = selectNodes([...downstream], nodes);
     setNodes(newNodes);
   };
@@ -805,22 +814,46 @@ export function _LineageView(
             // Only render context menu when select mode is action
             <Menu isOpen={true} onClose={closeContextMenu}>
               <MenuList
+                fontSize="11pt"
+                position="absolute"
+                width="250px"
                 style={{
-                  position: "absolute",
                   left: `${contextMenuPosition.x}px`,
                   top: `${contextMenuPosition.y}px`,
-                  // left: 0,
-                  // top: 0,
                 }}
               >
                 <MenuItem
                   icon={<BiArrowFromBottom />}
-                  onClick={selectParentNodes}
+                  onClick={() => {
+                    selectParentNodes(1);
+                  }}
                 >
                   Select parent nodes
                 </MenuItem>
-                <MenuItem icon={<BiArrowToBottom />} onClick={selectChildNodes}>
+                <MenuItem
+                  icon={<BiArrowToBottom />}
+                  onClick={() => {
+                    selectChildNodes(1);
+                  }}
+                >
                   Select child nodes
+                </MenuItem>
+                <MenuDivider></MenuDivider>
+                <MenuItem
+                  icon={<BiArrowFromBottom />}
+                  onClick={() => {
+                    selectParentNodes();
+                  }}
+                >
+                  Select all upstream nodes
+                </MenuItem>
+                <MenuItem
+                  icon={<BiArrowToBottom />}
+                  onClick={() => {
+                    selectChildNodes();
+                  }}
+                >
+                  Select all downstream nodes
                 </MenuItem>
               </MenuList>
             </Menu>

--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -475,7 +475,8 @@ export function selectNode(nodeId: string, nodes: Node<LineageGraphNode>[]) {
 
 export function selectNodes(
   nodeIds: string[],
-  nodes: Node<LineageGraphNode>[]
+  nodes: Node<LineageGraphNode>[],
+  reset: boolean = false
 ) {
   const newNodes = nodes.map((n) => {
     const isMatch = nodeIds.includes(n.id);
@@ -483,7 +484,7 @@ export function selectNodes(
       ...n,
       data: {
         ...n.data,
-        isSelected: n.data.isSelected || isMatch,
+        isSelected: reset ? isMatch : n.data.isSelected || isMatch,
       },
     };
   });


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/c419d929-ea64-4f53-9241-e4eb0d5810d5)


1. Show context menu before click 1-node
1. Support select parent, child, all downstream, all upstream nodes
1. Disable the highlighting effect when hovering on a node.
1. Fix the distance of right click position and context menu

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
