### PR TITLE
Support to analyze the partial breaking change.

### DIFF
--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -160,6 +160,9 @@ def _diff_select_scope(
         def _has_udtf(expr: exp.Expression) -> bool:
             return expr.find(exp.UDTF) is not None
 
+        def _has_aggregate(expr: exp.Expression) -> bool:
+            return expr.find(exp.AggFunc) is not None
+
         old_column = old_column_map.get(column_name)
         new_column = new_column_map.get(column_name)
         if old_column is None:
@@ -184,6 +187,9 @@ def _diff_select_scope(
                 return CHANGE_CATEGORY_BREAKING
 
             if _has_udtf(old_column) and _has_udtf(new_column):
+                return CHANGE_CATEGORY_BREAKING
+
+            if _has_aggregate(old_column) != _has_aggregate(new_column):
                 return CHANGE_CATEGORY_BREAKING
 
             changed_columns[column_name] = 'modified'

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -288,7 +288,7 @@ def parse_change_category(
     old_schema=None,
     new_schema=None,
     dialect=None,
-    optimizier_rules=None,
+    optimizer_rules=None,
 ) -> ChangeCategoryResult:
     if old_sql == new_sql:
         return ChangeCategoryResult('non_breaking')
@@ -301,8 +301,8 @@ def parse_change_category(
             if schema:
                 try:
                     kwargs = {}
-                    if optimizier_rules is not None:
-                        kwargs["rules"] = optimizier_rules
+                    if optimizer_rules is not None:
+                        kwargs["rules"] = optimizer_rules
                     exp = optimize(exp, schema=schema, dialect=dialect, **kwargs)
                 except Exception as e:
                     # cannot optimize, skip it.

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -186,6 +186,10 @@ def _diff_scope(
     # where
     for arg_key in new_select.args.keys():
         arg_value = new_select.args[arg_key]
+
+        if arg_key in ['expressions', 'with']:
+            continue
+
         if arg_value is None:
             continue
 

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -54,7 +54,7 @@ def _debug(*args):
 def is_breaking_change(old_sql, new_sql, dialect=None):
     # return _is_breaking_change(original_sql, modified_sql, dialect=dialect)
     result = parse_change_category(old_sql, new_sql, old_schema=None, new_schema=None, dialect=dialect)
-    return result.category != 'non_breaking'
+    return result.category == 'breaking'
 
 
 def _is_breaking_change(original_sql, modified_sql, dialect=None) -> bool:

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -283,7 +283,7 @@ def parse_change_category(
     old_schema=None,
     new_schema=None,
     dialect=None,
-    unit_test=False,
+    optimizier_rules=None,
 ) -> ChangeCategoryResult:
     if old_sql == new_sql:
         return ChangeCategoryResult('non_breaking')
@@ -295,27 +295,10 @@ def parse_change_category(
             exp = parse_one(sql, dialect=dialect)
             if schema:
                 try:
-                    if unit_test:
-                        from sqlglot.optimizer.qualify import qualify
-                        RULES = (
-                            qualify,
-                            # optimizer.pushdown_projections,
-                            # optimizer.qualify,
-                            # optimizer.unnest_subqueries,
-                            # optimizer.pushdown_predicates,
-                            # optimizer.optimize_joins,
-                            # optimizer.eliminate_subqueries,
-                            # optimizer.merge_subqueries,
-                            # optimizer.eliminate_joins,
-                            # optimizer.eliminate_ctes,
-                            # optimizer.qualify_columns,
-                            # optimizer.annotate_types,
-                            # optimizer.canonicalize,
-                            # optimizer.simplify,
-                        )
-                        exp = optimize(exp, schema=schema, dialect=dialect, rules=RULES)
-                    else:
-                        exp = optimize(exp, schema=schema, dialect=dialect)
+                    kwargs = {}
+                    if optimizier_rules is not None:
+                        kwargs["rules"] = optimizier_rules
+                    exp = optimize(exp, schema=schema, dialect=dialect, **kwargs)
                 except Exception as e:
                     # cannot optimize, skip it.
                     _debug(e)

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -46,10 +46,15 @@ BREAKING = ChangeCategoryResult('breaking')
 NON_BREAKING = ChangeCategoryResult('non_breaking')
 
 
+def _debug(*args):
+    pass
+    # print(*args)
+
+
 def is_breaking_change(old_sql, new_sql, dialect=None):
     # return _is_breaking_change(original_sql, modified_sql, dialect=dialect)
-    result = _diff_model(old_sql, new_sql, old_schema=None, new_schema=None, dialect=dialect)
-    return result.category == 'breaking'
+    result = parse_change_category(old_sql, new_sql, old_schema=None, new_schema=None, dialect=dialect)
+    return result.category != 'non_breaking'
 
 
 def _is_breaking_change(original_sql, modified_sql, dialect=None) -> bool:
@@ -103,40 +108,86 @@ def _is_breaking_change(original_sql, modified_sql, dialect=None) -> bool:
     return False
 
 
-def _diff_scope(old_scope: Scope, new_scope: Scope) -> ChangeCategoryResult:
+def _diff_scope(
+    old_scope: Scope,
+    new_scope: Scope,
+    scope_changes_map: dict[Scope, ChangeCategoryResult]
+) -> ChangeCategoryResult:
+    result = ChangeCategoryResult('non_breaking')
     if old_scope == new_scope:
         return ChangeCategoryResult('non_breaking')
 
     if not isinstance(old_scope.expression, exp.Select) or not isinstance(new_scope.expression, exp.Select):
         raise ValueError("Currently only SELECT statements are supported for comparison")
 
-    edits = diff(old_scope.expression, new_scope.expression, delta_only=True)
-    inserted_expressions = {
-        e.expression for e in edits if isinstance(e, Insert)
-    }
+    old_select = old_scope.expression  # type: exp.Select
+    new_select = new_scope.expression  # type: exp.Selects
 
-    for edit in edits:
-        if isinstance(edit, Insert):
-            inserted_expr = edit.expression
+    for arg_key in old_select.args.keys() | new_select.args.keys():
+        if arg_key in ['expressions', 'with']:
+            continue
 
-            if isinstance(inserted_expr, VALID_EXPRESSIONS):
-                return BREAKING
-
-            if isinstance(inserted_expr, exp.UDTF):
-                return BREAKING
-
-            if (
-                not isinstance(inserted_expr.parent, exp.Select) and
-                inserted_expr.parent not in inserted_expressions
-            ):
-                return BREAKING
-        elif not isinstance(edit, Keep):
+        if old_select.args.get(arg_key) != new_select.args.get(arg_key):
             return BREAKING
 
-    return NON_BREAKING
+    # selects
+    old_column_map = {projection.alias_or_name: projection for projection in old_select.selects}
+    new_column_map = {projection.alias_or_name: projection for projection in new_select.selects}
+    changed_columns = {}
+
+    for column_name in (old_column_map.keys() | new_column_map.keys()):
+        def _has_udtf(expresion: exp.Expression) -> bool:
+            for expr in expresion.walk():
+                if isinstance(expr, exp.UDTF):
+                    return True
+            return False
+
+        old_column = old_column_map.get(column_name)
+        new_column = new_column_map.get(column_name)
+        if old_column is None:
+
+            if _has_udtf(new_column):
+                return BREAKING
+
+            changed_columns[column_name] = 'added'
+        elif new_column is None:
+            if _has_udtf(old_column):
+                return BREAKING
+
+            changed_columns[column_name] = 'removed'
+            result.category = 'partial_breaking'
+        elif old_column != new_column:
+            if _has_udtf(old_column) and _has_udtf(new_column):
+                return BREAKING
+
+            changed_columns[column_name] = 'modified'
+            result.category = 'partial_breaking'
+        else:
+            ref_columns = new_column.find_all(exp.Column)
+            for ref_column in ref_columns:
+                table_name = ref_column.table
+                column_name = ref_column.name
+                source = new_scope.sources.get(table_name, None)  # type: exp.Table | Scope
+                if not isinstance(source, Scope):
+                    continue
+
+                change_category = scope_changes_map.get(source)
+                if not change_category:
+                    continue
+
+                if change_category.category == 'breaking':
+                    return BREAKING
+
+                if change_category.category == 'partial_breaking':
+                    if change_category.changed_columns.get(column_name) is not None:
+                        result.category = 'partial_breaking'
+                        changed_columns[column_name] = 'modified'
+
+    result.changed_columns = changed_columns
+    return result
 
 
-def _diff_model(old_sql, new_sql, old_schema, new_schema, dialect=None) -> ChangeCategoryResult:
+def parse_change_category(old_sql, new_sql, old_schema=None, new_schema=None, dialect=None) -> ChangeCategoryResult:
     if old_sql == new_sql:
         return ChangeCategoryResult('non_breaking')
 
@@ -145,16 +196,18 @@ def _diff_model(old_sql, new_sql, old_schema, new_schema, dialect=None) -> Chang
 
         def _parse(sql, schema):
             exp = parse_one(sql, dialect=dialect)
-            try:
-                exp = optimize(exp, schema=schema, dialect=dialect)
-            except Exception:
-                # cannot optimize, skip it.
-                pass
+            if schema:
+                try:
+                    exp = optimize(exp, schema=schema, dialect=dialect)
+                except Exception:
+                    # cannot optimize, skip it.
+                    pass
             return exp
 
         old_exp = _parse(old_sql, old_schema)
         new_exp = _parse(new_sql, new_schema)
-    except Exception:
+    except Exception as e:
+        _debug(e)
         return BREAKING
 
     old_scopes = traverse_scope(old_exp)
@@ -162,9 +215,12 @@ def _diff_model(old_sql, new_sql, old_schema, new_schema, dialect=None) -> Chang
     if len(old_scopes) != len(new_scopes):
         return BREAKING
 
+    scope_changes_map = {}
     for old_scope, new_scope in zip(old_scopes, new_scopes):
-        result = _diff_scope(old_scope, new_scope)
-        if result.category == 'breaking':
-            return BREAKING
+        result = _diff_scope(old_scope, new_scope, scope_changes_map)
+        scope_changes_map[new_scope] = result
+        if new_scope.is_root:
+            return result
 
-    return NON_BREAKING
+    return result
+    # return NON_BREAKING

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -136,7 +136,7 @@ def _diff_select_scope(
         if old_select.args.get(arg_key) != new_select.args.get(arg_key):
             return CHANGE_CATEGORY_BREAKING
 
-    def source_column_change_status(ref_column: exp.Column) -> ColumnChangeStatus | None:
+    def source_column_change_status(ref_column: exp.Column) -> Optional[ColumnChangeStatus]:
         table_name = ref_column.table
         column_name = ref_column.name
         source = new_scope.sources.get(table_name, None)  # type: exp.Table | Scope
@@ -205,7 +205,7 @@ def _diff_select_scope(
                     result.category = 'partial_breaking'
                     changed_columns[column_name] = 'modified'
 
-    def selected_column_change_status(ref_column: exp.Column) -> ColumnChangeStatus | None:
+    def selected_column_change_status(ref_column: exp.Column) -> Optional[ColumnChangeStatus]:
         column_name = ref_column.name
         return changed_columns.get(column_name)
 

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -1,16 +1,60 @@
-from sqlglot.optimizer import optimize
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+import sqlglot.expressions as exp
+from sqlglot import parse_one, diff, Dialect
+from sqlglot.diff import Insert, Keep
+from sqlglot.optimizer import optimize, traverse_scope, Scope
+
+ChangeCategory = Literal['breaking', 'partial_breaking', 'non_breaking']
+ColumnChangeStatus = Literal['added', 'removed', 'modified']
+VALID_EXPRESSIONS = (
+    exp.Where,
+    exp.Join,
+    exp.Order,
+    exp.Group,
+    exp.Having,
+    exp.Limit,
+    exp.Offset,
+    exp.Window,
+    exp.Union,
+    exp.Intersect,
+    exp.Except,
+    exp.Merge,
+    exp.Delete,
+    exp.Update,
+    exp.Insert,
+    exp.Subquery,
+)
 
 
-def is_breaking_change(original_sql, modified_sql, dialect=None):
+@dataclass
+class ChangeCategoryResult:
+    category: ChangeCategory
+    changed_columns: Optional[dict[str, ColumnChangeStatus]]
+
+    def __init__(
+        self,
+        category: ChangeCategory,
+        changed_columns: Optional[dict[str, ColumnChangeStatus]] = None
+    ):
+        self.category = category
+        self.changed_columns = changed_columns
+
+
+BREAKING = ChangeCategoryResult('breaking')
+NON_BREAKING = ChangeCategoryResult('non_breaking')
+
+
+def is_breaking_change(old_sql, new_sql, dialect=None):
+    # return _is_breaking_change(original_sql, modified_sql, dialect=dialect)
+    result = _diff_model(old_sql, new_sql, old_schema=None, new_schema=None, dialect=dialect)
+    return result.category == 'breaking'
+
+
+def _is_breaking_change(original_sql, modified_sql, dialect=None) -> bool:
     if original_sql == modified_sql:
         return False
-
-    try:
-        from sqlglot import parse_one, diff, Dialect
-        from sqlglot.diff import Insert, Keep
-        import sqlglot.expressions as exp
-    except ImportError:
-        return True
 
     try:
         dialect = Dialect.get(dialect)
@@ -38,25 +82,6 @@ def is_breaking_change(original_sql, modified_sql, dialect=None):
         e.expression for e in edits if isinstance(e, Insert)
     }
 
-    VALID_EXPRESSIONS = (
-        exp.Where,
-        exp.Join,
-        exp.Order,
-        exp.Group,
-        exp.Having,
-        exp.Limit,
-        exp.Offset,
-        exp.Window,
-        exp.Union,
-        exp.Intersect,
-        exp.Except,
-        exp.Merge,
-        exp.Delete,
-        exp.Update,
-        exp.Insert,
-        exp.Subquery,
-    )
-
     for edit in edits:
         if isinstance(edit, Insert):
             inserted_expr = edit.expression
@@ -76,3 +101,70 @@ def is_breaking_change(original_sql, modified_sql, dialect=None):
             return True
 
     return False
+
+
+def _diff_scope(old_scope: Scope, new_scope: Scope) -> ChangeCategoryResult:
+    if old_scope == new_scope:
+        return ChangeCategoryResult('non_breaking')
+
+    if not isinstance(old_scope.expression, exp.Select) or not isinstance(new_scope.expression, exp.Select):
+        raise ValueError("Currently only SELECT statements are supported for comparison")
+
+    edits = diff(old_scope.expression, new_scope.expression, delta_only=True)
+    inserted_expressions = {
+        e.expression for e in edits if isinstance(e, Insert)
+    }
+
+    for edit in edits:
+        if isinstance(edit, Insert):
+            inserted_expr = edit.expression
+
+            if isinstance(inserted_expr, VALID_EXPRESSIONS):
+                return BREAKING
+
+            if isinstance(inserted_expr, exp.UDTF):
+                return BREAKING
+
+            if (
+                not isinstance(inserted_expr.parent, exp.Select) and
+                inserted_expr.parent not in inserted_expressions
+            ):
+                return BREAKING
+        elif not isinstance(edit, Keep):
+            return BREAKING
+
+    return NON_BREAKING
+
+
+def _diff_model(old_sql, new_sql, old_schema, new_schema, dialect=None) -> ChangeCategoryResult:
+    if old_sql == new_sql:
+        return ChangeCategoryResult('non_breaking')
+
+    try:
+        dialect = Dialect.get(dialect)
+
+        def _parse(sql, schema):
+            exp = parse_one(sql, dialect=dialect)
+            try:
+                exp = optimize(exp, schema=schema, dialect=dialect)
+            except Exception:
+                # cannot optimize, skip it.
+                pass
+            return exp
+
+        old_exp = _parse(old_sql, old_schema)
+        new_exp = _parse(new_sql, new_schema)
+    except Exception:
+        return BREAKING
+
+    old_scopes = traverse_scope(old_exp)
+    new_scopes = traverse_scope(new_exp)
+    if len(old_scopes) != len(new_scopes):
+        return BREAKING
+
+    for old_scope, new_scope in zip(old_scopes, new_scopes):
+        result = _diff_scope(old_scope, new_scope)
+        if result.category == 'breaking':
+            return BREAKING
+
+    return NON_BREAKING

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -343,6 +343,9 @@ def parse_change_category(
             else:
                 result = ChangeCategoryResult('non_breaking', changed_columns={})
 
+        if result.category == 'breaking' or result.category == 'unknown':
+            return result
+
         scope_changes_map[new_scope] = result
         if new_scope.is_root:
             return result

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -266,6 +266,9 @@ def _diff_union_scope(
     assert old_scope.expression.key == 'union'
     assert new_scope.expression.key == 'union'
     assert len(old_scope.union_scopes) == len(new_scope.union_scopes)
+    assert new_scope.union_scopes is not None
+    assert len(new_scope.union_scopes) > 0
+
     result = scope_changes_map.get(new_scope.union_scopes[0])
     if result.category in ['breaking', 'unknown']:
         return result

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -218,7 +218,7 @@ def _diff_select_scope(
                     if source_column_change_status(ref_column) is not None:
                         return CHANGE_CATEGORY_BREAKING
 
-    # where caluses: Reference the source columns
+    # where clauses: Reference the source columns
     if new_select.args.get('where'):
         where = new_select.args.get('where')
         if isinstance(where, exp.Where):
@@ -234,7 +234,7 @@ def _diff_select_scope(
                 if source_column_change_status(ref_column) is not None:
                     return CHANGE_CATEGORY_BREAKING
 
-    # having clause: Reference the selected columns
+    # having clause: Reference the source columns, selected columns
     if new_select.args.get('having'):
         having = new_select.args.get('having')
         if isinstance(having, exp.Having):
@@ -244,7 +244,7 @@ def _diff_select_scope(
                 if selected_column_change_status(ref_column) is not None:
                     return CHANGE_CATEGORY_BREAKING
 
-    # order by clause: Reference the selected columns
+    # order by clause: Reference the source columns, selected columns, column index
     if new_select.args.get('order'):
         order = new_select.args.get('order')
         if isinstance(order, exp.Order):

--- a/recce/util/breaking.py
+++ b/recce/util/breaking.py
@@ -198,7 +198,7 @@ def _diff_scope(
 
     # joins clause: Reference the source columns
     if new_select.args.get('joins'):
-        joins = new_select.get('joins')
+        joins = new_select.args.get('joins')
         for join in joins:
             if isinstance(join, exp.Join):
                 for ref_column in join.find_all(exp.Column):
@@ -255,8 +255,9 @@ def parse_change_category(old_sql, new_sql, old_schema=None, new_schema=None, di
             if schema:
                 try:
                     exp = optimize(exp, schema=schema, dialect=dialect)
-                except Exception:
+                except Exception as e:
                     # cannot optimize, skip it.
+                    _debug(e)
                     pass
             return exp
 

--- a/tests/util/test_breaking.py
+++ b/tests/util/test_breaking.py
@@ -122,10 +122,10 @@ class BreakingChangeTest(unittest.TestCase):
         from Customers
         """
         modified_sql2 = """
-        --- thie is comment
+        --- this is comment
         select
-            a,
-            b
+            a, --- this is comment
+            b  --- this is comment
         from Customers
         """
         assert is_non_breaking_change(original_sql, modified_sql, {})
@@ -1024,8 +1024,16 @@ class BreakingChangeTest(unittest.TestCase):
         )
         select distinct a, b from cte
         """
+        modified_removed = """
+        with cte as (
+            select a, b from Customers
+        )
+        select distinct a from cte
+        """
         assert is_breaking_change(original, modified1)
         assert is_breaking_change(original, modified2)
+        assert is_breaking_change(original, modified_removed)
+        assert is_breaking_change(modified_removed, original)
 
     def test_udtf_function(self):
         no_udtf = """

--- a/tests/util/test_breaking.py
+++ b/tests/util/test_breaking.py
@@ -110,7 +110,7 @@ class BreakingChangeTest(unittest.TestCase):
             a, b
         from Customers
         """
-        # assert is_non_breaking_change(original_sql, modified_sql)
+        assert is_non_breaking_change(original_sql, modified_sql)
 
         # by cte
         original_sql = """
@@ -322,7 +322,7 @@ class BreakingChangeTest(unittest.TestCase):
         original_sql = """
         with cte as (
             select
-                a, b, c
+                a, b
             from Customers
         )
         select
@@ -339,11 +339,11 @@ class BreakingChangeTest(unittest.TestCase):
             *
         from cte
         """
-        # assert is_breaking_change(original_sql, modified_sql)
+        assert is_partial_breaking_change(original_sql, modified_sql, {'b': 'removed'})
         modified_sql = """
             with cte as (
                 select
-                    a,b,c,d
+                    a,b,c
                 from Customers
             )
             select

--- a/tests/util/test_breaking.py
+++ b/tests/util/test_breaking.py
@@ -260,6 +260,20 @@ class BreakingChangeTest(unittest.TestCase):
         select
             a
         from Customers
+        where b > 100
+        """
+        modified_sql = """
+        select
+            a + 1 as a
+        from Customers
+        where b > 100
+        """
+        assert is_partial_breaking_change(original_sql, modified_sql)
+
+        original_sql = """
+        select
+            a
+        from Customers
         where a > 100
         """
         modified_sql = """
@@ -268,9 +282,9 @@ class BreakingChangeTest(unittest.TestCase):
         from Customers
         where a > 100
         """
-        assert is_breaking_change(original_sql, modified_sql)
+        # The 'a' in where clause is use the 'Customers.a' not the 'a + 1 as a'
+        assert is_partial_breaking_change(original_sql, modified_sql)
 
-    def test_breaking_add_filter_alias_local(self):
         original_sql = """
         select
             a as b
@@ -283,7 +297,8 @@ class BreakingChangeTest(unittest.TestCase):
         from Customers
         where b > 100
         """
-        assert is_breaking_change(original_sql, modified_sql)
+        # The 'b' in where clause is use the 'Customers.b' not the 'a + 1 as b'
+        assert is_partial_breaking_change(original_sql, modified_sql)
 
     def test_breaking_change_filter(self):
         original_sql = """

--- a/tests/util/test_breaking.py
+++ b/tests/util/test_breaking.py
@@ -308,6 +308,23 @@ class BreakingChangeTest(unittest.TestCase):
         assert is_partial_breaking_change(original, modified2, {'order_count': 'removed'})
         assert is_partial_breaking_change(original, modified3, {'order_count': 'modified'})
 
+    def test_cte_rename_not_supported(self):
+        original = """
+        with cte as (
+            select * from Customers
+        )
+        select * from cte
+        """
+        modified = """
+        with cte2 as (
+            select * from Customers
+        )
+        select * from cte2
+        """
+
+        # This is not a breaking change, but we don't support this yet
+        assert is_breaking_change(original, modified)
+
     def test_cte_alias(self):
         original = """
         with O as (
@@ -969,6 +986,11 @@ class BreakingChangeTest(unittest.TestCase):
             select a from Customers where b > 100
         ) as t
         """
+        modified3 = """
+        select * from (
+            select a from Customers
+        ) as q
+        """
         added = """
         select * from (
             select a,b from Customers
@@ -978,6 +1000,20 @@ class BreakingChangeTest(unittest.TestCase):
         assert is_breaking_change(original, modified2)
         assert is_non_breaking_change(original, added, {'b': 'added'})
         assert is_partial_breaking_change(added, original, {'b': 'removed'})
+
+    def test_subquery_rename_not_supported(self):
+        original = """
+        select * from (
+            select a from Customers
+        ) as t
+        """
+        modified = """
+        select * from (
+            select a from Customers
+        ) as t2
+        """
+        # This is not a breaking change, but we don't support this yet
+        assert is_breaking_change(original, modified)
 
     def test_subquery_in_filter(self):
         original = """

--- a/tests/util/test_breaking.py
+++ b/tests/util/test_breaking.py
@@ -217,7 +217,7 @@ class BreakingChangeTest(unittest.TestCase):
         """
         assert is_breaking_change(original_sql, modified_sql)
 
-    def test_breaking_add_filter_outer(self):
+    def test_breaking_add_filter_local(self):
         original_sql = """
         select
             a
@@ -230,20 +230,39 @@ class BreakingChangeTest(unittest.TestCase):
         from MyTable
         where a > 100
         """
+        assert is_partial_breaking_change(original_sql, modified_sql, {'a': 'modified'})
+
+    def test_breaking_add_filter_alias_local(self):
+        original_sql = """
+        select
+            a as b
+        from MyTable
+        where b > 100
+        """
+        modified_sql = """
+        select
+            a + 1 as b
+        from MyTable
+        where b > 100
+        """
         assert is_breaking_change(original_sql, modified_sql)
 
     def test_breaking_change_filter(self):
         original_sql = """
-        select
-            a
-        from MyTable
-        where a > 100
+        with cte as (
+            select
+                a as b
+            from MyTable
+        )
+        select cte.a from cte where cte.a > 100
         """
         modified_sql = """
-        select
-            a
-        from MyTable
-        where a > 101
+        with cte as (
+            select
+                a + 1 as b
+            from MyTable
+        )
+        select cte.a from cte where cte.a > 100
         """
         assert is_breaking_change(original_sql, modified_sql)
 

--- a/tests/util/test_breaking.py
+++ b/tests/util/test_breaking.py
@@ -41,7 +41,7 @@ def _parse_change_catgory(
         old_schema=SOURCE_SCHEMA,
         new_schema=SOURCE_SCHEMA,
         dialect=dialect,
-        optimizier_rules=optimizer_rules,
+        optimizer_rules=optimizer_rules,
     )
 
 


### PR DESCRIPTION
This PR enhance original breaking change analysis feature. Now, it category the changed model to three categories:
- **Breaking change**: All downstream of the model is affected. Change the number of rows. 
- **Partial breaking change**: Only affect the downstream which use certain columns. The row count of this model is not changed.
- **Non breaking change**: No change or only new column added. 

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
