### PR TITLE
[Bug] Typo in NodeDiff parameter name causes 500 error

### DIFF
--- a/recce/adapter/base.py
+++ b/recce/adapter/base.py
@@ -42,7 +42,7 @@ class BaseAdapter(ABC):
 
                 diff[key] = NodeDiff(change_status='modified', change_category='breaking')
             elif base_node:
-                diff[key] = NodeDiff(chnage_status='removed')
+                diff[key] = NodeDiff(change_status='removed')
             elif curr_node:
                 diff[key] = NodeDiff(change_status='added')
         return LineageDiff(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
Fix the typo in NodeDiff parameter name causes 500 error

**Which issue(s) this PR fixes**:
#670 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
