### PR TITLE
[Bug] Add extra process in get_columns for databricks

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -259,9 +259,13 @@ class DbtAdapter(BaseAdapter):
 
     def get_columns(self, model: str, base=False) -> List[Column]:
         relation = self.create_relation(model, base)
+        get_columns_macro = 'get_columns_in_relation'
+        if self.adapter.connections.TYPE == 'databricks':
+            get_columns_macro = 'get_columns_comments'
+
         if dbt_version < 'v1.8':
-            return self.adapter.execute_macro(
-                'get_columns_in_relation',
+            columns = self.adapter.execute_macro(
+                get_columns_macro,
                 kwargs={"relation": relation},
                 manifest=self.manifest)
         else:
@@ -269,9 +273,25 @@ class DbtAdapter(BaseAdapter):
             macro_manifest = MacroManifest(self.manifest.macros)
             self.adapter.set_macro_resolver(macro_manifest)
             self.adapter.set_macro_context_generator(generate_runtime_macro_context)
-            return self.adapter.execute_macro(
-                'get_columns_in_relation',
+            columns = self.adapter.execute_macro(
+                get_columns_macro,
                 kwargs={"relation": relation})
+
+        if self.adapter.connections.TYPE == 'databricks':
+            from dbt.adapters.databricks import DatabricksColumn
+            rows = columns
+            columns = []
+            for row in rows:
+                if row["col_name"].startswith("#"):
+                    break
+                columns.append(
+                    DatabricksColumn(
+                        column=row["col_name"], dtype=row["data_type"], comment=row["comment"]
+                    )
+                )
+            return columns
+        else:
+            return columns
 
     def get_model(self, model_id: str, base=False):
         manifest = self.curr_manifest if base is False else self.base_manifest

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -278,6 +278,7 @@ class DbtAdapter(BaseAdapter):
                 kwargs={"relation": relation})
 
         if self.adapter.connections.TYPE == 'databricks':
+            # reference: get_columns_in_relation (dbt/adapters/databricks/impl.py)
             from dbt.adapters.databricks import DatabricksColumn
             rows = columns
             columns = []


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:
- execute `get_columns_in_relation` macro in databricks didn't work

**Which issue(s) this PR fixes**:
DRC-945

**Special notes for your reviewer**:
- the workaround refers databricks adapter 1.8
- it works with dbt 1.7 and 1.8

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE