### PR TITLE
[Bug] Fix missing change status for non-nodes lineage node

### DIFF
--- a/js/src/components/lineage/lineage.ts
+++ b/js/src/components/lineage/lineage.ts
@@ -169,8 +169,8 @@ export function buildLineageGraph(
   const modifiedSet: string[] = [];
 
   for (const [key, node] of Object.entries(nodes)) {
-    if (diff?.[key]) {
-      const diffNode = diff[key];
+    const diffNode = diff?.[key];
+    if (diffNode) {
       node.changeStatus = diffNode.change_status;
       if (diffNode.change) {
         node.change = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:
We currently have a limitation in identifying non-node objects that are `added/removed/modified` from the `lineage_diff` result.
So the workaround is to fall back to old logic to identify it in the lineage view.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
