### PR TITLE
fix: Include Python source files in recce-cloud wheel

### DIFF
--- a/recce_cloud/pyproject.toml
+++ b/recce_cloud/pyproject.toml
@@ -43,4 +43,7 @@ allow-direct-references = true
 [tool.hatch.metadata.hooks.custom]
 
 [tool.hatch.build.targets.wheel]
-packages = ["recce_cloud"]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "recce_cloud"


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

Fixes recce-cloud package building empty wheels with no Python source files.

The issue was that `packages = ["recce_cloud"]` in the hatch build config was looking for a `recce_cloud/recce_cloud/` subdirectory which doesn't exist. The Python source files are directly in `recce_cloud/` alongside `pyproject.toml`.

**Root cause**: When building as a uv workspace member with `uv build --package recce-cloud`, hatchling uses `recce_cloud/` as the build root. The directive `packages = ["recce_cloud"]` tells it to look for a nested `recce_cloud` directory inside that root, which doesn't exist.

**Fix**: Use hatch's source remapping:
```toml
[tool.hatch.build.targets.wheel]
packages = ["."]

[tool.hatch.build.targets.wheel.sources]
"." = "recce_cloud"
```

This includes all files from the current directory and maps them to the `recce_cloud` package in the wheel.

**Before fix** (published nightly wheel):
```
$ python -m zipfile -l recce_cloud_nightly-1.29.0.20251210-py3-none-any.whl
recce_cloud_nightly-1.29.0.20251210.dist-info/METADATA
recce_cloud_nightly-1.29.0.20251210.dist-info/WHEEL
recce_cloud_nightly-1.29.0.20251210.dist-info/entry_points.txt
recce_cloud_nightly-1.29.0.20251210.dist-info/RECORD
```

**After fix**:
```
$ python -m zipfile -l recce_cloud-1.29.0.dev0-py3-none-any.whl
recce_cloud/__init__.py
recce_cloud/cli.py
recce_cloud/upload.py
recce_cloud/api/client.py
... (all source files included)
```

**Which issue(s) this PR fixes**:

Fixes `ModuleNotFoundError: No module named 'recce_cloud'` when running `recce-cloud` after installing from PyPI.

**Special notes for your reviewer**:

Tested locally:
1. Built wheel with `uv build --package recce-cloud`
2. Verified wheel contains all Python source files
3. Installed and ran `recce-cloud version` successfully

**Does this PR introduce a user-facing change?**:

Yes - fixes broken recce-cloud-nightly package installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)