### PR TITLE
feat(ui): add TSV clipboard export for value diff results

### DIFF
--- a/js/packages/ui/src/components/run/RunResultPane.tsx
+++ b/js/packages/ui/src/components/run/RunResultPane.tsx
@@ -76,6 +76,8 @@ export interface CSVExportProps {
   copyAsTSV: () => Promise<void>;
   /** Download data as CSV file */
   downloadAsCSV: () => void;
+  /** Download data as TSV file */
+  downloadAsTSV: () => void;
 }
 
 /**
@@ -404,6 +406,18 @@ const DefaultExportMenu = memo(
             </ListItemIcon>
             <ListItemText>Download as CSV</ListItemText>
           </MenuItem>
+          <MenuItem
+            onClick={() => {
+              csvExport?.downloadAsTSV();
+              handleClose();
+            }}
+            disabled={disableExport || !csvExport?.canExportCSV}
+          >
+            <ListItemIcon>
+              <PiDownloadSimple />
+            </ListItemIcon>
+            <ListItemText>Download as TSV</ListItemText>
+          </MenuItem>
         </Menu>
       </>
     );
@@ -498,6 +512,18 @@ const DefaultShareMenu = memo(
               <PiDownloadSimple />
             </ListItemIcon>
             <ListItemText>Download as CSV</ListItemText>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              csvExport?.downloadAsTSV();
+              handleClose();
+            }}
+            disabled={disableExport || !csvExport?.canExportCSV}
+          >
+            <ListItemIcon>
+              <PiDownloadSimple />
+            </ListItemIcon>
+            <ListItemText>Download as TSV</ListItemText>
           </MenuItem>
           <Divider />
           {authed ? (

--- a/js/packages/ui/src/components/run/RunResultPane.tsx
+++ b/js/packages/ui/src/components/run/RunResultPane.tsx
@@ -41,6 +41,7 @@ import { IoClose } from "react-icons/io5";
 import {
   PiCaretDown,
   PiCheck,
+  PiClipboardText,
   PiDownloadSimple,
   PiImage,
   PiRepeat,
@@ -71,6 +72,8 @@ export interface CSVExportProps {
   canExportCSV: boolean;
   /** Copy data as CSV to clipboard */
   copyAsCSV: () => Promise<void>;
+  /** Copy data as TSV to clipboard (pastes into spreadsheets) */
+  copyAsTSV: () => Promise<void>;
   /** Download data as CSV file */
   downloadAsCSV: () => void;
 }
