### PR TITLE
Fix State Selection does not work as expected for row_count_diff

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -279,7 +279,7 @@ class DbtArgs:
     target_path: Optional[str] = (None,)
     project_only_flags: Optional[Dict[str, Any]] = None
     which: Optional[str] = None
-    state_modified_compare_more_unrendered_values: Optional[bool] = False  # new flag added since dbt v1.9
+    state_modified_compare_more_unrendered_values: Optional[bool] = True  # new flag added since dbt v1.9
 
 
 @dataclass


### PR DESCRIPTION
Fixes #826

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:
In dbt 1.9, it supports [new flag to prevent False Positives](https://docs.getdbt.com/reference/node-selection/state-comparison-caveats#false-positives) in the `state:modified` result.

**Which issue(s) this PR fixes**:
#826 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
