### PR TITLE
⚡️ Speed up function `find_column_dependencies` by 233%

### DIFF
--- a/recce/util/lineage.py
+++ b/recce/util/lineage.py
@@ -7,19 +7,17 @@ def find_upstream(node_ids: Iterable, parent_map):
     visited = set()
     upstream = set()
 
-    def dfs(current):
+    stack = list(node_ids)
+    while stack:
+        current = stack.pop()
         if current in visited:
-            return
+            continue
         visited.add(current)
-
         parents = parent_map.get(current, [])
         for parent in parents:
-            upstream.add(parent)
-            dfs(parent)
-
-    for node_id in node_ids:
-        dfs(node_id)
-
+            if parent not in upstream:
+                upstream.add(parent)
+                stack.append(parent)
     return upstream
 
 
@@ -27,19 +25,17 @@ def find_downstream(node_ids: Iterable, child_map):
     visited = set()
     downstream = set()
 
-    def dfs(current):
+    stack = list(node_ids)
+    while stack:
+        current = stack.pop()
         if current in visited:
-            return
+            continue
         visited.add(current)
-
         children = child_map.get(current, [])
         for child in children:
-            downstream.add(child)
-            dfs(child)
-
-    for node_id in node_ids:
-        dfs(node_id)
-
+            if child not in downstream:
+                downstream.add(child)
+                stack.append(child)
     return downstream
 
 


### PR DESCRIPTION
### 📄 233% (2.33x) speedup for ***`find_column_dependencies` in `recce/util/lineage.py`***

⏱️ Runtime :   **`10.8 milliseconds`**  **→** **`3.24 milliseconds`** (best of `532` runs)
### 📝 Explanation and details


The optimization replaces recursive DFS with iterative DFS using an explicit stack, delivering a **233% speedup** by eliminating Python's function call overhead.

**Key changes:**
- **Eliminated recursion**: Replaced nested `dfs()` functions with `while` loops using explicit stacks
- **Reduced function calls**: The line profiler shows the original code spent 99.8% of time in `dfs()` calls, which are now eliminated
- **Added duplicate prevention**: Added `if parent not in upstream` checks to avoid redundant stack operations

**Why it's faster:**
- **Function call overhead elimination**: Python function calls are expensive due to frame creation, local scope management, and argument passing
- **Better memory locality**: Iterative approach uses a simple list as stack vs. recursive call frames
- **Reduced stack depth**: No risk of hitting Python's recursion limit on deep graphs

**Performance characteristics by test case:**
- **Large dense graphs**: Massive gains (260% faster on dense 50-node graph, 79% faster on 100-node cycle) 
- **Deep linear chains**: Significant improvements (46% faster on 1000-node chain)
- **Small simple graphs**: Slight overhead (10-20% slower) due to additional stack operations and duplicate checks
- **Empty/trivial cases**: Faster (15-19% improvement) as setup cost is lower

The optimization excels on complex, large-scale dependency graphs where the recursive overhead dominated performance, while adding minimal overhead for simple cases.



✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **101 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | ✅ **1 Passed** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
from typing import Dict, Iterable, Set, Tuple

# imports
import pytest  # used for our unit tests
from recce.util.lineage import find_column_dependencies

# unit tests

# ---------------------- Basic Test Cases ----------------------

def test_basic_single_parent_child():
    # Simple dependency: A -> B -> C
    parent_map = {'B': ['A'], 'C': ['B']}
    child_map = {'A': ['B'], 'B': ['C']}
    # Test for node B
    upstream, downstream = find_column_dependencies('B', parent_map, child_map) # 2.42μs -> 2.73μs (11.6% slower)

def test_basic_multiple_parents():
    # D depends on both B and C, which both depend on A
    parent_map = {'B': ['A'], 'C': ['A'], 'D': ['B', 'C']}
    child_map = {'A': ['B', 'C'], 'B': ['D'], 'C': ['D']}
    # Test for node D
    upstream, downstream = find_column_dependencies('D', parent_map, child_map) # 2.83μs -> 3.21μs (11.9% slower)

def test_basic_multiple_children():
    # A is parent of B and C, which are both parents of D
    parent_map = {'B': ['A'], 'C': ['A'], 'D': ['B', 'C']}
    child_map = {'A': ['B', 'C'], 'B': ['D'], 'C': ['D']}
    # Test for node A
    upstream, downstream = find_column_dependencies('A', parent_map, child_map) # 2.60μs -> 3.00μs (13.5% slower)

