### PR TITLE
chore(ui): Fix ag grid warnings

### DIFF
--- a/js/src/components/schema/SchemaView.tsx
+++ b/js/src/components/schema/SchemaView.tsx
@@ -158,7 +158,7 @@ function PrivateSingleEnvSchemaView(
           getRowClass={getRowClass}
           onCellClicked={handleCellClicked}
           onGridReady={handleGridReady}
-          rowSelection="single"
+          rowSelection={{ mode: "singleRow" }}
         />
       )}
     </Box>
@@ -326,7 +326,7 @@ export function PrivateSchemaView(
           getRowClass={getRowClass}
           onCellClicked={handleCellClicked}
           onGridReady={handleGridReady}
-          rowSelection="single"
+          rowSelection={{ mode: "singleRow" }}
         />
       )}
     </Box>

--- a/js/src/components/ui/dataGrid/defaultRenderCell.tsx
+++ b/js/src/components/ui/dataGrid/defaultRenderCell.tsx
@@ -16,11 +16,20 @@ import { ColumnRenderMode, ColumnType, RowObjectType } from "@/lib/api/types";
 import { toRenderedValue } from "@/lib/dataGrid/shared/gridUtils";
 
 /**
- * Extended column definition with optional type metadata
+ * Custom context data for Recce columns
+ * Stored in colDef.context to avoid AG Grid validation warnings
  */
