### PR TITLE
Trigger the ai summary task after upload with a session id

### DIFF
--- a/recce_cloud/recce_cloud/api/client.py
+++ b/recce_cloud/recce_cloud/api/client.py
@@ -224,6 +224,42 @@ class RecceCloudClient:
             status_code=response.status_code,
         )
 
+    def upload_completed(self, session_id: str) -> dict:
+        """
+        Notify Recce Cloud that upload is complete for a session.
+
+        This triggers post-upload processing such as AI summary generation.
+
+        Args:
+            session_id: Session ID to notify completion for
+
+        Returns:
+            dict containing acknowledgement or empty dict
+
+        Raises:
+            RecceCloudException: If the request fails
+        """
+        api_url = f"{self.base_url_v2}/sessions/{session_id}/upload-completed"
+        response = self._request("POST", api_url)
+        if response.status_code in [200, 204]:
+            if response.status_code == 204 or not response.content:
+                return {}
+            return response.json()
+        if response.status_code == 403:
+            raise RecceCloudException(
+                reason=response.json().get("detail", "Permission denied"),
+                status_code=response.status_code,
+            )
+        if response.status_code == 404:
+            raise RecceCloudException(
+                reason="Session not found",
+                status_code=response.status_code,
+            )
+        raise RecceCloudException(
+            reason=response.text,
+            status_code=response.status_code,
+        )
+
 
 class ReportClient:
     """Client for fetching reports from Recce Cloud API."""

--- a/recce_cloud/recce_cloud/upload.py
+++ b/recce_cloud/recce_cloud/upload.py
@@ -102,6 +102,19 @@ def upload_to_existing_session(
         console.print(f"Reason: {e}")
         sys.exit(4)
 
+    # Notify upload completion
+    console.print("Notifying upload completion...")
+    try:
+        client.upload_completed(session_id)
+    except RecceCloudException as e:
+        console.print("[yellow]Warning:[/yellow] Failed to notify upload completion")
+        console.print(f"Reason: {e.reason}")
+        # Non-fatal, continue
+    except Exception as e:
+        console.print("[yellow]Warning:[/yellow] Failed to notify upload completion")
+        console.print(f"Reason: {e}")
+        # Non-fatal, continue
+
     # Success!
     console.rule("Uploaded Successfully", style="green")
     console.print(

--- a/recce_cloud/tests/test_client.py
+++ b/recce_cloud/tests/test_client.py
@@ -445,6 +445,101 @@ class RecceCloudClientTests(unittest.TestCase):
 
         self.assertEqual(context.exception.status_code, 500)
 
+    @patch("recce_cloud.api.client.requests.request")
+    def test_upload_completed_success_with_json(self, mock_request):
+        """Test successful upload_completed call with JSON response."""
+        client = RecceCloudClient(self.api_token)
+
+        # Mock 200 response with JSON body
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b'{"message": "Upload completed"}'
+        mock_response.json.return_value = {"message": "Upload completed"}
+        mock_request.return_value = mock_response
+
+        result = client.upload_completed(self.session_id)
+
+        self.assertEqual(result["message"], "Upload completed")
+
+        # Verify request was made correctly
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
+        self.assertEqual(call_args[0][0], "POST")
+        self.assertIn(self.session_id, call_args[0][1])
+        self.assertIn("upload-completed", call_args[0][1])
+
+    @patch("recce_cloud.api.client.requests.request")
+    def test_upload_completed_success_204_no_content(self, mock_request):
+        """Test successful upload_completed call with 204 No Content response."""
+        client = RecceCloudClient(self.api_token)
+
+        # Mock 204 No Content response
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.content = b""
+        mock_request.return_value = mock_response
+
+        result = client.upload_completed(self.session_id)
+
+        self.assertEqual(result, {})
+
+        # Verify request was made correctly
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
+        self.assertEqual(call_args[0][0], "POST")
+        self.assertIn(self.session_id, call_args[0][1])
+        self.assertIn("upload-completed", call_args[0][1])
+
+    @patch("recce_cloud.api.client.requests.request")
+    def test_upload_completed_not_found(self, mock_request):
+        """Test upload_completed with 404 response."""
+        client = RecceCloudClient(self.api_token)
+
+        # Mock 404 response
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Session not found"
+        mock_request.return_value = mock_response
+
+        with self.assertRaises(RecceCloudException) as context:
+            client.upload_completed(self.session_id)
+
+        self.assertEqual(context.exception.status_code, 404)
+        self.assertIn("Session not found", context.exception.reason)
+
+    @patch("recce_cloud.api.client.requests.request")
+    def test_upload_completed_forbidden(self, mock_request):
+        """Test upload_completed with 403 response."""
+        client = RecceCloudClient(self.api_token)
+
+        # Mock 403 response
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.json.return_value = {"detail": "Permission denied"}
+        mock_request.return_value = mock_response
+
+        with self.assertRaises(RecceCloudException) as context:
+            client.upload_completed(self.session_id)
+
+        self.assertEqual(context.exception.status_code, 403)
+        self.assertIn("Permission denied", context.exception.reason)
+
+    @patch("recce_cloud.api.client.requests.request")
+    def test_upload_completed_server_error(self, mock_request):
+        """Test upload_completed with 500 response."""
+        client = RecceCloudClient(self.api_token)
+
+        # Mock 500 response
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal server error"
+        mock_request.return_value = mock_response
+
+        with self.assertRaises(RecceCloudException) as context:
+            client.upload_completed(self.session_id)
+
+        self.assertEqual(context.exception.status_code, 500)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature (Enhancemnt)

**What this PR does / why we need it**:
Whenever using
```
recce-cloud upload --session-id <session-id>
```
It notify the server and trigger to generate the ai summary.
[Demo](https://www.loom.com/share/255c426e87da4b1ba57f0baff93d8223)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
