### PR TITLE
[Bug] The context menu would have offset if the history pane is open

### DIFF
--- a/js/src/components/lineage/LineageView.tsx
+++ b/js/src/components/lineage/LineageView.tsx
@@ -360,25 +360,7 @@ export function PrivateLineageView(
     filteredNodeIds,
   ]);
 
-  const reactFlowOffset = useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (!refReactFlow.current) {
-      return {
-        offsetX: 0,
-        offsetY: 0,
-      };
-    }
-
-    const pane = (refReactFlow.current as any).getBoundingClientRect();
-    const offsetTop = (refReactFlow.current as any).offsetTop as number;
-    return {
-      offsetX: -pane.left,
-      offsetY: -pane.top + offsetTop,
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refReactFlow.current]);
-
-  const lineageViewContextMenu = useLineageViewContextMenu(reactFlowOffset);
+  const lineageViewContextMenu = useLineageViewContextMenu();
 
   const toast = useToast();
 
@@ -748,7 +730,11 @@ export function PrivateLineageView(
     // Only show context menu when selectMode is action
     // Prevent native context menu from showing
     event.preventDefault();
-    lineageViewContextMenu.showContextMenu(event, node);
+    const reactFlowDiv = refReactFlow.current as HTMLDivElement;
+    const pane = reactFlowDiv.getBoundingClientRect();
+    const x = event.clientX - pane.left;
+    const y = event.clientY - pane.top + reactFlowDiv.offsetTop;
+    lineageViewContextMenu.showContextMenu(x, y, node);
   };
 
   const selectNode = (nodeId: string) => {

--- a/js/src/components/lineage/LineageViewContextMenu.tsx
+++ b/js/src/components/lineage/LineageViewContextMenu.tsx
@@ -349,13 +349,7 @@ export const LineageViewContextMenu = ({
   }
 };
 
-export const useLineageViewContextMenu = ({
-  offsetX,
-  offsetY,
-}: {
-  offsetX: number;
-  offsetY: number;
-}) => {
+export const useLineageViewContextMenu = () => {
   const { isOpen, onClose, onOpen } = useDisclosure();
   const [position, setPosition] = useState<{ x: number; y: number }>({
     x: 0,
@@ -363,10 +357,7 @@ export const useLineageViewContextMenu = ({
   });
   const [node, setNode] = useState<Node | NodeProps>();
 
-  const showContextMenu = (event: React.MouseEvent, node: Node | NodeProps) => {
-    const x = event.clientX + offsetX;
-    const y = event.clientY + offsetY;
-
+  const showContextMenu = (x: number, y: number, node: Node | NodeProps) => {
     setPosition({ x, y });
     setNode(node);
     onOpen();

--- a/js/src/components/lineage/LineageViewContextMenu.tsx
+++ b/js/src/components/lineage/LineageViewContextMenu.tsx
@@ -50,14 +50,17 @@ const ContextMenu = ({ menuItems, isOpen, onClose, x, y }: ContextMenuProps) => 
           top: `${y}px`,
         }}>
         {menuItems.length === 0 ? (
-          <MenuItem isDisabled>No action available</MenuItem>
+          <MenuItem isDisabled key="no action">
+            No action available
+          </MenuItem>
         ) : (
           menuItems.map((item) => {
             if (item.isSeparator) {
-              return <MenuDivider />;
+              return <MenuDivider key={item.label} />;
             } else {
               return (
                 <MenuItem
+                  key={item.label}
                   icon={item.icon}
                   isDisabled={item.isDisabled}
                   onClick={() => {
@@ -222,6 +225,7 @@ export const ModelNodeContextMenu = ({
   if (!singleEnv) {
     if (menuItems.length > 0) {
       menuItems.push({
+        label: "select group",
         isSeparator: true,
       });
     }


### PR DESCRIPTION
Steps
1. Open this history
2. Right click on a node

The context menu is popped up with wrong offset.

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
