### PR TITLE
[Fix] DRC-979 Allow Recce Server to launch without target-base

### DIFF
--- a/recce/adapter/base.py
+++ b/recce/adapter/base.py
@@ -10,6 +10,11 @@ logger = logging.getLogger('uvicorn')
 
 
 class BaseAdapter(ABC):
+
+    @classmethod
+    def load(cls, **kwargs):
+        raise NotImplementedError()
+
     @abstractmethod
     def get_lineage(self, base: Optional[bool] = False):
         raise NotImplementedError()

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -148,6 +148,10 @@ def previous_state(state_path: Path, target_path: Path, project_root: Path) -> P
     if dbt_version < 'v1.5.2':
         return PreviousState(state_path, target_path)
     else:
+        from dbt.events.types import WarnStateTargetEqual
+        from dbt_common.events import EventLevel
+
+        WarnStateTargetEqual.level_tag = lambda x: EventLevel.DEBUG
         return PreviousState(state_path, target_path, project_root)
 
 

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -235,7 +235,8 @@ def server(host, port, state_file=None, **kwargs):
     console = Console()
     cloud_options = None
     flag = {
-        'show_onboarding_guide': True
+        'show_onboarding_guide': True,
+        'onboarding_mode': False,
     }
     if is_cloud:
         cloud_options = {
@@ -245,6 +246,23 @@ def server(host, port, state_file=None, **kwargs):
         }
         cloud_onboarding_state = get_recce_cloud_onboarding_state(kwargs.get('cloud_token'))
         flag['show_onboarding_guide'] = False if cloud_onboarding_state == 'completed' else True
+
+    if not os.path.isdir(kwargs.get('target_base_path')):
+        # Mark as onboarding mode if user provides the target-path only
+        flag['onboarding_mode'] = True
+        target_path = kwargs.get('target_path')
+        target_base_path = kwargs.get('target_base_path')
+        # Use the target path as the base path
+        kwargs['target_base_path'] = target_path
+
+        # Show warning message
+        console.rule('Warning', style='orange3')
+        console.print(
+            f'The folder "{target_base_path}" is not provided. '
+            f'Will use the current target folder "{target_path}" as the base.\n')
+        console.print('To setup your base environment, please refer to the following link for more information')
+        console.print('https://datarecce.io/docs/get-started/#prepare-dbt-artifacts')
+        console.print()
 
     state_loader = create_state_loader(is_review, is_cloud, state_file, cloud_options)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- Allow `recce server` to launch without `target-base` folder
- Show a warning message if the `target-base` folder not provide
![CleanShot 2024-12-26 at 17 14 08](https://github.com/user-attachments/assets/081577e3-3d89-416f-b7fd-cea445fb9ed0)

- Enable `onboarding-mode` as True in server API `/api/flag` if the server launch without `target-base` folder
![CleanShot 2024-12-26 at 17 15 11](https://github.com/user-attachments/assets/855fe8ac-8203-49dd-8d75-557ccec43bd0)

- Add unit-test for this case

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
