### PR TITLE
[Feature] Capture the original manifest as base in single env

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -810,6 +810,8 @@ class DbtAdapter(BaseAdapter):
         if refresh_file_path is None:
             return self.load_artifacts()
 
+        # In single environment mode (target_path is equal to base_path),
+        # we capture the original manifest as base and only update the current
         target_type = os.path.basename(os.path.dirname(refresh_file_path))
         if self.target_path and target_type == os.path.basename(self.target_path):
             if refresh_file_path.endswith('manifest.json'):
@@ -817,9 +819,7 @@ class DbtAdapter(BaseAdapter):
                 self.manifest = as_manifest(self.curr_manifest)
             elif refresh_file_path.endswith('catalog.json'):
                 self.curr_catalog = load_catalog(path=refresh_file_path)
-
-        # In single environment mode, the target and base are the same. We need to update both.
-        if self.base_path and target_type == os.path.basename(self.base_path):
+        elif self.base_path and target_type == os.path.basename(self.base_path):
             if refresh_file_path.endswith('manifest.json'):
                 self.base_manifest = load_manifest(path=refresh_file_path)
             elif refresh_file_path.endswith('catalog.json'):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
To capture the original manifest as the base when launching recce server in the single env mode.
After rebuilding a model, it can show the lineage diff.

**Which issue(s) this PR fixes**:
DRC-1065

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE