### PR TITLE
[chore] Update wording for single environment mode

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -443,25 +443,19 @@ def server(host, port, lifetime, state_file=None, **kwargs):
         # Show warning message
         console.rule("Notice", style="orange3")
         console.print(
-            "Recce is ready to launch in Single Environment Mode with limited functionality."
-            "\n\n"
-            "Single Environment Mode allows you to explore your dbt project but won't show "
-            "data comparisons between environments. For full functionality, configure a "
-            "base environment."
-            "\n\n"
-            "To set up full environment comparison:"
-            "\n- Run `recce debug` for setup assistance"
-            "\n- Visit https://docs.datarecce.io/configure-diff/ for configuration guide"
+            "Recce will launch with limited features (no environment comparison).\n"
             "\n"
+            "For full functionality, set up a base environment first.\n"
+            "Setup help: 'recce debug' or https://docs.datarecce.io/configure-diff/\n"
         )
 
         single_env_flag = kwargs.get("single_env", False)
         if not single_env_flag:
-            lanch_in_single_env = Confirm.ask("Launch in [bold]Single Environment Mode[/bold]?")
+            lanch_in_single_env = Confirm.ask("Continue with limited mode?")
             if not lanch_in_single_env:
                 exit(0)
 
-        console.rule("Recce Server : Single Environment Mode")
+        console.rule("Recce Server : Limited Features")
     else:
         console.rule("Recce Server")
 

--- a/recce/core.py
+++ b/recce/core.py
@@ -286,7 +286,7 @@ class RecceContext:
             try:
                 DbtAdapter.load(**kwargs)
             except FileNotFoundError as e:
-                return False, f"Cannot load the manifest: '{e.filename}'"
+                return False, f"Cannot load the manifest: '{e.filename}'. Type 'recce debug'."
 
         return True, None
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Chore

**What this PR does / why we need it**:
1. Update wording for `recce debug` and launching single env mode
2. Fix logic while launching Recce with no folder for the current env

**Which issue(s) this PR fixes**:
PLA-458

**Special notes for your reviewer**:
- `recce debug` without base
<img width="829" alt="image" src="https://github.com/user-attachments/assets/1a546529-1da7-412a-a20c-6c21c524f1af" />

- `recce debug` all set
<img width="828" alt="image" src="https://github.com/user-attachments/assets/322636a0-05c8-4279-ba67-b626539de0f0" />

- `recce server` without current
<img width="826" alt="image" src="https://github.com/user-attachments/assets/a7a4f560-092b-4e8b-ad12-e36dd458e88d" />

- `recce server` in single mode
<img width="772" alt="image" src="https://github.com/user-attachments/assets/9b26c231-53ac-4d3e-87bb-97198d43e1ab" />


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
