### PR TITLE
fix: Correct package name in nightly recce-cloud build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -193,7 +193,7 @@ jobs:
           sed -i.bak 's/name = "recce-cloud"/name = "recce-cloud-nightly"/' recce_cloud/pyproject.toml
 
           # build and upload to pypi
-          uv build --package recce-cloud
+          uv build --package recce-cloud-nightly
           uv run twine upload dist/*
         env:
           PYPIRC: ${{ secrets.PYPI }}


### PR DESCRIPTION
## Problem

The nightly build workflow for `recce-cloud` was failing with:
```
error: Package `recce-cloud` not found in workspace
##[error]Process completed with exit code 2.
```

**Failed run:** GitHub Action #20008235810 (2025-12-07)

## Root Cause

The workflow performs these steps:
1. **Line 193:** Renames package via sed: `"recce-cloud"` → `"recce-cloud-nightly"`
2. **Line 196:** Attempts to build: `uv build --package recce-cloud` ❌

After the sed rename, the package `"recce-cloud"` no longer exists in the workspace, causing the build to fail.

## Solution

Changed line 196 to use the renamed package name:
```diff
- uv build --package recce-cloud
+ uv build --package recce-cloud-nightly
```

## Testing

Verified locally:
- ✅ Before sed: `uv build --package recce-cloud` works
- ❌ After sed: `uv build --package recce-cloud` fails
- ✅ After sed: `uv build --package recce-cloud-nightly` works

## Impact

- Fixes nightly builds for `recce-cloud-nightly` package
- No changes to release workflow (doesn't rename package)
- No changes to main `recce` package build