def test_basic_no_dependencies():
    # Node Z is isolated
    parent_map = {}
    child_map = {}
    upstream, downstream = find_column_dependencies('Z', parent_map, child_map) # 1.85μs -> 1.60μs (15.4% faster)

def test_basic_self_loop():
    # Node X depends on itself
    parent_map = {'X': ['X']}
    child_map = {'X': ['X']}
    upstream, downstream = find_column_dependencies('X', parent_map, child_map) # 2.11μs -> 2.10μs (0.143% faster)

# ---------------------- Edge Test Cases ----------------------

def test_edge_empty_maps():
    # All maps empty, node doesn't exist
    upstream, downstream = find_column_dependencies('foo', {}, {}) # 1.81μs -> 1.58μs (14.6% faster)

def test_edge_node_not_in_maps():
    # Node not present in either map, but maps have other data
    parent_map = {'A': ['B'], 'B': ['C']}
    child_map = {'B': ['A'], 'C': ['B']}
    upstream, downstream = find_column_dependencies('X', parent_map, child_map) # 1.77μs -> 1.49μs (18.9% faster)

def test_edge_cyclic_graph():
    # A <-> B <-> C <-> A (cycle)
    parent_map = {'A': ['C'], 'B': ['A'], 'C': ['B']}
    child_map = {'A': ['B'], 'B': ['C'], 'C': ['A']}
    upstream, downstream = find_column_dependencies('A', parent_map, child_map) # 2.61μs -> 3.17μs (17.5% slower)

def test_edge_disconnected_graph():
    # Two separate chains: A->B->C and X->Y->Z
    parent_map = {'B': ['A'], 'C': ['B'], 'Y': ['X'], 'Z': ['Y']}
    child_map = {'A': ['B'], 'B': ['C'], 'X': ['Y'], 'Y': ['Z']}
    # Test node from first chain
    upstream, downstream = find_column_dependencies('C', parent_map, child_map) # 2.20μs -> 2.65μs (16.9% slower)
    # Test node from second chain
    upstream2, downstream2 = find_column_dependencies('X', parent_map, child_map) # 1.39μs -> 1.43μs (3.08% slower)

def test_edge_multiple_independent_cycles():
    # Two cycles: A->B->A and X->Y->Z->X
    parent_map = {'A': ['B'], 'B': ['A'], 'X': ['Z'], 'Y': ['X'], 'Z': ['Y']}
    child_map = {'A': ['B'], 'B': ['A'], 'X': ['Y'], 'Y': ['Z'], 'Z': ['X']}
    upstream, downstream = find_column_dependencies('A', parent_map, child_map) # 2.18μs -> 2.56μs (14.8% slower)
    upstream2, downstream2 = find_column_dependencies('X', parent_map, child_map) # 1.59μs -> 1.57μs (1.27% faster)

def test_edge_node_with_no_parents_but_has_children():
    # Node A has no parents, but is parent of B and C
    parent_map = {'B': ['A'], 'C': ['A']}
    child_map = {'A': ['B', 'C']}
    upstream, downstream = find_column_dependencies('A', parent_map, child_map) # 2.14μs -> 2.48μs (13.7% slower)

def test_edge_node_with_no_children_but_has_parents():
    # Node D has parents B and C, but no children
    parent_map = {'D': ['B', 'C']}
    child_map = {'B': [], 'C': []}
    upstream, downstream = find_column_dependencies('D', parent_map, child_map) # 2.11μs -> 2.39μs (11.9% slower)

def test_edge_non_string_node_ids():
    # Node ids are integers
    parent_map = {2: [1], 3: [2]}
    child_map = {1: [2], 2: [3]}
    upstream, downstream = find_column_dependencies(2, parent_map, child_map) # 2.31μs -> 2.39μs (3.60% slower)

# ---------------------- Large Scale Test Cases ----------------------

def test_large_linear_chain():
    # Linear chain: 0 -> 1 -> 2 -> ... -> 99
    n = 100
    parent_map = {i: [i-1] for i in range(1, n)}
    child_map = {i: [i+1] for i in range(n-1)}
    # Test middle node
    upstream, downstream = find_column_dependencies(50, parent_map, child_map) # 12.8μs -> 14.2μs (9.84% slower)

