### PR TITLE
Remove dbt_version from RecceStateMetadata

### DIFF
--- a/recce/state/state.py
+++ b/recce/state/state.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
 
 from recce import get_version
-from recce.config import console
 from recce.exceptions import RecceException
 from recce.git import current_branch
 from recce.models.types import Check, Run
@@ -35,7 +34,6 @@ class GitRepoInfo(BaseModel):
 
 
 class RecceStateMetadata(BaseModel):
-    dbt_version: str = "0"
     schema_version: str = "v0"
     recce_version: str = Field(default_factory=lambda: get_version())
     generated_at: str = Field(default_factory=lambda: datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"))
@@ -67,9 +65,6 @@ class RecceState(BaseModel):
         state = RecceState(**dict_data)
         metadata = state.metadata
 
-        from recce.adapter.dbt_adapter import DbtVersion
-
-        dbt_version = DbtVersion()
         if metadata:
             if metadata.schema_version is None:
                 pass
@@ -77,11 +72,6 @@ class RecceState(BaseModel):
                 pass
             else:
                 raise RecceException(f"Unsupported state file version: {metadata.schema_version}")
-            if metadata.dbt_version != dbt_version:
-                console.print(
-                    f"[[yellow]WARN[/yellow]] dbt version mismatch. Local dbt adapter: {dbt_version} vs. Generated Manifest dbt adapter: {metadata.dbt_version}"
-                )
-                console.print("[[yellow]WARN[/yellow]] Version mismatch can lead to issues when generating queries")
         return state
 
     @staticmethod

--- a/tests/adapter/dbt_adapter/test_dbt_cll.py
+++ b/tests/adapter/dbt_adapter/test_dbt_cll.py
@@ -57,7 +57,9 @@ def assert_model(
         entry.change_category == change_category
     ), f"Node {node_id} change category mismatch: expected {change_category}, got {entry.change_category}"
 
-    assert (entry.impacted == impacted), f"Node {node_id} impacted status mismatch: expected {impacted}, got {entry.impacted}"
+    assert (
+        entry.impacted == impacted
+    ), f"Node {node_id} impacted status mismatch: expected {impacted}, got {entry.impacted}"
 
 
 def assert_cll_contain_nodes(cll_data: CllData, nodes):
@@ -652,7 +654,7 @@ def test_impact_radius_by_node_with_cll(dbt_test_helper):
 
     result = adapter.get_cll(node_id="model.model2", change_analysis=True, no_upstream=True)
     assert_model(result, "model.model2", parents=[], change_category="partial_breaking", impacted=False)
-    assert_model(result, "model.model3", parents=[('model.model2', 'y')], impacted=True)
+    assert_model(result, "model.model3", parents=[("model.model2", "y")], impacted=True)
     assert_column(result, "model.model2", "y", transformation_type="source", parents=[], change_status="modified")
     assert_cll_contain_nodes(result, ["model.model2", "model.model3"])
     assert_cll_contain_columns(result, [("model.model2", "y"), ("model.model4", "y")])

--- a/tests/recce_cloud/test_platform_clients.py
+++ b/tests/recce_cloud/test_platform_clients.py
@@ -5,6 +5,7 @@ Tests for platform-specific Recce Cloud API clients.
 import os
 from unittest.mock import patch
 from urllib.parse import urlparse
+
 import pytest
 
 from recce_cloud.api.factory import create_platform_client
@@ -23,7 +24,9 @@ class TestGitHubRecceCloudClient:
         assert client.repository == "owner/repo"
         parsed = urlparse(client.api_host)
         # Accept main domain or subdomains:
-        assert parsed.hostname == "cloud.datarecce.io" or (parsed.hostname and parsed.hostname.endswith(".cloud.datarecce.io"))
+        assert parsed.hostname == "cloud.datarecce.io" or (
+            parsed.hostname and parsed.hostname.endswith(".cloud.datarecce.io")
+        )
 
     def test_touch_recce_session_pr(self):
         """Test touch_recce_session for PR context."""


### PR DESCRIPTION
## Summary
Remove the redundant `dbt_version` field from `RecceStateMetadata` in state files. The dbt version information is already available in `manifest.metadata.dbt_version` from the artifact files.

## Problem
When running `recce summary`, users see false warning messages:
```
[WARN] dbt version mismatch. Local dbt adapter: 1.10.8 vs. Generated Manifest dbt adapter: 0
[WARN] Version mismatch can lead to issues when generating queries
```

This happens because:
1. `RecceStateMetadata.dbt_version` defaults to "0" and is never populated
2. After introducing Sessions, artifacts are stored separately in S3, not in state files
3. The dbt version is already available from manifest metadata

## Changes
- Remove `dbt_version` field from `RecceStateMetadata` class
- Remove dbt version mismatch warning logic from `RecceState.from_json()`
- Remove unused `console` import from `recce/state/state.py`

## Benefits
✅ Eliminates false warning messages  
✅ Cleaner state file metadata with only used fields  
✅ Simpler code that's easier to maintain  
✅ Backward compatible - old state files with `dbt_version` can still be loaded  

## Testing
- All 68 state-related tests pass
- Verified backward compatibility with old state file format
- Verified new state files don't include `dbt_version`
- Code passes flake8 linting and Black formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)