### PR TITLE
[Bug] DRC-2348 dbt-snowflake adapter Flags attribute error

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -285,7 +285,10 @@ class DbtArgs:
     target_path: Optional[str] = (None,)
     project_only_flags: Optional[Dict[str, Any]] = None
     which: Optional[str] = None
-    state_modified_compare_more_unrendered_values: Optional[bool] = True  # new flag added since dbt v1.9
+    # Behavior flags - need to be present on args object for set_from_args
+    state_modified_compare_more_unrendered_values: Optional[bool] = True  # dbt v1.9
+    require_unique_project_resource_names: Optional[bool] = False  # dbt v1.11
+    require_ref_searches_node_package_before_root: Optional[bool] = False  # dbt v1.11
 
 
 @dataclass


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug fix

**What this PR does / why we need it**:
Add the `require_unique_project_resource_names` and `require_ref_searches_node_package_before_root` flags to the DbtArgs dataclass. These flags were introduced in dbt-core v1.11 and are required by set_from_args() to avoid AttributeError when using dbt-snowflake or other adapters with the latest dbt versions.

Fixes: 'Flags' object has no attribute 'require_ref_searches_node_package_before_root'

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
