### PR TITLE
chore: add cloud artifact cleanup after smoke test completes

### DIFF
--- a/integration_tests/dbt/smoke_test_cloud.sh
+++ b/integration_tests/dbt/smoke_test_cloud.sh
@@ -66,5 +66,6 @@ function check_server_status() {
 echo "Starting the server (cloud and review mode)..."
 recce server --cloud --review &
 check_server_status
+recce cloud purge --force
 
 export GITHUB_EVENT_PATH="$HOLD_GITHUB_EVENT_PATH"


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Chore - CI/CD improvement

**What this PR does / why we need it**:

Adds `recce cloud purge --force` after the server test completes in the cloud smoke test script. This ensures cloud artifacts are completely cleaned up when the entire smoke test finishes, preventing test data accumulation in cloud storage during CI runs.

**Which issue(s) this PR fixes**:

N/A - No Linear issue for this cleanup improvement

**Special notes for your reviewer**:

The purge command is placed after the server startup validation (line 69) to ensure cleanup happens after ALL smoke test operations complete, including:
- Upload artifacts
- Run checks
- Download/upload state
- Generate summary
- Server startup test
- **Final cleanup** ← NEW

**Does this PR introduce a user-facing change?**:

NONE

🤖 Generated with [Claude Code](https://claude.com/claude-code)