def test_large_star_topology():
    # Star: center node 0, all others depend on 0
    n = 100
    parent_map = {i: [0] for i in range(1, n)}
    child_map = {0: list(range(1, n))}
    # Test center node
    upstream, downstream = find_column_dependencies(0, parent_map, child_map) # 13.4μs -> 15.4μs (13.1% slower)
    # Test leaf node
    upstream2, downstream2 = find_column_dependencies(42, parent_map, child_map) # 1.15μs -> 1.30μs (12.2% slower)

def test_large_complete_dag():
    # Complete DAG: each node i has parents 0..i-1, children i+1..n-1
    n = 30  # keep n reasonable for test performance
    parent_map = {i: list(range(i)) for i in range(n)}
    child_map = {i: list(range(i+1, n)) for i in range(n)}
    # Test for node 15
    upstream, downstream = find_column_dependencies(15, parent_map, child_map) # 14.7μs -> 9.19μs (60.3% faster)

def test_large_disconnected_components():
    # 10 chains of length 10, disconnected
    n_chains = 10
    chain_len = 10
    parent_map = {}
    child_map = {}
    for c in range(n_chains):
        base = c * chain_len
        for i in range(base+1, base+chain_len):
            parent_map[i] = [i-1]
            child_map.setdefault(i-1, []).append(i)
    # Test a node in the middle of the 5th chain
    node = 5 * chain_len + 5
    upstream, downstream = find_column_dependencies(node, parent_map, child_map) # 3.50μs -> 3.89μs (9.91% slower)

def test_large_cycle():
    # Large cycle: 0->1->2->...->n-1->0
    n = 100
    parent_map = {i: [(i-1)%n] for i in range(n)}
    child_map = {i: [(i+1)%n] for i in range(n)}
    # All nodes except itself are upstream/downstream
    upstream, downstream = find_column_dependencies(0, parent_map, child_map) # 45.6μs -> 25.4μs (79.4% faster)

def test_large_sparse_graph():
    # Sparse graph: only a few random edges
    parent_map = {10: [2], 20: [3], 30: [4], 40: [5]}
    child_map = {2: [10], 3: [20], 4: [30], 5: [40]}
    # Test node 10
    upstream, downstream = find_column_dependencies(10, parent_map, child_map) # 2.28μs -> 2.28μs (0.219% slower)
    # Test node 2
    upstream2, downstream2 = find_column_dependencies(2, parent_map, child_map) # 1.23μs -> 1.18μs (4.58% faster)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
#------------------------------------------------
from typing import Dict, Iterable, Set, Tuple

# imports
import pytest  # used for our unit tests
from recce.util.lineage import find_column_dependencies

# unit tests

# -----------------------
# BASIC TEST CASES
# -----------------------

def test_no_dependencies():
    # Test when the node has no parents or children
    parent_map = {}
    child_map = {}
    node = "A"
    upstream, downstream = find_column_dependencies(node, parent_map, child_map) # 1.84μs -> 1.69μs (9.24% faster)

def test_single_parent_and_child():
    # Test when the node has one parent and one child
    parent_map = {"B": ["A"]}
    child_map = {"A": ["B"]}
    node = "B"
    upstream, downstream = find_column_dependencies(node, parent_map, child_map) # 2.02μs -> 2.37μs (14.6% slower)
    # Test downstream from A
    upstream2, downstream2 = find_column_dependencies("A", parent_map, child_map) # 1.16μs -> 1.23μs (5.79% slower)

def test_simple_chain():
    # Test a simple chain: A -> B -> C
    parent_map = {"B": ["A"], "C": ["B"]}
    child_map = {"A": ["B"], "B": ["C"]}
    node = "B"
    upstream, downstream = find_column_dependencies(node, parent_map, child_map) # 2.14μs -> 2.46μs (12.8% slower)
    # Test for "C"
    up, down = find_column_dependencies("C", parent_map, child_map) # 1.25μs -> 1.46μs (14.5% slower)
    # Test for "A"
    up, down = find_column_dependencies("A", parent_map, child_map) # 1.06μs -> 1.31μs (18.8% slower)

