### PR TITLE
[Bug] Profile diff result is empty if profile on only added columns

### DIFF
--- a/recce/tasks/profile.py
+++ b/recce/tasks/profile.py
@@ -76,6 +76,11 @@ class ProfileDiffTask(Task):
                 self.check_cancel()
             current = DataFrame.from_agate(merge_tables(tables))
 
+            if len(base.columns) == 0 and len(current.columns) != 0:
+                base.columns = current.columns
+            elif len(base.columns) != 0 and len(current.columns) == 0:
+                current.columns = base.columns
+
             return ProfileDiffResult(base=base, current=current)
 
     def _verify_dbt_profiler(self, dbt_adapter):


### PR DESCRIPTION
1. Run profile difff
2. Select only the added columns
3. It would show empty result.

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
