### PR TITLE
[Fix] DRC-1127 Check password option when upload/download state file

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -583,7 +583,7 @@ def download(**kwargs):
 
     # check if state exists in cloud
     state_manager = RecceCloudStateManager(cloud_options)
-    if state_manager.verify():
+    if not state_manager.verify():
         error, hint = state_manager.error_and_hint
         console.print(f"[[red]Error[/red]] {error}")
         console.print(f"{hint}")

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -541,6 +541,12 @@ def upload(state_file, **kwargs):
 
     # check if state exists in cloud
     state_manager = RecceCloudStateManager(cloud_options)
+    if not state_manager.verify():
+        error, hint = state_manager.error_and_hint
+        console.print(f"[[red]Error[/red]] {error}")
+        console.print(f"{hint}")
+        exit(1)
+
     cloud_state_file_exists = state_manager.check_cloud_state_exists()
 
     if cloud_state_file_exists and not click.confirm('\nDo you want to overwrite the existing state file?'):
@@ -577,6 +583,12 @@ def download(**kwargs):
 
     # check if state exists in cloud
     state_manager = RecceCloudStateManager(cloud_options)
+    if state_manager.verify():
+        error, hint = state_manager.error_and_hint
+        console.print(f"[[red]Error[/red]] {error}")
+        console.print(f"{hint}")
+        exit(1)
+
     cloud_state_file_exists = state_manager.check_cloud_state_exists()
 
     if not cloud_state_file_exists:

--- a/recce/state.py
+++ b/recce/state.py
@@ -513,6 +513,8 @@ class RecceCloudStateManager:
     def __init__(self, cloud_options: Optional[Dict[str, str]] = None):
         self.cloud_options = cloud_options or {}
         self.pr_info = None
+        self.error_message = None
+        self.hint_message = None
 
         if not self.cloud_options.get('token'):
             raise Exception('No GitHub token is provided to access the pull request information.')

--- a/recce/state.py
+++ b/recce/state.py
@@ -197,7 +197,7 @@ class RecceStateLoader:
 
         if self.cloud_mode:
             if not self.cloud_options.get('token'):
-                raise Exception('No GitHub token is provided to access the pull request information.')
+                raise Exception(RECCE_CLOUD_TOKEN_MISSING.error_message)
             self.pr_info = fetch_pr_metadata(cloud=self.cloud_mode, github_token=self.cloud_options.get('token'))
             if self.pr_info.id is None:
                 raise Exception('Cannot get the pull request information from GitHub.')
@@ -517,7 +517,7 @@ class RecceCloudStateManager:
         self.hint_message = None
 
         if not self.cloud_options.get('token'):
-            raise Exception('No GitHub token is provided to access the pull request information.')
+            raise Exception(RECCE_CLOUD_TOKEN_MISSING.error_message)
         self.pr_info = fetch_pr_metadata(cloud=True, github_token=self.cloud_options.get('token'))
         if self.pr_info.id is None:
             raise Exception('Cannot get the pull request information from GitHub.')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
- Check `password` when uploading/downloading the recce state file in Recce Cloud
- Refactor class `RecceCloudStateManager` to add `verify` method and store the error and hint messages.
- Extract the cloud-related error message as global variables

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
