### PR TITLE
[Feature] DRC-1895 Notify Recce Cloud after the state-file is uploaed

### DIFF
--- a/recce/state/cloud.py
+++ b/recce/state/cloud.py
@@ -411,6 +411,9 @@ class CloudStateLoader(RecceStateLoader):
 
         if message:
             logger.warning(message)
+        else:
+            # Notify Recce Cloud that the state has been uploaded if upload is successful
+            self.recce_cloud.post_recce_state_uploaded_by_session_id(org_id, project_id, self.session_id)
         return message, None
 
     def _upload_state_to_url(

--- a/recce/util/recce_cloud.py
+++ b/recce/util/recce_cloud.py
@@ -345,6 +345,16 @@ class RecceCloud:
             presigned_urls[key] = self._replace_localhost_with_docker_internal(url)
         return presigned_urls
 
+    def post_recce_state_uploaded_by_session_id(self, org_id: str, project_id: str, session_id: str):
+        api_url = f"{self.base_url_v2}/organizations/{org_id}/projects/{project_id}/sessions/{session_id}/recce-state-uploaded"
+        response = self._request("POST", api_url)
+        if response.status_code != 204:
+            raise RecceCloudException(
+                message="Failed to notify state uploaded for session in Recce Cloud.",
+                reason=response.text,
+                status_code=response.status_code,
+            )
+
     def list_organizations(self) -> list:
         """List all organizations the user has access to."""
         api_url = f"{self.base_url_v2}/organizations"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- Due to we use AWS S3 presigned URL to upload `recce_state.json`, the Recce Cloud won't be notified after the file is uploaded. Invoke API to notify Recce Cloud that the `recce_state.json` is uploaded.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
