### PR TITLE
[Fix] DRC-1092 Skip auto-focus logic when some specific run types

### DIFF
--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -601,7 +601,7 @@ export function PrivateLineageView(
     }
     if (
       !runResultType ||
-      ["query_diff", "query", "row_count"].find((x) => x === runResultType)
+      ["query_diff", "query", "row_count"].includes(runResultType)
     ) {
       // Skip the following logic if the run result type is not related to a node
       return;

--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -590,6 +590,7 @@ export function PrivateLineageView(
   const valueDiffAlertDialog = useValueDiffAlertDialog();
 
   useEffect(() => {
+    const runResultType = run?.type;
     if (!interactive) {
       // Skip the following logic if the view is not interactive
       return;
@@ -598,6 +599,14 @@ export function PrivateLineageView(
       // Skip the following logic if the run result is not open
       return;
     }
+    if (
+      !runResultType ||
+      ["query_diff", "query", "row_count"].find((x) => x === runResultType)
+    ) {
+      // Skip the following logic if the run result type is not related to a node
+      return;
+    }
+
     const selectedRunModel = run?.params?.model;
     // Create a mock MouseEvent
     const mockEvent = new MouseEvent("click", {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
- Skip auto focus logic when the run type is `query`, `query_diff` or `row_count`
- Execute `Run Query` won't break the `Sandbox` or `Single Env Query` Modal

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