def test_branching_graph():
    # Test a graph with branching:   A   B
    #                                \ /
    #                                 C
    #                                 |
    #                                 D
    parent_map = {"C": ["A", "B"], "D": ["C"]}
    child_map = {"A": ["C"], "B": ["C"], "C": ["D"]}
    node = "C"
    upstream, downstream = find_column_dependencies(node, parent_map, child_map) # 2.22μs -> 2.73μs (18.9% slower)
    # Test for "D"
    up, down = find_column_dependencies("D", parent_map, child_map) # 1.37μs -> 1.65μs (16.8% slower)
    # Test for "A"
    up, down = find_column_dependencies("A", parent_map, child_map) # 1.06μs -> 1.25μs (14.7% slower)

def test_multiple_paths():
    # Test a graph where multiple paths lead to the same node
    # A -> C <- B
    #      |
    #      v
    #      D
    parent_map = {"C": ["A", "B"], "D": ["C"]}
    child_map = {"A": ["C"], "B": ["C"], "C": ["D"]}
    node = "D"
    upstream, downstream = find_column_dependencies(node, parent_map, child_map) # 2.14μs -> 2.58μs (17.1% slower)

# -----------------------
# EDGE TEST CASES
# -----------------------

def test_empty_node_id():
    # Test with empty string as node id
    parent_map = {"": ["A"], "A": []}
    child_map = {"A": [""]}
    upstream, downstream = find_column_dependencies("", parent_map, child_map) # 2.00μs -> 1.93μs (4.05% faster)

def test_nonexistent_node():
    # Test with a node that does not exist in either map
    parent_map = {"A": ["B"]}
    child_map = {"B": ["A"]}
    upstream, downstream = find_column_dependencies("Z", parent_map, child_map) # 1.81μs -> 1.52μs (19.1% faster)

def test_cycle_in_graph():
    # Test a cycle: A -> B -> C -> A
    parent_map = {"A": ["C"], "B": ["A"], "C": ["B"]}
    child_map = {"A": ["B"], "B": ["C"], "C": ["A"]}
    # For "A", upstream should be {"B", "C"}
    upstream, downstream = find_column_dependencies("A", parent_map, child_map) # 2.51μs -> 2.97μs (15.6% slower)
    # For "B", upstream should be {"A", "C"}
    up, down = find_column_dependencies("B", parent_map, child_map) # 1.51μs -> 1.85μs (18.4% slower)
    # For "C", upstream should be {"A", "B"}
    up, down = find_column_dependencies("C", parent_map, child_map) # 1.38μs -> 1.50μs (8.18% slower)

def test_self_loop():
    # Test a node that is its own parent and child
    parent_map = {"A": ["A"]}
    child_map = {"A": ["A"]}
    upstream, downstream = find_column_dependencies("A", parent_map, child_map) # 1.97μs -> 2.04μs (3.67% slower)

def test_disconnected_graph():
    # Test a graph with two disconnected components
    parent_map = {"A": [], "B": [], "C": ["B"], "D": ["C"]}
    child_map = {"B": ["C"], "C": ["D"]}
    # "A" is isolated
    upstream, downstream = find_column_dependencies("A", parent_map, child_map) # 1.82μs -> 1.63μs (11.5% faster)
    # "D" is part of a chain
    upstream, downstream = find_column_dependencies("D", parent_map, child_map) # 1.34μs -> 1.60μs (16.6% slower)

def test_node_with_no_parents_but_children():
    # Node is only a parent, not a child
    parent_map = {"B": ["A"], "C": ["A"]}
    child_map = {"A": ["B", "C"]}
    upstream, downstream = find_column_dependencies("A", parent_map, child_map) # 2.05μs -> 2.52μs (18.9% slower)

def test_node_with_no_children_but_parents():
    # Node is only a child, not a parent
    parent_map = {"A": [], "B": ["A"], "C": ["A"]}
    child_map = {"A": ["B", "C"]}
    upstream, downstream = find_column_dependencies("B", parent_map, child_map) # 2.10μs -> 2.15μs (2.33% slower)

def test_duplicate_edges():
    # Test that duplicate edges do not affect result
    parent_map = {"B": ["A", "A"], "C": ["B", "B"]}
    child_map = {"A": ["B", "B"], "B": ["C", "C"]}
    upstream, downstream = find_column_dependencies("C", parent_map, child_map) # 2.55μs -> 2.65μs (3.92% slower)

def test_node_with_none_in_maps():
    # Test node ids as None (should work as any other hashable)
    parent_map = {None: ["A"], "A": []}
    child_map = {"A": [None]}
    upstream, downstream = find_column_dependencies(None, parent_map, child_map) # 2.33μs -> 2.24μs (4.06% faster)

