### PR TITLE
fix: Don't show 100% if the value is not 1 in the value diff

### DIFF
--- a/js/src/components/valuediff/ValueDiffResultView.tsx
+++ b/js/src/components/valuediff/ValueDiffResultView.tsx
@@ -182,7 +182,7 @@ function _ValueDiffResultView(
           if (value > 0.9999 && value < 1) {
             displayValue = "~99.99 %";
           } else if (value < 0.0001 && value > 0) {
-            displayValue = "~00.01 %";
+            displayValue = "~0.01 %";
           } else {
             displayValue = `${(value * 100).toFixed(2)} %`;
           }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug fix

**What this PR does / why we need it**:
If the value is 99.999% it show to 100% by rounding.

Now, it show ~99.99%
<img width="1616" height="392" alt="image" src="https://github.com/user-attachments/assets/2802f64d-c20a-40ed-a85e-e617b09747dd" />


**Which issue(s) this PR fixes**:
DRC-2241

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
