### PR TITLE
[Bug] UI checklist badge broken when page resize

### DIFF
--- a/js/app/page.tsx
+++ b/js/app/page.tsx
@@ -234,6 +234,7 @@ function TabBadge<T, R extends number>({
   return (
     <Box
       ml="2px"
+      maxH={"20px"}
       height="80%"
       aspectRatio={1}
       borderRadius="full"

--- a/js/src/components/app/EnvInfo.tsx
+++ b/js/src/components/app/EnvInfo.tsx
@@ -105,7 +105,7 @@ export function EnvInfo() {
     <>
       <Tooltip label="Environment Info" placement="bottom-end">
         <div className="flex items-center hover:cursor-pointer hover:text-black" onClick={onOpen}>
-          <div className="flex flex-col text-sm">
+          <div className="hidden text-sm lg:flex lg:flex-col">
             <span>
               {Array.from(baseSchemas).join(", ")} ({baseRelativeTime})
             </span>
@@ -116,7 +116,7 @@ export function EnvInfo() {
           <IconButton
             size="sm"
             variant="unstyled"
-            aria-label="Export state"
+            aria-label="Environment Info"
             icon={<Icon verticalAlign="middle" as={IconInfo} boxSize={"16px"} />}
           />
         </div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:
- UI broken when browser window is resized to a certain width.

before:
<img width="1435" alt="截圖 2025-05-26 上午11 08 14" src="https://github.com/user-attachments/assets/66e66c1c-46e9-4aab-aa98-e2eed2127bfa" />


after: add height limitation and responsive display (to see the manifest timestamp, users need to click info icon)
<img width="1438" alt="截圖 2025-05-26 上午11 08 47" src="https://github.com/user-attachments/assets/2672297e-32c7-49a4-935d-4ad46e78d070" />

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

