### PR TITLE
[Feature] Mark onboarding state as `installed` when api-token is set

### DIFF
--- a/recce/event/__init__.py
+++ b/recce/event/__init__.py
@@ -68,6 +68,10 @@ def get_recce_api_token():
     return load_user_profile().get("api_token")
 
 
+def update_recce_api_token(token):
+    return update_user_profile({"api_token": token})
+
+
 def is_anonymous_tracking():
     return load_user_profile().get("anonymous_tracking", False)
 

--- a/recce/util/api_token.py
+++ b/recce/util/api_token.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 from click import Abort
 from rich.console import Console
@@ -17,11 +19,11 @@ def show_invalid_api_token_message():
     console.print(f"Please check your API token from {RECCE_CLOUD_BASE_URL}/settings#tokens")
 
 
-def prepare_api_token(interaction=False, **kwargs, ) -> str | None:
+def prepare_api_token(interaction=False, **kwargs, ) -> Optional[str, None]:
     """
     Prepare the API token for the request.
     """
-    # Verify the API token for Recce Clous Share Link
+    # Verify the API token for Recce Cloud Share Link
     api_token = get_recce_api_token()
     new_api_token = kwargs.get('api_token')
     if api_token != new_api_token and new_api_token is not None:

--- a/recce/util/api_token.py
+++ b/recce/util/api_token.py
@@ -1,10 +1,14 @@
 import click
-from click import Abort
 from rich.console import Console
 
 from recce.event import get_recce_api_token, update_recce_api_token
-from recce.util.recce_cloud import RecceCloud, get_recce_cloud_onboarding_state, set_recce_cloud_onboarding_state, \
-    RECCE_CLOUD_BASE_URL
+from recce.exceptions import RecceConfigException
+from recce.util.recce_cloud import (
+    RECCE_CLOUD_BASE_URL,
+    RecceCloud,
+    get_recce_cloud_onboarding_state,
+    set_recce_cloud_onboarding_state,
+)
 
 console = Console()
 
@@ -17,19 +21,21 @@ def show_invalid_api_token_message():
     console.print(f"Please check your API token from {RECCE_CLOUD_BASE_URL}/settings#tokens")
 
 
-def prepare_api_token(interaction=False, **kwargs, ):
+def prepare_api_token(
+    interaction=False,
+    **kwargs,
+):
     """
     Prepare the API token for the request.
     """
     # Verify the API token for Recce Cloud Share Link
     api_token = get_recce_api_token()
-    new_api_token = kwargs.get('api_token')
+    new_api_token = kwargs.get("api_token")
     if api_token != new_api_token and new_api_token is not None:
         # Handle the API token provided by option `--api-token`
         valid = RecceCloud(new_api_token).verify_token()
         if not valid:
-            show_invalid_api_token_message()
-            exit(1)
+            raise RecceConfigException("Invalid Recce Cloud API token")
         api_token = new_api_token
         update_recce_api_token(api_token)
         console.print("[[green]Success[/green]] Update the user profile for Recce Cloud API Token.")
@@ -47,15 +53,10 @@ def prepare_api_token(interaction=False, **kwargs, ):
                 f"{RECCE_CLOUD_BASE_URL}/settings#tokens\n"
                 "Your API token will be added to '~/.recce/profile.yml' for more convenient sharing."
             )
-            try:
-                api_token = click.prompt("Your Recce API token", type=str, hide_input=True, show_default=False)
-            except Abort:
-                console.print("[yellow]Aborted[/yellow]")
-                exit(1)
+            api_token = click.prompt("Your Recce API token", type=str, hide_input=True, show_default=False)
             valid = RecceCloud(api_token).verify_token()
             if not valid:
-                show_invalid_api_token_message()
-                exit(1)
+                raise RecceConfigException("Invalid Recce Cloud API token")
             update_recce_api_token(api_token)
             console.print("[[green]Success[/green]] Update the user profile for Recce Cloud API Token.")
 

--- a/recce/util/api_token.py
+++ b/recce/util/api_token.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import click
 from click import Abort
 from rich.console import Console
@@ -19,7 +17,7 @@ def show_invalid_api_token_message():
     console.print(f"Please check your API token from {RECCE_CLOUD_BASE_URL}/settings#tokens")
 
 
-def prepare_api_token(interaction=False, **kwargs, ) -> Optional[str, None]:
+def prepare_api_token(interaction=False, **kwargs, ):
     """
     Prepare the API token for the request.
     """

