### PR TITLE
fix(api): pass through cloud API error status codes in check endpoints

### DIFF
--- a/recce/apis/check_api.py
+++ b/recce/apis/check_api.py
@@ -15,6 +15,7 @@ from recce.core import default_context
 from recce.event import log_api_event
 from recce.exceptions import RecceException
 from recce.models import Check, CheckDAO, Run, RunDAO, RunType
+from recce.util.recce_cloud import RecceCloudException
 
 check_router = APIRouter(tags=["check"])
 
@@ -135,6 +136,8 @@ async def create_check(check_in: CreateCheckIn, background_tasks: BackgroundTask
                 track_props=check_in.track_props,
             ),
         )
+    except RecceCloudException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e.reason))
     except NameError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except ValueError as e:
@@ -214,7 +217,11 @@ class PatchCheckIn(BaseModel):
     response_model_exclude_none=True,
 )
 async def update_check_handler(check_id: UUID, patch: PatchCheckIn, background_tasks: BackgroundTasks):
-    check = CheckDAO().update_check_by_id(check_id, patch)
+    try:
+        check = CheckDAO().update_check_by_id(check_id, patch)
+    except RecceCloudException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e.reason))
+
     if check is None:
         raise HTTPException(status_code=404, detail="Not Found")
 
@@ -228,7 +235,11 @@ class DeleteCheckOut(BaseModel):
 
 @check_router.delete("/checks/{check_id}", status_code=200, response_model=DeleteCheckOut)
 async def delete_handler(check_id: UUID, background_tasks: BackgroundTasks):
-    CheckDAO().delete(check_id)
+    try:
+        CheckDAO().delete(check_id)
+    except RecceCloudException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e.reason))
+
     background_tasks.add_task(export_persistent_state)
     return DeleteCheckOut(check_id=check_id)
 
@@ -261,5 +272,7 @@ async def mark_as_preset_check_handler(check_id: UUID, background_tasks: Backgro
     try:
         CheckDAO().mark_as_preset_check(check_id)
         background_tasks.add_task(export_persistent_state)
+    except RecceCloudException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e.reason))
     except RecceException as e:
         raise HTTPException(status_code=400, detail=e.message)

--- a/recce/apis/check_api.py
+++ b/recce/apis/check_api.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
@@ -11,6 +10,7 @@ from recce.apis.check_func import (
     create_check_without_run,
     export_persistent_state,
 )
+from recce.apis.cloud_utils import log_cloud_exception
 from recce.apis.run_func import submit_run
 from recce.core import default_context
 from recce.event import log_api_event
@@ -18,22 +18,7 @@ from recce.exceptions import RecceException
 from recce.models import Check, CheckDAO, Run, RunDAO, RunType
 from recce.util.recce_cloud import RecceCloudException
 
-logger = logging.getLogger("uvicorn")
-
 check_router = APIRouter(tags=["check"])
-
-
-def _log_cloud_exception(msg: str, exc: RecceCloudException):
-    """Log cloud API errors at appropriate severity based on HTTP status code.
-
-    4xx errors (client errors like 403 Forbidden, 404 Not Found) are logged as
-    warnings since they represent expected outcomes. 5xx errors (server failures)
-    are logged as errors since they indicate unexpected system issues.
-    """
-    if exc.status_code is not None and exc.status_code >= 500:
-        logger.error(msg)
-    else:
-        logger.warning(msg)
 
 
 class CreateCheckIn(BaseModel):
