### PR TITLE
chore: Fix more linting issues, remove (default is error)

### DIFF
--- a/js/app/page.tsx
+++ b/js/app/page.tsx
@@ -142,6 +142,7 @@ interface TabProps {
   disable?: boolean;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 function TabBadge<T, R extends number>({
   queryKey,
   fetchCallback,
@@ -150,7 +151,7 @@ function TabBadge<T, R extends number>({
   queryKey: string[];
   fetchCallback: () => Promise<T>;
   selectCallback?: (data: T) => R;
-}) {
+}): ReactNode {
   const {
     data: count,
     isLoading,

--- a/js/eslint.config.mjs
+++ b/js/eslint.config.mjs
@@ -75,12 +75,12 @@ export default tseslint.config(
       "react/prop-types": "off",
       "react/react-in-jsx-scope": "off",
       // 'react/no-array-index-key': 'error',
-      // "react/no-unknown-property": [
-      //   "error",
-      //   {
-      //     ignore: ["jsx", "global"],
-      //   },
-      // ],
+      "react/no-unknown-property": [
+        "error",
+        {
+          ignore: ["jsx", "global"],
+        },
+      ],
       // '@typescript-eslint/no-explicit-any': 'error',
       "@typescript-eslint/explicit-module-boundary-types": "off",
       "@typescript-eslint/no-empty-function": "off",
@@ -104,25 +104,16 @@ export default tseslint.config(
       //  Marking the below as warnings ""for now"" - They need to be addressed in the future
       //  ------------------------------------------------------------------------------------
       "react/no-array-index-key": "warn",
-      "react/no-unknown-property": [
-        "warn",
-        {
-          ignore: ["jsx", "global"],
-        },
-      ],
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unsafe-function-type": "warn",
       "@typescript-eslint/no-extra-non-null-assertion": "warn",
-      "@typescript-eslint/array-type": "warn",
       "@typescript-eslint/restrict-plus-operands": "warn",
       "@typescript-eslint/no-inferrable-types": "warn",
       "@typescript-eslint/no-unnecessary-type-arguments": "warn",
       "@typescript-eslint/consistent-indexed-object-style": "warn",
-      "@typescript-eslint/no-deprecated": "warn",
       "@typescript-eslint/no-unnecessary-boolean-literal-compare": "warn",
       "@typescript-eslint/no-unnecessary-type-assertion": "warn",
       "@typescript-eslint/no-empty-object-type": "warn",
-      "@typescript-eslint/dot-notation": "warn",
       "@typescript-eslint/no-wrapper-object-types": "warn",
       "@typescript-eslint/consistent-generic-constructors": "warn",
       "@typescript-eslint/no-unnecessary-template-expression": "warn",
@@ -140,10 +131,7 @@ export default tseslint.config(
       "@typescript-eslint/no-unsafe-call": "warn",
       "@typescript-eslint/no-redundant-type-constituents": "warn",
       "@typescript-eslint/no-unsafe-return": "warn",
-      "@typescript-eslint/unbound-method": "warn",
-      "@typescript-eslint/no-unnecessary-type-parameters": "warn",
       "@typescript-eslint/no-unused-expressions": "warn",
-      "@typescript-eslint/prefer-optional-chain": "warn",
       "@typescript-eslint/require-await": "warn",
       "@typescript-eslint/await-thenable": "warn",
       "@typescript-eslint/no-confusing-void-expression": "warn",

--- a/js/src/components/app/EnvInfo.tsx
+++ b/js/src/components/app/EnvInfo.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useLineageGraphContext } from "@/lib/hooks/LineageGraphContext";
 import {
   Tooltip,
@@ -35,7 +36,7 @@ export function formatTimestamp(timestamp: string): string {
   return formattedTimestamp;
 }
 
-function renderInfoEntries(info: object): JSX.Element[] {
+function renderInfoEntries(info: object): React.JSX.Element[] {
   if (Object.values(info).every((value) => value === null)) {
     return [
       <Flex key={"no info"} ml="10px">

--- a/js/src/components/errorboundary/ErrorBoundary.tsx
+++ b/js/src/components/errorboundary/ErrorBoundary.tsx
@@ -18,6 +18,7 @@ export const ErrorButton = () => {
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/unbound-method
 const Fallback: FallbackRender = ({ error, resetError }) => {
   return (
     <Center height="100%" backgroundColor="gray.50">

--- a/js/src/components/lineage/lineage.test.ts
+++ b/js/src/components/lineage/lineage.test.ts
@@ -171,13 +171,13 @@ test("lineage diff 2", () => {
   expect(Object.keys(edges).length).toBe(4);
   expect(nodes.a.changeStatus).toBe("removed");
   expect(nodes.a2.changeStatus).toBe("added");
-  expect(nodes.b.changeStatus).toBeUndefined;
+  expect(nodes.b.changeStatus).toBeUndefined();
   expect(nodes.c.changeStatus).toBe("modified");
-  expect(nodes.d.changeStatus).toBeUndefined;
+  expect(nodes.d.changeStatus).toBeUndefined();
 
   expect(nodes.b.parents.a.changeStatus).toBe("removed");
   expect(nodes.b.parents.a2.changeStatus).toBe("added");
-  expect(nodes.b.children.c.changeStatus).toBeUndefined;
+  expect(nodes.b.children.c.changeStatus).toBeUndefined();
 });
 
 test("hightlight", () => {

--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -180,7 +180,11 @@ export function buildLineageGraph(
       nodes[key] = buildNode(key, "current");
     }
     if (nodeData) {
-      nodes[key].data.current = current.nodes && current.nodes[key];
+      // TODO `current.nodes` is treated as potentially falsy here
+      //  this means either that a) the typing needs to be adjusted
+      //  on `current.nodes` or b) the input to `current.nodes`
+      //  should default to a value
+      nodes[key].data.current = current.nodes?.[key];
       nodes[key].name = nodeData.name;
       nodes[key].resourceType = nodeData.resource_type;
       nodes[key].packageName = nodeData.package_name;

--- a/js/src/components/query/QueryDiffResultView.tsx
+++ b/js/src/components/query/QueryDiffResultView.tsx
@@ -253,11 +253,7 @@ export const QueryDiffResultView = forwardRef((props: QueryDiffResultViewProps, 
     baseTitle = "Original";
     currentTitle = "Editor";
   }
-  if (
-    props.run.result !== undefined &&
-    props.run.result.diff !== null &&
-    props.run.result.diff !== undefined
-  ) {
+  if (props.run.result?.diff != null) {
     const ResultView = forwardRef(PrivateQueryDiffJoinResultView);
     return <ResultView {...props} ref={ref} baseTitle={baseTitle} currentTitle={currentTitle} />;
   } else {

--- a/js/src/components/run/RunView.tsx
+++ b/js/src/components/run/RunView.tsx
@@ -13,7 +13,7 @@ import {
 } from "@chakra-ui/react";
 import { RunResultViewProps } from "./types";
 import { ErrorBoundary } from "@sentry/react";
-import { ElementType } from "react";
+import React, { ElementType } from "react";
 
 interface RunViewProps<PT, RT, VO = any> {
   isRunning?: boolean;
@@ -27,6 +27,7 @@ interface RunViewProps<PT, RT, VO = any> {
   viewOptions?: VO;
   onViewOptionsChanged?: (viewOptions: VO) => void;
   RunResultView?: ComponentWithAs<ElementType, RunResultViewProps<PT, RT, VO>>;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   children?: <T extends RunResultViewProps<PT, RT, VO>>(params: T) => React.ReactNode;
 }
 

--- a/js/src/components/schema/SqlDiffView.tsx
+++ b/js/src/components/schema/SqlDiffView.tsx
@@ -9,7 +9,11 @@ interface SqlDiffProps {
   current?: NodeData;
 }
 
-function useDiffEditorSync(value: string, onChange: (value: string) => void) {
+interface UseDiffEditorSync {
+  onMount: (editor: monacoEditor.IStandaloneDiffEditor) => void;
+}
+
+function useDiffEditorSync(value: string, onChange: (value: string) => void): UseDiffEditorSync {
   const editorRef = useRef<any>(null);
 
   useEffect(() => {

--- a/js/theme/components/Checkbox.ts
+++ b/js/theme/components/Checkbox.ts
@@ -1,6 +1,7 @@
 import { checkboxAnatomy as parts } from "@chakra-ui/anatomy";
 import { createMultiStyleConfigHelpers, defineStyle } from "@chakra-ui/styled-system";
 
+// eslint-disable-next-line @typescript-eslint/unbound-method
 const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(parts.keys);
 
 // Defining a custom variant


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Chore

**What this PR does / why we need it**:

This PR continues to fixe eslint configurations - fixing seven more.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- Fix react/no-unknown-property
- Fix @typescript-eslint/array-type
- Fix @typescript-eslint/no-deprecated
- Fix @typescript-eslint/dot-notation
- Fix @typescript-eslint/unbound-method
- Fix @typescript-eslint/no-unnecessary-type-parameters
- Fix @typescript-eslint/prefer-optional-chain

Fix test expect() lines that were not running
Disable a few unbound-method checks
Add TODO regarding typing inconsistency for `LineageData` Fix `prefer-optional-chain` in QueryDiffResultView.tsx: `value != null` is a preferred way to test if a value is either null or undefined


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE