### PR TITLE
feat: support mcp server with transport sse

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -1730,7 +1730,7 @@ def read_only(ctx, state_file=None, **kwargs):
 
 @cli.command(cls=TrackCommand)
 @click.option("--sse", is_flag=True, default=False, help="Start in HTTP/SSE mode instead of stdio mode")
-@click.option("--host", default="0.0.0.0", help="Host to bind to in SSE mode (default: 0.0.0.0)")
+@click.option("--host", default="localhost", help="Host to bind to in SSE mode (default: localhost)")
 @click.option("--port", default=8000, type=int, help="Port to bind to in SSE mode (default: 8000)")
 @add_options(dbt_related_options)
 @add_options(sqlmesh_related_options)

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -618,11 +618,11 @@ class RecceMCPServer:
         async with stdio_server() as (read_stream, write_stream):
             await self.server.run(read_stream, write_stream, self.server.create_initialization_options())
 
-    async def run_sse(self, host: str = "0.0.0.0", port: int = 8000):
+    async def run_sse(self, host: str = "localhost", port: int = 8000):
         """Run the MCP server in HTTP mode using Server-Sent Events (SSE)
 
         Args:
-            host: Host to bind to (default: 0.0.0.0)
+            host: Host to bind to (default: localhost)
             port: Port to bind to (default: 8000)
         """
         import uvicorn
@@ -670,13 +670,13 @@ class RecceMCPServer:
         await server.serve()
 
 
-async def run_mcp_server(sse: bool = False, host: str = "0.0.0.0", port: int = 8000, **kwargs):
+async def run_mcp_server(sse: bool = False, host: str = "localhost", port: int = 8000, **kwargs):
     """
     Entry point for running the MCP server
 
     Args:
         sse: Whether to run in HTTP/SSE mode (default: False for stdio mode)
-        host: Host to bind to in SSE mode (default: 0.0.0.0)
+        host: Host to bind to in SSE mode (default: localhost)
         port: Port to bind to in SSE mode (default: 8000)
         **kwargs: Arguments for loading RecceContext (dbt options, etc.)
                Optionally includes 'mode' for server mode (server, preview, read-only)


### PR DESCRIPTION
Refine the #932

Usage

```
#stdio
recce mcp-server            

# sse
recce mcp-server --sse  

# sse 
recce mcp-server --sse  --host '0.0.0.0' --port 8888
```

MCP
```shell
claude mcp add --transport sse --scope project recce http://localhost:8000/sse
```
or
```json
{
  "mcpServers": {
    "recce": {
      "type": "sse",
      "url": "http://localhost:8000/sse"
    }
  }
}
```