@@ -153,7 +138,7 @@ async def create_check(check_in: CreateCheckIn, background_tasks: BackgroundTask
             ),
         )
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to create check: {e}", e)
+        log_cloud_exception(f"Failed to create check: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
     except NameError as e:
         raise HTTPException(status_code=404, detail=str(e))
@@ -173,7 +158,7 @@ async def run_check_handler(check_id: UUID, input: RunCheckIn):
     try:
         check = CheckDAO().find_check_by_id(check_id)
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to get check {check_id} for run: {e}", e)
+        log_cloud_exception(f"Failed to get check {check_id} for run: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
 
     if not check:
@@ -208,7 +193,7 @@ async def list_checks_handler():
     try:
         check_list = CheckDAO().list()
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to list checks: {e}", e)
+        log_cloud_exception(f"Failed to list checks: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
 
     artifact_time = _get_latest_artifact_time()
@@ -224,7 +209,7 @@ async def get_check_handler(check_id: UUID):
     try:
         check = CheckDAO().find_check_by_id(check_id)
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to get check {check_id}: {e}", e)
+        log_cloud_exception(f"Failed to get check {check_id}: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
 
     if check is None:
@@ -252,7 +237,7 @@ async def update_check_handler(check_id: UUID, patch: PatchCheckIn, background_t
     try:
         check = CheckDAO().update_check_by_id(check_id, patch)
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to update check {check_id}: {e}", e)
+        log_cloud_exception(f"Failed to update check {check_id}: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
 
     if check is None:
@@ -271,7 +256,7 @@ async def delete_handler(check_id: UUID, background_tasks: BackgroundTasks):
     try:
         CheckDAO().delete(check_id)
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to delete check {check_id}: {e}", e)
+        log_cloud_exception(f"Failed to delete check {check_id}: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
 
     background_tasks.add_task(export_persistent_state)
@@ -307,7 +292,7 @@ async def mark_as_preset_check_handler(check_id: UUID, background_tasks: Backgro
         CheckDAO().mark_as_preset_check(check_id)
         background_tasks.add_task(export_persistent_state)
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to mark check {check_id} as preset: {e}", e)
+        log_cloud_exception(f"Failed to mark check {check_id} as preset: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
     except RecceException as e:
         raise HTTPException(status_code=400, detail=e.message)

--- a/recce/apis/check_api.py
+++ b/recce/apis/check_api.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
@@ -17,7 +18,22 @@ from recce.exceptions import RecceException
 from recce.models import Check, CheckDAO, Run, RunDAO, RunType
 from recce.util.recce_cloud import RecceCloudException
 
+logger = logging.getLogger("uvicorn")
+
 check_router = APIRouter(tags=["check"])
+
+
+def _log_cloud_exception(msg: str, exc: RecceCloudException):
+    """Log cloud API errors at appropriate severity based on HTTP status code.
+
+    4xx errors (client errors like 403 Forbidden, 404 Not Found) are logged as
+    warnings since they represent expected outcomes. 5xx errors (server failures)
+    are logged as errors since they indicate unexpected system issues.
+    """
+    if exc.status_code is not None and exc.status_code >= 500:
+        logger.error(msg)
+    else:
+        logger.warning(msg)
 
 
 class CreateCheckIn(BaseModel):
@@ -137,6 +153,7 @@ async def create_check(check_in: CreateCheckIn, background_tasks: BackgroundTask
             ),
         )
     except RecceCloudException as e:
+        _log_cloud_exception(f"Failed to create check: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
     except NameError as e:
         raise HTTPException(status_code=404, detail=str(e))
@@ -153,7 +170,12 @@ class RunCheckIn(BaseModel):
 
 @check_router.post("/checks/{check_id}/run", status_code=201, response_model=Run)
 async def run_check_handler(check_id: UUID, input: RunCheckIn):
-    check = CheckDAO().find_check_by_id(check_id)
+    try:
+        check = CheckDAO().find_check_by_id(check_id)
+    except RecceCloudException as e:
+        _log_cloud_exception(f"Failed to get check {check_id} for run: {e}", e)
+        raise HTTPException(status_code=e.status_code, detail=str(e.reason))
+
     if not check:
         raise HTTPException(status_code=404, detail=f"Check ID '{check_id}' not found")
 
@@ -183,10 +205,15 @@ async def run_check_handler(check_id: UUID, input: RunCheckIn):
     response_model_exclude_none=True,
 )
 async def list_checks_handler():
+    try:
+        check_list = CheckDAO().list()
+    except RecceCloudException as e:
+        _log_cloud_exception(f"Failed to list checks: {e}", e)
+        raise HTTPException(status_code=e.status_code, detail=str(e.reason))
+
     artifact_time = _get_latest_artifact_time()
     checks = []
-
-    for check in CheckDAO().list():
+    for check in check_list:
         checks.append(CheckOut.from_check(check, artifact_time=artifact_time))
 
     return checks
@@ -194,7 +221,12 @@ async def list_checks_handler():
 
 @check_router.get("/checks/{check_id}", status_code=200, response_model=CheckOut)
 async def get_check_handler(check_id: UUID):
-    check = CheckDAO().find_check_by_id(check_id)
+    try:
+        check = CheckDAO().find_check_by_id(check_id)
+    except RecceCloudException as e:
+        _log_cloud_exception(f"Failed to get check {check_id}: {e}", e)
+        raise HTTPException(status_code=e.status_code, detail=str(e.reason))
+
     if check is None:
         raise HTTPException(status_code=404, detail="Not Found")
 
@@ -220,6 +252,7 @@ async def update_check_handler(check_id: UUID, patch: PatchCheckIn, background_t
     try:
         check = CheckDAO().update_check_by_id(check_id, patch)
     except RecceCloudException as e:
+        _log_cloud_exception(f"Failed to update check {check_id}: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
 
     if check is None:
@@ -238,6 +271,7 @@ async def delete_handler(check_id: UUID, background_tasks: BackgroundTasks):
     try:
         CheckDAO().delete(check_id)
     except RecceCloudException as e:
+        _log_cloud_exception(f"Failed to delete check {check_id}: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
 
     background_tasks.add_task(export_persistent_state)
@@ -273,6 +307,7 @@ async def mark_as_preset_check_handler(check_id: UUID, background_tasks: Backgro
         CheckDAO().mark_as_preset_check(check_id)
         background_tasks.add_task(export_persistent_state)
     except RecceCloudException as e:
+        _log_cloud_exception(f"Failed to mark check {check_id} as preset: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
     except RecceException as e:
         raise HTTPException(status_code=400, detail=e.message)

--- a/recce/apis/check_events_api.py
+++ b/recce/apis/check_events_api.py
@@ -12,6 +12,7 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from recce.apis.cloud_utils import log_cloud_exception
 from recce.core import default_context
 from recce.event import get_recce_api_token
 from recce.exceptions import RecceException
@@ -22,24 +23,6 @@ from recce.websocket import get_current_cloud_user
 logger = logging.getLogger("uvicorn")
 
 check_events_router = APIRouter(tags=["check_events"])
-
-
-# ============================================================================
-# Helper Functions
-# ============================================================================
-
-
-def _log_cloud_exception(msg: str, exc: RecceCloudException):
-    """Log cloud API errors at appropriate severity based on HTTP status code.
-
-    4xx errors (client errors like 403 Forbidden, 404 Not Found) are logged as
-    warnings since they represent expected outcomes. 5xx errors (server failures)
-    are logged as errors since they indicate unexpected system issues.
-    """
-    if exc.status_code is not None and exc.status_code >= 500:
-        logger.error(msg)
-    else:
-        logger.warning(msg)
 
 
 def _is_cloud_user() -> bool:
@@ -103,7 +86,7 @@ def _get_session_info() -> tuple:
         return org_id, project_id, session_id
 
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to get session info: {e}", e)
+        log_cloud_exception(f"Failed to get session info: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
 
 
@@ -207,7 +190,7 @@ async def list_check_events(check_id: UUID):
         return events
 
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to list check events: {e}", e)
+        log_cloud_exception(f"Failed to list check events: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
     except RecceException as e:
         logger.error(f"Failed to list check events: {e}")
@@ -243,7 +226,7 @@ async def get_check_event(check_id: UUID, event_id: UUID):
         return event
 
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to get check event: {e}", e)
+        log_cloud_exception(f"Failed to get check event: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
     except RecceException as e:
         logger.error(f"Failed to get check event: {e}")
@@ -288,7 +271,7 @@ async def create_comment(check_id: UUID, body: CreateCommentIn):
         return event
 
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to create comment: {e}", e)
+        log_cloud_exception(f"Failed to create comment: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
     except RecceException as e:
         logger.error(f"Failed to create comment: {e}")
@@ -337,7 +320,7 @@ async def update_comment(check_id: UUID, event_id: UUID, body: UpdateCommentIn):
         return event
 
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to update comment: {e}", e)
+        log_cloud_exception(f"Failed to update comment: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
     except RecceException as e:
         logger.error(f"Failed to update comment: {e}")
@@ -372,7 +355,7 @@ async def delete_comment(check_id: UUID, event_id: UUID):
         client.delete_comment(org_id, project_id, session_id, str(check_id), str(event_id))
 
     except RecceCloudException as e:
-        _log_cloud_exception(f"Failed to delete comment: {e}", e)
+        log_cloud_exception(f"Failed to delete comment: {e}", e)
         raise HTTPException(status_code=e.status_code, detail=str(e.reason))
     except RecceException as e:
         logger.error(f"Failed to delete comment: {e}")

--- a/recce/apis/cloud_utils.py
+++ b/recce/apis/cloud_utils.py
@@ -1,0 +1,20 @@
+"""Shared utilities for cloud API error handling in API endpoints."""
+
+import logging
+
+from recce.util.recce_cloud import RecceCloudException
+
+logger = logging.getLogger("uvicorn")
+
+
+def log_cloud_exception(msg: str, exc: RecceCloudException):
+    """Log cloud API errors at appropriate severity based on HTTP status code.
+
+    4xx errors (client errors like 403 Forbidden, 404 Not Found) are logged as
+    warnings since they represent expected outcomes. 5xx errors (server failures)
+    are logged as errors since they indicate unexpected system issues.
+    """
+    if exc.status_code is not None and exc.status_code >= 500:
+        logger.error(msg)
+    else:
+        logger.warning(msg)

--- a/recce/models/check.py
+++ b/recce/models/check.py
@@ -277,6 +277,8 @@ class CheckDAO:
 
                 cloud_data = cloud_client.get_check(org_id, project_id, session_id, str(check_id))
                 return self._cloud_to_check(cloud_data)
+            except RecceCloudException:
+                raise
             except Exception as e:
                 logger.error(f"Failed to get check {check_id} from cloud: {e}")
                 return None
@@ -401,6 +403,8 @@ class CheckDAO:
 
                 cloud_checks = cloud_client.list_checks(org_id, project_id, session_id)
                 return [self._cloud_to_check(check_data) for check_data in cloud_checks]
+            except RecceCloudException:
+                raise
             except AttributeError as e:
                 logger.error(f"Attribute error while listing checks from cloud: {e}")
                 return []

--- a/recce/models/check.py
+++ b/recce/models/check.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 from uuid import UUID
 
 from recce.exceptions import RecceException
+from recce.util.recce_cloud import RecceCloudException
 
 from .types import Check, RunType
 
@@ -246,6 +247,8 @@ class CheckDAO:
 
                 logger.debug(f"Created check {new_check.check_id} in cloud and local state")
                 return new_check
+            except RecceCloudException:
+                raise
             except Exception as e:
                 logger.error(f"Failed to create check in cloud: {e}")
                 raise RecceException(f"Failed to create check in Recce Cloud: {e}")
@@ -321,6 +324,8 @@ class CheckDAO:
 
                 logger.debug(f"Updated check {check_id} in cloud")
                 return self._cloud_to_check(cloud_data)
+            except RecceCloudException:
+                raise
             except Exception as e:
                 logger.error(f"Failed to update check {check_id} in cloud: {e}")
                 return None
@@ -365,6 +370,8 @@ class CheckDAO:
                 cloud_client.delete_check(org_id, project_id, session_id, str(check_id))
                 logger.debug(f"Deleted check {check_id} from cloud")
                 return True
+            except RecceCloudException:
+                raise
             except Exception as e:
                 logger.error(f"Failed to delete check {check_id} from cloud: {e}")
                 return False
@@ -492,6 +499,8 @@ class CheckDAO:
             cloud_client.create_preset_check(org_id, project_id, preset_data)
 
             logger.debug(f"Created preset check from check {check_id}")
+        except RecceCloudException:
+            raise
         except Exception as e:
             logger.error(f"Failed to mark check {check_id} as preset: {e}")
             raise RecceException(f"Failed to create preset check: {e}")

--- a/tests/apis/test_check_api.py
+++ b/tests/apis/test_check_api.py
@@ -256,6 +256,7 @@ class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
             run_async(create_check(check_in, background_tasks))
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot create checks", ctx.exception.detail)
 
     @patch("recce.apis.check_api.export_persistent_state")
     @patch("recce.apis.check_api.CheckDAO")
@@ -274,6 +275,7 @@ class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
             run_async(update_check_handler(uuid4(), patch_in, background_tasks))
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot update checks", ctx.exception.detail)
 
     @patch("recce.apis.check_api.export_persistent_state")
     @patch("recce.apis.check_api.CheckDAO")
@@ -291,6 +293,7 @@ class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
             run_async(delete_handler(uuid4(), background_tasks))
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot delete checks", ctx.exception.detail)
 
     @patch("recce.apis.check_api.export_persistent_state")
     @patch("recce.apis.check_api.CheckDAO")
@@ -308,6 +311,7 @@ class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
             run_async(mark_as_preset_check_handler(uuid4(), background_tasks))
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot create presets", ctx.exception.detail)
 
     @patch("recce.apis.check_api.CheckDAO")
     def test_get_check_returns_403_on_cloud_forbidden(self, mock_dao_cls):
@@ -322,6 +326,7 @@ class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
             run_async(get_check_handler(uuid4()))
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot access check", ctx.exception.detail)
 
     @patch("recce.apis.check_api.CheckDAO")
     def test_list_checks_returns_403_on_cloud_forbidden(self, mock_dao_cls):
@@ -336,6 +341,7 @@ class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
             run_async(list_checks_handler())
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot list checks", ctx.exception.detail)
 
     @patch("recce.apis.check_api.CheckDAO")
     def test_run_check_returns_403_on_cloud_forbidden(self, mock_dao_cls):
@@ -352,3 +358,4 @@ class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
             run_async(run_check_handler(uuid4(), run_in))
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot access check", ctx.exception.detail)

--- a/tests/apis/test_check_api.py
+++ b/tests/apis/test_check_api.py
@@ -11,10 +11,24 @@ from uuid import uuid4
 
 from recce.apis.check_api import (
     CheckOut,
+    CreateCheckIn,
+    PatchCheckIn,
     _get_latest_artifact_time,
     _is_check_outdated,
+    create_check,
+    delete_handler,
+    mark_as_preset_check_handler,
+    update_check_handler,
 )
 from recce.models.types import Check, Run, RunType
+from recce.util.recce_cloud import RecceCloudException
+
+
+def run_async(coro):
+    """Helper to run async functions in sync tests."""
+    import asyncio
+
+    return asyncio.get_event_loop().run_until_complete(coro)
 
 
 def _make_run(run_at: str = "2026-03-20T10:00:00Z") -> Run:
@@ -205,3 +219,94 @@ class TestCheckOutFromCheck(unittest.TestCase):
         self.assertTrue(out.is_checked)
         self.assertTrue(out.is_preset)
         self.assertEqual(out.check_id, check.check_id)
+
+
+class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
+    """Tests that check API endpoints pass through RecceCloudException status codes.
+
+    DRC-3200: When Recce Cloud returns 403 (or any error), the OSS proxy
+    must return that same status code to the browser, not 500.
+    """
+
+    @patch("recce.apis.check_func.get_current_cloud_user")
+    @patch("recce.apis.check_func.CheckDAO")
+    def test_create_check_returns_403_on_cloud_forbidden(self, mock_dao_cls, mock_get_cloud_user):
+        """POST /checks should return 403 when cloud API returns 403."""
+        mock_get_cloud_user.return_value = None
+        mock_dao_instance = MagicMock()
+        mock_dao_instance.create.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot create checks", status_code=403
+        )
+        mock_dao_cls.return_value = mock_dao_instance
+
+        check_in = CreateCheckIn(
+            name="Test Check",
+            type=RunType.SCHEMA_DIFF,
+            params={"node_id": "model.test.users"},
+        )
+        background_tasks = MagicMock()
+
+        from fastapi import HTTPException
+
+        with self.assertRaises(HTTPException) as ctx:
+            run_async(create_check(check_in, background_tasks))
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    @patch("recce.apis.check_api.export_persistent_state")
+    @patch("recce.apis.check_api.CheckDAO")
+    def test_update_check_returns_403_on_cloud_forbidden(self, mock_dao_cls, mock_export):
+        """PATCH /checks/{id} should return 403 when cloud API returns 403."""
+        mock_dao_instance = MagicMock()
+        mock_dao_instance.update_check_by_id.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot update checks", status_code=403
+        )
+        mock_dao_cls.return_value = mock_dao_instance
+
+        patch_in = PatchCheckIn(name="Updated")
+        background_tasks = MagicMock()
+
+        from fastapi import HTTPException
+
+        with self.assertRaises(HTTPException) as ctx:
+            run_async(update_check_handler(uuid4(), patch_in, background_tasks))
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    @patch("recce.apis.check_api.export_persistent_state")
+    @patch("recce.apis.check_api.CheckDAO")
+    def test_delete_check_returns_403_on_cloud_forbidden(self, mock_dao_cls, mock_export):
+        """DELETE /checks/{id} should return 403 when cloud API returns 403."""
+        mock_dao_instance = MagicMock()
+        mock_dao_instance.delete.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot delete checks", status_code=403
+        )
+        mock_dao_cls.return_value = mock_dao_instance
+
+        background_tasks = MagicMock()
+
+        from fastapi import HTTPException
+
+        with self.assertRaises(HTTPException) as ctx:
+            run_async(delete_handler(uuid4(), background_tasks))
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    @patch("recce.apis.check_api.export_persistent_state")
+    @patch("recce.apis.check_api.CheckDAO")
+    def test_mark_as_preset_returns_403_on_cloud_forbidden(self, mock_dao_cls, mock_export):
+        """POST /checks/{id}/mark-as-preset should return 403 when cloud API returns 403."""
+        mock_dao_instance = MagicMock()
+        mock_dao_instance.mark_as_preset_check.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot create presets", status_code=403
+        )
+        mock_dao_cls.return_value = mock_dao_instance
+
+        background_tasks = MagicMock()
+
+        from fastapi import HTTPException
+
+        with self.assertRaises(HTTPException) as ctx:
+            run_async(mark_as_preset_check_handler(uuid4(), background_tasks))
+
+        self.assertEqual(ctx.exception.status_code, 403)

--- a/tests/apis/test_check_api.py
+++ b/tests/apis/test_check_api.py
@@ -9,15 +9,21 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+from fastapi import HTTPException
+
 from recce.apis.check_api import (
     CheckOut,
     CreateCheckIn,
     PatchCheckIn,
+    RunCheckIn,
     _get_latest_artifact_time,
     _is_check_outdated,
     create_check,
     delete_handler,
+    get_check_handler,
+    list_checks_handler,
     mark_as_preset_check_handler,
+    run_check_handler,
     update_check_handler,
 )
 from recce.models.types import Check, Run, RunType
@@ -246,8 +252,6 @@ class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
         )
         background_tasks = MagicMock()
 
-        from fastapi import HTTPException
-
         with self.assertRaises(HTTPException) as ctx:
             run_async(create_check(check_in, background_tasks))
 
@@ -266,8 +270,6 @@ class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
         patch_in = PatchCheckIn(name="Updated")
         background_tasks = MagicMock()
 
-        from fastapi import HTTPException
-
         with self.assertRaises(HTTPException) as ctx:
             run_async(update_check_handler(uuid4(), patch_in, background_tasks))
 
@@ -284,8 +286,6 @@ class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
         mock_dao_cls.return_value = mock_dao_instance
 
         background_tasks = MagicMock()
-
-        from fastapi import HTTPException
 
         with self.assertRaises(HTTPException) as ctx:
             run_async(delete_handler(uuid4(), background_tasks))
@@ -304,9 +304,51 @@ class TestCheckApiCloudExceptionPassthrough(unittest.TestCase):
 
         background_tasks = MagicMock()
 
-        from fastapi import HTTPException
-
         with self.assertRaises(HTTPException) as ctx:
             run_async(mark_as_preset_check_handler(uuid4(), background_tasks))
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    @patch("recce.apis.check_api.CheckDAO")
+    def test_get_check_returns_403_on_cloud_forbidden(self, mock_dao_cls):
+        """GET /checks/{id} should return 403 when cloud API returns 403."""
+        mock_dao_instance = MagicMock()
+        mock_dao_instance.find_check_by_id.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot access check", status_code=403
+        )
+        mock_dao_cls.return_value = mock_dao_instance
+
+        with self.assertRaises(HTTPException) as ctx:
+            run_async(get_check_handler(uuid4()))
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    @patch("recce.apis.check_api.CheckDAO")
+    def test_list_checks_returns_403_on_cloud_forbidden(self, mock_dao_cls):
+        """GET /checks should return 403 when cloud API returns 403."""
+        mock_dao_instance = MagicMock()
+        mock_dao_instance.list.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot list checks", status_code=403
+        )
+        mock_dao_cls.return_value = mock_dao_instance
+
+        with self.assertRaises(HTTPException) as ctx:
+            run_async(list_checks_handler())
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    @patch("recce.apis.check_api.CheckDAO")
+    def test_run_check_returns_403_on_cloud_forbidden(self, mock_dao_cls):
+        """POST /checks/{id}/run should return 403 when cloud API returns 403 on find."""
+        mock_dao_instance = MagicMock()
+        mock_dao_instance.find_check_by_id.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot access check", status_code=403
+        )
+        mock_dao_cls.return_value = mock_dao_instance
+
+        run_in = RunCheckIn(nowait=True)
+
+        with self.assertRaises(HTTPException) as ctx:
+            run_async(run_check_handler(uuid4(), run_in))
 
         self.assertEqual(ctx.exception.status_code, 403)

--- a/tests/models/test_check.py
+++ b/tests/models/test_check.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from recce.exceptions import RecceException
 from recce.models.check import CheckDAO
 from recce.models.types import Check, RunType
+from recce.util.recce_cloud import RecceCloudException
 
 
 class TestCheckDAOLocalMode(unittest.TestCase):
@@ -725,6 +726,120 @@ class TestCheckDAODataTransformation(unittest.TestCase):
         self.assertFalse(check.is_preset)
         self.assertIsNotNone(check.created_at)
         self.assertIsNotNone(check.updated_at)
+
+
+class TestCheckDAOCloudExceptionPassthrough(unittest.TestCase):
+    """Tests that RecceCloudException propagates through CheckDAO methods.
+
+    DRC-3200: The DAO layer must not swallow RecceCloudException inside
+    a generic 'except Exception' — it must re-raise so the API layer
+    can map the HTTP status code to the response.
+    """
+
+    def _make_cloud_dao(self, mock_default_context, mock_recce_cloud_class):
+        """Helper to set up a cloud-mode DAO with mocked cloud client."""
+        mock_loader = Mock()
+        mock_loader.session_id = "test-session-123"
+        mock_loader.org_id = "org-456"
+        mock_loader.project_id = "proj-789"
+
+        mock_context = Mock()
+        mock_context.state_loader = mock_loader
+        mock_context.checks = []
+        mock_default_context.return_value = mock_context
+
+        mock_cloud_client = Mock()
+        mock_recce_cloud = Mock()
+        mock_recce_cloud.checks = mock_cloud_client
+        mock_recce_cloud_class.return_value = mock_recce_cloud
+
+        return CheckDAO(), mock_cloud_client
+
+    @patch("recce.util.recce_cloud.RecceCloud")
+    @patch("recce.event.get_recce_api_token", return_value="test-token")
+    @patch("recce.core.default_context")
+    def test_create_reraises_cloud_403(self, mock_default_context, mock_get_token, mock_recce_cloud_class):
+        """Test that create() re-raises RecceCloudException (e.g. 403 Forbidden)."""
+        dao, mock_cloud_client = self._make_cloud_dao(mock_default_context, mock_recce_cloud_class)
+        mock_cloud_client.create_check.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot create checks", status_code=403
+        )
+
+        sample_check = Check(name="Test", type=RunType.SCHEMA_DIFF, params={})
+
+        with self.assertRaises(RecceCloudException) as ctx:
+            dao.create(sample_check)
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    @patch("recce.util.recce_cloud.RecceCloud")
+    @patch("recce.event.get_recce_api_token", return_value="test-token")
+    @patch("recce.core.default_context")
+    def test_update_reraises_cloud_403(self, mock_default_context, mock_get_token, mock_recce_cloud_class):
+        """Test that update_check_by_id() re-raises RecceCloudException."""
+        dao, mock_cloud_client = self._make_cloud_dao(mock_default_context, mock_recce_cloud_class)
+        mock_cloud_client.update_check.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot update checks", status_code=403
+        )
+
+        from recce.apis.check_api import PatchCheckIn
+
+        patch = PatchCheckIn(name="Updated")
+
+        with self.assertRaises(RecceCloudException) as ctx:
+            dao.update_check_by_id(uuid4(), patch)
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    @patch("recce.util.recce_cloud.RecceCloud")
+    @patch("recce.event.get_recce_api_token", return_value="test-token")
+    @patch("recce.core.default_context")
+    def test_delete_reraises_cloud_403(self, mock_default_context, mock_get_token, mock_recce_cloud_class):
+        """Test that delete() re-raises RecceCloudException."""
+        dao, mock_cloud_client = self._make_cloud_dao(mock_default_context, mock_recce_cloud_class)
+        mock_cloud_client.delete_check.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot delete checks", status_code=403
+        )
+
+        with self.assertRaises(RecceCloudException) as ctx:
+            dao.delete(uuid4())
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    @patch("recce.util.recce_cloud.RecceCloud")
+    @patch("recce.event.get_recce_api_token", return_value="test-token")
+    @patch("recce.core.default_context")
+    def test_mark_as_preset_reraises_cloud_403(self, mock_default_context, mock_get_token, mock_recce_cloud_class):
+        """Test that mark_as_preset_check() re-raises RecceCloudException."""
+        dao, mock_cloud_client = self._make_cloud_dao(mock_default_context, mock_recce_cloud_class)
+
+        # mark_as_preset_check calls find_check_by_id first, so mock that too
+        check_id = uuid4()
+        session_id = uuid4()
+        cloud_check_data = {
+            "id": str(check_id),
+            "session_id": str(session_id),
+            "name": "Test",
+            "description": "",
+            "type": "schema_diff",
+            "params": {},
+            "view_options": {},
+            "is_checked": False,
+            "is_preset": False,
+            "created_by": {"email": "test@test.com"},
+            "updated_by": {"email": "test@test.com"},
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        mock_cloud_client.get_check.return_value = cloud_check_data
+        mock_cloud_client.create_preset_check.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot create presets", status_code=403
+        )
+
+        with self.assertRaises(RecceCloudException) as ctx:
+            dao.mark_as_preset_check(check_id)
+
+        self.assertEqual(ctx.exception.status_code, 403)
 
 
 if __name__ == "__main__":

--- a/tests/models/test_check.py
+++ b/tests/models/test_check.py
@@ -771,6 +771,7 @@ class TestCheckDAOCloudExceptionPassthrough(unittest.TestCase):
             dao.create(sample_check)
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot create checks", ctx.exception.reason)
 
     @patch("recce.util.recce_cloud.RecceCloud")
     @patch("recce.event.get_recce_api_token", return_value="test-token")
@@ -790,6 +791,7 @@ class TestCheckDAOCloudExceptionPassthrough(unittest.TestCase):
             dao.update_check_by_id(uuid4(), patch)
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot update checks", ctx.exception.reason)
 
     @patch("recce.util.recce_cloud.RecceCloud")
     @patch("recce.event.get_recce_api_token", return_value="test-token")
@@ -805,6 +807,7 @@ class TestCheckDAOCloudExceptionPassthrough(unittest.TestCase):
             dao.delete(uuid4())
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot delete checks", ctx.exception.reason)
 
     @patch("recce.util.recce_cloud.RecceCloud")
     @patch("recce.event.get_recce_api_token", return_value="test-token")
@@ -840,6 +843,7 @@ class TestCheckDAOCloudExceptionPassthrough(unittest.TestCase):
             dao.mark_as_preset_check(check_id)
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot create presets", ctx.exception.reason)
 
     @patch("recce.util.recce_cloud.RecceCloud")
     @patch("recce.event.get_recce_api_token", return_value="test-token")
@@ -855,6 +859,7 @@ class TestCheckDAOCloudExceptionPassthrough(unittest.TestCase):
             dao.find_check_by_id(uuid4())
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot access check", ctx.exception.reason)
 
     @patch("recce.util.recce_cloud.RecceCloud")
     @patch("recce.event.get_recce_api_token", return_value="test-token")
@@ -870,6 +875,7 @@ class TestCheckDAOCloudExceptionPassthrough(unittest.TestCase):
             dao.list()
 
         self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("Viewer cannot list checks", ctx.exception.reason)
 
 
 if __name__ == "__main__":

--- a/tests/models/test_check.py
+++ b/tests/models/test_check.py
@@ -841,6 +841,36 @@ class TestCheckDAOCloudExceptionPassthrough(unittest.TestCase):
 
         self.assertEqual(ctx.exception.status_code, 403)
 
+    @patch("recce.util.recce_cloud.RecceCloud")
+    @patch("recce.event.get_recce_api_token", return_value="test-token")
+    @patch("recce.core.default_context")
+    def test_find_check_by_id_reraises_cloud_403(self, mock_default_context, mock_get_token, mock_recce_cloud_class):
+        """Test that find_check_by_id() re-raises RecceCloudException."""
+        dao, mock_cloud_client = self._make_cloud_dao(mock_default_context, mock_recce_cloud_class)
+        mock_cloud_client.get_check.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot access check", status_code=403
+        )
+
+        with self.assertRaises(RecceCloudException) as ctx:
+            dao.find_check_by_id(uuid4())
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    @patch("recce.util.recce_cloud.RecceCloud")
+    @patch("recce.event.get_recce_api_token", return_value="test-token")
+    @patch("recce.core.default_context")
+    def test_list_reraises_cloud_403(self, mock_default_context, mock_get_token, mock_recce_cloud_class):
+        """Test that list() re-raises RecceCloudException."""
+        dao, mock_cloud_client = self._make_cloud_dao(mock_default_context, mock_recce_cloud_class)
+        mock_cloud_client.list_checks.side_effect = RecceCloudException(
+            message="Forbidden", reason="Viewer cannot list checks", status_code=403
+        )
+
+        with self.assertRaises(RecceCloudException) as ctx:
+            dao.list()
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

Fixes the OSS proxy swallowing HTTP status codes from Recce Cloud API responses. When Cloud returns 403 Forbidden (e.g., a viewer trying to create a check), the proxy was converting it to 500 Internal Server Error.

**Root cause:** Two layers of broken exception handling:
1. All CheckDAO cloud methods caught RecceCloudException in generic `except Exception` blocks, losing the status code
2. check_api.py endpoints had no handler for RecceCloudException

**Fix (3 commits):**

**Commit 1 — Initial fix:**
- DAO layer: Added `except RecceCloudException: raise` before `except Exception` in `create`, `update_check_by_id`, `delete`, and `mark_as_preset_check`
- API layer: Added RecceCloudException handlers to `create_check`, `update_check_handler`, `delete_handler`, `mark_as_preset_check_handler`

**Commit 2 — Review round 1 findings:**
- DAO layer: Extended to `find_check_by_id` and `list` which also swallowed RecceCloudException
- API layer: Added handlers to `get_check_handler`, `list_checks_handler`, and `run_check_handler`
- Logging: Added `_log_cloud_exception` helper with graduated severity (WARNING for 4xx, ERROR for 5xx)

**Commit 3 — Review round 2 findings:**
- Extracted `log_cloud_exception` into shared `recce/apis/cloud_utils.py` module, removing duplication between `check_api.py` and `check_events_api.py`
- Added `detail`/`reason` message assertions to all 13 cloud exception tests to catch detail-dropping regressions
- Investigated all other CheckDAO consumers (mcp_server.py, state/cloud.py, event/__init__.py, summary.py, run.py, check_func.py) — created follow-up ticket DRC-3202 for remaining gaps outside this PR scope

**Which issue(s) this PR fixes**:

Closes DRC-3200

**Special notes for your reviewer**:

- 13 regression tests total: 6 DAO-level + 7 API-level, all asserting both status code AND detail message
- All 88 check-related tests pass, flake8 clean
- Follows and consolidates the pattern from `check_events_api.py`
- Unblocks DRC-3201 (frontend error display for viewers)
- Follow-up DRC-3202 tracks remaining CheckDAO consumers that need exception handling (mcp_server.py, state/cloud.py, etc.)

**Does this PR introduce a user-facing change?**:

Cloud users will now see proper HTTP error codes (e.g., 403 Forbidden) instead of generic 500 errors when performing check operations they dont have permission for. This also enables the frontend to display meaningful error messages (DRC-3201).

Generated with [Claude Code](https://claude.com/claude-code)