### PR TITLE
[Feature] DRC-1272 Show restart button when the end of share instance

### DIFF
--- a/js/src/components/lineage/SeverDisconnectedModalContent.tsx
+++ b/js/src/components/lineage/SeverDisconnectedModalContent.tsx
@@ -1,0 +1,40 @@
+import { Button, ModalBody, ModalContent, ModalFooter, ModalHeader, Text } from "@chakra-ui/react";
+import NextLink from "next/link";
+
+export function ServerDisconnectedModalContent({ connect }: { connect: () => void }) {
+  return (
+    <ModalContent>
+      <ModalHeader>Server Disconnected</ModalHeader>
+      <ModalBody>
+        <Text>
+          The server connection has been lost. Please restart the Recce server and try again.
+        </Text>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          colorScheme="blue"
+          onClick={() => {
+            connect();
+          }}>
+          Retry
+        </Button>
+      </ModalFooter>
+    </ModalContent>
+  );
+}
+
+export function RecceShareInstanceDisconnectedModalContent({ shareUrl }: { shareUrl: string }) {
+  return (
+    <ModalContent>
+      <ModalHeader>Share Instance Expired</ModalHeader>
+      <ModalBody>
+        <Text>This Share Instance has expired. Please restart the share instance.</Text>
+      </ModalBody>
+      <ModalFooter>
+        <NextLink href={shareUrl} passHref>
+          <Button colorScheme="blue">Restart</Button>
+        </NextLink>
+      </ModalFooter>
+    </ModalContent>
+  );
+}

