### PR TITLE
[Bug] Fix n validation error for NodeDiff

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -710,7 +710,7 @@ class DbtAdapter(BaseAdapter):
 
                 diff[key] = NodeDiff(change_status='modified', change_category=change_category)
             elif base_node:
-                diff[key] = NodeDiff(chnage_status='removed')
+                diff[key] = NodeDiff(change_status='removed')
             elif curr_node:
                 diff[key] = NodeDiff(change_status='added')
         return LineageDiff(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug fix
**What this PR does / why we need it**:

Error message
```
  File "/Users/popcorny/Documents/infuseai/repo/recce/recce/adapter/dbt_adapter/__init__.py", line 552, in get_lineage_diff
    return self._get_lineage_diff_cached(cache_key)
  File "/Users/popcorny/Documents/infuseai/repo/recce/recce/adapter/dbt_adapter/__init__.py", line 713, in _get_lineage_diff_cached
    diff[key] = NodeDiff(chnage_status='removed')
  File "/Users/popcorny/Documents/infuseai/repo/jaffle_shop_duckdb/venv/lib/python3.10/site-packages/pydantic/main.py", line 171, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for NodeDiff
change_status
  Field required [type=missing, input_value={'chnage_status': 'removed'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.6/v/missing
    ```
**Which issue(s) this PR fixes**:
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
