### PR TITLE
fix: Prevent unnecessary WebSocket reconnections on toast notifications

### DIFF
--- a/js/src/lib/hooks/LineageGraphContext.tsx
+++ b/js/src/lib/hooks/LineageGraphContext.tsx
@@ -108,9 +108,11 @@ function useLineageWatcher() {
   const ref = useRef<{
     ws: WebSocket | undefined;
     status: LineageWatcherStatus;
+    artifactsUpdatedToastId: string | undefined;
   }>({
     ws: undefined,
     status: "pending",
+    artifactsUpdatedToastId: undefined,
   });
 
   const [status, setStatus] = useState<LineageWatcherStatus>("pending");
@@ -120,6 +122,11 @@ function useLineageWatcher() {
   useEffect(() => {
     ref.current.status = status;
   }, [status]);
+
+  // Keep artifactsUpdatedToastId in sync with ref
+  useEffect(() => {
+    ref.current.artifactsUpdatedToastId = artifactsUpdatedToastId;
+  }, [artifactsUpdatedToastId]);
 
   const queryClient = useQueryClient();
 
@@ -156,7 +163,7 @@ function useLineageWatcher() {
           const [targetName, fileName] = srcPath.split("/").slice(-2);
           const name = path.parse(fileName).name;
           const eventId = `${targetName}-${name}-${eventType}`;
-          if (artifactsUpdatedToastId == null) {
+          if (ref.current.artifactsUpdatedToastId == null) {
             setArtifactsUpdatedToastId(
               toaster.create({
                 id: eventId,
@@ -201,7 +208,7 @@ function useLineageWatcher() {
 
       ref.current.ws = undefined;
     };
-  }, [artifactsUpdatedToastId, invalidateCaches]);
+  }, [invalidateCaches]);
 
   useEffect(() => {
     const refObj = ref.current;


### PR DESCRIPTION
Fixed a bug where WebSocket connections were being disconnected and reconnected every time a toast notification appeared. The issue was caused by `artifactsUpdatedToastId` being included in the `connect` callback's dependency array, causing it to be recreated on every toast state change.

Changes:
- Added `artifactsUpdatedToastId` to the ref object for stable access
- Created a useEffect to sync state with ref
- Updated WebSocket message handler to use ref instead of closure
- Removed `artifactsUpdatedToastId` from connect's dependency array

This ensures the WebSocket connection remains stable while still allowing the toast notification logic to function correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