@@ -367,6 +370,18 @@ const DefaultExportMenu = memo(
           </MenuItem>
           <MenuItem
             onClick={async () => {
+              await csvExport?.copyAsTSV();
+              handleClose();
+            }}
+            disabled={disableExport || !csvExport?.canExportCSV}
+          >
+            <ListItemIcon>
+              <PiClipboardText />
+            </ListItemIcon>
+            <ListItemText>Copy as Text</ListItemText>
+          </MenuItem>
+          <MenuItem
+            onClick={async () => {
               await csvExport?.copyAsCSV();
               handleClose();
             }}
@@ -447,6 +462,18 @@ const DefaultShareMenu = memo(
               <PiImage />
             </ListItemIcon>
             <ListItemText>Copy as Image</ListItemText>
+          </MenuItem>
+          <MenuItem
+            onClick={async () => {
+              await csvExport?.copyAsTSV();
+              handleClose();
+            }}
+            disabled={disableExport || !csvExport?.canExportCSV}
+          >
+            <ListItemIcon>
+              <PiClipboardText />
+            </ListItemIcon>
+            <ListItemText>Copy as Text</ListItemText>
           </MenuItem>
           <MenuItem
             onClick={async () => {

--- a/js/packages/ui/src/components/run/RunResultPane.tsx
+++ b/js/packages/ui/src/components/run/RunResultPane.tsx
@@ -73,11 +73,11 @@ export interface CSVExportProps {
   /** Copy data as CSV to clipboard */
   copyAsCSV: () => Promise<void>;
   /** Copy data as TSV to clipboard (pastes into spreadsheets) */
-  copyAsTSV: () => Promise<void>;
+  copyAsTSV?: () => Promise<void>;
   /** Download data as CSV file */
   downloadAsCSV: () => void;
   /** Download data as TSV file */
-  downloadAsTSV: () => void;
+  downloadAsTSV?: () => void;
 }
 
 /**
@@ -372,7 +372,7 @@ const DefaultExportMenu = memo(
           </MenuItem>
           <MenuItem
             onClick={async () => {
-              await csvExport?.copyAsTSV();
+              await csvExport?.copyAsTSV?.();
               handleClose();
             }}
             disabled={disableExport || !csvExport?.canExportCSV}
@@ -408,7 +408,7 @@ const DefaultExportMenu = memo(
           </MenuItem>
           <MenuItem
             onClick={() => {
-              csvExport?.downloadAsTSV();
+              csvExport?.downloadAsTSV?.();
               handleClose();
             }}
             disabled={disableExport || !csvExport?.canExportCSV}
@@ -479,7 +479,7 @@ const DefaultShareMenu = memo(
           </MenuItem>
           <MenuItem
             onClick={async () => {
-              await csvExport?.copyAsTSV();
+              await csvExport?.copyAsTSV?.();
               handleClose();
             }}
             disabled={disableExport || !csvExport?.canExportCSV}
@@ -515,7 +515,7 @@ const DefaultShareMenu = memo(
           </MenuItem>
           <MenuItem
             onClick={() => {
-              csvExport?.downloadAsTSV();
+              csvExport?.downloadAsTSV?.();
               handleClose();
             }}
             disabled={disableExport || !csvExport?.canExportCSV}

--- a/js/packages/ui/src/hooks/useCSVExport.ts
+++ b/js/packages/ui/src/hooks/useCSVExport.ts
@@ -9,6 +9,7 @@ import {
   type CSVExportOptions,
   copyCSVToClipboard,
   downloadCSV,
+  downloadTSV,
   extractCSVData,
   generateCSVFilename,
   supportsCSVExport,
@@ -31,6 +32,8 @@ interface UseCSVExportResult {
   copyAsTSV: () => Promise<void>;
   /** Download result data as CSV file */
   downloadAsCSV: () => void;
+  /** Download result data as TSV file */
+  downloadAsTSV: () => void;
 }
 
 export function useCSVExport({
@@ -172,10 +175,46 @@ export function useCSVExport({
     }
   }, [getTSVContent]);
 
+  const downloadAsTSV = useCallback(() => {
+    const content = getTSVContent();
+    if (!content) {
+      toaster.create({
+        title: "Export failed",
+        description: "Unable to extract data for export",
+        type: "error",
+        duration: 3000,
+      });
+      return;
+    }
+
+    try {
+      const filename = generateCSVFilename(
+        run?.type ?? "",
+        run?.params as Record<string, unknown>,
+      ).replace(/\.csv$/, ".tsv");
+      downloadTSV(content, filename);
+      toaster.create({
+        title: "Downloaded",
+        description: filename,
+        type: "success",
+        duration: 3000,
+      });
+    } catch (error) {
+      console.error("Failed to download TSV file:", error);
+      toaster.create({
+        title: "Download failed",
+        description: "Failed to download TSV file",
+        type: "error",
+        duration: 3000,
+      });
+    }
+  }, [getTSVContent, run]);
+
   return {
     canExportCSV,
     copyAsCSV,
     copyAsTSV,
     downloadAsCSV,
+    downloadAsTSV,
   };
 }

--- a/js/packages/ui/src/hooks/useCSVExport.ts
+++ b/js/packages/ui/src/hooks/useCSVExport.ts
@@ -7,7 +7,7 @@ import type { Run } from "../api";
 import { toaster } from "../components/ui/Toaster";
 import {
   type CSVExportOptions,
-  copyCSVToClipboard,
+  copyToClipboard,
   downloadCSV,
   downloadTSV,
   extractCSVData,
@@ -91,7 +91,7 @@ export function useCSVExport({
     }
 
     try {
-      await copyCSVToClipboard(content);
+      await copyToClipboard(content);
       toaster.create({
         title: "Copied to clipboard",
         description: "CSV data copied successfully",
@@ -157,7 +157,7 @@ export function useCSVExport({
     }
 
     try {
-      await copyCSVToClipboard(content);
+      await copyToClipboard(content);
       toaster.create({
         title: "Copied to clipboard",
         description: "Text data copied — paste into any spreadsheet",

--- a/js/packages/ui/src/utils/csv/__tests__/format.test.ts
+++ b/js/packages/ui/src/utils/csv/__tests__/format.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for CSV formatting utilities
  */
-import { toCSV } from "../format";
+import { toCSV, toTSV } from "../format";
 
 describe("toCSV", () => {
   describe("basic formatting", () => {
@@ -206,6 +206,240 @@ describe("toCSV", () => {
 
       expect(result).toContain("Hello \u4e16\u754c");
       expect(result).toContain("\u00e9\u00e0\u00fc");
+    });
+  });
+});
+
+describe("toTSV", () => {
+  describe("basic formatting", () => {
+    test("should format simple data with tab-separated headers and rows", () => {
+      const columns = ["name", "age"];
+      const rows = [
+        ["Alice", 30],
+        ["Bob", 25],
+      ];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toContain("name\tage");
+      expect(result).toContain("Alice\t30");
+      expect(result).toContain("Bob\t25");
+    });
+
+    test("should use CRLF line endings", () => {
+      const columns = ["col1"];
+      const rows = [["a"], ["b"]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe("col1\r\na\r\nb");
+    });
+
+    test("should NOT include UTF-8 BOM", () => {
+      const columns = ["col"];
+      const rows = [["data"]];
+
+      const result = toTSV(columns, rows);
+
+      // TSV for clipboard pasting should not include BOM
+      expect(result.charCodeAt(0)).not.toBe(0xfeff);
+    });
+
+    test("should handle empty rows", () => {
+      const columns = ["col1", "col2"];
+      const rows: unknown[][] = [];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe("col1\tcol2");
+    });
+
+    test("should handle single column", () => {
+      const columns = ["value"];
+      const rows = [[1], [2], [3]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe("value\r\n1\r\n2\r\n3");
+    });
+  });
+
+  describe("special character handling", () => {
+    test("should replace tab characters in values with spaces", () => {
+      const columns = ["text"];
+      const rows = [["before\tafter"]];
+
+      const result = toTSV(columns, rows);
+
+      // Tabs within values must be replaced to avoid column misalignment
+      expect(result).toBe("text\r\nbefore after");
+    });
+
+    test("should replace newline characters in values with spaces", () => {
+      const columns = ["text"];
+      const rows = [["line1\nline2"]];
+
+      const result = toTSV(columns, rows);
+
+      // Newlines within values must be replaced to avoid row misalignment
+      expect(result).toBe("text\r\nline1 line2");
+    });
+
+    test("should replace carriage return characters in values with spaces", () => {
+      const columns = ["text"];
+      const rows = [["line1\rline2"]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe("text\r\nline1 line2");
+    });
+
+    test("should replace CRLF sequences in values with spaces", () => {
+      const columns = ["text"];
+      const rows = [["line1\r\nline2"]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe("text\r\nline1 line2");
+    });
+
+    test("should preserve commas (not a delimiter in TSV)", () => {
+      const columns = ["name"];
+      const rows = [["Smith, John"]];
+
+      const result = toTSV(columns, rows);
+
+      // Commas are fine in TSV - not a delimiter
+      expect(result).toBe("name\r\nSmith, John");
+    });
+
+    test("should preserve double quotes (not special in TSV)", () => {
+      const columns = ["quote"];
+      const rows = [['He said "hello"']];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe('quote\r\nHe said "hello"');
+    });
+  });
+
+  describe("null and undefined handling", () => {
+    test("should convert null to empty string", () => {
+      const columns = ["value"];
+      const rows = [[null]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe("value\r\n");
+    });
+
+    test("should convert undefined to empty string", () => {
+      const columns = ["value"];
+      const rows = [[undefined]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe("value\r\n");
+    });
+
+    test("should handle mixed null and values", () => {
+      const columns = ["a", "b", "c"];
+      const rows = [[1, null, 3]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe("a\tb\tc\r\n1\t\t3");
+    });
+  });
+
+  describe("data type handling", () => {
+    test("should convert numbers to strings", () => {
+      const columns = ["num"];
+      const rows = [[42], [3.14], [-100]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe("num\r\n42\r\n3.14\r\n-100");
+    });
+
+    test("should convert booleans to strings", () => {
+      const columns = ["bool"];
+      const rows = [[true], [false]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe("bool\r\ntrue\r\nfalse");
+    });
+
+    test("should JSON stringify objects", () => {
+      const columns = ["obj"];
+      const rows = [[{ key: "value" }]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe('obj\r\n{"key":"value"}');
+    });
+
+    test("should JSON stringify arrays", () => {
+      const columns = ["arr"];
+      const rows = [[[1, 2, 3]]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toBe("arr\r\n[1,2,3]");
+    });
+  });
+
+  describe("unicode support", () => {
+    test("should handle unicode characters", () => {
+      const columns = ["unicode"];
+      const rows = [["Hello \u4e16\u754c"], ["\u00e9\u00e0\u00fc"]];
+
+      const result = toTSV(columns, rows);
+
+      expect(result).toContain("Hello \u4e16\u754c");
+      expect(result).toContain("\u00e9\u00e0\u00fc");
+    });
+  });
+
+  describe("Google Sheets compatibility", () => {
+    test("should produce output that maps to spreadsheet cells", () => {
+      const columns = ["Column A", "Column B", "Column C"];
+      const rows = [
+        ["row1a", "row1b", "row1c"],
+        ["row2a", "row2b", "row2c"],
+      ];
+
+      const result = toTSV(columns, rows);
+      const lines = result.split("\r\n");
+
+      // Header row should have 3 tab-separated values
+      expect(lines[0].split("\t")).toEqual([
+        "Column A",
+        "Column B",
+        "Column C",
+      ]);
+      // Data rows should have 3 tab-separated values
+      expect(lines[1].split("\t")).toEqual(["row1a", "row1b", "row1c"]);
+      expect(lines[2].split("\t")).toEqual(["row2a", "row2b", "row2c"]);
+    });
+
+    test("should handle value_diff-like data (column name, matched count, matched percent)", () => {
+      const columns = ["column_name", "matched", "matched_percent"];
+      const rows = [
+        ["user_id", 1000, 1.0],
+        ["email", 950, 0.95],
+        ["status", 800, 0.8],
+      ];
+
+      const result = toTSV(columns, rows);
+      const lines = result.split("\r\n");
+
+      expect(lines).toHaveLength(4); // header + 3 data rows
+      expect(lines[0]).toBe("column_name\tmatched\tmatched_percent");
+      expect(lines[1]).toBe("user_id\t1000\t1");
+      expect(lines[2]).toBe("email\t950\t0.95");
+      expect(lines[3]).toBe("status\t800\t0.8");
     });
   });
 });

--- a/js/packages/ui/src/utils/csv/__tests__/format.test.ts
+++ b/js/packages/ui/src/utils/csv/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for CSV formatting utilities
+ * Tests for CSV and TSV formatting utilities
  */
 import { toCSV, toTSV } from "../format";
 

--- a/js/packages/ui/src/utils/csv/browser.ts
+++ b/js/packages/ui/src/utils/csv/browser.ts
@@ -17,6 +17,18 @@ export function downloadCSV(content: string, filename: string): void {
 }
 
 /**
+ * Trigger browser download of TSV file
+ * @param content - TSV string content
+ * @param filename - Name for the downloaded file
+ */
+export function downloadTSV(content: string, filename: string): void {
+  const blob = new Blob([content], {
+    type: "text/tab-separated-values;charset=utf-8",
+  });
+  saveAs(blob, filename);
+}
+
+/**
  * Copy CSV content to clipboard
  * Requires a secure context (HTTPS or localhost)
  * @param content - CSV string content to copy

--- a/js/packages/ui/src/utils/csv/browser.ts
+++ b/js/packages/ui/src/utils/csv/browser.ts
@@ -29,12 +29,12 @@ export function downloadTSV(content: string, filename: string): void {
 }
 
 /**
- * Copy CSV content to clipboard
+ * Copy text content to clipboard
  * Requires a secure context (HTTPS or localhost)
- * @param content - CSV string content to copy
+ * @param content - Text content to copy (CSV, TSV, or any string)
  * @throws Error if Clipboard API is not available
  */
-export async function copyCSVToClipboard(content: string): Promise<void> {
+export async function copyToClipboard(content: string): Promise<void> {
   if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
     throw new Error(
       "Clipboard API not available. Ensure you're using HTTPS or localhost.",

--- a/js/packages/ui/src/utils/csv/format.ts
+++ b/js/packages/ui/src/utils/csv/format.ts
@@ -62,10 +62,10 @@ function escapeTSVValue(value: unknown): string {
 }
 
 /**
- * Convert tabular data to TSV string for clipboard pasting into spreadsheets
+ * Convert tabular data to TSV string
  * @param columns - Column headers
  * @param rows - Row data (array of arrays)
- * @returns TSV string (no BOM - intended for clipboard, not file download)
+ * @returns TSV string (no BOM — plain text suitable for clipboard and file download)
  */
 export function toTSV(columns: string[], rows: unknown[][]): string {
   const headerRow = columns.map(escapeTSVValue).join("\t");

--- a/js/packages/ui/src/utils/csv/format.ts
+++ b/js/packages/ui/src/utils/csv/format.ts
@@ -1,6 +1,6 @@
 /**
  * @file csv/format.ts
- * @description CSV formatting utilities with Excel-friendly output
+ * @description CSV and TSV formatting utilities
  */
 
 /**
@@ -42,4 +42,34 @@ export function toCSV(columns: string[], rows: unknown[][]): string {
   const dataRows = rows.map((row) => row.map(escapeCSVValue).join(","));
 
   return BOM + [headerRow, ...dataRows].join("\r\n");
+}
+
+/**
+ * Escape a value for TSV format
+ * - Replace tabs, newlines, and carriage returns with spaces
+ * - No quoting needed (tabs are the only delimiter)
+ */
+function escapeTSVValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  const stringValue =
+    typeof value === "object" ? JSON.stringify(value) : String(value);
+
+  // Replace characters that would break TSV structure
+  return stringValue.replace(/[\t\r\n]+/g, " ");
+}
+
+/**
+ * Convert tabular data to TSV string for clipboard pasting into spreadsheets
+ * @param columns - Column headers
+ * @param rows - Row data (array of arrays)
+ * @returns TSV string (no BOM - intended for clipboard, not file download)
+ */
+export function toTSV(columns: string[], rows: unknown[][]): string {
+  const headerRow = columns.map(escapeTSVValue).join("\t");
+  const dataRows = rows.map((row) => row.map(escapeTSVValue).join("\t"));
+
+  return [headerRow, ...dataRows].join("\r\n");
 }

--- a/js/packages/ui/src/utils/csv/index.ts
+++ b/js/packages/ui/src/utils/csv/index.ts
@@ -1,9 +1,9 @@
 /**
  * @file csv/index.ts
- * @description CSV export utilities
+ * @description CSV/TSV export utilities
  */
 
-export { copyCSVToClipboard, downloadCSV, downloadTSV } from "./browser";
+export { copyToClipboard, downloadCSV, downloadTSV } from "./browser";
 export {
   type CSVData,
   type CSVExportOptions,

--- a/js/packages/ui/src/utils/csv/index.ts
+++ b/js/packages/ui/src/utils/csv/index.ts
@@ -3,7 +3,7 @@
  * @description CSV export utilities
  */
 
-export { copyCSVToClipboard, downloadCSV } from "./browser";
+export { copyCSVToClipboard, downloadCSV, downloadTSV } from "./browser";
 export {
   type CSVData,
   type CSVExportOptions,

--- a/js/packages/ui/src/utils/csv/index.ts
+++ b/js/packages/ui/src/utils/csv/index.ts
@@ -10,7 +10,7 @@ export {
   extractCSVData,
   supportsCSVExport,
 } from "./extractors";
-export { toCSV } from "./format";
+export { toCSV, toTSV } from "./format";
 
 /**
  * Generate timestamp string for filenames

--- a/js/packages/ui/src/utils/index.ts
+++ b/js/packages/ui/src/utils/index.ts
@@ -7,7 +7,7 @@
 export {
   type CSVData,
   type CSVExportOptions,
-  copyCSVToClipboard,
+  copyToClipboard,
   downloadCSV,
   downloadTSV,
   extractCSVData,

--- a/js/packages/ui/src/utils/index.ts
+++ b/js/packages/ui/src/utils/index.ts
@@ -9,6 +9,7 @@ export {
   type CSVExportOptions,
   copyCSVToClipboard,
   downloadCSV,
+  downloadTSV,
   extractCSVData,
   generateCSVFilename,
   generateTimestamp,

--- a/js/packages/ui/src/utils/index.ts
+++ b/js/packages/ui/src/utils/index.ts
@@ -14,6 +14,7 @@ export {
   generateTimestamp,
   supportsCSVExport,
   toCSV,
+  toTSV,
 } from "./csv";
 // Grid generators
 export type {


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Feature

**What this PR does / why we need it**:

Adds TSV (tab-separated values) export capabilities to the Export/Share menus:

1. **Copy as Text** — Copies TSV data to the clipboard. When pasted into Google Sheets or Excel, the data automatically fills into cells — no import step needed.
2. **Download as TSV** — Downloads result data as a `.tsv` file, mirroring the existing "Download as CSV" option.

This directly addresses user feedback requesting a way to copy value diff results into spreadsheets for collaborative review during data migrations.

**Which issue(s) this PR fixes**:

Closes #864
Resolves [DRC-2732](https://linear.app/recce/issue/DRC-2732)

**Special notes for your reviewer**:

- TSV was chosen over CSV for clipboard because TSV pastes natively into Google Sheets (CSV requires an import step)
- The `toTSV` function replaces tabs/newlines within values with spaces to prevent column/row misalignment
- No BOM is included (unlike CSV) since TSV is plain text
- The existing CSV extractors are reused — `getExtractedData()` was factored out of `getCSVContent()` to avoid duplication
- `downloadTSV` reuses `generateCSVFilename` with a `.csv` → `.tsv` extension swap
- 21 new tests cover the `toTSV` function (basic formatting, escaping, null handling, data types, Google Sheets compatibility)

**Does this PR introduce a user-facing change?**:

Yes — two new options appear in the Export/Share dropdown menus for all run types that support data export:
- **Copy as Text** — copies tab-separated data to clipboard, pastes directly into spreadsheet applications
- **Download as TSV** — downloads a `.tsv` file with the result data

🤖 Generated with [Claude Code](https://claude.com/claude-code)