### PR TITLE
[Bug] Text in checklist description is not easy to read

### DIFF
--- a/js/src/components/check/CheckDescription.tsx
+++ b/js/src/components/check/CheckDescription.tsx
@@ -22,12 +22,6 @@ export function CheckDescription({ value, onChange }: CheckDescriptionProps) {
     setEditing(true);
   };
 
-  const handleKeyDown: KeyboardEventHandler = (event) => {
-    if (event.key === "Escape") {
-      setEditing(false);
-    }
-  };
-
   const handleCancel = () => {
     setTimeout(() => {
       setEditing(false);
@@ -38,6 +32,19 @@ export function CheckDescription({ value, onChange }: CheckDescriptionProps) {
     if (onChange) {
       onChange(tempValue);
       setEditing(false);
+    }
+  };
+
+  const handleKeyDown: KeyboardEventHandler = (event) => {
+    if (event.key === "Escape") {
+      setEditing(false);
+    }
+    if (
+      (event.metaKey || event.ctrlKey) && // mac: cmd, windows: ctrl
+      event.key === "Enter"
+    ) {
+      event.preventDefault();
+      handleUpdate();
     }
   };
 
@@ -77,10 +84,12 @@ export function CheckDescription({ value, onChange }: CheckDescriptionProps) {
 
   return (
     <Text
+      height="100%"
       overflow="auto"
       fontSize="11pt"
       onClick={handleEdit}
-      whiteSpace="pre"
+      whiteSpace="pre-wrap"
+      wordBreak="break-word"
       color={!value ? "lightgray" : "inherit"}
     >
       {!value ? "Add description here" : value}

--- a/js/src/components/check/CheckDetail.tsx
+++ b/js/src/components/check/CheckDetail.tsx
@@ -216,13 +216,8 @@ export const CheckDetail = ({ checkId }: CheckDetailProps) => {
       sizes={[30, 70]}
       style={{ height: "100%", width: "100%", maxHeight: "100%" }}
     >
-      <Box
-        style={{ contain: "strict" }}
-        display="flex"
-        flexDirection="column"
-        overflow="auto"
-      >
-        <Flex p="0px 16px" alignItems="center">
+      <Box style={{ contain: "strict" }} display="flex" flexDirection="column">
+        <Flex p="0px 16px" alignItems="center" h="40px">
           <CheckBreadcrumb
             name={check?.name || ""}
             setName={(name) => {


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/ca67ba6e-bf8e-4680-beac-036eae263123)

If the description is too long, the text should wrap instead of scroll.

In this PR, we also support to use cmd+enter to update the description.
