### PR TITLE
fix: Fix missing keyword arg for GitHub recce cloud client

### DIFF
--- a/recce_cloud/api/github.py
+++ b/recce_cloud/api/github.py
@@ -27,6 +27,7 @@ class GitHubRecceCloudClient(BaseRecceCloudClient):
         branch: str,
         adapter_type: str,
         cr_number: Optional[int] = None,
+        commit_sha: Optional[str] = None,
         session_type: Optional[str] = None,
     ) -> Dict:
         """
@@ -52,7 +53,7 @@ class GitHubRecceCloudClient(BaseRecceCloudClient):
         # Only include pr_number for "cr" type sessions
         # For "prod" type, omit pr_number even if cr_number is detected
         if session_type == "cr" and cr_number is not None:
-            payload["pr_number"] = cr_number
+            payload["pr_number"] = str(cr_number)
 
         return self._make_request("POST", url, json=payload)
 

--- a/recce_cloud/api/gitlab.py
+++ b/recce_cloud/api/gitlab.py
@@ -57,7 +57,7 @@ class GitLabRecceCloudClient(BaseRecceCloudClient):
         # Only include mr_iid for "cr" type sessions
         # For "prod" type, omit mr_iid even if cr_number is detected
         if session_type == "cr" and cr_number is not None:
-            payload["mr_iid"] = cr_number
+            payload["mr_iid"] = str(cr_number)
 
         return self._make_request("POST", url, json=payload)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bug

**What this PR does / why we need it**:
- keyword arg `commit_sha` is missing in `GitHubRecceCloud` implementation

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