-export type ColDefWithMetadata<TData = RowObjectType> = ColDef<TData> & {
+export interface RecceColumnContext {
   columnType?: ColumnType;
   columnRenderMode?: ColumnRenderMode;
+}
+
+/**
+ * Extended column definition with context metadata
+ * Uses context property for custom data per AG Grid best practices
+ */
+export type ColDefWithMetadata<TData = RowObjectType> = ColDef<TData> & {
+  context?: RecceColumnContext;
 };
 
 /**
@@ -37,8 +46,8 @@ export const defaultRenderCell = (
   params: ICellRendererParams<RowObjectType>,
 ) => {
   const colDef = params.colDef as ColDefWithMetadata;
-  const columnType = colDef?.columnType;
-  const columnRenderMode = colDef?.columnRenderMode;
+  const columnType = colDef?.context?.columnType;
+  const columnRenderMode = colDef?.context?.columnRenderMode;
   const fieldName = colDef?.field ?? "";
 
   if (!params.data) {

--- a/js/src/components/ui/dataGrid/inlineRenderCell.test.tsx
+++ b/js/src/components/ui/dataGrid/inlineRenderCell.test.tsx
@@ -74,8 +74,10 @@ function createMockColDef(
   return {
     field,
     headerName: field,
-    columnType: options.columnType,
-    columnRenderMode: options.columnRenderMode,
+    context: {
+      columnType: options.columnType,
+      columnRenderMode: options.columnRenderMode,
+    },
   };
 }
 

--- a/js/src/components/ui/dataGrid/inlineRenderCell.tsx
+++ b/js/src/components/ui/dataGrid/inlineRenderCell.tsx
@@ -27,11 +27,20 @@ import {
 } from "@/lib/dataGrid/shared/gridUtils";
 
 /**
- * Extended column definition with optional type metadata
+ * Custom context data for Recce columns
+ * Stored in colDef.context to avoid AG Grid validation warnings
  */
-type ColDefWithMetadata = ColDef<RowObjectType> & {
+interface RecceColumnContext {
   columnType?: ColumnType;
   columnRenderMode?: ColumnRenderMode;
+}
+
+/**
+ * Extended column definition with context metadata
+ * Uses context property for custom data per AG Grid best practices
+ */
+type ColDefWithMetadata = ColDef<RowObjectType> & {
+  context?: RecceColumnContext;
 };
 
 /**
@@ -51,8 +60,8 @@ export const inlineRenderCell = (
   params: ICellRendererParams<RowObjectType>,
 ) => {
   const colDef = params.colDef as ColDefWithMetadata;
-  const columnType = colDef?.columnType;
-  const columnRenderMode = colDef?.columnRenderMode;
+  const columnType = colDef?.context?.columnType;
+  const columnRenderMode = colDef?.context?.columnRenderMode;
   const columnKey = colDef?.field ?? "";
 
   if (!params.data) {

--- a/js/src/lib/dataGrid/crossFunctionConsistency.test.ts
+++ b/js/src/lib/dataGrid/crossFunctionConsistency.test.ts
@@ -426,21 +426,27 @@ describe("Column type preservation consistency", () => {
     const diffResult = toDataDiffGrid(df, df, { primaryKeys: ["id"] });
     const joinedResult = toValueDiffGrid(joinedDf, ["id"]);
 
-    // Helper to find column type
+    // Helper to find column type (now stored in context property)
     const findColumnType = (
       columns: GridColumn[],
       key: string,
     ): ColumnType | undefined => {
       for (const col of columns) {
-        if ("field" in col && col.field === key && "columnType" in col) {
-          return col.columnType as ColumnType;
+        if ("field" in col && col.field === key && "context" in col) {
+          const context = col.context as
+            | { columnType?: ColumnType }
+            | undefined;
+          return context?.columnType;
         }
         if ("children" in col && Array.isArray(col.children)) {
           const child = col.children.find(
             (c) => "field" in c && c.field === `base__${key}`,
           );
-          if (child && "columnType" in child) {
-            return (child as GridColumn).columnType as ColumnType;
+          if (child && "context" in child) {
+            const context = (child as GridColumn).context as
+              | { columnType?: ColumnType }
+              | undefined;
+            return context?.columnType;
           }
         }
       }

--- a/js/src/lib/dataGrid/shared/diffColumnBuilder.tsx
+++ b/js/src/lib/dataGrid/shared/diffColumnBuilder.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dataGrid";
 import { ColumnRenderMode, ColumnType, RowObjectType } from "@/lib/api/types";
 import { ColumnConfig } from "./columnBuilders";
+import { type RecceColumnContext } from "./simpleColumnBuilder";
 import { toDiffColumn } from "./toDiffColumn";
 
 // ============================================================================
@@ -21,15 +22,13 @@ import { toDiffColumn } from "./toDiffColumn";
 // ============================================================================
 
 /**
- * Extended column type with metadata (matches existing pattern)
+ * Extended column type with context metadata
+ * Uses context property for custom data per AG Grid best practices
+ * Note: Distributed form allows TypeScript to narrow types correctly
  */
-export type DiffColumnDefinition = (
-  | ColDef<RowObjectType>
-  | ColGroupDef<RowObjectType>
-) & {
-  columnType?: ColumnType;
-  columnRenderMode?: ColumnRenderMode;
-};
+export type DiffColumnDefinition =
+  | (ColDef<RowObjectType> & { context?: RecceColumnContext })
+  | (ColGroupDef<RowObjectType> & { context?: RecceColumnContext });
 
 /**
  * Configuration for building diff column definitions
@@ -137,8 +136,7 @@ function createPrimaryKeyColumn(
       return undefined;
     },
     cellRenderer: defaultRenderCell,
-    columnType,
-    columnRenderMode,
+    context: { columnType, columnRenderMode },
   };
 }
 

--- a/js/src/lib/dataGrid/shared/simpleColumnBuilder.tsx
+++ b/js/src/lib/dataGrid/shared/simpleColumnBuilder.tsx
@@ -25,15 +25,22 @@ import { ColumnConfig } from "./columnBuilders";
 // ============================================================================
 
 /**
- * Extended column type with metadata (matches existing pattern)
+ * Custom context data for Recce columns
+ * Stored in colDef.context to avoid AG Grid validation warnings
  */
-export type SimpleColumnDefinition = (
-  | ColDef<RowObjectType>
-  | ColGroupDef<RowObjectType>
-) & {
+export interface RecceColumnContext {
   columnType?: ColumnType;
   columnRenderMode?: ColumnRenderMode;
-};
+}
+
+/**
+ * Extended column type with context metadata
+ * Uses context property for custom data per AG Grid best practices
+ * Note: Distributed form allows TypeScript to narrow types correctly
+ */
+export type SimpleColumnDefinition =
+  | (ColDef<RowObjectType> & { context?: RecceColumnContext })
+  | (ColGroupDef<RowObjectType> & { context?: RecceColumnContext });
 
 /**
  * Configuration for building simple column definitions
@@ -125,8 +132,7 @@ function createPrimaryKeyColumn(
     ),
     pinned: "left",
     cellRenderer: defaultRenderCell,
-    columnType,
-    columnRenderMode,
+    context: { columnType, columnRenderMode },
   };
 }
 
@@ -154,8 +160,7 @@ function createRegularColumn(
       />
     ),
     cellRenderer: defaultRenderCell,
-    columnType,
-    columnRenderMode,
+    context: { columnType, columnRenderMode },
   };
 }
 

--- a/js/src/lib/dataGrid/shared/toDiffColumn.test.tsx
+++ b/js/src/lib/dataGrid/shared/toDiffColumn.test.tsx
@@ -52,6 +52,14 @@ jest.mock("./gridUtils", () => ({
 // ============================================================================
 
 /**
+ * Context for custom column metadata
+ */
+interface TestColumnContext {
+  columnType?: ColumnType;
+  columnRenderMode?: ColumnRenderMode;
+}
+
+/**
  * Test-friendly Column type (based on AG Grid ColDef)
  */
 interface TestColumn {
@@ -63,8 +71,7 @@ interface TestColumn {
     | string
     | ((params: CellClassParams<RowObjectType>) => string | undefined);
   cellRenderer?: unknown;
-  columnType?: ColumnType;
-  columnRenderMode?: ColumnRenderMode;
+  context?: TestColumnContext;
 }
 
 /**
@@ -74,8 +81,7 @@ interface TestColumnGroup {
   headerName?: string;
   headerClass?: string;
   children: readonly TestColumn[];
-  columnType?: ColumnType;
-  columnRenderMode?: ColumnRenderMode;
+  context?: TestColumnContext;
 }
 
 // ============================================================================
@@ -403,7 +409,7 @@ describe("toDiffColumn - inline mode", () => {
       createConfig({ columnType: "number", displayMode: "inline" }),
     );
 
-    expect(result.columnType).toBe("number");
+    expect(result.context?.columnType).toBe("number");
   });
 
   test("preserves columnRenderMode", () => {
@@ -411,13 +417,13 @@ describe("toDiffColumn - inline mode", () => {
       createConfig({ columnRenderMode: "percent", displayMode: "inline" }),
     );
 
-    expect(result.columnRenderMode).toBe("percent");
+    expect(result.context?.columnRenderMode).toBe("percent");
   });
 
   test("uses undefined as default columnRenderMode (triggers smart formatting)", () => {
     const result = toDiffColumn(createConfig({ displayMode: "inline" }));
 
-    expect(result.columnRenderMode).toBeUndefined();
+    expect(result.context?.columnRenderMode).toBeUndefined();
   });
 
   test("sets headerClass for added column", () => {
@@ -545,8 +551,8 @@ describe("toDiffColumn - side_by_side mode", () => {
 
     const children = getChildren(result);
     children.forEach((child) => {
-      expect(child.columnType).toBe("number");
-      expect(child.columnRenderMode).toBe(2);
+      expect(child.context?.columnType).toBe("number");
+      expect(child.context?.columnRenderMode).toBe(2);
     });
   });
 
@@ -640,7 +646,7 @@ describe("toDiffColumn - edge cases", () => {
 
     types.forEach((type) => {
       const result = toDiffColumn(createConfig({ columnType: type }));
-      expect(result.columnType).toBe(type);
+      expect(result.context?.columnType).toBe(type);
     });
   });
 
@@ -649,7 +655,7 @@ describe("toDiffColumn - edge cases", () => {
 
     modes.forEach((mode) => {
       const result = toDiffColumn(createConfig({ columnRenderMode: mode }));
-      expect(result.columnRenderMode).toBe(mode);
+      expect(result.context?.columnRenderMode).toBe(mode);
     });
   });
 

--- a/js/src/lib/dataGrid/shared/toDiffColumn.tsx
+++ b/js/src/lib/dataGrid/shared/toDiffColumn.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dataGrid";
 import { ColumnRenderMode, ColumnType, RowObjectType } from "@/lib/api/types";
 import { getHeaderCellClass } from "./gridUtils";
+import { type RecceColumnContext } from "./simpleColumnBuilder";
 
 // ============================================================================
 // Types
@@ -44,15 +45,13 @@ export interface DiffColumnConfig {
 }
 
 /**
- * Extended column type with metadata
+ * Extended column type with context metadata
+ * Uses context property for custom data per AG Grid best practices
+ * Note: Distributed form allows TypeScript to narrow types correctly
  */
-export type DiffColumnResult = (
-  | ColDef<RowObjectType>
-  | ColGroupDef<RowObjectType>
-) & {
-  columnType?: ColumnType;
-  columnRenderMode?: ColumnRenderMode;
-};
+export type DiffColumnResult =
+  | (ColDef<RowObjectType> & { context?: RecceColumnContext })
+  | (ColGroupDef<RowObjectType> & { context?: RecceColumnContext });
 
 // ============================================================================
 // Cell Class Factories
@@ -197,8 +196,7 @@ export function toDiffColumn(config: DiffColumnConfig): DiffColumnResult {
       headerClass: headerCellClass,
       headerComponent,
       cellRenderer: inlineRenderCell,
-      columnType,
-      columnRenderMode,
+      context: { columnType, columnRenderMode },
     };
   }
 
@@ -210,8 +208,7 @@ export function toDiffColumn(config: DiffColumnConfig): DiffColumnResult {
     headerName: name,
     headerClass: headerCellClass,
     headerGroupComponent: headerComponent,
-    columnType,
-    columnRenderMode,
+    context: { columnType, columnRenderMode },
     children: [
       {
         field: `base__${name}`,
@@ -219,8 +216,7 @@ export function toDiffColumn(config: DiffColumnConfig): DiffColumnResult {
         headerClass: headerCellClass,
         cellClass: cellClassBase,
         cellRenderer: defaultRenderCell,
-        columnType,
-        columnRenderMode,
+        context: { columnType, columnRenderMode },
       } as ColDef<RowObjectType>,
       {
         field: `current__${name}`,
@@ -228,8 +224,7 @@ export function toDiffColumn(config: DiffColumnConfig): DiffColumnResult {
         headerClass: headerCellClass,
         cellClass: cellClassCurrent,
         cellRenderer: defaultRenderCell,
-        columnType,
-        columnRenderMode,
+        context: { columnType, columnRenderMode },
       } as ColDef<RowObjectType>,
     ],
   };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Fix

**What this PR does / why we need it**:
Summary of Changes

Issue 1: Invalid colDef Properties (columnType, columnRenderMode)

Moved custom metadata from direct colDef properties to the context property per AG Grid best practices:

Type Definitions Updated:
- src/lib/dataGrid/shared/simpleColumnBuilder.tsx - Added RecceColumnContext interface, updated SimpleColumnDefinition type
- src/lib/dataGrid/shared/diffColumnBuilder.tsx - Updated DiffColumnDefinition type to use context
- src/lib/dataGrid/shared/toDiffColumn.tsx - Updated DiffColumnResult type to use context

Property Setters Updated:
- Column builders now set context: { columnType, columnRenderMode } instead of direct properties

Property Consumers Updated:
- src/components/ui/dataGrid/defaultRenderCell.tsx - Access via colDef?.context?.columnType
- src/components/ui/dataGrid/inlineRenderCell.tsx - Access via colDef?.context?.columnType

Issue 2: Deprecated rowSelection String Format

Updated src/components/schema/SchemaView.tsx:
- Line 161: rowSelection="single" → rowSelection={{ mode: "singleRow" }}
- Line 329: rowSelection="single" → rowSelection={{ mode: "singleRow" }}

Test Files Updated

- src/components/ui/dataGrid/inlineRenderCell.test.tsx
- src/lib/dataGrid/shared/diffColumnBuilder.test.tsx
- src/lib/dataGrid/shared/toDiffColumn.test.tsx

All lint checks, type checks, and tests pass successfully.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Check the Developer Console and look for any warnings from AG Grid. There should be none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Remove ag grid warnings