### PR TITLE
[Chore] Replace Menu with IconButton in Value Diff Result View

### DIFF
--- a/js/src/components/valuediff/ValueDiffResultView.tsx
+++ b/js/src/components/valuediff/ValueDiffResultView.tsx
@@ -10,6 +10,7 @@ import {
   MenuGroup,
   MenuItem,
   MenuList,
+  Portal,
   Spacer,
 } from "@chakra-ui/react";
 
@@ -70,27 +71,31 @@ function ColumnNameCell({
               size={"sm"}
             />
 
-            <MenuList lineHeight="20px">
-              <MenuGroup title="Action" as={Box} fontSize="8pt">
-                <MenuItem
-                  fontSize="10pt"
-                  onClick={() => handleValueDiffDetail({}, { showForm: true })}
-                >
-                  Show mismatched values...
-                </MenuItem>
-                <MenuItem
-                  fontSize="10pt"
-                  onClick={() =>
-                    handleValueDiffDetail(
-                      { columns: [column] },
-                      { showForm: false }
-                    )
-                  }
-                >
-                  Show mismatched values for &apos;{column}&apos;
-                </MenuItem>
-              </MenuGroup>
-            </MenuList>
+            <Portal>
+              <MenuList lineHeight="20px">
+                <MenuGroup title="Action" as={Box} fontSize="8pt">
+                  <MenuItem
+                    fontSize="10pt"
+                    onClick={() =>
+                      handleValueDiffDetail({}, { showForm: true })
+                    }
+                  >
+                    Show mismatched values...
+                  </MenuItem>
+                  <MenuItem
+                    fontSize="10pt"
+                    onClick={() =>
+                      handleValueDiffDetail(
+                        { columns: [column] },
+                        { showForm: false }
+                      )
+                    }
+                  >
+                    Show mismatched values for &apos;{column}&apos;
+                  </MenuItem>
+                </MenuGroup>
+              </MenuList>
+            </Portal>
           </>
         )}
       </Menu>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Chore

**What this PR does / why we need it**:
The action menu in the value diff result view is hard to use when there are fewer results.
We simplify the actions from 2 to 1 and replace them with an icon button to open the value diff detail form.

**Which issue(s) this PR fixes**:
DRC-996

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
