### PR TITLE
Add telemetry event for breaking change analysis

### DIFF
--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -891,7 +891,7 @@ export function PrivateLineageView(
                         Breaking changes are determined by analyzing SQL for
                         changes that may impact downstream models.{" "}
                         <Link
-                          href="https://datarecce.io/docs/features/lineage/"
+                          href="https://datarecce.io/docs/features/breaking-change-analysis/"
                           target="_blank"
                         >
                           Learn more

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -96,10 +96,8 @@ import { createSchemaDiffCheck } from "@/lib/api/schemacheck";
 import { useLocation } from "wouter";
 import { Check } from "@/lib/api/checks";
 import useValueDiffAlertDialog from "./useValueDiffAlertDialog";
-import { trackMultiNodesAction } from "@/lib/api/track";
+import { trackBreakingChange, trackMultiNodesAction } from "@/lib/api/track";
 import { PresetCheckRecommendation } from "./PresetCheckRecommendation";
-
-
 
 export interface LineageViewProps {
   viewOptions?: LineageDiffViewOptions;
@@ -867,9 +865,10 @@ export function PrivateLineageView(
                   <Switch
                     isChecked={breakingChangeEnabled}
                     onChange={(e) => {
-                      const advancedImpactRadius = e.target.checked;
-                      setBreakingChangeEnabled(advancedImpactRadius);
-                      highlightImpactRadius(advancedImpactRadius);
+                      const enabled = e.target.checked;
+                      setBreakingChangeEnabled(enabled);
+                      highlightImpactRadius(enabled);
+                      trackBreakingChange({ enabled });
                     }}
                     alignItems={"center"}
                   ></Switch>

--- a/js/src/lib/api/checks.ts
+++ b/js/src/lib/api/checks.ts
@@ -3,6 +3,7 @@ import { axiosClient } from "./axiosClient";
 import { Run, RunType } from "./types";
 import { useQuery } from "@tanstack/react-query";
 import { cacheKeys } from "./cacheKeys";
+import { getExperimentTrackingBreakingChangeEnabled } from "./track";
 
 export interface Check<PT = any, RT = any, VO = any> {
   check_id: string;
@@ -29,9 +30,13 @@ export async function createCheckByRun(
   runId: string,
   viewOptions?: any
 ): Promise<Check> {
+  const track_props = getExperimentTrackingBreakingChangeEnabled()
+    ? { breaking_change_analysis: true }
+    : {};
   const response = await axiosClient.post("/api/checks", {
     run_id: runId,
     view_options: viewOptions,
+    track_props,
   });
   const check = response.data;
 

--- a/js/src/lib/api/runs.ts
+++ b/js/src/lib/api/runs.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import { axiosClient } from "./axiosClient";
 import { Run, RunType } from "./types";
+import { getExperimentTrackingBreakingChangeEnabled } from "./track";
 
 export interface SubmitOptions {
   nowait?: boolean;
@@ -11,10 +12,14 @@ export async function submitRun<PT = any, RT = any>(
   params?: PT,
   options?: SubmitOptions
 ) {
+  const track_props = getExperimentTrackingBreakingChangeEnabled()
+    ? { breaking_change_analysis: true }
+    : {};
   const response = await axiosClient.post("/api/runs", {
     type,
     params,
     nowait: options?.nowait,
+    track_props,
   });
 
   const run: Run<PT, RT> | Pick<Run, "run_id"> = response.data;

--- a/js/src/lib/api/track.ts
+++ b/js/src/lib/api/track.ts
@@ -82,3 +82,19 @@ interface RecommendPresetCheckProps {
 export function trackRecommendCheck(props: RecommendPresetCheckProps) {
   amplitude.track("[Experiment] recommend_preset_check", props);
 }
+
+
+interface BreakingChangeAnalysisProps {
+  enabled: boolean;
+}
+
+let _breakingChangeEnabled = false;
+
+export function trackBreakingChange(props: BreakingChangeAnalysisProps) {
+  amplitude.track("[Experiment] breaking_change_analysis", props);
+  _breakingChangeEnabled = props.enabled;
+}
+
+export function getExperimentTrackingBreakingChangeEnabled() {
+  return _breakingChangeEnabled;
+}

--- a/recce/apis/check_api.py
+++ b/recce/apis/check_api.py
@@ -21,6 +21,7 @@ class CreateCheckIn(BaseModel):
     type: Optional[RunType] = None,
     params: Optional[dict] = None
     view_options: Optional[dict] = None
+    track_props: Optional[dict] = None
 
 
 class CheckOut(BaseModel):
@@ -67,6 +68,7 @@ async def create_check(check_in: CreateCheckIn, background_tasks: BackgroundTask
             )
         log_api_event('create_check', dict(
             type=str(check.type),
+            track_props=check_in.track_props,
         ))
     except NameError as e:
         raise HTTPException(status_code=404, detail=str(e))

--- a/recce/apis/run_api.py
+++ b/recce/apis/run_api.py
@@ -18,12 +18,14 @@ class CreateRunIn(BaseModel):
     params: dict
     check_id: Optional[str] = None
     nowait: Optional[bool] = False
+    track_props: Optional[dict] = None
 
 
 @run_router.post("/runs", status_code=201)
 async def create_run_handler(input: CreateRunIn):
     log_api_event('create_run', dict(
         type=input.type,
+        track_props=input.track_props,
     ))
     try:
         run, future = submit_run(input.type, input.params)


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Chore

**What this PR does / why we need it**:
Add telemetry events. We would like to track the usage for the breaking change analysis feature. The question to ask
- How many active users enable this feature
- How many(percentage) users create run when breaking change analysis is enabled
- How many(percentage) users create check when breaking change analysis is enabled

FrontEnd
Event type: `[Experiment] breaking_change_analysis`
```js
{
   'enabled': true
}
```

**Backend**
Event type: `api_event` (existing)
```js
{
  'action': 'create_run',
  'track_props': {
     'breaking_change_analysis': true
  }
}
```

```js
{
  'action': 'create_check',
  'track_props': {
     'breaking_change_analysis': true
  }
}
```


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
