### PR TITLE
[Feature] Overwrite response 304 when etag not match

### DIFF
--- a/recce/server.py
+++ b/recce/server.py
@@ -161,7 +161,16 @@ async def disable_cache(request: Request, call_next):
 
     # disable cache for '/' and '/index.html'
     if request.url.path in ['/', '/index.html']:
-        response.headers['Cache-Control'] = 'no-store'
+        if response.status_code == 304:
+            if_none_match = request.headers.get('If-None-Match')
+            etag = response.headers.get('ETag')
+            if if_none_match != etag:
+                file_path = static_folder_path / 'index.html'
+                with open(file_path, 'rb') as f:
+                    content = f.read()
+                response = Response(content=content, media_type='text/html')
+
+        response.headers['Cache-Control'] = 'no-cache, must-revalidate, max-age=0'
 
     return response
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- Instead of disable cache with `no-store`, we overwrite the 304 response when the etag is not matched.

**Which issue(s) this PR fixes**:
DRC-995

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE