### PR TITLE
[Bug] Modified of contract would fail the node selection

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -319,6 +319,8 @@ class DbtAdapter(BaseAdapter):
                 adapter_name = runtime_config.credentials.type
                 adapter_cls = get_adapter_class_by_name(adapter_name)
                 adapter: SQLAdapter = adapter_cls(runtime_config, get_mp_context())
+                from dbt.adapters.factory import FACTORY
+                FACTORY.adapters[adapter_name] = adapter
 
             adapter.connections.set_connection_name()
             runtime_config.adapter = adapter
@@ -1204,6 +1206,7 @@ class DbtAdapter(BaseAdapter):
         spec = SelectionIntersection(specs)
 
         manifest = Manifest()
+        manifest.metadata.adapter_type = self.adapter.type()
         manifest_prev = self.previous_state.manifest
         manifest_curr = self.manifest
 


### PR DESCRIPTION
Fix #717 

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:
In dbt 1.9, the `state:modifed` method would check the contract and it requires `adapter`. But in current flow, the adapter could not be found in the `select_nodes` path.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
