### PR TITLE
[Bug] In breaking change analysis is on, should not show columns if the model is not highlighted

### DIFF
--- a/js/src/components/lineage/GraphColumnNode.tsx
+++ b/js/src/components/lineage/GraphColumnNode.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Icon, Spacer, Tag, TagLabel } from "@chakra-ui/react";
 import React from "react";
 
 import { Handle, NodeProps, Position, useStore } from "reactflow";
-import { LinageGraphColumnNode } from "./lineage";
+import { COLUMN_HEIGHT, LinageGraphColumnNode } from "./lineage";
 
 import "./styles.css";
 
@@ -47,7 +47,7 @@ export const TransformationType = ({
           <TagLabel>{letter}</TagLabel>
         </Tag>
       ) : (
-        <Tag fontSize="6pt" size="xs" colorScheme={color} borderRadius="full" paddingX="2px">
+        <Tag fontSize="8pt" size="xs" colorScheme={color} borderRadius="full" paddingX="4px">
           <TagLabel>{letter}</TagLabel>
         </Tag>
       )}
@@ -76,7 +76,6 @@ export function GraphColumnNode(nodeProps: GrapeColumnNodeProps) {
   return (
     <Flex
       width="280px"
-      height="16px"
       padding="0px 10px"
       border="1px solid gray"
       backgroundColor={isFocus ? "#f0f0f0" : "inherit"}
@@ -89,17 +88,23 @@ export function GraphColumnNode(nodeProps: GrapeColumnNodeProps) {
       onMouseLeave={() => {
         setIsHovered(false);
       }}>
-      <Flex fontSize="11px" color="gray" width="100%" gap="3px" alignItems="center">
+      <Flex
+        fontSize="11px"
+        color="black"
+        width="100%"
+        gap="3px"
+        alignItems="center"
+        height={`${COLUMN_HEIGHT - 1}px`}>
         {changeStatus && (
           <Icon
-            boxSize="12px"
+            boxSize="14px"
             display="inline-flex"
             color={colorChangeStatus}
             as={iconChangeStatus}
           />
         )}
         {transformationType && <TransformationType transformationType={transformationType} />}
-        <Box height="16px">{column}</Box>
+        <Box height={`${COLUMN_HEIGHT + 1} px`}>{column}</Box>
         <Spacer></Spacer>
 
         {isHovered ? (
@@ -116,7 +121,7 @@ export function GraphColumnNode(nodeProps: GrapeColumnNodeProps) {
             }}
           />
         ) : (
-          <Box height="16px">{type}</Box>
+          <Box height={`${COLUMN_HEIGHT + 1} px`}>{type}</Box>
         )}
       </Flex>
       <Handle

--- a/js/src/components/lineage/GraphColumnNode.tsx
+++ b/js/src/components/lineage/GraphColumnNode.tsx
@@ -56,18 +56,19 @@ export const TransformationType = ({
 };
 
 export function GraphColumnNode(nodeProps: GrapeColumnNodeProps) {
-  const { data } = nodeProps;
+  const { id: columnNodeId, data } = nodeProps;
   const { id: nodeId } = data.node;
   const { column, type, transformationType, changeStatus } = data;
   const showContent = useStore((s) => s.transform[2] > 0.3);
 
-  const { viewOptions, showContextMenu } = useLineageViewContextSafe();
+  const { viewOptions, showContextMenu, isNodeHighlighted } = useLineageViewContextSafe();
 
   const selectedNode = viewOptions.column_level_lineage?.node;
   const selectedColumn = viewOptions.column_level_lineage?.column;
   const isFocus = column === selectedColumn && nodeId === selectedNode;
   const { color: colorChangeStatus, icon: iconChangeStatus } = getIconForChangeStatus(changeStatus);
   const [isHovered, setIsHovered] = React.useState(false);
+  const isHighlighted = isNodeHighlighted(columnNodeId);
 
   if (!showContent) {
     return <></>;
@@ -87,7 +88,8 @@ export function GraphColumnNode(nodeProps: GrapeColumnNodeProps) {
       }}
       onMouseLeave={() => {
         setIsHovered(false);
-      }}>
+      }}
+      filter={isHighlighted ? "none" : "opacity(0.2) grayscale(50%)"}>
       <Flex
         fontSize="11px"
         color="black"

--- a/js/src/components/lineage/GraphNode.tsx
+++ b/js/src/components/lineage/GraphNode.tsx
@@ -12,7 +12,7 @@ import {
 import React, { useState } from "react";
 
 import { Handle, NodeProps, Position, useStore } from "reactflow";
-import { LineageGraphNode } from "./lineage";
+import { COLUMN_HEIGHT, LineageGraphNode } from "./lineage";
 import { getIconForChangeStatus, getIconForResourceType } from "./styles";
 
 import "./styles.css";
@@ -385,7 +385,7 @@ export function GraphNode(nodeProps: GraphNodeProps) {
           borderTopWidth={0}
           borderStyle={borderStyle}
           borderBottomRadius={8}>
-          <Box height={`${columnSet.size * 15}px`} overflow="auto"></Box>
+          <Box height={`${columnSet.size * COLUMN_HEIGHT}px`} overflow="auto"></Box>
         </Box>
       )}
       {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}

--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/api/info";
 import { CllNodeData, ColumnLineageData } from "@/lib/api/cll";
 
+export const COLUMN_HEIGHT = 20;
 /**
  * The types for internal data structures.
  */
@@ -433,7 +434,7 @@ export function toReactflow(
 
         nodes.push({
           id: columnKey,
-          position: { x: 10, y: 70 + columnIndex * 15 },
+          position: { x: 10, y: 70 + columnIndex * COLUMN_HEIGHT },
           parentId: node.id,
           extent: "parent",
           draggable: false,
@@ -480,7 +481,7 @@ export function toReactflow(
 
         nodes.push({
           id: columnKey,
-          position: { x: 10, y: 70 + columnIndex * 15 },
+          position: { x: 10, y: 70 + columnIndex * COLUMN_HEIGHT },
           parentId: node.id,
           extent: "parent",
           draggable: false,
@@ -507,7 +508,7 @@ export function toReactflow(
 
     let height = 60;
     if (columnIndex > 0) {
-      height += 20 + columnIndex * 15;
+      height += 20 + columnIndex * COLUMN_HEIGHT;
     }
 
     nodes.push({


### PR DESCRIPTION
Steps
1. Switch on breaking change analysis
2. Select a node
3. The non focused partial or non-breaking node, it would show the column highlighted

Before
![image](https://github.com/user-attachments/assets/b2836916-b990-4716-9f4f-b722b9c95f28)
After
![image](https://github.com/user-attachments/assets/2bb71cf9-ac5a-47df-9cf8-9e44161727d4)


**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
