### PR TITLE
feat: Add basic instrumentation for tracking usage patterns

### DIFF
--- a/js/app/(mainComponents)/NavBar.tsx
+++ b/js/app/(mainComponents)/NavBar.tsx
@@ -4,7 +4,7 @@ import { Box, Flex, Link, Tabs } from "@chakra-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import NextLink from "next/link";
 import { usePathname } from "next/navigation";
-import React, { Activity, ReactNode, useEffect, useMemo } from "react";
+import React, { Activity, ReactNode, useEffect, useMemo, useRef } from "react";
 import { EnvInfo } from "@/components/app/EnvInfo";
 import { Filename } from "@/components/app/Filename";
 import { StateExporter } from "@/components/app/StateExporter";
@@ -83,9 +83,14 @@ export default function NavBar() {
       }}
     />
   );
-  // Track navigation changes
+
+  // Track navigation changes with previous pathname
+  const prevPathnameRef = useRef<string | null>(null);
   useEffect(() => {
-    trackNavigation({ from: location.pathname, to: pathname });
+    if (prevPathnameRef.current && prevPathnameRef.current !== pathname) {
+      trackNavigation({ from: prevPathnameRef.current, to: pathname });
+    }
+    prevPathnameRef.current = pathname;
   }, [pathname]);
 
   // Get current tab value from pathname

--- a/js/src/lib/hooks/LineageGraphContext.tsx
+++ b/js/src/lib/hooks/LineageGraphContext.tsx
@@ -40,7 +40,7 @@ import { PUBLIC_API_URL } from "../const";
 import { useIdleTimeout } from "./IdleTimeoutContext";
 import { useRecceServerFlag } from "./useRecceServerFlag";
 
-interface EnvInfo {
+export interface EnvInfo {
   stateMetadata?: stateMetadata;
   adapterType?: string;
   git?: gitInfo;


### PR DESCRIPTION
## Summary
This PR adds telemetry tracking for key user interactions to help understand usage patterns and improve the product. The implementation includes console logging for development/debugging purposes.

## Changes

### Tracking Events Added

1. **Lineage View Rendering** (src/components/lineage/LineageView.tsx:259-293)
   - Tracks when lineage view renders with node counts
   - Groups nodes by change status (added, removed, modified, unchanged)
   - Captures view configuration:
     - View mode (changed_models vs all)
     - Impact radius enabled state
     - Column-level lineage active state
     - Right sidebar open state

2. **Navigation Tracking** (app/(mainComponents)/NavBar.tsx:87-94)
   - Tracks tab navigation changes between Lineage, Query, and Checklist tabs
   - Uses useRef to maintain previous pathname for accurate from/to tracking

3. **Environment Configuration Tracking** (src/components/app/EnvInfo.tsx:160-173)
   - Tracks environment setup once at startup
   - Captures non-sensitive configuration data:
     - Review mode status
     - Adapter type (dbt/sqlmesh)
     - Git and PR info presence
     - Schema counts and dbt versions (for dbt adapter)
     - Environment presence (for sqlmesh adapter)

### Development/Debug Features

4. **Console Logging** (src/lib/api/track.ts:15-57)
   - Adds amplitudeInitialized flag to track initialization state
   - Logs all tracking events to console when Amplitude is not initialized
   - Adds startup message indicating tracking mode (Amplitude vs console only)
   - Makes tracking events visible during local development
   - Helps verify tracking implementation without Amplitude API key

## Implementation Details

- All tracking functions are non-blocking and don't affect user experience
- Tracking data excludes sensitive information (PII-safe)
- Console logging is always enabled (not just in dev mode) to help verify tracking in all environments
- Uses existing Amplitude tracking infrastructure
- Follows existing tracking patterns in the codebase

## Test Plan

- [x] Build frontend successfully
- [x] All Jest tests pass
- [x] Linting passes (biome check)
- [x] TypeScript compilation succeeds
- [x] Server starts and serves frontend
- [ ] Verify tracking events appear in browser console when navigating
- [ ] Verify lineage view render tracking includes node counts
- [ ] Verify environment config tracking fires once at startup

## Testing Locally

1. Start Recce server without Amplitude API key
2. Open browser console
3. Navigate to lineage view - should see `[Tracking] [Web] lineage_view_render` with node counts
4. Navigate between tabs - should see `[Tracking] [Web] navigation_change` with from/to paths
5. Refresh page - should see `[Tracking] [Web] environment_config` at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)