# -----------------------
# LARGE SCALE TEST CASES
# -----------------------

def test_large_linear_chain():
    # Test a long chain: 0 -> 1 -> 2 -> ... -> 999
    N = 1000
    parent_map = {str(i): [str(i-1)] for i in range(1, N)}
    parent_map[str(0)] = []
    child_map = {str(i): [str(i+1)] for i in range(N-1)}
    child_map[str(N-1)] = []
    # Test from the middle
    node = str(N//2)
    upstream, downstream = find_column_dependencies(node, parent_map, child_map) # 243μs -> 166μs (45.9% faster)

def test_large_branching_tree():
    # Create a binary tree of depth 5 (max 31 nodes)
    def make_binary_tree(depth):
        parent_map = {}
        child_map = {}
        for i in range(2**depth - 1):
            left = 2*i + 1
            right = 2*i + 2
            children = []
            if left < 2**depth - 1:
                children.append(str(left))
                parent_map[str(left)] = [str(i)]
            if right < 2**depth - 1:
                children.append(str(right))
                parent_map[str(right)] = [str(i)]
            if children:
                child_map[str(i)] = children
        return parent_map, child_map

    parent_map, child_map = make_binary_tree(5)
    # Test from root
    upstream, downstream = find_column_dependencies("0", parent_map, child_map) # 8.33μs -> 9.84μs (15.4% slower)
    # Should reach all other nodes
    expected_downstream = set(str(i) for i in range(1, 31))
    # Test from a leaf
    leaf = "30"
    upstream, downstream = find_column_dependencies(leaf, parent_map, child_map) # 2.03μs -> 2.63μs (22.7% slower)

def test_large_dense_graph():
    # Test a dense graph where every node is parent of every other node (excluding self)
    N = 50  # keep small to avoid performance issues
    nodes = [str(i) for i in range(N)]
    parent_map = {n: [m for m in nodes if m != n] for n in nodes}
    child_map = {n: [m for m in nodes if m != n] for n in nodes}
    # For any node, upstream and downstream should be all other nodes
    for node in nodes:
        upstream, downstream = find_column_dependencies(node, parent_map, child_map) # 10.3ms -> 2.86ms (260% faster)
        expected = set(nodes) - {node}

def test_large_disconnected_components():
    # 10 components, each of 10 nodes in a chain
    parent_map = {}
    child_map = {}
    for c in range(10):
        base = c * 10
        for i in range(base, base+10):
            if i == base:
                parent_map[str(i)] = []
            else:
                parent_map[str(i)] = [str(i-1)]
            if i < base+9:
                child_map[str(i)] = [str(i+1)]
            else:
                child_map[str(i)] = []
    # Test from middle of one component
    node = str(45)
    upstream, downstream = find_column_dependencies(node, parent_map, child_map) # 3.87μs -> 4.49μs (13.8% slower)
    # Test from start of another component
    node = str(70)
    upstream, downstream = find_column_dependencies(node, parent_map, child_map) # 2.56μs -> 2.87μs (10.9% slower)

def test_large_cycle():
    # 100 nodes in a cycle: 0->1->2->...->99->0
    N = 100
    parent_map = {str(i): [str((i-1)%N)] for i in range(N)}
    child_map = {str(i): [str((i+1)%N)] for i in range(N)}
    node = "0"
    upstream, downstream = find_column_dependencies(node, parent_map, child_map) # 53.8μs -> 36.6μs (47.1% faster)
    # Should be all other nodes
    expected = set(str(i) for i in range(1, N))
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
#------------------------------------------------
from recce.util.lineage import find_column_dependencies

def test_find_column_dependencies():
    find_column_dependencies('', {}, {})
```

</details>

<details>
<summary>🔎 Concolic Coverage Tests and Runtime</summary>

| Test File::Test Function                                                                           | Original ⏱️   | Optimized ⏱️   | Speedup   |
|:---------------------------------------------------------------------------------------------------|:--------------|:---------------|:----------|
| `codeflash_concolic_odjsdz_6/tmpc1zsnsir/test_concolic_coverage.py::test_find_column_dependencies` | 1.98μs        | 1.71μs         | 16.1%✅   |

</details>


To edit these changes `git checkout codeflash/optimize-find_column_dependencies-meco5ygu` and push.

[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)