### PR TITLE
bugfix: Fix direct navigation issue

### DIFF
--- a/js/next.config.js
+++ b/js/next.config.js
@@ -4,6 +4,7 @@ const { join } = require("node:path");
 const nextConfig = {
   outputFileTracingRoot: join(__dirname),
   output: "export",
+  trailingSlash: true,
   env: {
     AMPLITUDE_API_KEY: process.env.AMPLITUDE_API_KEY,
     GTM_ID: process.env.GTM_ID,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

Direct URL access to routes like /query, /lineage, and /checks was returning 404 errors because Next.js static export generated route.html files (e.g., query.html) while FastAPI's StaticFiles only looks for index.html inside directories.

Adding trailingSlash: true to next.config.js causes the build to generate index.html inside route directories (e.g., query/index.html), which FastAPI's StaticFiles with html=True can serve correctly.

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
fix

**What this PR does / why we need it**:
Ensure direct access to lineage, query, or checklist does not 404

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
- Test that you can navigate directly to /lineage, /query, and /checklist

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
