### PR TITLE
[Bug] Dont break the loading logic if parsing cll error

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -811,7 +811,6 @@ class DbtAdapter(BaseAdapter):
                 ref=ref_func,
                 source=source_func,
             )
-            compiled_sql = self.generate_sql(raw_code, base=base, context=jinja_context)
 
             schema = {}
             for parent_id in parent_map[node.get('id')]:
@@ -830,6 +829,7 @@ class DbtAdapter(BaseAdapter):
                 }
 
             try:
+                compiled_sql = self.generate_sql(raw_code, base=base, context=jinja_context)
                 dialect = self.adapter.type()
                 column_lineage = cll(compiled_sql, schema=schema, dialect=dialect)
             except RecceException:


### PR DESCRIPTION
Fix #655 

Sometimes, we cannot compile sql for some reason. (different var, envvar from the dbt run), we should not break the initiating process but left it as parse error.

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug, Hotfix

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
#655

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
