### PR TITLE
[Feature]support breaking change analysis

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = W605, F401, E501, E125, E126
+ignore = W605, F401, E501, E125, E126, W504
 max-line-length = 120
 exclude = tests,
           docs,

--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -146,7 +146,8 @@ export function GraphNode({ data }: GraphNodeProps) {
 
   const { icon: resourceIcon } = getIconForResourceType(resourceType);
   const [isHovered, setIsHovered] = useState(false);
-  const { interactive, selectNodeMulti, selectMode } = useLineageViewContext();
+  const { interactive, selectNodeMulti, selectMode, advancedImpactRadius } =
+    useLineageViewContext();
   const { lineageGraph } = useLineageGraphContext();
 
   // text color, icon
@@ -218,7 +219,9 @@ export function GraphNode({ data }: GraphNodeProps) {
         <Flex
           // backgroundColor={color}
           bg={
-            changeStatus === "modified" && lineageGraph?.nonBreakingSet.has(id)
+            advancedImpactRadius &&
+            changeStatus === "modified" &&
+            lineageGraph?.nonBreakingSet.has(id)
               ? "repeating-linear-gradient(45deg, orange, orange 5px, white 5px, white 10px)"
               : color
           }

--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -215,7 +215,12 @@ export function GraphNode({ data }: GraphNodeProps) {
         onMouseLeave={() => setIsHovered(false)}
       >
         <Flex
-          backgroundColor={color}
+          // backgroundColor={color}
+          bg={
+            changeStatus === "modified"
+              ? "repeating-linear-gradient(45deg, orange, orange 5px, white 5px, white 10px)"
+              : color
+          }
           padding={interactive ? "8px" : "2px"}
           borderRightWidth={borderWidth}
           borderColor={selectMode === "multi" ? "#00000020" : borderColor}

--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -141,12 +141,13 @@ const GraphNodeCheckbox = ({
 };
 
 export function GraphNode({ data }: GraphNodeProps) {
-  const { isHighlighted, isSelected, resourceType, changeStatus } = data;
+  const { id, isHighlighted, isSelected, resourceType, changeStatus } = data;
   const showContent = useStore((s) => s.transform[2] > 0.3);
 
   const { icon: resourceIcon } = getIconForResourceType(resourceType);
   const [isHovered, setIsHovered] = useState(false);
   const { interactive, selectNodeMulti, selectMode } = useLineageViewContext();
+  const { lineageGraph } = useLineageGraphContext();
 
   // text color, icon
   const {
@@ -217,7 +218,7 @@ export function GraphNode({ data }: GraphNodeProps) {
         <Flex
           // backgroundColor={color}
           bg={
-            changeStatus === "modified"
+            changeStatus === "modified" && lineageGraph?.nonBreakingSet.has(id)
               ? "repeating-linear-gradient(45deg, orange, orange 5px, white 5px, white 10px)"
               : color
           }

--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -149,6 +149,10 @@ export function GraphNode({ data }: GraphNodeProps) {
   const { interactive, selectNodeMulti, selectMode, advancedImpactRadius } =
     useLineageViewContext();
   const { lineageGraph } = useLineageGraphContext();
+  const isNonBreakingChange =
+    advancedImpactRadius &&
+    changeStatus === "modified" &&
+    lineageGraph?.nonBreakingSet.has(id);
 
   // text color, icon
   const {
@@ -162,11 +166,11 @@ export function GraphNode({ data }: GraphNodeProps) {
         color: "gray.400",
         backgroundColor: "gray.100",
       };
-  let borderStyle = "solid";
+  let borderStyle = isNonBreakingChange ? "dashed" : "solid";
 
   // border width and color
   const selectedNodeShadowBox = "rgba(3, 102, 214, 0.5) 5px 5px 10px 3px";
-  let borderWidth = 1;
+  let borderWidth = "2px";
   let borderColor = color;
   let boxShadow = data.isSelected ? selectedNodeShadowBox : "unset";
 
@@ -182,6 +186,7 @@ export function GraphNode({ data }: GraphNodeProps) {
         borderColor={borderColor}
         borderWidth={borderWidth}
         borderStyle={borderStyle}
+        borderRadius={8}
         backgroundColor={(function () {
           if (showContent) {
             if (selectMode === "multi") {
@@ -199,7 +204,6 @@ export function GraphNode({ data }: GraphNodeProps) {
             return isSelected ? color : backgroundColor;
           }
         })()}
-        borderRadius={3}
         // boxShadow={boxShadow}
         transition="box-shadow 0.2s ease-in-out"
         padding={0}
@@ -218,13 +222,7 @@ export function GraphNode({ data }: GraphNodeProps) {
       >
         <Flex
           // backgroundColor={color}
-          bg={
-            advancedImpactRadius &&
-            changeStatus === "modified" &&
-            lineageGraph?.nonBreakingSet.has(id)
-              ? "repeating-linear-gradient(45deg, orange, orange 5px, white 5px, white 10px)"
-              : color
-          }
+          bg={color}
           padding={interactive ? "8px" : "2px"}
           borderRightWidth={borderWidth}
           borderColor={selectMode === "multi" ? "#00000020" : borderColor}

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -29,6 +29,7 @@ import {
   MenuDivider,
   Checkbox,
   Switch,
+  Badge,
 } from "@chakra-ui/react";
 import React, {
   Ref,
@@ -842,16 +843,19 @@ export function PrivateLineageView(
             </Panel>
             <Panel position="top-left">
               <Flex direction="column">
-                <Switch
-                  isChecked={advancedImpactRadius}
-                  onChange={(e) => {
-                    const advancedImpactRadius = e.target.checked;
-                    setAdvancedImpactRadius(advancedImpactRadius);
-                    highlightImpactRadius(advancedImpactRadius);
-                  }}
-                >
-                  Advanced Impact Radius (Experimental)
-                </Switch>
+                <Flex direction="row" alignItems="center" gap="5px">
+                  <Switch
+                    isChecked={advancedImpactRadius}
+                    onChange={(e) => {
+                      const advancedImpactRadius = e.target.checked;
+                      setAdvancedImpactRadius(advancedImpactRadius);
+                      highlightImpactRadius(advancedImpactRadius);
+                    }}
+                  >
+                    Breaking Change Analysis{" "}
+                  </Switch>
+                  <Badge>Beta</Badge>
+                </Flex>
                 {nodes.length == 0 && (
                   <Text fontSize="xl" color="grey" opacity={0.5}>
                     No nodes

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -889,8 +889,8 @@ export function PrivateLineageView(
                     </PopoverTrigger>
                     <PopoverContent bg="black" color="white">
                       <PopoverBody fontSize="sm">
-                        Analyze the SQL code in the model to determine if the
-                        modified code introduces a breaking change.{" "}
+                        Breaking changes are determined by analyzing SQL for
+                        changes that may impact downstream models.{" "}
                         <Link
                           href="https://datarecce.io/docs/features/lineage/"
                           target="_blank"

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -358,7 +358,8 @@ export function PrivateLineageView(
       return;
     }
 
-    const nodeSet = selectDownstream(lineageGraph, lineageGraph.modifiedSet);
+    // const nodeSet = selectDownstream(lineageGraph, lineageGraph.modifiedSet);
+    const nodeSet = lineageGraph.impactedSet;
 
     const [newNodes, newEdges] = highlightNodes(
       Array.from(nodeSet),

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -27,10 +27,15 @@ import {
   StackDivider,
   useToast,
   MenuDivider,
-  Checkbox,
   Switch,
   Badge,
+  Link,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
 } from "@chakra-ui/react";
+import { InfoOutlineIcon } from "@chakra-ui/icons";
 import React, {
   Ref,
   RefObject,
@@ -93,6 +98,8 @@ import { Check } from "@/lib/api/checks";
 import useValueDiffAlertDialog from "./useValueDiffAlertDialog";
 import { trackMultiNodesAction } from "@/lib/api/track";
 import { PresetCheckRecommendation } from "./PresetCheckRecommendation";
+
+
 
 export interface LineageViewProps {
   viewOptions?: LineageDiffViewOptions;
@@ -843,7 +850,17 @@ export function PrivateLineageView(
             </Panel>
             <Panel position="top-left">
               <Flex direction="column">
-                <Flex direction="row" alignItems="center" gap="5px">
+                <Flex
+                  direction="row"
+                  alignItems="center"
+                  gap="5px"
+                  p="5px 10px"
+                  borderRadius="md"
+                  boxShadow="md"
+                  border="1px solid"
+                  borderColor="gray.200"
+                  bg="white"
+                >
                   <Switch
                     isChecked={advancedImpactRadius}
                     onChange={(e) => {
@@ -851,10 +868,34 @@ export function PrivateLineageView(
                       setAdvancedImpactRadius(advancedImpactRadius);
                       highlightImpactRadius(advancedImpactRadius);
                     }}
-                  >
-                    Breaking Change Analysis{" "}
-                  </Switch>
-                  <Badge>Beta</Badge>
+                    alignItems={"center"}
+                  ></Switch>
+                  <Flex alignItems={"center"}>
+                    <Text fontSize="10pt" lineHeight="1">
+                      Breaking Change Analysis
+                    </Text>
+                  </Flex>
+                  <Popover trigger="hover" placement="top-start">
+                    <PopoverTrigger>
+                      <Icon
+                        boxSize="10px"
+                        as={InfoOutlineIcon}
+                        color="gray.500"
+                        cursor="pointer"
+                      />
+                    </PopoverTrigger>
+                    <PopoverContent bg="black" color="white">
+                      <PopoverBody fontSize="sm">
+                        Analyze the SQL code in the model to determine if the
+                        modified code introduces a breaking change.{" "}
+                        <Link href="https://datarecce.io/docs/features/lineage/">
+                          Learn more
+                        </Link>
+                        .
+                      </PopoverBody>
+                    </PopoverContent>
+                  </Popover>
+                  <Badge color="gray">Beta</Badge>
                 </Flex>
                 {nodes.length == 0 && (
                   <Text fontSize="xl" color="grey" opacity={0.5}>

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -290,7 +290,7 @@ export function PrivateLineageView(
     selectedNode?: Node;
   }>({ x: 0, y: 0 });
 
-  const [advancedImpactRadius, setAdvancedImpactRadius] = useState(false);
+  const [breakingChangeEnabled, setBreakingChangeEnabled] = useState(false);
 
   const toast = useToast();
 
@@ -322,8 +322,9 @@ export function PrivateLineageView(
         selectedNodes = result.nodes;
       }
 
-      const [nodes, edges] = toReactflow(lineageGraph, selectedNodes);
-
+      let [nodes, edges] = toReactflow(lineageGraph, selectedNodes);
+      const nodeSet = selectImpactRadius(lineageGraph, breakingChangeEnabled);
+      [nodes, edges] = highlightNodes(Array.from(nodeSet), nodes, edges);
       layout(nodes, edges);
       setNodes(nodes);
       setEdges(edges);
@@ -362,12 +363,14 @@ export function PrivateLineageView(
     setEdges(newEdges);
   };
 
-  const highlightImpactRadius = (advanced: boolean = advancedImpactRadius) => {
+  const highlightImpactRadius = (
+    _breakingChangeEnabled: boolean = breakingChangeEnabled
+  ) => {
     if (!lineageGraph) {
       return;
     }
 
-    const nodeSet = selectImpactRadius(lineageGraph, advanced);
+    const nodeSet = selectImpactRadius(lineageGraph, _breakingChangeEnabled);
     const [newNodes, newEdges] = highlightNodes(
       Array.from(nodeSet),
       nodes,
@@ -696,8 +699,8 @@ export function PrivateLineageView(
     onViewOptionsChanged: handleViewOptionsChanged,
     selectNodeMulti,
     deselect,
-    advancedImpactRadius,
-    setAdvancedImpactRadius,
+    advancedImpactRadius: breakingChangeEnabled,
+    setAdvancedImpactRadius: setBreakingChangeEnabled,
     runRowCountDiff: async () => {
       if (selectMode === "multi") {
         await multiNodeAction.runRowCountDiff();
@@ -862,10 +865,10 @@ export function PrivateLineageView(
                   bg="white"
                 >
                   <Switch
-                    isChecked={advancedImpactRadius}
+                    isChecked={breakingChangeEnabled}
                     onChange={(e) => {
                       const advancedImpactRadius = e.target.checked;
-                      setAdvancedImpactRadius(advancedImpactRadius);
+                      setBreakingChangeEnabled(advancedImpactRadius);
                       highlightImpactRadius(advancedImpactRadius);
                     }}
                     alignItems={"center"}
@@ -888,14 +891,17 @@ export function PrivateLineageView(
                       <PopoverBody fontSize="sm">
                         Analyze the SQL code in the model to determine if the
                         modified code introduces a breaking change.{" "}
-                        <Link href="https://datarecce.io/docs/features/lineage/">
+                        <Link
+                          href="https://datarecce.io/docs/features/lineage/"
+                          target="_blank"
+                        >
                           Learn more
                         </Link>
                         .
                       </PopoverBody>
                     </PopoverContent>
                   </Popover>
-                  <Badge color="gray">Beta</Badge>
+                  <Badge color="gray">Experiment</Badge>
                 </Flex>
                 {nodes.length == 0 && (
                   <Text fontSize="xl" color="grey" opacity={0.5}>

--- a/js/src/components/lineage/LineageViewContext.tsx
+++ b/js/src/components/lineage/LineageViewContext.tsx
@@ -31,6 +31,10 @@ export interface LineageViewContextType {
     completed: number;
     total: number;
   };
+
+  // advancedImpactRadius
+  advancedImpactRadius: boolean;
+  setAdvancedImpactRadius: (value: boolean) => void;
 }
 
 export const LineageViewContext = createContext<

--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -281,6 +281,17 @@ export function selectDownstream(
   );
 }
 
+export function selectImpactRadius(
+  lineageGraph: LineageGraph,
+  advanced: boolean
+) {
+  if (!advanced) {
+    return selectDownstream(lineageGraph, lineageGraph.modifiedSet);
+  } else {
+    return lineageGraph.impactedSet;
+  }
+}
+
 export function toReactflow(
   lineageGraph: LineageGraph,
   selectedNodes?: string[]

--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -283,9 +283,9 @@ export function selectDownstream(
 
 export function selectImpactRadius(
   lineageGraph: LineageGraph,
-  advanced: boolean
+  breakingChangeEnabled: boolean
 ) {
-  if (!advanced) {
+  if (!breakingChangeEnabled) {
     return selectDownstream(lineageGraph, lineageGraph.modifiedSet);
   } else {
     return lineageGraph.impactedSet;
@@ -364,7 +364,8 @@ export function toReactflow(
 
   layout(nodes, edges);
 
-  return highlightChanged(lineageGraph, nodes, edges);
+  // return highlightChanged(lineageGraph, nodes, edges);
+  return [nodes, edges];
 }
 
 export function filterNodes(

--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -6,10 +6,12 @@ import { LineageDiffViewOptions } from "@/lib/api/lineagecheck";
 import {
   CatalogMetadata,
   LineageData,
+  LineageDiffData,
   ManifestMetadata,
   NodeData,
 } from "@/lib/api/info";
 import { Manifest } from "next/dist/lib/metadata/types/manifest-types";
+import { select } from "@/lib/api/select";
 
 /**
  * THe types for internal data structures.
@@ -66,6 +68,8 @@ export interface LineageGraph {
     [key: string]: LineageGraphEdge;
   };
   modifiedSet: string[];
+  nonBreakingSet: Set<string>;
+  impactedSet: Set<string>;
 
   manifestMetadata: {
     base?: ManifestMetadata;
@@ -79,7 +83,8 @@ export interface LineageGraph {
 
 export function buildLineageGraph(
   base: LineageData,
-  current: LineageData
+  current: LineageData,
+  diff?: LineageDiffData
 ): LineageGraph {
   const nodes: { [key: string]: LineageGraphNode } = {};
   const edges: { [key: string]: LineageGraphEdge } = {};
@@ -173,8 +178,23 @@ export function buildLineageGraph(
   }
 
   const modifiedSet: string[] = [];
+  const nonBreakingSet: string[] = [];
+  const breakingSet: string[] = [];
+
   for (const [key, node] of Object.entries(nodes)) {
-    if (node.from === "base") {
+    if (diff) {
+      const diffNode = diff[key];
+      if (diffNode) {
+        node.changeStatus = diffNode.change_status;
+        modifiedSet.push(key);
+
+        if (diffNode.change_category === "non-breaking") {
+          nonBreakingSet.push(key);
+        } else {
+          breakingSet.push(key);
+        }
+      }
+    } else if (node.from === "base") {
       node.changeStatus = "removed";
       modifiedSet.push(node.id);
     } else if (node.from === "current") {
@@ -187,6 +207,7 @@ export function buildLineageGraph(
       if (checksum1 && checksum2 && checksum1 !== checksum2) {
         node.changeStatus = "modified";
         modifiedSet.push(node.id);
+        breakingSet.push(key);
       }
     }
   }
@@ -199,10 +220,22 @@ export function buildLineageGraph(
     }
   }
 
+  const impactedSet = union(
+    new Set(modifiedSet),
+    getNeighborSet(breakingSet, (key) => {
+      if (nodes[key] === undefined) {
+        return [];
+      }
+      return Object.keys(nodes[key].children);
+    })
+  );
+
   return {
     nodes,
     edges,
     modifiedSet,
+    nonBreakingSet: new Set(nonBreakingSet),
+    impactedSet,
     manifestMetadata: {
       base: base.manifest_metadata || undefined,
       current: current.manifest_metadata || undefined,

--- a/js/src/lib/api/info.ts
+++ b/js/src/lib/api/info.ts
@@ -58,6 +58,13 @@ export interface LineageData {
   manifest_metadata?: ManifestMetadata | null;
   catalog_metadata?: CatalogMetadata | null;
 }
+export interface LineageDiffData {
+  [key: string]: {
+    change_status: "added" | "removed" | "modified";
+    change_category: "breaking" | "non-breaking";
+  };
+}
+
 interface LineageOutput {
   error?: string;
   data?: LineageData;
@@ -133,6 +140,7 @@ export interface ServerInfoResult {
   lineage: {
     base: LineageData;
     current: LineageData;
+    diff: LineageDiffData;
   };
   demo: boolean;
   support_tasks: { [key: string]: boolean };

--- a/js/src/lib/hooks/LineageGraphContext.tsx
+++ b/js/src/lib/hooks/LineageGraphContext.tsx
@@ -191,7 +191,7 @@ export function LineageGraphContextProvider({ children }: LineageGraphProps) {
       return undefined;
     }
 
-    return buildLineageGraph(lineage.base, lineage.current);
+    return buildLineageGraph(lineage.base, lineage.current, lineage.diff);
   }, [queryServerInfo.data]);
 
   const errorMessage = queryServerInfo.error?.message;

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -18,6 +18,7 @@ from recce.adapter.base import BaseAdapter
 from recce.state import ArtifactsRoot
 from .dbt_version import DbtVersion
 from ...models import RunType
+from ...models.types import LineageDiff, NodeDiff
 from ...tasks import Task, QueryTask, QueryBaseTask, QueryDiffTask, ValueDiffTask, ValueDiffDetailTask, ProfileDiffTask, \
     RowCountDiffTask, TopKDiffTask, HistogramDiffTask
 
@@ -656,6 +657,47 @@ class DbtAdapter(BaseAdapter):
             nodes=nodes,
             manifest_metadata=manifest_metadata,
             catalog_metadata=catalog_metadata,
+        )
+
+    def get_lineage_diff(self) -> LineageDiff:
+        base = self.get_lineage(base=True)
+        current = self.get_lineage(base=False)
+        keys = {
+            *base.get('nodes', {}).keys(),
+            *current.get('nodes', {}).keys()
+        }
+
+        # for each node, compare the base and current lineage
+        diff = {}
+        for key in keys:
+            base_node = base.get('nodes', {}).get(key)
+            curr_node = current.get('nodes', {}).get(key)
+            if base_node and curr_node:
+                base_checksum = base_node.get('checksum', {}).get('checksum')
+                curr_checksum = curr_node.get('checksum', {}).get('checksum')
+                if base_checksum is None or curr_checksum is None or base_checksum == curr_checksum:
+                    continue
+
+                change_category = 'breaking'
+                if curr_node.get('resource_type') == 'model':
+                    try:
+                        from recce.adapter.dbt_adapter.breaking import is_breaking_change
+                        base_sql = self.generate_sql(base_node.get('raw_code'))
+                        curr_sql = self.generate_sql(curr_node.get('raw_code'))
+                        if not is_breaking_change(base_sql, curr_sql):
+                            change_category = 'non-breaking'
+                    except Exception as e:
+                        pass
+
+                diff[key] = NodeDiff(change_status='modified', change_category=change_category)
+            elif base_node:
+                diff[key] = NodeDiff(chnage_status='removed')
+            elif curr_node:
+                diff[key] = NodeDiff(change_status='added')
+        return LineageDiff(
+            base=base,
+            current=current,
+            diff=diff,
         )
 
     def get_manifests_by_id(self, unique_id: str):

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -705,7 +705,7 @@ class DbtAdapter(BaseAdapter):
                         curr_sql = self.generate_sql(curr_node.get('raw_code'))
                         if not is_breaking_change(base_sql, curr_sql):
                             change_category = 'non-breaking'
-                    except Exception as e:
+                    except Exception:
                         pass
 
                 diff[key] = NodeDiff(change_status='modified', change_category=change_category)

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -681,7 +681,7 @@ class DbtAdapter(BaseAdapter):
                 change_category = 'breaking'
                 if curr_node.get('resource_type') == 'model':
                     try:
-                        from recce.adapter.dbt_adapter.breaking import is_breaking_change
+                        from recce.util.breaking import is_breaking_change
                         base_sql = self.generate_sql(base_node.get('raw_code'))
                         curr_sql = self.generate_sql(curr_node.get('raw_code'))
                         if not is_breaking_change(base_sql, curr_sql):

--- a/recce/adapter/dbt_adapter/breaking.py
+++ b/recce/adapter/dbt_adapter/breaking.py
@@ -23,6 +23,9 @@ def is_breaking_change(original_sql, modified_sql):
         if isinstance(edit, Insert):
             inserted_expr = edit.expression
 
+            if isinstance(inserted_expr, exp.Where):
+                return True
+
             if (
                 not isinstance(inserted_expr.parent, exp.Select)
                 and inserted_expr.parent not in inserted_expressions

--- a/recce/adapter/dbt_adapter/breaking.py
+++ b/recce/adapter/dbt_adapter/breaking.py
@@ -1,0 +1,34 @@
+def is_breaking_change(original_sql, modified_sql):
+    if original_sql == modified_sql:
+        return False
+
+    try:
+        from sqlglot import parse_one, diff
+        from sqlglot.diff import Insert, Keep
+        import sqlglot.expressions as exp
+    except ImportError:
+        return True
+    original_ast = parse_one(original_sql)
+    modified_ast = parse_one(modified_sql)
+    if not isinstance(original_ast, exp.Select) or not isinstance(modified_ast, exp.Select):
+        raise ValueError("Currently only SELECT statements are supported for comparison")
+
+    edits = diff(original_ast, modified_ast)
+
+    inserted_expressions = {
+        e.expression for e in edits if isinstance(e, Insert)
+    }
+
+    for edit in edits:
+        if isinstance(edit, Insert):
+            inserted_expr = edit.expression
+
+            if (
+                not isinstance(inserted_expr.parent, exp.Select)
+                and inserted_expr.parent not in inserted_expressions
+            ):
+                return True
+        elif not isinstance(edit, Keep):
+            return True
+
+    return False

--- a/recce/core.py
+++ b/recce/core.py
@@ -7,6 +7,7 @@ from typing import Callable, Dict, Optional, List, Tuple
 
 from recce.adapter.base import BaseAdapter
 from recce.models import Check, Run
+from recce.models.types import LineageDiff
 from recce.state import RecceState, RecceStateMetadata, GitRepoInfo, PullRequestInfo, RecceStateLoader
 from recce.util.recce_cloud import set_recce_cloud_onboarding_state
 
@@ -66,6 +67,9 @@ class RecceContext:
 
     def get_lineage(self, base: Optional[bool] = False):
         return self.adapter.get_lineage(base=base)
+
+    def get_lineage_diff(self) -> LineageDiff:
+        return self.adapter.get_lineage_diff()
 
     def build_name_to_unique_id_index(self) -> Dict[str, str]:
         name_to_unique_id = {}

--- a/recce/models/types.py
+++ b/recce/models/types.py
@@ -93,7 +93,7 @@ ChangeCategory = Literal[
 
 class NodeDiff(BaseModel):
     change_status: ChangeStatus
-    change_category: Optional[ChangeCategory]
+    change_category: Optional[ChangeCategory] = None
 
 
 class LineageDiff(BaseModel):

--- a/recce/models/types.py
+++ b/recce/models/types.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Optional
+from typing import Optional, Literal
 
 from pydantic import BaseModel, UUID4, Field
 
@@ -81,6 +81,22 @@ class Check(BaseModel):
         return True
 
 
-class Lineage(BaseModel):
+ChangeStatus = Literal[
+    'added',
+    'removed',
+    'modified',
+]
+ChangeCategory = Literal[
+    'breaking', 'non-breaking'
+]
+
+
+class NodeDiff(BaseModel):
+    change_status: ChangeStatus
+    change_category: Optional[ChangeCategory]
+
+
+class LineageDiff(BaseModel):
     base: dict
     current: dict
+    diff: dict[str, NodeDiff]

--- a/recce/server.py
+++ b/recce/server.py
@@ -209,16 +209,15 @@ async def get_info():
     else:
         filename = None
 
+    lineage_diff = context.get_lineage_diff()
+
     try:
         info = {
             'adapter_type': context.adapter_type,
             'review_mode': context.review_mode,
             'git': state.git.to_dict() if state.git else None,
             'pull_request': state.pull_request.to_dict() if state.pull_request else None,
-            'lineage': {
-                'base': context.get_lineage(base=True),
-                'current': context.get_lineage(base=False),
-            },
+            'lineage': lineage_diff,
             'demo': bool(demo),
             'cloud_mode': context.state_loader.cloud_mode,
             'file_mode': context.state_loader.state_file is not None,

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -1,4 +1,4 @@
-def is_breaking_change(original_sql, modified_sql, dialet=None):
+def is_breaking_change(original_sql, modified_sql, dialect=None):
     if original_sql == modified_sql:
         return False
 
@@ -10,8 +10,8 @@ def is_breaking_change(original_sql, modified_sql, dialet=None):
         return True
 
     try:
-        original_ast = parse_one(original_sql, dialect=dialet)
-        modified_ast = parse_one(modified_sql, dialet=dialet)
+        original_ast = parse_one(original_sql, dialect=dialect)
+        modified_ast = parse_one(modified_sql, dialect=dialect)
     except Exception:
         return True
 

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -1,3 +1,6 @@
+from sqlglot.optimizer import optimize
+
+
 def is_breaking_change(original_sql, modified_sql, dialect=None):
     if original_sql == modified_sql:
         return False
@@ -10,15 +13,15 @@ def is_breaking_change(original_sql, modified_sql, dialect=None):
         return True
 
     try:
-        original_ast = parse_one(original_sql, dialect=dialect)
-        modified_ast = parse_one(modified_sql, dialect=dialect)
+        original_ast = optimize(parse_one(original_sql, dialect=dialect))
+        modified_ast = optimize(parse_one(modified_sql, dialect=dialect))
     except Exception:
         return True
 
     if not isinstance(original_ast, exp.Select) or not isinstance(modified_ast, exp.Select):
         raise ValueError("Currently only SELECT statements are supported for comparison")
 
-    edits = diff(original_ast, modified_ast)
+    edits = diff(original_ast, modified_ast, delta_only=True)
 
     inserted_expressions = {
         e.expression for e in edits if isinstance(e, Insert)
@@ -28,7 +31,24 @@ def is_breaking_change(original_sql, modified_sql, dialect=None):
         if isinstance(edit, Insert):
             inserted_expr = edit.expression
 
-            if isinstance(inserted_expr, exp.Where):
+            if (
+                isinstance(inserted_expr, exp.Where) or
+                isinstance(inserted_expr, exp.Join) or
+                isinstance(inserted_expr, exp.Order) or
+                isinstance(inserted_expr, exp.Group) or
+                isinstance(inserted_expr, exp.Having) or
+                isinstance(inserted_expr, exp.Limit) or
+                isinstance(inserted_expr, exp.Offset) or
+                isinstance(inserted_expr, exp.Window) or
+                isinstance(inserted_expr, exp.Union) or
+                isinstance(inserted_expr, exp.Intersect) or
+                isinstance(inserted_expr, exp.Except) or
+                isinstance(inserted_expr, exp.Merge) or
+                isinstance(inserted_expr, exp.Delete) or
+                isinstance(inserted_expr, exp.Update) or
+                isinstance(inserted_expr, exp.Insert) or
+                isinstance(inserted_expr, exp.Subquery)
+            ):
                 return True
 
             if (

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -30,30 +30,31 @@ def is_breaking_change(original_sql, modified_sql, dialect=None):
     for edit in edits:
         if isinstance(edit, Insert):
             inserted_expr = edit.expression
+            VALID_EXPRESSIONS = (
+                exp.Where,
+                exp.Join,
+                exp.Order,
+                exp.Group,
+                exp.Having,
+                exp.Limit,
+                exp.Offset,
+                exp.Window,
+                exp.Union,
+                exp.Intersect,
+                exp.Except,
+                exp.Merge,
+                exp.Delete,
+                exp.Update,
+                exp.Insert,
+                exp.Subquery,
+            )
 
-            if (
-                isinstance(inserted_expr, exp.Where) or
-                isinstance(inserted_expr, exp.Join) or
-                isinstance(inserted_expr, exp.Order) or
-                isinstance(inserted_expr, exp.Group) or
-                isinstance(inserted_expr, exp.Having) or
-                isinstance(inserted_expr, exp.Limit) or
-                isinstance(inserted_expr, exp.Offset) or
-                isinstance(inserted_expr, exp.Window) or
-                isinstance(inserted_expr, exp.Union) or
-                isinstance(inserted_expr, exp.Intersect) or
-                isinstance(inserted_expr, exp.Except) or
-                isinstance(inserted_expr, exp.Merge) or
-                isinstance(inserted_expr, exp.Delete) or
-                isinstance(inserted_expr, exp.Update) or
-                isinstance(inserted_expr, exp.Insert) or
-                isinstance(inserted_expr, exp.Subquery)
-            ):
+            if isinstance(inserted_expr, VALID_EXPRESSIONS):
                 return True
 
             if (
-                not isinstance(inserted_expr.parent, exp.Select)
-                and inserted_expr.parent not in inserted_expressions
+                not isinstance(inserted_expr.parent, exp.Select) and
+                inserted_expr.parent not in inserted_expressions
             ):
                 return True
         elif not isinstance(edit, Keep):

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -1,4 +1,4 @@
-def is_breaking_change(original_sql, modified_sql):
+def is_breaking_change(original_sql, modified_sql, dialet=None):
     if original_sql == modified_sql:
         return False
 
@@ -8,8 +8,13 @@ def is_breaking_change(original_sql, modified_sql):
         import sqlglot.expressions as exp
     except ImportError:
         return True
-    original_ast = parse_one(original_sql)
-    modified_ast = parse_one(modified_sql)
+
+    try:
+        original_ast = parse_one(original_sql, dialect=dialet)
+        modified_ast = parse_one(modified_sql, dialet=dialet)
+    except Exception:
+        return True
+
     if not isinstance(original_ast, exp.Select) or not isinstance(modified_ast, exp.Select):
         raise ValueError("Currently only SELECT statements are supported for comparison")
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(name='recce',
           'python-multipart',
           'GitPython',
           'PyGithub',
+          'sqlglot',
       ],
       tests_require=['pytest'],
       extras_require={

--- a/tests/adapter/dbt_adapter/dbt_test_helper.py
+++ b/tests/adapter/dbt_adapter/dbt_test_helper.py
@@ -54,6 +54,8 @@ class DbtTestHelper:
         model_name,
         base_csv=None,
         curr_csv=None,
+        base_sql=None,
+        curr_sql=None,
         depends_on=[],
         disabled=False,
         unique_id=None,
@@ -112,11 +114,19 @@ class DbtTestHelper:
                 _add_model_to_manifest(True, base_csv)
                 df_base = pd.read_csv(StringIO(base_csv))
                 dbt_adapter.execute(f"CREATE TABLE {self.base_schema}.{model_name} AS SELECT * FROM df_base")
+            elif base_sql:
+                bas_sql = textwrap.dedent(base_sql)
+                _add_model_to_manifest(True, base_sql)
+
             if curr_csv:
                 curr_csv = textwrap.dedent(curr_csv)
                 _add_model_to_manifest(False, curr_csv)
                 df_curr = pd.read_csv(StringIO(curr_csv))
                 dbt_adapter.execute(f"CREATE TABLE {self.curr_schema}.{model_name} AS SELECT * FROM df_curr")
+            elif curr_sql:
+                curr_sql = textwrap.dedent(curr_sql)
+                _add_model_to_manifest(False, curr_sql)
+
         self.adapter.set_artifacts(
             self.base_manifest.writable_manifest(),
             self.curr_manifest.writable_manifest(),

--- a/tests/adapter/dbt_adapter/test_selector.py
+++ b/tests/adapter/dbt_adapter/test_selector.py
@@ -17,7 +17,7 @@ def test_select(dbt_test_helper):
         """
 
     dbt_test_helper.create_model("customers_1", csv_data_base, csv_data_curr)
-    dbt_test_helper.create_model("customers_2", csv_data_base, csv_data_base, ["customers_1"])
+    dbt_test_helper.create_model("customers_2", csv_data_base, csv_data_base, depends_on=["customers_1"])
     adapter: DbtAdapter = dbt_test_helper.context.adapter
 
     # Test methods
@@ -60,7 +60,7 @@ def test_select(dbt_test_helper):
 
     # Test resource type: snapshot
     dbt_test_helper.create_snapshot("snapshot_1", csv_data_base, csv_data_curr)
-    dbt_test_helper.create_model("use_snapshot", csv_data_base, csv_data_base, ["snapshot_1"])
+    dbt_test_helper.create_model("use_snapshot", csv_data_base, csv_data_base, depends_on=["snapshot_1"])
 
     node_ids = adapter.select_nodes('resource_type:snapshot')
     assert len(node_ids) == 1

--- a/tests/tasks/test_row_count.py
+++ b/tests/tasks/test_row_count.py
@@ -48,8 +48,9 @@ def test_row_count_with_selector(dbt_test_helper):
         2,Bob,25
         """
 
-    dbt_test_helper.create_model("model_1", csv_data_1, csv_data_2, [])
-    dbt_test_helper.create_model("model_2", csv_data_1, csv_data_1, ['model_1'], package_name='other_package')
+    dbt_test_helper.create_model("model_1", csv_data_1, csv_data_2, depends_on=[])
+    dbt_test_helper.create_model("model_2", csv_data_1, csv_data_1, depends_on=['model_1'],
+                                 package_name='other_package')
     task = RowCountDiffTask(dict(select='model_1'))
     run_result = task.execute()
     assert len(run_result) == 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,17 @@
+# noinspection PyUnresolvedReferences
+from tests.adapter.dbt_adapter.conftest import dbt_test_helper
+
+
+def test_lineage_diff(dbt_test_helper):
+    sql_base = """
+        select a from {{ref('a')}}
+        """
+
+    sql_curr = """
+        select a, b from {{ref('a')}}
+        """
+
+    dbt_test_helper.create_model("customers_1", sql_base, sql_curr)
+    result = dbt_test_helper.context.get_lineage_diff()
+    nodediff = result.diff.get('customers_1')
+    assert nodediff is not None and nodediff.change_status == 'modified'

--- a/tests/util/test_breaking.py
+++ b/tests/util/test_breaking.py
@@ -1,8 +1,6 @@
 import textwrap
 import unittest
 
-import pytest
-
 from recce.util.breaking import is_breaking_change
 
 
@@ -108,20 +106,20 @@ class BreakingChangeTest(unittest.TestCase):
         """
         assert is_breaking_change(original_sql, modified_sql)
 
-    @pytest.mark.skip("The case when cannot be detected by sqlglot")
-    def test_non_breaking_change_add_column_by_case_when(self):
-        original_sql = """
-        select
-            a
-        from MyTable
-        """
-        modified_sql = """
-        select
-            a,
-            case when a > 100 then 1 else 0 end as b
-        from MyTable
-        """
-        assert not is_breaking_change(original_sql, modified_sql)
+    # @pytest.mark.skip("The case when cannot be detected by sqlglot")
+    # def test_non_breaking_change_add_column_by_case_when(self):
+    #     original_sql = """
+    #     select
+    #         a
+    #     from MyTable
+    #     """
+    #     modified_sql = """
+    #     select
+    #         a,
+    #         case when a > 100 then 1 else 0 end as b
+    #     from MyTable
+    #     """
+    #     assert not is_breaking_change(original_sql, modified_sql)
 
     def test_breaking_change_add_filter(self):
         original_sql = """

--- a/tests/util/test_breaking.py
+++ b/tests/util/test_breaking.py
@@ -1,164 +1,251 @@
 import textwrap
+import unittest
+
+import pytest
 
 from recce.util.breaking import is_breaking_change
 
 
-def test_no_change():
-    original_sql = """
-    select
-        a, b
-    from MyTable
-    """
-    modified_sql = """
-    select
-        a, b
-    from MyTable
-    """
-    assert not is_breaking_change(original_sql, modified_sql)
-    assert not is_breaking_change(original_sql, textwrap.dedent(modified_sql))
-
-
-def test_non_breaking_change():
-    original_sql = """
-    select
-        a
-    from MyTable
-    """
-    modified_sql = """
-    select
-        a, b
-    from MyTable
-    """
-    assert not is_breaking_change(original_sql, modified_sql)
-
-
-def test_breaking_change():
-    original_sql = """
-    select
-        a
-    from MyTable
-    """
-    modified_sql = """
-    select
-        a as a2
-    from MyTable
-    """
-    assert is_breaking_change(original_sql, modified_sql)
-    modified_sql = """
-        select
-            b
-        from MyTable
-        """
-    assert is_breaking_change(original_sql, modified_sql)
-    modified_sql = """
-            select
-                a
-            from MyTable
-            where a > 100
-            """
-    assert is_breaking_change(original_sql, modified_sql)
-    modified_sql = """
-                select
-                    a
-                from MyTable
-                limit 100
-                """
-    assert is_breaking_change(original_sql, modified_sql)
-
-
-def test_cte():
-    original_sql = """
-    with cte as (
-        select
-            a
-        from MyTable
-    )
-    select
-        a
-    from cte
-    """
-    modified_sql = """
-    with cte as (
+class BreakingChangeTest(unittest.TestCase):
+    def test_no_change_identical(self):
+        original_sql = """
         select
             a, b
         from MyTable
-    )
-    select
-        a
-    from cte
-    """
-    assert not is_breaking_change(original_sql, modified_sql)
-    modified_sql = """
-    with cte as (
+        """
+        modified_sql = """
         select
-            a
+            a,
+            b
         from MyTable
-    )
-    select
-        a, b
-    from cte
-    """
-    assert not is_breaking_change(original_sql, modified_sql)
-    # test a breaking case by a where filter in cte
-    modified_sql = """
-    with cte as (
-        select
-            a
-        from MyTable
-        where a > 100
-    )
-    select
-        a
-    from cte
-    """
+        """
+        assert not is_breaking_change(original_sql, modified_sql)
+        assert not is_breaking_change(original_sql, textwrap.dedent(modified_sql))
 
-
-def test_cte_with_select_star():
-    original_sql = """
-    with cte as (
-        select
-            a, b, c
-        from MyTable
-    )
-    select
-        *
-    from cte
-    """
-    modified_sql = """
-    with cte as (
+    def test_no_change_add_column(self):
+        original_sql = """
         select
             a
         from MyTable
-    )
-    select
-        *
-    from cte
-    """
-    assert is_breaking_change(original_sql, modified_sql)
-    modified_sql = """
+        """
+        modified_sql = """
+        select
+            a, b
+        from MyTable
+        """
+        assert not is_breaking_change(original_sql, modified_sql)
+
+        # by cte
+        original_sql = """
         with cte as (
             select
-                a,b,c,d
+                a
             from MyTable
         )
         select
             *
         from cte
         """
-    assert not is_breaking_change(original_sql, modified_sql)
+        modified_sql = """
+        with cte as (
+            select
+                a, b
+            from MyTable
+        )
+        select
+            *
+        from cte
+        """
+        assert not is_breaking_change(original_sql, modified_sql)
 
+    def test_breaking_change_rename_column(self):
+        original_sql = """
+        select
+            a
+        from MyTable
+        """
+        modified_sql = """
+        select
+            a as a2
+        from MyTable
+        """
+        assert is_breaking_change(original_sql, modified_sql)
 
-def test_non_sql():
-    original_sql = """
-    select
-        a
-    from
-    """
+        # by cte
+        original_sql = """
+        with cte as (
+            select
+                a
+            from MyTable
+        )
+        select
+            *
+        from cte
+        """
+        modified_sql = """
+        with cte as (
+            select
+                a as a2
+            from MyTable
+        )
+        select
+            *
+        from cte
+        """
+        assert is_breaking_change(original_sql, modified_sql)
 
-    malformed_sql = """
-    selects
-        a
-    from MyTable
-    """
+    def test_breaking_change_remove_column(self):
+        original_sql = """
+        select
+            a,
+            b
+        from MyTable
+        """
+        modified_sql = """
+        select
+            b
+        from MyTable
+        """
+        assert is_breaking_change(original_sql, modified_sql)
 
-    assert is_breaking_change(original_sql, malformed_sql)
+    @pytest.mark.skip("The case when cannot be detected by sqlglot")
+    def test_non_breaking_change_add_column_by_case_when(self):
+        original_sql = """
+        select
+            a
+        from MyTable
+        """
+        modified_sql = """
+        select
+            a,
+            case when a > 100 then 1 else 0 end as b
+        from MyTable
+        """
+        assert not is_breaking_change(original_sql, modified_sql)
+
+    def test_breaking_change_add_filter(self):
+        original_sql = """
+        select
+            a
+        from MyTable
+        """
+        modified_sql = """
+        select
+            a
+        from MyTable
+        where a > 100
+        """
+        assert is_breaking_change(original_sql, modified_sql)
+
+    def test_breaking_change_change_filter(self):
+        original_sql = """
+        select
+            a
+        from MyTable
+        where a > 100
+        """
+        modified_sql = """
+        select
+            a
+        from MyTable
+        where a > 101
+        """
+        assert is_breaking_change(original_sql, modified_sql)
+
+    def test_breaking_change_add_limit(self):
+        original_sql = """
+        select
+            a
+        from MyTable
+        """
+        modified_sql = """
+        select
+            a
+        from MyTable
+        limit 100
+        """
+        assert is_breaking_change(original_sql, modified_sql)
+
+    def test_cte_with_select_star(self):
+        original_sql = """
+        with cte as (
+            select
+                a, b, c
+            from MyTable
+        )
+        select
+            *
+        from cte
+        """
+        modified_sql = """
+        with cte as (
+            select
+                a
+            from MyTable
+        )
+        select
+            *
+        from cte
+        """
+        # assert is_breaking_change(original_sql, modified_sql)
+        modified_sql = """
+            with cte as (
+                select
+                    a,b,c,d
+                from MyTable
+            )
+            select
+                *
+            from cte
+            """
+        assert not is_breaking_change(original_sql, modified_sql)
+
+    def test_non_sql(self):
+        original_sql = """
+        select
+            a
+        from
+        """
+
+        malformed_sql = """
+        selects
+            a
+        from MyTable
+        """
+
+        assert is_breaking_change(original_sql, malformed_sql)
+
+    def test_pr42(self):
+        original_sql = """
+        with source as (
+            select * from MyTable
+        ),
+        renamed as (
+            select
+                id as order_id,
+                user_id as customer_id,
+                order_date,
+                status,
+            from source
+        )
+
+        select * from renamed
+        """
+        modified_sql = """
+        with source as (
+            select * from MyTable
+        ),
+        renamed as (
+            select
+                id as order_id,
+                user_id as customer_id,
+                order_date,
+                status,
+                status = 'completed' as is_closed
+            from source
+        )
+        select *,
+
+        from renamed
+        """
+        assert not is_breaking_change(original_sql, modified_sql)

--- a/tests/util/test_breaking.py
+++ b/tests/util/test_breaking.py
@@ -1,0 +1,164 @@
+import textwrap
+
+from recce.util.breaking import is_breaking_change
+
+
+def test_no_change():
+    original_sql = """
+    select
+        a, b
+    from MyTable
+    """
+    modified_sql = """
+    select
+        a, b
+    from MyTable
+    """
+    assert not is_breaking_change(original_sql, modified_sql)
+    assert not is_breaking_change(original_sql, textwrap.dedent(modified_sql))
+
+
+def test_non_breaking_change():
+    original_sql = """
+    select
+        a
+    from MyTable
+    """
+    modified_sql = """
+    select
+        a, b
+    from MyTable
+    """
+    assert not is_breaking_change(original_sql, modified_sql)
+
+
+def test_breaking_change():
+    original_sql = """
+    select
+        a
+    from MyTable
+    """
+    modified_sql = """
+    select
+        a as a2
+    from MyTable
+    """
+    assert is_breaking_change(original_sql, modified_sql)
+    modified_sql = """
+        select
+            b
+        from MyTable
+        """
+    assert is_breaking_change(original_sql, modified_sql)
+    modified_sql = """
+            select
+                a
+            from MyTable
+            where a > 100
+            """
+    assert is_breaking_change(original_sql, modified_sql)
+    modified_sql = """
+                select
+                    a
+                from MyTable
+                limit 100
+                """
+    assert is_breaking_change(original_sql, modified_sql)
+
+
+def test_cte():
+    original_sql = """
+    with cte as (
+        select
+            a
+        from MyTable
+    )
+    select
+        a
+    from cte
+    """
+    modified_sql = """
+    with cte as (
+        select
+            a, b
+        from MyTable
+    )
+    select
+        a
+    from cte
+    """
+    assert not is_breaking_change(original_sql, modified_sql)
+    modified_sql = """
+    with cte as (
+        select
+            a
+        from MyTable
+    )
+    select
+        a, b
+    from cte
+    """
+    assert not is_breaking_change(original_sql, modified_sql)
+    # test a breaking case by a where filter in cte
+    modified_sql = """
+    with cte as (
+        select
+            a
+        from MyTable
+        where a > 100
+    )
+    select
+        a
+    from cte
+    """
+
+
+def test_cte_with_select_star():
+    original_sql = """
+    with cte as (
+        select
+            a, b, c
+        from MyTable
+    )
+    select
+        *
+    from cte
+    """
+    modified_sql = """
+    with cte as (
+        select
+            a
+        from MyTable
+    )
+    select
+        *
+    from cte
+    """
+    assert is_breaking_change(original_sql, modified_sql)
+    modified_sql = """
+        with cte as (
+            select
+                a,b,c,d
+            from MyTable
+        )
+        select
+            *
+        from cte
+        """
+    assert not is_breaking_change(original_sql, modified_sql)
+
+
+def test_non_sql():
+    original_sql = """
+    select
+        a
+    from
+    """
+
+    malformed_sql = """
+    selects
+        a
+    from MyTable
+    """
+
+    assert is_breaking_change(original_sql, malformed_sql)


### PR DESCRIPTION
This PR support he breaking change analysis.

For modified nodes, it will use raw(templated) sql code. A node would mark as non-breaking change if
1. The sql sementic tree is identical
2. Or only new column added
Otherwise, it would mark as breaking change.

For non-breaking change, it will not mark the downstream as impacted. See the screenshot

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/089bf424-b62c-41b9-8672-9acdc9295f7c" />


**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
