### PR TITLE
Feature/drc 1552 oss allow to do data diff when launching with a shared link

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -488,12 +488,18 @@ def server(host, port, lifetime, state_file=None, **kwargs):
             #
             # Usage:
             #    Used in cloud managed instance. For cloud onboarding to preview the uploaded artifacts.
-            is_review = kwargs["review"] = True
             cloud_options = {
                 "host": kwargs.get("state_file_host"),
                 "api_token": api_token,
                 "share_id": share_id,
             }
+        else:
+            # recce server --mode preview recce_state.json
+            if state_file is None:
+                console.print("[[red]Error[/red]] The state_file is required in 'Preview' mode.")
+                console.print("Please provide recce_state json file exported by Recce OSS.")
+                exit(1)
+        is_review = kwargs["review"] = True
         flag = {
             "preview": True,
         }
@@ -509,12 +515,18 @@ def server(host, port, lifetime, state_file=None, **kwargs):
             #
             # Usage:
             #    Used in cloud managed instance. Launch when user click a share link.
-            is_review = kwargs["review"] = True
             cloud_options = {
                 "host": kwargs.get("state_file_host"),
                 "api_token": api_token,
                 "share_id": share_id,
             }
+        else:
+            # recce server --mode read-only recce_state.json
+            if state_file is None:
+                console.print("[[red]Error[/red]] The state_file is required in 'Read-Only' mode.")
+                console.print("Please provide recce_state json file exported by Recce OSS.")
+                exit(1)
+        is_review = kwargs["review"] = True
         flag = {
             "read_only": True,
         }

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -403,9 +403,15 @@ def server(host, port, lifetime, state_file=None, **kwargs):
     recce server --review recce_state.json
 
     \b
-    # Launch the server and synchronize the state with the cloud
+    # Launch the server using the state from the PR of your current branch. (Requires GitHub token)
+    export GITHUB_TOKEN=<your-github-token>
     recce server --cloud
     recce server --review --cloud
+
+    \b
+    # Launch the server using the state from a shared URL. (Requires Recce API token)
+    export RECCE_API_TOKEN=<your-recce-api-token>
+    recce server --cloud --share-url <share-url>
 
     """
 
@@ -438,6 +444,9 @@ def server(host, port, lifetime, state_file=None, **kwargs):
         if is_cloud:
             share_url = kwargs.get("share_url")
             if share_url:
+                # recce server --cloud --share-url <share-url>
+                # Use state file stored for the share url
+                # For to use the review mode.
                 is_review = kwargs["review"] = True
                 share_id = share_url.split("/")[-1]
                 cloud_options = {
@@ -446,6 +455,9 @@ def server(host, port, lifetime, state_file=None, **kwargs):
                     "share_id": share_id,
                 }
             else:
+                # recce server --cloud
+                # recce server --cloud --review
+                # Use state file stored for the PR of the current branch
                 cloud_options = {
                     "host": kwargs.get("state_file_host"),
                     "github_token": kwargs.get("cloud_token"),
@@ -463,6 +475,14 @@ def server(host, port, lifetime, state_file=None, **kwargs):
             kwargs["target_base_path"] = kwargs.get("target_path")
     elif server_mode == RecceServerMode.preview:
         if is_cloud:
+            # recce server --cloud --share-url <share-url> --mode preview
+            # Use state file stored for the share url
+            #
+            # Read-only mode disable these features
+            # - run query
+            #
+            # Usage:
+            #    Used in cloud managed instance. For cloud onboarding to preview the uploaded artifacts.
             is_review = kwargs["review"] = True
             share_url = kwargs.get("share_url")
             share_id = share_url.split("/")[-1] if share_url else None
@@ -476,6 +496,16 @@ def server(host, port, lifetime, state_file=None, **kwargs):
         }
     elif server_mode == RecceServerMode.read_only:
         if is_cloud:
+            # recce server --cloud --share-url <share-url> --mode read-only
+            # Use state file stored for the share url
+            #
+            # Read-only mode disable these features
+            # - run query
+            # - use checklist
+            # - share
+            #
+            # Usage:
+            #    Used in cloud managed instance. Launch when user click a share link.
             is_review = kwargs["review"] = True
             share_url = kwargs.get("share_url")
             share_id = share_url.split("/")[-1] if share_url else None

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -439,16 +439,21 @@ def server(host, port, lifetime, state_file=None, **kwargs):
         "api_token": api_token,
     }
 
+    share_url = kwargs.get("share_url")
+    if share_url:
+        share_id = share_url.split("/")[-1]
+        if not share_id:
+            console.print("[[red]Error[/red]] Invalid share URL format.")
+            exit(1)
+
     if server_mode == RecceServerMode.server:
         flag = {"single_env_onboarding": False, "show_relaunch_hint": False}
         if is_cloud:
-            share_url = kwargs.get("share_url")
             if share_url:
                 # recce server --cloud --share-url <share-url>
                 # Use state file stored for the share url
-                # For to use the review mode.
+                # Forces use of the review mode.
                 is_review = kwargs["review"] = True
-                share_id = share_url.split("/")[-1]
                 cloud_options = {
                     "host": kwargs.get("state_file_host"),
                     "api_token": api_token,
@@ -484,8 +489,6 @@ def server(host, port, lifetime, state_file=None, **kwargs):
             # Usage:
             #    Used in cloud managed instance. For cloud onboarding to preview the uploaded artifacts.
             is_review = kwargs["review"] = True
-            share_url = kwargs.get("share_url")
-            share_id = share_url.split("/")[-1] if share_url else None
             cloud_options = {
                 "host": kwargs.get("state_file_host"),
                 "api_token": api_token,
@@ -507,8 +510,6 @@ def server(host, port, lifetime, state_file=None, **kwargs):
             # Usage:
             #    Used in cloud managed instance. Launch when user click a share link.
             is_review = kwargs["review"] = True
-            share_url = kwargs.get("share_url")
-            share_id = share_url.split("/")[-1] if share_url else None
             cloud_options = {
                 "host": kwargs.get("state_file_host"),
                 "api_token": api_token,

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -478,7 +478,7 @@ def server(host, port, lifetime, state_file=None, **kwargs):
             # recce server --cloud --share-url <share-url> --mode preview
             # Use state file stored for the share url
             #
-            # Read-only mode disable these features
+            # Preview mode disable these features
             # - run query
             #
             # Usage:


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:

When --share-url is provides
1. always use the state file in the cloud
2. always use the review mode, that is, the artifacts are from the cloud.
3. Support server mode = normal, which is used to enable data diff.

Examples
```
recce server --cloud --share-url <share_url>
recce server --cloud --share-url <share_url> --mode read-only
recce server --cloud --share-url <share_url> --mode preview
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