--- a/recce/util/api_token.py
+++ b/recce/util/api_token.py
@@ -1,0 +1,68 @@
+import click
+from click import Abort
+from rich.console import Console
+
+from recce.event import get_recce_api_token, update_recce_api_token
+from recce.util.recce_cloud import RecceCloud, get_recce_cloud_onboarding_state, set_recce_cloud_onboarding_state, \
+    RECCE_CLOUD_BASE_URL
+
+console = Console()
+
+
+def show_invalid_api_token_message():
+    """
+    Show the message when the API token is invalid.
+    """
+    console.print("[[red]Error[/red]] Invalid Recce Cloud API token.")
+    console.print(f"Please check your API token from {RECCE_CLOUD_BASE_URL}/settings#tokens")
+
+
+def prepare_api_token(interaction=False, **kwargs, ) -> str | None:
+    """
+    Prepare the API token for the request.
+    """
+    # Verify the API token for Recce Clous Share Link
+    api_token = get_recce_api_token()
+    new_api_token = kwargs.get('api_token')
+    if api_token != new_api_token and new_api_token is not None:
+        # Handle the API token provided by option `--api-token`
+        valid = RecceCloud(new_api_token).verify_token()
+        if not valid:
+            show_invalid_api_token_message()
+            exit(1)
+        api_token = new_api_token
+        update_recce_api_token(api_token)
+        console.print("[[green]Success[/green]] Update the user profile for Recce Cloud API Token.")
+    elif api_token:
+        # Verify the API token from the user profile
+        valid = RecceCloud(api_token).verify_token()
+        if not valid:
+            console.print("[[yellow]Warning[/yellow]] Invalid Recce Cloud API token. Skipping the share link.")
+            api_token = None
+    else:
+        # No api_token provided
+        if interaction is True:
+            console.print(
+                "An API token is required to this. This can be obtained in your user account settings.\n"
+                f"{RECCE_CLOUD_BASE_URL}/settings#tokens\n"
+                "Your API token will be added to '~/.recce/profile.yml' for more convenient sharing."
+            )
+            try:
+                api_token = click.prompt("Your Recce API token", type=str, hide_input=True, show_default=False)
+            except Abort:
+                console.print("[yellow]Aborted[/yellow]")
+                exit(1)
+            valid = RecceCloud(api_token).verify_token()
+            if not valid:
+                show_invalid_api_token_message()
+                exit(1)
+            update_recce_api_token(api_token)
+            console.print("[[green]Success[/green]] Update the user profile for Recce Cloud API Token.")
+
+    if api_token:
+        cloud_onboarding_state = get_recce_cloud_onboarding_state(api_token)
+        if cloud_onboarding_state == "new":
+            # Mark the onboarding state as "installed" if the user is new
+            set_recce_cloud_onboarding_state(api_token, "installed")
+
+    return api_token

