### PR TITLE
Add missing dependencies pytz and packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ setup(
         "GitPython",
         "PyGithub",
         "sqlglot",
+        "pytz",
+        "packaging",
     ],
     tests_require=["pytest"],
     extras_require={


### PR DESCRIPTION
## Summary
- Add `pytz` to install_requires in setup.py
- Add `packaging` to install_requires in setup.py

## Rationale
These packages are already being used in the codebase but were not declared as dependencies:
- `pytz`: Used in `recce/server.py:28` for timezone handling (`from pytz import utc`)
- `packaging`: Used in `recce/__init__.py:4` and `recce/adapter/dbt_adapter/dbt_version.py` for version comparison

Without these explicit dependencies, the package installation may fail or have missing runtime dependencies.

## Test plan
- [x] Verify setup.py syntax is valid
- [x] Pre-commit hooks pass (black, isort, flake8)
- [x] Test installation in clean environment: `pip install -e .`
- [x] Verify imports work: `python -c "from pytz import utc; from packaging.version import Version"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)