### PR TITLE
[Feature] Add notifications to read-only mode

### DIFF
--- a/js/app/page.tsx
+++ b/js/app/page.tsx
@@ -19,8 +19,6 @@ import {
   HStack,
   extendTheme,
   useToast,
-  Grid,
-  GridItem,
 } from "@chakra-ui/react";
 import React, { ReactNode, useLayoutEffect } from "react";
 import { QueryClientProvider, useQuery } from "@tanstack/react-query";

--- a/js/src/components/app/Filename.tsx
+++ b/js/src/components/app/Filename.tsx
@@ -30,6 +30,7 @@ import { AxiosError } from "axios";
 import { localStorageKeys } from "@/lib/api/localStorageKeys";
 import { useChecks } from "@/lib/api/checks";
 import { useRecceInstanceContext } from "@/lib/hooks/RecceInstanceContext";
+import { formatRunDateTime } from "../run/RunStatusAndDate";
 
 const useRecceToast = () => {
   const toast = useToast();
@@ -95,7 +96,7 @@ interface FilenameState {
 
 export const Filename = () => {
   const { readOnly } = useRecceInstanceContext();
-  const { fileName, cloudMode, isDemoSite } = useLineageGraphContext();
+  const { fileName, cloudMode, isDemoSite, envInfo } = useLineageGraphContext();
   const modalDisclosure = useDisclosure();
   const overwriteDisclosure = useDisclosure();
   const isStateless = !fileName && !cloudMode && !isDemoSite;
@@ -180,11 +181,17 @@ export const Filename = () => {
   }
 
   const titleNewInstance = "New Instance" + (hasNonPresetChecks ? " (unsaved)" : "");
+  let titleReadOnlyState;
+  if (readOnly && fileName) {
+    const generatedAt = envInfo?.stateMetadata?.generated_at;
+    const formattedDate = generatedAt ? formatRunDateTime(new Date(generatedAt)) : null;
+    titleReadOnlyState = formattedDate ? `${fileName} (${formattedDate})` : null;
+  }
 
   return (
     <>
       <Flex justifyContent="center" alignItems="center">
-        <Box fontWeight="600">{fileName ?? titleNewInstance}</Box>
+        <Box fontWeight="600">{titleReadOnlyState ?? fileName ?? titleNewInstance}</Box>
         {!readOnly && (
           <Tooltip label={fileName ? "Change Filename" : "Save"} openDelay={1000}>
             <IconButton onClick={handleOpen} aria-label={""} variant="unstyled" size="sm">

--- a/js/src/components/query/QueryPage.tsx
+++ b/js/src/components/query/QueryPage.tsx
@@ -81,6 +81,10 @@ export const QueryPage = () => {
     sqlQuery = `select * from db.mymodel`;
   }
 
+  if (readOnly) {
+    sqlQuery = `--- Would like to do query here? Book a demo with us at https://datarecce.io/\n${sqlQuery}`;
+  }
+
   const { showRunId } = useRecceActionContext();
   const queryFn = async (type: "query" | "query_base" | "query_diff") => {
     function queryFactory(type: string) {

--- a/js/src/lib/api/info.ts
+++ b/js/src/lib/api/info.ts
@@ -120,6 +120,12 @@ export async function getLineageDiff(): Promise<LineageDiffResult> {
   };
 }
 
+export interface stateMetadata {
+  schema_version: string;
+  recce_version: string;
+  generated_at: string;
+}
+
 export interface gitInfo {
   branch?: string;
 }
@@ -133,6 +139,7 @@ export interface pullRequestInfo {
 }
 
 export interface ServerInfoResult {
+  state_metadata: stateMetadata;
   adapter_type: string;
   review_mode: boolean;
   cloud_mode: boolean;

--- a/js/src/lib/hooks/LineageGraphContext.tsx
+++ b/js/src/lib/hooks/LineageGraphContext.tsx
@@ -16,6 +16,7 @@ import {
   getServerInfo,
   gitInfo,
   pullRequestInfo,
+  stateMetadata,
 } from "../api/info";
 import {
   Button,
@@ -37,6 +38,7 @@ import { useRecceServerFlag } from "./useRecceServerFlag";
 import { trackSingleEnvironment } from "../api/track";
 
 interface EnvInfo {
+  stateMetadata?: stateMetadata;
   adapterType?: string;
   git?: gitInfo;
   pullRequest?: pullRequestInfo;
@@ -201,6 +203,7 @@ export function LineageGraphContextProvider({ children }: LineageGraphProps) {
 
   const errorMessage = queryServerInfo.error?.message;
   const {
+    state_metadata: stateMetadata,
     lineage,
     sqlmesh,
     demo: isDemoSite,
@@ -218,6 +221,7 @@ export function LineageGraphContextProvider({ children }: LineageGraphProps) {
   const dbtCurrent = lineage?.current.manifest_metadata;
 
   const envInfo: EnvInfo = {
+    stateMetadata,
     adapterType,
     git,
     pullRequest,

--- a/recce/server.py
+++ b/recce/server.py
@@ -232,10 +232,12 @@ async def get_info():
     else:
         filename = None
 
+    state_metadata = context.state_loader.state.metadata if context.state_loader.state else None
     lineage_diff = context.get_lineage_diff()
 
     try:
         info = {
+            'state_metadata': state_metadata,
             'adapter_type': context.adapter_type,
             'review_mode': context.review_mode,
             'git': state.git.to_dict() if state.git else None,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- In read-only mode, add the state generated time in the file name title.
<img width="1013" alt="截圖 2025-04-25 上午10 58 20" src="https://github.com/user-attachments/assets/91d7209e-6f9e-44fe-b7c1-a02354e4734c" />

- Add message to query page in read-only mode.
<img width="1028" alt="截圖 2025-04-28 下午3 50 32" src="https://github.com/user-attachments/assets/8dc1b0fe-2205-49da-ab2c-5a3337b53162" />

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
