### PR TITLE
feat(DRC-1898): add dynamic loading messages for Share button

### DIFF
--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'
   - unrs-resolver


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Feature / Enhancement

**What this PR does / why we need it**:

Add dynamic loading messages to the Share button to provide better user feedback during the 5-70 second upload process. Messages rotate every 30 seconds to reassure users that the system is still processing.

## Changes
- **StateSharing.tsx**: 
  - Added `useInterval` hook to cycle through loading messages every 30 seconds
  - Added `LOADING_MESSAGES` array with progressive feedback messages (ready for i18n)
  - Implemented state management to track and reset message index
  - Display loading message next to Share button during upload process
  
- **pnpm-workspace.yaml**: 
  - Fixed missing `packages` field causing pnpm scripts to fail

**Which issue(s) this PR fixes**:

Fixes DRC-1898

**Special notes for your reviewer**:

- Loading messages cycle every 30 seconds (adjusted to 1 second in demo video for demonstration purposes)
- Messages are extracted to `LOADING_MESSAGES` array for future i18n integration
- Also includes fix for pnpm-workspace.yaml configuration issue that was blocking pre-commit hooks

## Screenshots

Demo video - interval changed from 30s to 1sec to demonstrate the text changes:
https://www.loom.com/share/7cd552a5f3c4490cb56f83d8d3099143?sid=daa4e0cd-e24c-46c1-96e5-e4f4456a87d8

## Test Plan

- [x] Lint checks passed (`npx eslint`)
- [x] TypeScript type checks passed (`npx tsc --noEmit`)
- [x] Manual testing: Loading messages display correctly and cycle every 30 seconds
- [x] Manual testing: Message index resets when loading completes

## Impact

- **Visual**: Loading text appears next to Share button showing "Processing..." → "Still processing, please wait..." → "Almost there, thanks for your patience..."
- **Functional**: Improved UX by providing feedback during long upload times (5-70s), reducing user confusion about whether the feature is working
- **Code Quality**: Messages extracted to array for easy i18n integration, proper TypeScript types maintained

**Does this PR introduce a user-facing change?**:

Yes. Users will now see progressive loading messages when clicking the Share button, improving feedback during 5-70 second upload times. The messages update every 30 seconds to reassure users the system is still processing.