### PR TITLE
fix(theme): include MUI augmentations in UI package tsconfig

### DIFF
--- a/js/packages/ui/src/theme/theme.ts
+++ b/js/packages/ui/src/theme/theme.ts
@@ -218,7 +218,7 @@ const progressColorVariants = [
   ...createProgressColorVariant("iochmara", colors.iochmara),
 ];
 
-// Module augmentations are in ./mui.d.ts for global visibility
+// Module augmentations are in js/mui-augmentations.d.ts (included via tsconfig)
 
 /**
  * System font stack for optimal cross-platform rendering

--- a/js/packages/ui/tsconfig.json
+++ b/js/packages/ui/tsconfig.json
@@ -20,6 +20,6 @@
     },
     "types": ["node", "vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../../mui-augmentations.d.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
**PR checklist**
- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug fix

**What this PR does / why we need it**:
The UI package's `tsconfig.json` was not including the root `mui-augmentations.d.ts` file, causing TypeScript errors for custom palette colors (`brand`, `iochmara`, `cyan`, etc.) in `theme.ts`.

Changes:
- Added `../../mui-augmentations.d.ts` to the UI package's tsconfig include array
- Updated misleading comment in `theme.ts` that referenced a non-existent `./mui.d.ts` file

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
The MUI type augmentations were created at the monorepo root level but the UI package had its own tsconfig that didn't reference them. This is a common issue in monorepo setups where packages have independent TypeScript configurations.

**Does this PR introduce a user-facing change?**:
NONE