### PR TITLE
Replace ZoneInfo with datetime.timezone

### DIFF
--- a/recce/event/collector.py
+++ b/recce/event/collector.py
@@ -6,7 +6,7 @@ import time
 from contextlib import contextmanager
 from datetime import datetime
 from json import JSONDecodeError
-from zoneinfo import ZoneInfo
+from datetime import timezone
 
 import portalocker
 import requests
@@ -89,8 +89,8 @@ class Collector:
         if event_triggered_at is None:
             created_at = datetime.now()
         else:
-            # Convert to GMT timezone
-            created_at = event_triggered_at.astimezone(ZoneInfo("GMT"))
+            # Convert to UTC timezone
+            created_at = event_triggered_at.astimezone(timezone.utc)
         python_version = f'{sys.version_info.major}.{sys.version_info.minor}'
 
         # when the recce is running in automation use cases


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
ZoneInfo is not supported in Python 3.8.
To remain Recce support Python 3.8, we replace the ZoneInfo with datetime.timezone.

**Which issue(s) this PR fixes**:
#557 
DRC-991

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
