### PR TITLE
Add server mode for recce mcp

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,6 +8,7 @@ pytest.importorskip("mcp")
 from recce.core import RecceContext  # noqa: E402
 from recce.mcp_server import RecceMCPServer, run_mcp_server  # noqa: E402
 from recce.models.types import LineageDiff  # noqa: E402
+from recce.server import RecceServerMode  # noqa: E402
 from recce.tasks.profile import ProfileDiffTask  # noqa: E402
 from recce.tasks.query import QueryDiffTask, QueryTask  # noqa: E402
 from recce.tasks.rowcount import RowCountDiffTask  # noqa: E402
@@ -206,3 +207,25 @@ def test_mcp_cli_command_exists():
     # Check that mcp_server is in the CLI commands
     commands = [cmd.name for cmd in cli.commands.values()]
     assert "mcp_server" in commands or "mcp-server" in commands
+
+
+class TestMCPServerModes:
+    """Test cases for MCP server mode functionality"""
+
+    def test_server_mode_default(self):
+        """Test that server mode is the default when not specified"""
+        mock_context = MagicMock(spec=RecceContext)
+        server = RecceMCPServer(mock_context)
+
+        # Default mode should be server
+        assert server.mode == RecceServerMode.server
+
+    def test_non_server_mode_restricts_tools(self):
+        """Test that non-server mode (preview, read-only) restricts diff tools"""
+        mock_context = MagicMock(spec=RecceContext)
+        server = RecceMCPServer(mock_context, mode=RecceServerMode.preview)
+
+        # Verify mode is set correctly
+        assert server.mode == RecceServerMode.preview
+        # Verify it's not server mode
+        assert server.mode != RecceServerMode.server


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
We need to preview server mode and metadata-only preview) mode for cases that warehouse connection is not avaiable in the recce cloud instance.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:


## Usage

MCP config
```
{
  "mcpServers": {
    "recce": {
      "command": "recce",
      "args": [
        "mcp-server"
      ],
      "env": {}
    }
  }
}
```


## Server mode (default)
```
claude
```
<img width="284" height="210" alt="image" src="https://github.com/user-attachments/assets/b7091e63-0f09-4b2b-9365-0a577812066c" />

## Metadata-only (preview) mode
```
RECCE_SERVER_MODE=preview claude    
```
<img width="659" height="162" alt="image" src="https://github.com/user-attachments/assets/b67e3cb8-8b91-45d3-9823-0fb97b674d28" />




