### PR TITLE
feature/drc-2578-timeline-event-comments-show-incorrect-avatar-user-id-when

### DIFF
--- a/js/packages/ui/src/components/check/timeline/TimelineEventOss.tsx
+++ b/js/packages/ui/src/components/check/timeline/TimelineEventOss.tsx
@@ -21,7 +21,6 @@ import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import MuiTooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { useQuery } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { type MouseEvent, useState } from "react";
 import {
@@ -35,8 +34,8 @@ import {
   PiTrashSimple,
 } from "react-icons/pi";
 import { type CheckEvent, getEventIconType } from "../../../api";
+import { useAvatar } from "../../../hooks/useAvatar";
 import { useIsDark } from "../../../hooks/useIsDark";
-import { fetchGitHubAvatar } from "../../../lib/api/user";
 import { MarkdownContent } from "../../../primitives";
 
 interface TimelineEventProps {
@@ -75,15 +74,7 @@ function EventIcon({ event }: { event: CheckEvent }) {
 
 function UserAvatar({ event }: { event: CheckEvent }) {
   const { actor } = event;
-  const userId = actor.user_id?.toString();
-
-  const { data: avatarUrl } = useQuery({
-    queryKey: ["github-avatar", userId],
-    queryFn: () => (userId ? fetchGitHubAvatar(userId) : Promise.resolve(null)),
-    enabled: !!userId,
-    retry: false,
-    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
-  });
+  const { avatarUrl } = useAvatar({ userId: actor.user_id });
 
   const displayName = actor.fullname || actor.login || "User";
   const initials = displayName.charAt(0).toUpperCase();

--- a/js/packages/ui/src/hooks/__tests__/useAvatar.test.tsx
+++ b/js/packages/ui/src/hooks/__tests__/useAvatar.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * @file useAvatar.test.tsx
+ * @description Tests for useAvatar hook
+ *
+ * Tests verify:
+ * - Returns null when userId is not provided
+ * - Returns null for non-GitHub users (email login)
+ * - Returns GitHub avatar URL for GitHub users when user_id matches current user
+ * - Returns null when user_id doesn't match current user
+ * - Caches user and avatar queries appropriately
+ */
+
+import { vi } from "vitest";
+
+// ============================================================================
+// Mocks - MUST be set up before imports
+// ============================================================================
+
+const mockApiClient = {
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock("../useApiConfig", () => ({
+  useApiConfig: vi.fn(() => ({ apiClient: mockApiClient })),
+}));
+
+const mockFetchUser = vi.fn();
+const mockFetchGitHubAvatar = vi.fn();
+
+vi.mock("../../lib/api/user", () => ({
+  fetchUser: (...args: unknown[]) => mockFetchUser(...args),
+  fetchGitHubAvatar: (...args: unknown[]) => mockFetchGitHubAvatar(...args),
+}));
+
+vi.mock("../../api", () => ({
+  cacheKeys: {
+    user: () => ["user"],
+  },
+}));
+
+// ============================================================================
+// Imports
+// ============================================================================
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useAvatar } from "../useAvatar";
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const createMockUser = (overrides = {}) => ({
+  id: "123",
+  login: "testuser",
+  login_type: "github",
+  email: "test@example.com",
+  onboarding_state: "completed",
+  ...overrides,
+});
+
+describe("useAvatar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchUser.mockReset();
+    mockFetchGitHubAvatar.mockReset();
+  });
+
+  describe("when userId is not provided", () => {
+    it("returns null avatarUrl and does not fetch", () => {
+      const { result } = renderHook(() => useAvatar({ userId: null }), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.avatarUrl).toBe(null);
+      expect(result.current.isGitHubUser).toBe(false);
+      expect(mockFetchUser).not.toHaveBeenCalled();
+      expect(mockFetchGitHubAvatar).not.toHaveBeenCalled();
+    });
+
+    it("returns null for undefined userId", () => {
+      const { result } = renderHook(() => useAvatar({ userId: undefined }), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.avatarUrl).toBe(null);
+      expect(result.current.isGitHubUser).toBe(false);
+    });
+  });
+
+  describe("when current user is a GitHub user", () => {
+    it("fetches GitHub avatar when userId matches current user", async () => {
+      const githubUser = createMockUser({ id: "456", login_type: "github" });
+      const avatarUrl = "https://avatars.githubusercontent.com/u/456";
+
+      mockFetchUser.mockResolvedValue(githubUser);
+      mockFetchGitHubAvatar.mockResolvedValue(avatarUrl);
+
+      const { result } = renderHook(() => useAvatar({ userId: "456" }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.avatarUrl).toBe(avatarUrl);
+      });
+
+      expect(result.current.isGitHubUser).toBe(true);
+      expect(mockFetchGitHubAvatar).toHaveBeenCalledWith("456");
+    });
+
+    it("handles numeric userId", async () => {
+      const githubUser = createMockUser({ id: "789", login_type: "github" });
+      const avatarUrl = "https://avatars.githubusercontent.com/u/789";
+
+      mockFetchUser.mockResolvedValue(githubUser);
+      mockFetchGitHubAvatar.mockResolvedValue(avatarUrl);
+
+      const { result } = renderHook(() => useAvatar({ userId: 789 }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.avatarUrl).toBe(avatarUrl);
+      });
+
+      expect(result.current.isGitHubUser).toBe(true);
+    });
+  });
+
+  describe("when current user is NOT a GitHub user (email login)", () => {
+    it("returns null avatarUrl and does not fetch GitHub avatar", async () => {
+      const emailUser = createMockUser({ id: "123", login_type: "email" });
+
+      mockFetchUser.mockResolvedValue(emailUser);
+
+      const { result } = renderHook(() => useAvatar({ userId: "123" }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.avatarUrl).toBe(null);
+      expect(result.current.isGitHubUser).toBe(false);
+      expect(mockFetchGitHubAvatar).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when userId does not match current user", () => {
+    it("returns null avatarUrl (cannot verify other users login_type)", async () => {
+      const currentUser = createMockUser({ id: "100", login_type: "github" });
+
+      mockFetchUser.mockResolvedValue(currentUser);
+
+      const { result } = renderHook(() => useAvatar({ userId: "999" }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Different user ID, so we can't verify if they're a GitHub user
+      expect(result.current.avatarUrl).toBe(null);
+      expect(result.current.isGitHubUser).toBe(false);
+      expect(mockFetchGitHubAvatar).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when enabled is false", () => {
+    it("does not fetch anything", () => {
+      const { result } = renderHook(
+        () => useAvatar({ userId: "123", enabled: false }),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      expect(result.current.avatarUrl).toBe(null);
+      expect(result.current.isLoading).toBe(false);
+      expect(mockFetchUser).not.toHaveBeenCalled();
+      expect(mockFetchGitHubAvatar).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns null when fetchUser fails", async () => {
+      mockFetchUser.mockRejectedValue(new Error("Network error"));
+
+      const { result } = renderHook(() => useAvatar({ userId: "123" }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.avatarUrl).toBe(null);
+      expect(result.current.isGitHubUser).toBe(false);
+    });
+
+    it("returns null when fetchGitHubAvatar fails", async () => {
+      const githubUser = createMockUser({ id: "123", login_type: "github" });
+
+      mockFetchUser.mockResolvedValue(githubUser);
+      mockFetchGitHubAvatar.mockRejectedValue(new Error("GitHub API error"));
+
+      const { result } = renderHook(() => useAvatar({ userId: "123" }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.avatarUrl).toBe(null);
+      expect(result.current.isGitHubUser).toBe(true);
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows loading while fetching user", async () => {
+      let resolveUser: (value: unknown) => void;
+      const userPromise = new Promise((resolve) => {
+        resolveUser = resolve;
+      });
+      mockFetchUser.mockReturnValue(userPromise);
+
+      const { result } = renderHook(() => useAvatar({ userId: "123" }), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+
+      resolveUser!(createMockUser({ id: "123", login_type: "email" }));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+    });
+  });
+});

--- a/js/packages/ui/src/hooks/index.ts
+++ b/js/packages/ui/src/hooks/index.ts
@@ -31,6 +31,11 @@ export {
   useImageDownloadModal,
 } from "./ScreenShot";
 export { type ApiConfigContextType, useApiConfig } from "./useApiConfig";
+export {
+  type UseAvatarOptions,
+  type UseAvatarResult,
+  useAvatar,
+} from "./useAvatar";
 export { useCheckEvents } from "./useCheckEvents";
 export { useClipBoardToast } from "./useClipBoardToast";
 export { useCountdownToast } from "./useCountdownToast";

--- a/js/packages/ui/src/hooks/useAvatar.ts
+++ b/js/packages/ui/src/hooks/useAvatar.ts
@@ -1,0 +1,97 @@
+/**
+ * useAvatar - Hook for fetching user avatars with proper fallback handling.
+ *
+ * Solves the issue where email-only login users (non-GitHub) were showing
+ * incorrect GitHub avatars because their Recce Cloud user_id was being
+ * passed to the GitHub API.
+ *
+ * Logic:
+ * 1. Fetch current user data to get login_type
+ * 2. If actor's user_id matches current user AND login_type is "github":
+ *    - Fetch and return GitHub avatar URL
+ * 3. Otherwise:
+ *    - Return null (component should show initials fallback)
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { cacheKeys } from "../api";
+import { fetchGitHubAvatar, fetchUser } from "../lib/api/user";
+import { useApiConfig } from "./useApiConfig";
+
+export interface UseAvatarOptions {
+  /** The user ID from the event actor */
+  userId: string | number | null | undefined;
+  /** Whether to enable the query */
+  enabled?: boolean;
+}
+
+export interface UseAvatarResult {
+  /** The avatar URL if available, null otherwise */
+  avatarUrl: string | null;
+  /** Whether the avatar is loading */
+  isLoading: boolean;
+  /** Whether this user is a GitHub user */
+  isGitHubUser: boolean;
+}
+
+/**
+ * Hook to fetch a user's avatar with proper fallback handling.
+ *
+ * Only fetches GitHub avatars for users who authenticated via GitHub.
+ * For email-only users, returns null so the component can show initials.
+ *
+ * @example
+ * ```tsx
+ * function UserAvatar({ userId, displayName }: Props) {
+ *   const { avatarUrl } = useAvatar({ userId });
+ *
+ *   return (
+ *     <MuiAvatar src={avatarUrl || undefined}>
+ *       {displayName.charAt(0).toUpperCase()}
+ *     </MuiAvatar>
+ *   );
+ * }
+ * ```
+ */
+export function useAvatar({
+  userId,
+  enabled = true,
+}: UseAvatarOptions): UseAvatarResult {
+  const { apiClient } = useApiConfig();
+  const userIdString = userId?.toString();
+
+  // Fetch current user to get login_type
+  const { data: currentUser, isLoading: isUserLoading } = useQuery({
+    queryKey: cacheKeys.user(),
+    queryFn: () => fetchUser(apiClient),
+    enabled: enabled && !!userIdString,
+    retry: false,
+    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+  });
+
+  // Determine if this is a GitHub user
+  // Only fetch GitHub avatar if:
+  // 1. The actor's user_id matches the current user's id
+  // 2. The current user authenticated via GitHub
+  const isCurrentUser = Boolean(
+    currentUser && userIdString && currentUser.id === userIdString,
+  );
+  const isGitHubUser = isCurrentUser && currentUser?.login_type === "github";
+  const shouldFetchAvatar = Boolean(enabled && isGitHubUser && userIdString);
+
+  // Fetch GitHub avatar only for GitHub users
+  const { data: avatarUrl, isLoading: isAvatarLoading } = useQuery({
+    queryKey: ["github-avatar", userIdString],
+    queryFn: () =>
+      userIdString ? fetchGitHubAvatar(userIdString) : Promise.resolve(null),
+    enabled: shouldFetchAvatar,
+    retry: false,
+    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+  });
+
+  return {
+    avatarUrl: typeof avatarUrl === "string" ? avatarUrl : null,
+    isLoading: isUserLoading || (shouldFetchAvatar && isAvatarLoading),
+    isGitHubUser: Boolean(isGitHubUser),
+  };
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

Timeline event comments were displaying incorrect avatars for users who logged in via email (non-GitHub authentication). The issue occurred because the Recce Cloud `user_id` was being      
passed directly to the GitHub API, which expects GitHub user IDs. This caused random GitHub user avatars to appear for email-only users.

This PR introduces a `useAvatar` hook that:
1. Fetches the current user's data to determine their `login_type`
2. Only fetches GitHub avatars when the `user_id` matches the current user AND `login_type` is `"github"`
3. Returns `null` for non-GitHub users, allowing the component to fall back to displaying initials

**Which issue(s) this PR fixes**:

Fixes DRC-2578

**Special notes for your reviewer**:

- The fix only applies to `TimelineEventOss.tsx` (OSS version). The Cloud version (`TimelineEvent.tsx`) already receives `avatarUrl` as a prop, so the consumer handles avatar fetching      
  correctly.
- For events from other users (not the current user), we cannot determine their `login_type`, so they will show initials. This is acceptable since we can't verify if they authenticated via
  GitHub.
- Added 10 tests covering all scenarios: GitHub users, email users, mismatched user IDs, disabled state, and error handling.

**Does this PR introduce a user-facing change?**:

  ```release-note                                                                                                                                                                              
  Fixed timeline event comments showing incorrect avatars for users logged in via email instead of GitHub