### PR TITLE
[Fix] DRC-1106 auto-de/select node logic should only effect when mode…

### DIFF
--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -607,33 +607,37 @@ export function PrivateLineageView(
       return;
     }
 
-    const selectedRunModel = run?.params?.model;
-    // Create a mock MouseEvent
-    const mockEvent = new MouseEvent("click", {
-      bubbles: true,
-      cancelable: true,
-      view: window,
-    }) as unknown as React.MouseEvent<Element, MouseEvent>;
+    if (selectMode === "single") {
+      // Skip the following logic if the select mode is not single
+      const selectedRunModel = run?.params?.model;
+      // Create a mock MouseEvent
+      const mockEvent = new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      }) as unknown as React.MouseEvent<Element, MouseEvent>;
 
-    if (selectedRunModel) {
-      // If the run result is related to a node, select the node to show NodeView
-      const node = findNodeByName(selectedRunModel);
-      if (!node) {
-        // Cannot find the node in the current nodes, try to change the view mode to 'all'
-        handleViewOptionsChanged({
-          ...viewOptions,
-          view_mode: "all",
-        });
-      } else if (selectedNode !== node.data) {
-        // Only select the node if it is not already selected
-        onNodeClick(mockEvent, node);
+      if (selectedRunModel) {
+        // If the run result is related to a node, select the node to show NodeView
+        const node = findNodeByName(selectedRunModel);
+        if (!node) {
+          // Cannot find the node in the current nodes, try to change the view mode to 'all'
+          handleViewOptionsChanged({
+            ...viewOptions,
+            view_mode: "all",
+          });
+        } else if (selectedNode !== node.data) {
+          // Only select the node if it is not already selected
+          onNodeClick(mockEvent, node);
+        }
+      } else {
+        // If the run result is not related to a node, close the NodeView
+        onNodeViewClosed();
       }
-    } else {
-      // If the run result is not related to a node, close the NodeView
-      onNodeViewClosed();
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [run, viewOptions, isRunResultOpen]);
+  }, [run, viewOptions, isRunResultOpen, selectMode]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
… is single

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
BugFix 

**What this PR does / why we need it**:
- The auto-select/deselect nodes logic should only effect when the mode is `single` 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
