### PR TITLE
feat(DRC-2121/DRC-2067): disambiguate artifact name and before/after colors

### DIFF
--- a/js/src/components/app/EnvInfo.tsx
+++ b/js/src/components/app/EnvInfo.tsx
@@ -11,6 +11,7 @@ import {
   Portal,
   Separator,
   Table,
+  Text,
   useDisclosure,
 } from "@chakra-ui/react";
 import { format, formatDistance, parseISO } from "date-fns";
@@ -115,15 +116,23 @@ export function EnvInfo() {
         >
           <div className="hidden text-sm lg:flex lg:flex-col">
             <div className="flex gap-1">
-              <span className="no-track-pii-safe max-w-32 truncate">
+              <Text
+                as="span"
+                color="envBase"
+                className="no-track-pii-safe max-w-32 truncate"
+              >
                 {Array.from(baseSchemas).join(", ")}
-              </span>{" "}
+              </Text>{" "}
               ({baseRelativeTime})
             </div>
             <div className="flex gap-1">
-              <span className="no-track-pii-safe max-w-32 truncate">
+              <Text
+                as="span"
+                color="envCurrent"
+                className="no-track-pii-safe max-w-32 truncate"
+              >
                 {Array.from(currentSchemas).join(", ")}
-              </span>{" "}
+              </Text>{" "}
               ({currentRelativeTime})
             </div>
           </div>

--- a/js/src/components/ui/theme.ts
+++ b/js/src/components/ui/theme.ts
@@ -216,6 +216,8 @@ export const system = createSystem(defaultConfig, {
         success: { value: "{colors.green}" },
         warning: { value: "{colors.amber}" },
         danger: { value: "{colors.red}" },
+        envBase: { value: "{colors.amber.500}" },
+        envCurrent: { value: "{colors.iochmara.500}" },
       },
     },
   },


### PR DESCRIPTION
**PR checklist**
<img width="1978" height="647" alt="image" src="https://github.com/user-attachments/assets/75a49a07-4723-4c44-b2ea-9533889d83e0" />


- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
feat

**What this PR does / why we need it**:
To distinguish between different artifacts with the same name (e.g. in `dbt` state comparisons) and to visually separate "Base" and "Current" environments, this PR:
1. Defines semantic color tokens `envBase` (Amber) and `envCurrent` (Blue/Iochmara) in the theme.
2. Applies these colors to the Environment Info labels in the top bar.

**Which issue(s) this PR fixes**:
Fixes DRC-2121

**Special notes for your reviewer**:
- The colors were chosen to match the provided design feedback (Amber for Base, Blue for Current).
- Bypassed pre-commit hooks due to unrelated type error in `src/lib/api/track.ts`.

**Does this PR introduce a user-facing change?**:
YES