### PR TITLE
fix(ui): correct diff-cell-modified styling to use amber instead of red

### DIFF
--- a/js/packages/storybook/stories/data/ScreenshotDataGrid.stories.tsx
+++ b/js/packages/storybook/stories/data/ScreenshotDataGrid.stories.tsx
@@ -226,7 +226,123 @@ export const WithDiffCells: Story = {
     docs: {
       description: {
         story:
-          "Grid with diff cell styling: added (green background), removed (red background), modified (red background - currently shares styling with removed due to component bug). The ID column uses diff-header styling (bold colors), while data columns use diff-cell styling (lighter colors).",
+          "Grid with diff cell styling: added (green background), removed (red background), modified (amber/yellow background). The ID column uses diff-header styling (bold colors), while data columns use diff-cell styling (lighter colors).",
+      },
+    },
+  },
+};
+
+export const DiffRowStatuses: Story = {
+  name: "Diff Row Status Variations",
+  args: {
+    style: STANDARD_GRID_STYLE,
+    columnDefs: [
+      createGridColumn({
+        field: "id",
+        headerName: "ID",
+        width: 80,
+        pinned: "left",
+        cellClass: (params: CellClassParams) => {
+          if (params.data?.__status) {
+            return `diff-header-${params.data.__status}`;
+          }
+          return undefined;
+        },
+      }),
+      createGridColumn({
+        field: "name",
+        headerName: "Name",
+        width: 200,
+        cellClass: (params: CellClassParams) => {
+          if (params.data?.__status && params.data.__status !== "unchanged") {
+            return `diff-cell-${params.data.__status}`;
+          }
+          return undefined;
+        },
+      }),
+      createGridColumn({
+        field: "value",
+        headerName: "Value",
+        width: 120,
+        cellClass: (params: CellClassParams) => {
+          if (params.data?.__status && params.data.__status !== "unchanged") {
+            return `diff-cell-${params.data.__status}`;
+          }
+          return undefined;
+        },
+      }),
+      createGridColumn({
+        field: "status",
+        headerName: "Status",
+        width: 120,
+        cellClass: (params: CellClassParams) => {
+          if (params.data?.__status && params.data.__status !== "unchanged") {
+            return `diff-cell-${params.data.__status}`;
+          }
+          return undefined;
+        },
+      }),
+      createGridColumn({
+        field: "created_at",
+        headerName: "Created",
+        width: 180,
+        cellClass: (params: CellClassParams) => {
+          if (params.data?.__status && params.data.__status !== "unchanged") {
+            return `diff-cell-${params.data.__status}`;
+          }
+          return undefined;
+        },
+      }),
+    ],
+    rowData: [
+      {
+        __rowKey: "1",
+        __status: "added",
+        created_at: "2026-01-22T01:36:30.581Z",
+        id: 1,
+        name: "Added Row",
+        status: "active",
+        value: 100,
+      },
+      {
+        __rowKey: "2",
+        __status: "removed",
+        created_at: "2026-01-22T01:36:30.581Z",
+        id: 2,
+        name: "Removed Row",
+        status: "inactive",
+        value: 200,
+      },
+      {
+        __rowKey: "3",
+        __status: "modified",
+        created_at: "2026-01-22T01:36:30.581Z",
+        id: 3,
+        name: "Modified Row",
+        status: "active",
+        value: 300,
+      },
+      {
+        __rowKey: "4",
+        __status: "unchanged",
+        created_at: "2026-01-22T01:36:30.581Z",
+        id: 4,
+        name: "Unchanged Row",
+        status: "inactive",
+        value: 400,
+      },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `Demonstrates all four diff row status variations:
+- **Added** (green): Row 1 - New rows that exist only in the current version
+- **Removed** (red): Row 2 - Rows that exist only in the base version
+- **Modified** (amber/yellow): Row 3 - Rows with changed values between versions
+- **Unchanged** (no styling): Row 4 - Rows that are identical in both versions
+
+The ID column uses \`diff-header-*\` classes for bold indicator colors, while data columns use \`diff-cell-*\` classes for lighter background colors.`,
       },
     },
   },

--- a/js/packages/ui/src/components/data/ScreenshotDataGrid.tsx
+++ b/js/packages/ui/src/components/data/ScreenshotDataGrid.tsx
@@ -273,7 +273,7 @@ function _ScreenshotDataGrid<TData = DataGridRow>(
           color: "var(--mui-palette-text-primary)",
         },
         "& .diff-cell-modified": {
-          backgroundColor: isDark ? "#5c1f1f !important" : "#ffc5c5 !important",
+          backgroundColor: isDark ? "#713F12 !important" : "#FEF3C7 !important",
           color: "var(--mui-palette-text-primary)",
         },
         // Diff header styling
@@ -283,6 +283,10 @@ function _ScreenshotDataGrid<TData = DataGridRow>(
         },
         "& .diff-header-removed": {
           backgroundColor: "#f43f5e !important",
+          color: "white",
+        },
+        "& .diff-header-modified": {
+          backgroundColor: "#f59e0b !important",
           color: "white",
         },
         // Index column styling


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

The `ScreenshotDataGrid` component was using red colors (`#ffc5c5` in light mode, `#5c1f1f` in dark mode) for `diff-cell-modified` styling, making modified rows visually indistinguishable from removed rows.

This PR:
1. Changes `diff-cell-modified` to use amber/yellow colors (`#FEF3C7` light / `#713F12` dark) per the design system defined in `colors.ts` and `useThemeColors.ts`
2. Adds the missing `diff-header-modified` CSS rule with amber (`#f59e0b`) background
3. Adds a new Storybook story demonstrating all four diff row status variations

**Which issue(s) this PR fixes**:

Fixes DRC-2613

**Special notes for your reviewer**:

To verify the fix visually:
```bash
cd js/packages/storybook
pnpm storybook
```
Then navigate to **Visualizations > Data > ScreenshotDataGrid > Diff Row Status Variations**

The story shows all four row statuses side-by-side:
- **Added** (green): Row 1
- **Removed** (red): Row 2
- **Modified** (amber/yellow): Row 3 ← This was previously red
- **Unchanged** (no styling): Row 4

**Does this PR introduce a user-facing change?**:

Yes - Modified rows in data grids now display with amber/yellow highlighting instead of red, making them visually distinct from removed rows.

<img width="1761" height="1582" alt="Screenshot 2026-02-04 at 15 15 26" src="https://github.com/user-attachments/assets/795b3c85-0dc6-4f68-beef-9b44966889c6" />
<img width="1761" height="1582" alt="Screenshot 2026-02-04 at 15 15 31" src="https://github.com/user-attachments/assets/a1b3a2c8-ff6a-42f4-897c-9f3d3da7b82b" />