--- a/js/src/lib/api/instanceInfo.ts
+++ b/js/src/lib/api/instanceInfo.ts
@@ -6,6 +6,7 @@ export interface RecceInstanceInfo {
   single_env: boolean;
   authed: boolean;
   lifetime_expired_at?: Date;
+  share_url?: string;
 }
 
 export async function getRecceInstanceInfo(): Promise<RecceInstanceInfo> {

--- a/js/src/lib/hooks/LineageGraphContext.tsx
+++ b/js/src/lib/hooks/LineageGraphContext.tsx
@@ -36,6 +36,11 @@ import { aggregateRuns, RunsAggregated } from "../api/runs";
 import { markRelaunchHintCompleted } from "../api/flag";
 import { useRecceServerFlag } from "./useRecceServerFlag";
 import { trackSingleEnvironment } from "../api/track";
+import { useRecceInstanceInfo } from "./useRecceInstanceInfo";
+import {
+  RecceShareInstanceDisconnectedModalContent,
+  ServerDisconnectedModalContent,
+} from "@/components/lineage/SeverDisconnectedModalContent";
 
 interface EnvInfo {
   stateMetadata?: stateMetadata;
@@ -276,6 +281,7 @@ export function LineageGraphContextProvider({ children }: LineageGraphProps) {
 
   const { connectionStatus, connect, envStatus } = useLineageWatcher();
   const { data: flags, isLoading } = useRecceServerFlag();
+  const { data: instanceInfo } = useRecceInstanceInfo();
   const { onClose } = useDisclosure();
   const [relaunchHintOpen, setRelaunchHintOpen] = useState<boolean>(false);
   const queryClient = useQueryClient();
@@ -305,6 +311,8 @@ export function LineageGraphContextProvider({ children }: LineageGraphProps) {
     }
   }, [flags, envStatus, isLoading]);
 
+  const { share_url: shareUrl } = instanceInfo ?? {};
+
   return (
     <>
       <LineageGraphContext.Provider
@@ -333,23 +341,11 @@ export function LineageGraphContextProvider({ children }: LineageGraphProps) {
 
       <Modal isOpen={connectionStatus === "disconnected"} onClose={() => {}} isCentered>
         <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>Server Disconnected</ModalHeader>
-          <ModalBody>
-            <Text>
-              The server connection has been lost. Please restart the Recce server and try again.
-            </Text>
-          </ModalBody>
-          <ModalFooter>
-            <Button
-              colorScheme="blue"
-              onClick={() => {
-                connect();
-              }}>
-              Retry
-            </Button>
-          </ModalFooter>
-        </ModalContent>
+        {shareUrl ? (
+          <RecceShareInstanceDisconnectedModalContent shareUrl={shareUrl} />
+        ) : (
+          <ServerDisconnectedModalContent connect={connect} />
+        )}
       </Modal>
 
       {flags?.single_env_onboarding && (

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -20,7 +20,6 @@ from recce.util.recce_cloud import (
     RecceCloudException,
     get_recce_cloud_onboarding_state,
 )
-
 from .core import RecceContext, set_default_context
 from .event.track import TrackCommand
 
@@ -1021,6 +1020,8 @@ def share(state_file, **kwargs):
 @click.option("--host", default="localhost", show_default=True, help="The host to bind to.")
 @click.option("--port", default=8000, show_default=True, help="The port to bind to.", type=int)
 @click.option("--lifetime", default=0, show_default=True, help="The lifetime of the server in seconds.", type=int)
+@click.option("--share-url", help="The share URL triggers this instance.", type=click.STRING, hidden=True,
+              envvar="RECCE_SHARE_URL")
 def read_only(host, port, lifetime, state_file=None, **kwargs):
     from rich.console import Console
 
@@ -1047,7 +1048,8 @@ def read_only(host, port, lifetime, state_file=None, **kwargs):
         console.print(f"[[red]Error[/red]] {message}")
         exit(1)
 
-    app.state = AppState(command="read_only", state_loader=state_loader, kwargs=kwargs, flag=flag, lifetime=lifetime)
+    app.state = AppState(command="read_only", state_loader=state_loader, kwargs=kwargs, flag=flag, lifetime=lifetime,
+                         share_url=kwargs.get("share_url"))
     set_default_context(RecceContext.load(**kwargs, review=is_review, state_loader=state_loader))
 
     uvicorn.run(app, host=host, port=port, lifespan="on")

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -1020,8 +1020,7 @@ def share(state_file, **kwargs):
 @click.option("--host", default="localhost", show_default=True, help="The host to bind to.")
 @click.option("--port", default=8000, show_default=True, help="The port to bind to.", type=int)
 @click.option("--lifetime", default=0, show_default=True, help="The lifetime of the server in seconds.", type=int)
-@click.option("--share-url", help="The share URL triggers this instance.", type=click.STRING, hidden=True,
-              envvar="RECCE_SHARE_URL")
+@click.option("--share-url", help="The share URL triggers this instance.", type=click.STRING, envvar="RECCE_SHARE_URL")
 def read_only(host, port, lifetime, state_file=None, **kwargs):
     from rich.console import Console
 

--- a/recce/server.py
+++ b/recce/server.py
@@ -51,6 +51,7 @@ class AppState:
     auth_options: Optional[dict] = None
     lifetime: Optional[int] = None
     lifetime_expired_at: Optional[datetime] = None
+    share_url: Optional[str] = None
 
 
 def schedule_lifetime_termination(app_state):
@@ -235,6 +236,7 @@ class RecceInstanceInfoOut(BaseModel):
     single_env: bool
     authed: bool
     lifetime_expired_at: Optional[datetime] = None
+    share_url: Optional[str] = None
 
 
 @app.get("/api/instance-info", response_model=RecceInstanceInfoOut, response_model_exclude_none=True)
@@ -252,6 +254,7 @@ async def recce_instance_info():
         "single_env": single_env,
         "authed": True if api_token else False,
         "lifetime_expired_at": app_state.lifetime_expired_at,  # UTC timezone
+        "share_url": app_state.share_url,
         # TODO: Add more instance info which won't change during the instance lifecycle
         # review_mode
         # cloud_mode


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- Show the `restart` button when the Share Instance has expired
![Google Chrome 2025-05-13 16 08 01](https://github.com/user-attachments/assets/8a13e4e7-9290-416c-91b4-52c34dc5fa5d)
- The `share_url` will be provided by EnvVar `RECCE_SHARE_URL` when execute `read-only` command

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
