### PR TITLE
[Feature] DRC-998 Improve the ux when user back and forth checklist tab

### DIFF
--- a/js/app/page.tsx
+++ b/js/app/page.tsx
@@ -321,7 +321,7 @@ function Main() {
     useRecceActionContext();
   const { data: flag } = useRecceServerFlag();
   const [location] = useLocation();
-  const _isRunResultOpen = isRunResultOpen && !location.startsWith("/checks");
+  const _isRunResultOpen = isRunResultOpen;
   const _isHistoryOpen = isHistoryOpen && !location.startsWith("/checks");
 
   return (

--- a/js/src/components/check/CheckPage.tsx
+++ b/js/src/components/check/CheckPage.tsx
@@ -17,12 +17,18 @@ import { buildDescription, buildTitle } from "./check";
 import { stripIndents } from "common-tags";
 import { HSplit } from "../split/Split";
 import { StateImporter } from "../app/StateImporter";
+import { useRecceCheckContext } from "@/lib/hooks/RecceCheckContext";
 
 export const CheckPage = () => {
   const [, setLocation] = useLocation();
   const [, params] = useRoute("/checks/:checkId");
+  const { latestSelectedCheckId, setLatestSelectedCheckId } =
+    useRecceCheckContext();
   const queryClient = useQueryClient();
   const selectedItem = params?.checkId;
+  if (selectedItem) {
+    setLatestSelectedCheckId(selectedItem);
+  }
 
   const {
     isLoading,
@@ -81,11 +87,23 @@ export const CheckPage = () => {
     }
 
     if (!selectedItem && checks.length > 0) {
-      setLocation(`/checks/${checks[0].check_id}`);
+      if (latestSelectedCheckId) {
+        setLocation(`/checks/${latestSelectedCheckId}`);
+      } else {
+        // If no check is selected, select the first one by default
+        setLocation(`/checks/${checks[0].check_id}`);
+      }
     }
 
     setOrderedChecks(checks);
-  }, [status, selectedItem, checks, setOrderedChecks, setLocation]);
+  }, [
+    status,
+    selectedItem,
+    checks,
+    setOrderedChecks,
+    setLocation,
+    latestSelectedCheckId,
+  ]);
 
   if (isLoading) {
     return <></>;

--- a/js/src/lib/hooks/RecceActionContext.tsx
+++ b/js/src/lib/hooks/RecceActionContext.tsx
@@ -199,15 +199,6 @@ export function RecceActionContextProvider({
     }
   };
 
-  useEffect(() => {
-    if (runId) {
-      if (location.startsWith("/checks")) {
-        setLocation("/lineage");
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runId]);
-
   return (
     <RecceActionContext.Provider
       value={{

--- a/js/src/lib/hooks/RecceCheckContext.tsx
+++ b/js/src/lib/hooks/RecceCheckContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext } from "react";
+
+export interface CheckContext {
+  latestSelectedCheckId: string;
+  setLatestSelectedCheckId: (selectCheckId: string) => void;
+}
+
+interface CheckContextProps {
+  children: React.ReactNode;
+}
+
+const RecceCheckContext = createContext<CheckContext>({
+  latestSelectedCheckId: "",
+  setLatestSelectedCheckId: () => {},
+});
+
+export function RecceCheckContextProvider({ children }: CheckContextProps) {
+  const [selectCheckId, setSelectCheckId] = React.useState<string>("");
+  return (
+    <RecceCheckContext.Provider
+      value={{
+        setLatestSelectedCheckId: setSelectCheckId,
+        latestSelectedCheckId: selectCheckId,
+      }}
+    >
+      {children}
+    </RecceCheckContext.Provider>
+  );
+}
+
+export const useRecceCheckContext = () => useContext(RecceCheckContext);

--- a/js/src/lib/hooks/RecceContextProvider.tsx
+++ b/js/src/lib/hooks/RecceContextProvider.tsx
@@ -6,6 +6,7 @@ import {
 } from "./RecceQueryContext";
 import { LineageGraphContextProvider } from "./LineageGraphContext";
 import { RecceActionContextProvider } from "./RecceActionContext";
+import { RecceCheckContextProvider } from "./RecceCheckContext";
 
 interface RecceContextProps {
   children: React.ReactNode;
@@ -17,7 +18,9 @@ export default function RecceContextProvider({ children }: RecceContextProps) {
       <RecceQueryContextProvider>
         <LineageGraphContextProvider>
           <RowCountStateContextProvider>
-            <RecceActionContextProvider>{children}</RecceActionContextProvider>
+            <RecceActionContextProvider>
+              <RecceCheckContextProvider>{children}</RecceCheckContextProvider>
+            </RecceActionContextProvider>
           </RowCountStateContextProvider>
         </LineageGraphContextProvider>
       </RecceQueryContextProvider>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Improve UX

**What this PR does / why we need it**:
- Memorize the latest check item from the Checklist tab. We will remember the previous index when switching back to the Checklist tab.

- Auto-select the related Lineage Node when the run action is triggered from the check result. (Ex. Show mismatched values...). Select history runs will also apply this logic.
   - If the selected node is not included in `changed_models` mode, the lineage view will auto-switch to `all` mode.

- When selecting a node in Lineage View, the flow graph will autofocus to the selected node.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