--- a/tests/util/test_api_token.py
+++ b/tests/util/test_api_token.py
@@ -1,0 +1,118 @@
+import unittest
+from unittest.mock import patch
+
+from recce.exceptions import RecceConfigException
+
+
+class PrepareApiTokenTest(unittest.TestCase):
+
+    @patch("recce.util.api_token.console.print")
+    def test_show_invalid_api_token_message(self, mock_print):
+        from recce.util.api_token import (
+            RECCE_CLOUD_BASE_URL,
+            show_invalid_api_token_message,
+        )
+
+        show_invalid_api_token_message()
+        mock_print.assert_any_call("[[red]Error[/red]] Invalid Recce Cloud API token.")
+        mock_print.assert_any_call(f"Please check your API token from {RECCE_CLOUD_BASE_URL}/settings#tokens")
+
+    @patch("recce.util.api_token.get_recce_api_token", return_value=None)
+    def test_no_token_provided_no_interaction(self, mock_get_token):
+        from recce.util.api_token import prepare_api_token
+
+        token = prepare_api_token(interaction=False)
+        self.assertIsNone(token)
+
+    @patch("recce.util.api_token.update_recce_api_token")
+    @patch("recce.util.api_token.RecceCloud")
+    @patch("recce.util.api_token.get_recce_api_token", return_value="old-token")
+    def test_new_token_invalid(self, mock_get_token, mock_recce_cloud, mock_update_token):
+        from recce.util.api_token import prepare_api_token
+
+        mock_recce_cloud.return_value.verify_token.return_value = False
+        with self.assertRaises(RecceConfigException):
+            prepare_api_token(api_token="new-invalid-token")
+
+    @patch("recce.util.api_token.update_recce_api_token")
+    @patch("recce.util.api_token.RecceCloud")
+    @patch("recce.util.api_token.get_recce_api_token", return_value="old-token")
+    def test_new_token_valid(self, mock_get_token, mock_recce_cloud, mock_update_token):
+        from recce.util.api_token import prepare_api_token
+
+        mock_recce_cloud.return_value.verify_token.return_value = True
+        token = prepare_api_token(api_token="new-valid-token")
+        self.assertEqual(token, "new-valid-token")
+        mock_update_token.assert_called_once()
+
+    @patch("recce.util.api_token.console.print")
+    @patch("recce.util.api_token.RecceCloud")
+    @patch("recce.util.api_token.get_recce_api_token", return_value="valid-token")
+    def test_existing_token_valid(self, mock_get_token, mock_recce_cloud, mock_print):
+        from recce.util.api_token import prepare_api_token
+
+        mock_recce_cloud.return_value.verify_token.return_value = True
+        token = prepare_api_token()
+        self.assertEqual(token, "valid-token")
+
+    @patch("recce.util.api_token.console.print")
+    @patch("recce.util.api_token.RecceCloud")
+    @patch("recce.util.api_token.get_recce_api_token", return_value="invalid-token")
+    def test_existing_token_invalid(self, mock_get_token, mock_recce_cloud, mock_print):
+        from recce.util.api_token import prepare_api_token
+
+        mock_recce_cloud.return_value.verify_token.return_value = False
+        token = prepare_api_token()
+        self.assertIsNone(token)
+        mock_print.assert_any_call("[[yellow]Warning[/yellow]] Invalid Recce Cloud API token. Skipping the share link.")
+
+    @patch("recce.util.api_token.set_recce_cloud_onboarding_state")
+    @patch("recce.util.api_token.get_recce_cloud_onboarding_state", return_value="new")
+    @patch("recce.util.api_token.update_recce_api_token")
+    @patch("recce.util.api_token.click.prompt", return_value="token")
+    @patch("recce.util.api_token.console.print")
+    @patch("recce.util.api_token.RecceCloud")
+    @patch("recce.util.api_token.get_recce_api_token", return_value=None)
+    def test_interactive_token_flow(
+        self,
+        mock_get_token,
+        mock_recce_cloud,
+        mock_print,
+        mock_prompt,
+        mock_update_token,
+        mock_get_onboard,
+        mock_set_onboard,
+    ):
+        from recce.util.api_token import prepare_api_token
+
+        mock_recce_cloud.return_value.verify_token.return_value = True
+        token = prepare_api_token(interaction=True)
+        self.assertEqual(token, "token")
+        mock_prompt.assert_called_once()
+        mock_update_token.assert_called_once()
+        mock_set_onboard.assert_called_once_with("token", "installed")
+
+    @patch("recce.util.api_token.set_recce_cloud_onboarding_state")
+    @patch("recce.util.api_token.get_recce_cloud_onboarding_state", return_value="new")
+    @patch("recce.util.api_token.update_recce_api_token")
+    @patch("recce.util.api_token.click.prompt", return_value="token")
+    @patch("recce.util.api_token.console.print")
+    @patch("recce.util.api_token.RecceCloud")
+    @patch("recce.util.api_token.get_recce_api_token", return_value=None)
+    def test_interactive_token_invalid_flow(
+        self,
+        mock_get_token,
+        mock_recce_cloud,
+        mock_print,
+        mock_prompt,
+        mock_update_token,
+        mock_get_onboard,
+        mock_set_onboard,
+    ):
+        from recce.util.api_token import prepare_api_token
+
+        mock_recce_cloud.return_value.verify_token.return_value = False
+        mock_prompt.return_value = "invalid-token"
+        with self.assertRaises(RecceConfigException):
+            prepare_api_token(interaction=True)
+            mock_prompt.assert_called_once()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- Update the option description of `--cloud-token` specific for GitHub
- Verify the api-token with Recce Cloud when it's provided by option
- Store the user provied api-token to recce user profile if it's valided
- Update user's onboarding_state to `installed` when user provided api-token

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
