### PR TITLE
feat: viewer role gating and error handling for check creation

### DIFF
--- a/js/packages/ui/src/api/instanceInfo.ts
+++ b/js/packages/ui/src/api/instanceInfo.ts
@@ -25,6 +25,7 @@ export interface RecceInstanceInfo {
   organization_name?: string;
   web_url?: string;
   python_version?: string;
+  user_role?: string;
 }
 
 /**

--- a/js/packages/ui/src/components/lineage/__tests__/SetupConnectionBanner.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/SetupConnectionBanner.test.tsx
@@ -19,6 +19,7 @@ describe("SetupConnectionBanner", () => {
     disableViewActionDropdown: false,
     disableNodeActionDropdown: false,
     disableShare: false,
+    checklistPermissionDenied: false,
   };
 
   const defaultProps: SetupConnectionBannerProps = {

--- a/js/packages/ui/src/components/lineage/topbar/LineageViewTopBar.tsx
+++ b/js/packages/ui/src/components/lineage/topbar/LineageViewTopBar.tsx
@@ -796,6 +796,8 @@ export const LineageViewTopBar = ({
                         <MenuItem
                           disabled={featureToggles.checklistPermissionDenied}
                           onClick={() => {
+                            if (featureToggles.checklistPermissionDenied)
+                              return;
                             onAddLineageDiffCheck?.(viewOptions.view_mode);
                             handleActionsClose();
                           }}
@@ -819,6 +821,8 @@ export const LineageViewTopBar = ({
                         <MenuItem
                           disabled={featureToggles.checklistPermissionDenied}
                           onClick={() => {
+                            if (featureToggles.checklistPermissionDenied)
+                              return;
                             onAddSchemaDiffCheck?.();
                             handleActionsClose();
                           }}

--- a/js/packages/ui/src/components/lineage/topbar/LineageViewTopBar.tsx
+++ b/js/packages/ui/src/components/lineage/topbar/LineageViewTopBar.tsx
@@ -775,35 +775,63 @@ export const LineageViewTopBar = ({
                   </MenuItem>
                 </SetupConnectionPopoverSlot>
 
-                <Divider />
-
-                <ListSubheader
-                  sx={{ lineHeight: "32px", bgcolor: "transparent" }}
-                >
-                  Add to Checklist
-                </ListSubheader>
-                <MenuItem
-                  onClick={() => {
-                    onAddLineageDiffCheck?.(viewOptions.view_mode);
-                    handleActionsClose();
-                  }}
-                >
-                  <ListItemIcon>
-                    <LineageDiffIcon fontSize="small" />
-                  </ListItemIcon>
-                  <ListItemText>Lineage Diff</ListItemText>
-                </MenuItem>
-                <MenuItem
-                  onClick={() => {
-                    onAddSchemaDiffCheck?.();
-                    handleActionsClose();
-                  }}
-                >
-                  <ListItemIcon>
-                    <SchemaDiffIcon fontSize="small" />
-                  </ListItemIcon>
-                  <ListItemText>Schema Diff</ListItemText>
-                </MenuItem>
+                {!featureToggles.disableUpdateChecklist ||
+                featureToggles.checklistPermissionDenied ? (
+                  <>
+                    <Divider />
+                    <ListSubheader
+                      sx={{ lineHeight: "32px", bgcolor: "transparent" }}
+                    >
+                      Add to Checklist
+                    </ListSubheader>
+                    <MuiTooltip
+                      title={
+                        featureToggles.checklistPermissionDenied
+                          ? "You don't have permission to add checks"
+                          : ""
+                      }
+                      placement="left"
+                    >
+                      <span>
+                        <MenuItem
+                          disabled={featureToggles.checklistPermissionDenied}
+                          onClick={() => {
+                            onAddLineageDiffCheck?.(viewOptions.view_mode);
+                            handleActionsClose();
+                          }}
+                        >
+                          <ListItemIcon>
+                            <LineageDiffIcon fontSize="small" />
+                          </ListItemIcon>
+                          <ListItemText>Lineage Diff</ListItemText>
+                        </MenuItem>
+                      </span>
+                    </MuiTooltip>
+                    <MuiTooltip
+                      title={
+                        featureToggles.checklistPermissionDenied
+                          ? "You don't have permission to add checks"
+                          : ""
+                      }
+                      placement="left"
+                    >
+                      <span>
+                        <MenuItem
+                          disabled={featureToggles.checklistPermissionDenied}
+                          onClick={() => {
+                            onAddSchemaDiffCheck?.();
+                            handleActionsClose();
+                          }}
+                        >
+                          <ListItemIcon>
+                            <SchemaDiffIcon fontSize="small" />
+                          </ListItemIcon>
+                          <ListItemText>Schema Diff</ListItemText>
+                        </MenuItem>
+                      </span>
+                    </MuiTooltip>
+                  </>
+                ) : null}
               </Menu>
             </Box>
           </ControlItem>

--- a/js/packages/ui/src/components/run/RunList.tsx
+++ b/js/packages/ui/src/components/run/RunList.tsx
@@ -53,6 +53,8 @@ export interface RunListItemProps {
   goToCheckIcon?: ReactNode;
   /** Hide add to checklist action */
   hideAddToChecklist?: boolean;
+  /** Disable add to checklist due to insufficient permissions — shows disabled icon with tooltip */
+  disableAddToChecklist?: boolean;
   /** Optional CSS class */
   className?: string;
 }
@@ -83,12 +85,15 @@ function RunListItemComponent({
   addToChecklistIcon,
   goToCheckIcon,
   hideAddToChecklist = false,
+  disableAddToChecklist = false,
   className,
 }: RunListItemProps) {
   const isDark = useIsDark();
   const hasCheckLink = run.checkId != null;
   const showAddToChecklist =
-    !hideAddToChecklist && !hasCheckLink && onAddToChecklist;
+    !hideAddToChecklist &&
+    !hasCheckLink &&
+    (onAddToChecklist || disableAddToChecklist);
 
   return (
     <Box
@@ -162,21 +167,30 @@ function RunListItemComponent({
           </Tooltip>
         )}
         {showAddToChecklist && (
-          <Tooltip title="Add to Checklist">
-            <IconButton
-              size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                onAddToChecklist(run.id);
-              }}
-              sx={{ p: 0.5 }}
-            >
-              {addToChecklistIcon || (
-                <Box component="span" sx={{ fontSize: 14 }}>
-                  ○
-                </Box>
-              )}
-            </IconButton>
+          <Tooltip
+            title={
+              disableAddToChecklist
+                ? "You don't have permission to add checks"
+                : "Add to Checklist"
+            }
+          >
+            <span>
+              <IconButton
+                size="small"
+                disabled={disableAddToChecklist}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onAddToChecklist?.(run.id);
+                }}
+                sx={{ p: 0.5 }}
+              >
+                {addToChecklistIcon || (
+                  <Box component="span" sx={{ fontSize: 14 }}>
+                    ○
+                  </Box>
+                )}
+              </IconButton>
+            </span>
           </Tooltip>
         )}
       </Box>
@@ -210,6 +224,8 @@ export interface RunListProps {
   getRunIcon?: (runType: string) => ReactNode;
   /** Hide add to checklist action */
   hideAddToChecklist?: boolean;
+  /** Disable add to checklist due to insufficient permissions — shows disabled icon with tooltip */
+  disableAddToChecklist?: boolean;
   /** List title */
   title?: string;
   /** Header action buttons */
@@ -304,6 +320,7 @@ function RunListComponent({
   onGoToCheck,
   getRunIcon,
   hideAddToChecklist = false,
+  disableAddToChecklist = false,
   title = "Runs",
   headerActions,
   emptyMessage = "No runs",
@@ -350,6 +367,7 @@ function RunListComponent({
             onAddToChecklist={onAddToChecklist}
             onGoToCheck={onGoToCheck}
             hideAddToChecklist={hideAddToChecklist}
+            disableAddToChecklist={disableAddToChecklist}
             addToChecklistIcon={addToChecklistIcon}
             goToCheckIcon={goToCheckIcon}
           />

--- a/js/packages/ui/src/components/run/RunListOss.tsx
+++ b/js/packages/ui/src/components/run/RunListOss.tsx
@@ -137,7 +137,11 @@ export function RunListOss() {
       onAddToChecklist={handleAddToChecklist}
       onGoToCheck={handleGoToCheck}
       getRunIcon={getRunIcon}
-      hideAddToChecklist={featureToggles.disableUpdateChecklist}
+      hideAddToChecklist={
+        featureToggles.disableUpdateChecklist &&
+        !featureToggles.checklistPermissionDenied
+      }
+      disableAddToChecklist={featureToggles.checklistPermissionDenied}
       title="History"
       headerActions={headerActions}
       emptyMessage="No runs"

--- a/js/packages/ui/src/components/run/RunResultPane.tsx
+++ b/js/packages/ui/src/components/run/RunResultPane.tsx
@@ -733,7 +733,8 @@ const DefaultAddToCheckButton = memo(
       return null;
     }
 
-    if (checkId && !checklistPermissionDenied) {
+    // "Go to Check" is always available — viewers can navigate to existing checks
+    if (checkId) {
       return (
         <Button
           disabled={disabled}

--- a/js/packages/ui/src/components/run/RunResultPane.tsx
+++ b/js/packages/ui/src/components/run/RunResultPane.tsx
@@ -29,6 +29,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Stack from "@mui/material/Stack";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { formatDistanceToNow } from "date-fns";
 import {
@@ -130,6 +131,8 @@ export interface AddToCheckButtonProps {
   run?: Run;
   /** Whether the button is disabled due to feature toggle */
   disableUpdateChecklist?: boolean;
+  /** Whether the checklist is disabled specifically due to permission denial (viewer role) — shows tooltip */
+  checklistPermissionDenied?: boolean;
   /** Whether there's an error */
   hasError?: boolean;
   /** Handler for navigating to existing check */
@@ -209,6 +212,9 @@ export interface RunResultPaneProps<VO = unknown, RefType = unknown> {
 
   /** Disable update checklist functionality */
   disableUpdateChecklist?: boolean;
+
+  /** Whether checklist is disabled due to permission denial (viewer role) — shows disabled button with tooltip instead of hiding */
+  checklistPermissionDenied?: boolean;
 
   // ============================================================================
   // Event Handlers
@@ -714,6 +720,7 @@ const DefaultAddToCheckButton = memo(
     runId,
     run,
     disableUpdateChecklist,
+    checklistPermissionDenied,
     hasError,
     onGoToCheck,
     onAddToChecklist,
@@ -721,11 +728,12 @@ const DefaultAddToCheckButton = memo(
     const checkId = run?.check_id;
     const disabled = !runId || !run?.result || hasError;
 
-    if (disableUpdateChecklist) {
+    // Hide entirely when disabled for non-permission reasons (single_env, read-only)
+    if (disableUpdateChecklist && !checklistPermissionDenied) {
       return null;
     }
 
-    if (checkId) {
+    if (checkId && !checklistPermissionDenied) {
       return (
         <Button
           disabled={disabled}
@@ -741,16 +749,26 @@ const DefaultAddToCheckButton = memo(
     }
 
     return (
-      <Button
-        disabled={disabled}
-        size="small"
-        variant="contained"
-        onClick={onAddToChecklist}
-        startIcon={<PiCheck />}
-        sx={{ textTransform: "none" }}
+      <Tooltip
+        title={
+          checklistPermissionDenied
+            ? "You don't have permission to add checks"
+            : ""
+        }
       >
-        Add to Checklist
-      </Button>
+        <span>
+          <Button
+            disabled={disabled || checklistPermissionDenied}
+            size="small"
+            variant="contained"
+            onClick={onAddToChecklist}
+            startIcon={<PiCheck />}
+            sx={{ textTransform: "none" }}
+          >
+            Add to Checklist
+          </Button>
+        </span>
+      </Tooltip>
     );
   },
 );
@@ -856,6 +874,7 @@ function RunResultPaneComponent<VO = unknown, RefType = unknown>({
   disableDatabaseQuery,
   disableShare,
   disableUpdateChecklist,
+  checklistPermissionDenied,
 
   // Event handlers
   onClose,
@@ -1010,6 +1029,7 @@ function RunResultPaneComponent<VO = unknown, RefType = unknown>({
             runId={runId}
             run={run}
             disableUpdateChecklist={disableUpdateChecklist}
+            checklistPermissionDenied={checklistPermissionDenied}
             hasError={!!error}
             onGoToCheck={onGoToCheck}
             onAddToChecklist={onAddToChecklist}

--- a/js/packages/ui/src/components/run/RunResultPaneOss.tsx
+++ b/js/packages/ui/src/components/run/RunResultPaneOss.tsx
@@ -41,6 +41,7 @@ import {
   useRun,
 } from "../../hooks";
 import { trackCopyToClipboard, trackShareState } from "../../lib/api/track";
+import { isHttpError } from "../../lib/fetchClient";
 import AuthModal from "../app/AuthModal";
 import { LearnHowLink, RecceNotification } from "../onboarding-guide";
 import { DualSqlEditor, SqlEditor } from "../query";
@@ -225,7 +226,6 @@ export const PrivateLoadableRunView = ({
       await queryClient.invalidateQueries({ queryKey: cacheKeys.checks() });
       router.push(`${basePath}/checks/?id=${check.check_id}`);
     } catch (error) {
-      const { isHttpError } = await import("../../lib/fetchClient");
       if (isHttpError(error) && error.status === 403) {
         toaster.error({
           title: "Permission denied",

--- a/js/packages/ui/src/components/run/RunResultPaneOss.tsx
+++ b/js/packages/ui/src/components/run/RunResultPaneOss.tsx
@@ -44,6 +44,7 @@ import { trackCopyToClipboard, trackShareState } from "../../lib/api/track";
 import AuthModal from "../app/AuthModal";
 import { LearnHowLink, RecceNotification } from "../onboarding-guide";
 import { DualSqlEditor, SqlEditor } from "../query";
+import { toaster } from "../ui/Toaster";
 import { RunResultPane as BaseRunResultPane } from "./RunResultPane";
 import { findByRunType } from "./registry";
 import { RefTypes, RegistryEntry, ViewOptionTypes } from "./types";
@@ -215,13 +216,32 @@ export const PrivateLoadableRunView = ({
     if (!runId) {
       return;
     }
-    const check = await createCheckByRun(
-      runId,
-      viewOptions as Record<string, unknown>,
-      apiClient,
-    );
-    await queryClient.invalidateQueries({ queryKey: cacheKeys.checks() });
-    router.push(`${basePath}/checks/?id=${check.check_id}`);
+    try {
+      const check = await createCheckByRun(
+        runId,
+        viewOptions as Record<string, unknown>,
+        apiClient,
+      );
+      await queryClient.invalidateQueries({ queryKey: cacheKeys.checks() });
+      router.push(`${basePath}/checks/?id=${check.check_id}`);
+    } catch (error) {
+      const { isHttpError } = await import("../../lib/fetchClient");
+      if (isHttpError(error) && error.status === 403) {
+        toaster.error({
+          title: "Permission denied",
+          description:
+            "You don't have permission to add checks. Contact your org admin for access.",
+        });
+      } else {
+        toaster.error({
+          title: "Failed to create check",
+          description:
+            error instanceof Error
+              ? error.message
+              : "An unexpected error occurred",
+        });
+      }
+    }
   }, [runId, viewOptions, apiClient, queryClient, router.push, basePath]);
 
   return (
@@ -239,6 +259,7 @@ export const PrivateLoadableRunView = ({
       disableDatabaseQuery={featureToggles.disableDatabaseQuery}
       disableShare={featureToggles.disableShare}
       disableUpdateChecklist={featureToggles.disableUpdateChecklist}
+      checklistPermissionDenied={featureToggles.checklistPermissionDenied}
       // Event handlers
       onClose={onClose}
       onCancel={onCancel}

--- a/js/packages/ui/src/contexts/instance/RecceInstanceContext.tsx
+++ b/js/packages/ui/src/contexts/instance/RecceInstanceContext.tsx
@@ -104,8 +104,12 @@ export function RecceInstanceInfoProvider({
       toggles.disableShare = true;
     }
     if (instanceInfo.user_role === "viewer") {
+      // Only show permission-denied tooltip when checklist isn't already disabled
+      // by mode (read-only) or env (single_env) — in those cases, hide entirely
+      if (!toggles.disableUpdateChecklist) {
+        toggles.checklistPermissionDenied = true;
+      }
       toggles.disableUpdateChecklist = true;
-      toggles.checklistPermissionDenied = true;
     }
     setFeatureToggles(toggles);
   }

--- a/js/packages/ui/src/contexts/instance/RecceInstanceContext.tsx
+++ b/js/packages/ui/src/contexts/instance/RecceInstanceContext.tsx
@@ -103,6 +103,10 @@ export function RecceInstanceInfoProvider({
     if (instanceInfo.cloud_instance) {
       toggles.disableShare = true;
     }
+    if (instanceInfo.user_role === "viewer") {
+      toggles.disableUpdateChecklist = true;
+      toggles.checklistPermissionDenied = true;
+    }
     setFeatureToggles(toggles);
   }
 

--- a/js/packages/ui/src/contexts/instance/__tests__/RecceInstanceContext.test.tsx
+++ b/js/packages/ui/src/contexts/instance/__tests__/RecceInstanceContext.test.tsx
@@ -78,6 +78,9 @@ function TestConsumer() {
       <span data-testid="disable-checklist">
         {String(context.featureToggles.disableUpdateChecklist)}
       </span>
+      <span data-testid="checklist-permission-denied">
+        {String(context.featureToggles.checklistPermissionDenied)}
+      </span>
       <span data-testid="lifetime-expired">
         {context.lifetimeExpiredAt?.toISOString() ?? "none"}
       </span>
@@ -535,6 +538,174 @@ describe("RecceInstanceContext (@datarecce/ui)", () => {
       expect(screen.getByTestId("authed")).toHaveTextContent("true");
       // Cloud instance also disables share (in addition to preview mode)
       expect(screen.getByTestId("disable-share")).toHaveTextContent("true");
+    });
+  });
+
+  describe("viewer role gating", () => {
+    it("sets checklistPermissionDenied for viewer role in normal mode", async () => {
+      const instanceData: RecceInstanceInfo = {
+        server_mode: "server",
+        single_env: false,
+        authed: true,
+        cloud_instance: true,
+        user_role: "viewer",
+      };
+
+      const loadingReturn = createMockReturnValue(undefined, true);
+      const loadedReturn = createMockReturnValue(instanceData, false);
+      mockUseRecceInstanceInfo.mockReturnValue(loadingReturn);
+
+      const queryClient = createTestQueryClient();
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <RecceInstanceInfoProvider>
+            <TestConsumer />
+          </RecceInstanceInfoProvider>
+        </QueryClientProvider>,
+      );
+
+      mockUseRecceInstanceInfo.mockReturnValue(loadedReturn);
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <RecceInstanceInfoProvider>
+            <TestConsumer />
+          </RecceInstanceInfoProvider>
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("disable-checklist")).toHaveTextContent(
+          "true",
+        );
+      });
+      expect(
+        screen.getByTestId("checklist-permission-denied"),
+      ).toHaveTextContent("true");
+    });
+
+    it("does not set checklistPermissionDenied for viewer in read-only mode", async () => {
+      const instanceData: RecceInstanceInfo = {
+        server_mode: "read-only",
+        single_env: false,
+        authed: true,
+        cloud_instance: false,
+        user_role: "viewer",
+      };
+
+      const loadingReturn = createMockReturnValue(undefined, true);
+      const loadedReturn = createMockReturnValue(instanceData, false);
+      mockUseRecceInstanceInfo.mockReturnValue(loadingReturn);
+
+      const queryClient = createTestQueryClient();
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <RecceInstanceInfoProvider>
+            <TestConsumer />
+          </RecceInstanceInfoProvider>
+        </QueryClientProvider>,
+      );
+
+      mockUseRecceInstanceInfo.mockReturnValue(loadedReturn);
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <RecceInstanceInfoProvider>
+            <TestConsumer />
+          </RecceInstanceInfoProvider>
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("disable-checklist")).toHaveTextContent(
+          "true",
+        );
+      });
+      // read-only takes precedence — hide entirely, no permission tooltip
+      expect(
+        screen.getByTestId("checklist-permission-denied"),
+      ).toHaveTextContent("false");
+    });
+
+    it("does not set checklistPermissionDenied for viewer in single_env mode", async () => {
+      const instanceData: RecceInstanceInfo = {
+        server_mode: "server",
+        single_env: true,
+        authed: true,
+        cloud_instance: false,
+        user_role: "viewer",
+      };
+
+      const loadingReturn = createMockReturnValue(undefined, true);
+      const loadedReturn = createMockReturnValue(instanceData, false);
+      mockUseRecceInstanceInfo.mockReturnValue(loadingReturn);
+
+      const queryClient = createTestQueryClient();
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <RecceInstanceInfoProvider>
+            <TestConsumer />
+          </RecceInstanceInfoProvider>
+        </QueryClientProvider>,
+      );
+
+      mockUseRecceInstanceInfo.mockReturnValue(loadedReturn);
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <RecceInstanceInfoProvider>
+            <TestConsumer />
+          </RecceInstanceInfoProvider>
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("disable-checklist")).toHaveTextContent(
+          "true",
+        );
+      });
+      // single_env takes precedence — hide entirely, no permission tooltip
+      expect(
+        screen.getByTestId("checklist-permission-denied"),
+      ).toHaveTextContent("false");
+    });
+
+    it("does not set checklistPermissionDenied for non-viewer roles", async () => {
+      const instanceData: RecceInstanceInfo = {
+        server_mode: "server",
+        single_env: false,
+        authed: true,
+        cloud_instance: true,
+        user_role: "member",
+      };
+
+      const loadingReturn = createMockReturnValue(undefined, true);
+      const loadedReturn = createMockReturnValue(instanceData, false);
+      mockUseRecceInstanceInfo.mockReturnValue(loadingReturn);
+
+      const queryClient = createTestQueryClient();
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <RecceInstanceInfoProvider>
+            <TestConsumer />
+          </RecceInstanceInfoProvider>
+        </QueryClientProvider>,
+      );
+
+      mockUseRecceInstanceInfo.mockReturnValue(loadedReturn);
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <RecceInstanceInfoProvider>
+            <TestConsumer />
+          </RecceInstanceInfoProvider>
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("disable-checklist")).toHaveTextContent(
+          "false",
+        );
+      });
+      expect(
+        screen.getByTestId("checklist-permission-denied"),
+      ).toHaveTextContent("false");
     });
   });
 });

--- a/js/packages/ui/src/contexts/instance/types.ts
+++ b/js/packages/ui/src/contexts/instance/types.ts
@@ -31,6 +31,8 @@ export interface RecceFeatureToggles {
   disableNodeActionDropdown: boolean;
   /** Disable share functionality */
   disableShare: boolean;
+  /** Checklist disabled due to insufficient permissions (viewer role) — show disabled button with tooltip instead of hiding */
+  checklistPermissionDenied: boolean;
 }
 
 /**
@@ -67,6 +69,7 @@ export const defaultFeatureToggles: RecceFeatureToggles = {
   disableViewActionDropdown: false,
   disableNodeActionDropdown: false,
   disableShare: false,
+  checklistPermissionDenied: false,
 };
 
 /**

--- a/js/src/components/run/__tests__/RunList.test.tsx
+++ b/js/src/components/run/__tests__/RunList.test.tsx
@@ -90,6 +90,7 @@ vi.mock("@datarecce/ui/components/run/RunList", () => ({
     onGoToCheck,
     getRunIcon,
     hideAddToChecklist,
+    disableAddToChecklist,
     title,
     headerActions,
     emptyMessage,
@@ -107,6 +108,7 @@ vi.mock("@datarecce/ui/components/run/RunList", () => ({
     onGoToCheck?: (checkId: string) => void;
     getRunIcon?: (runType: string) => React.ReactNode;
     hideAddToChecklist?: boolean;
+    disableAddToChecklist?: boolean;
     title?: string;
     headerActions?: React.ReactNode;
     emptyMessage?: string;
@@ -128,6 +130,10 @@ vi.mock("@datarecce/ui/components/run/RunList", () => ({
               typeof run.name === "string" && run.name.trim().length > 0
                 ? run.name
                 : "<no name>";
+            const showAddToChecklist =
+              !hideAddToChecklist &&
+              !run.checkId &&
+              (onAddToChecklist || disableAddToChecklist);
             return (
               <div
                 key={run.id}
@@ -136,8 +142,9 @@ vi.mock("@datarecce/ui/components/run/RunList", () => ({
               >
                 <span>{name}</span>
                 {getRunIcon?.(run.type)}
-                {!hideAddToChecklist && !run.checkId ? (
+                {showAddToChecklist ? (
                   <button
+                    disabled={disableAddToChecklist}
                     onClick={(event) => {
                       event.stopPropagation();
                       onAddToChecklist?.(run.id);
@@ -612,6 +619,28 @@ describe("RunList", () => {
           name: /Add to Checklist/i,
         });
         expect(button).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows disabled add to checklist when checklistPermissionDenied", async () => {
+      const run = createMockRun({ check_id: undefined });
+      mockListRuns.mockResolvedValue([run]);
+
+      mockUseRecceInstanceContext.mockReturnValue({
+        featureToggles: {
+          disableUpdateChecklist: true,
+          checklistPermissionDenied: true,
+        },
+      });
+
+      renderWithQueryClient(<RunListOss />);
+
+      await waitFor(() => {
+        const button = screen.getByRole("button", {
+          name: /Add to Checklist/i,
+        });
+        expect(button).toBeInTheDocument();
+        expect(button).toBeDisabled();
       });
     });
   });

--- a/js/src/components/run/__tests__/RunResultPane.test.tsx
+++ b/js/src/components/run/__tests__/RunResultPane.test.tsx
@@ -253,20 +253,20 @@ function MockRunResultPane({
                   "Share",
                 )),
         ]),
-      // Add to Checklist button
-      // Hide when disabled for non-permission reasons; show disabled with tooltip for permission denial
-      disableUpdateChecklist && !checklistPermissionDenied
-        ? null
-        : checkId && !checklistPermissionDenied
-          ? React.createElement(
-              "button",
-              {
-                key: "go-to-check",
-                disabled: !run?.run_id || !run?.result || !!error,
-                onClick: () => onGoToCheck?.(checkId),
-              },
-              "Go to Check",
-            )
+      // Go to Check — always available (viewers can navigate to existing checks)
+      checkId
+        ? React.createElement(
+            "button",
+            {
+              key: "go-to-check",
+              disabled: !run?.run_id || !run?.result || !!error,
+              onClick: () => onGoToCheck?.(checkId),
+            },
+            "Go to Check",
+          )
+        : // Add to Checklist — hide for non-permission reasons; show disabled for permission denial
+          disableUpdateChecklist && !checklistPermissionDenied
+          ? null
           : React.createElement(
               "button",
               {
@@ -1093,6 +1093,40 @@ describe("RunResultPane", () => {
       });
       expect(addButton).toBeInTheDocument();
       expect(addButton).toBeDisabled();
+    });
+
+    it("shows Go to Check for viewer when run is linked to existing check", () => {
+      hoistedMocks.useRecceInstanceContext.mockReturnValue({
+        featureToggles: {
+          disableUpdateChecklist: true,
+          checklistPermissionDenied: true,
+        },
+      });
+
+      hoistedMocks.useRun.mockReturnValue({
+        error: null,
+        run: {
+          run_id: "test-run-id",
+          type: "query",
+          params: {},
+          result: { data: [] },
+          check_id: "existing-check-123",
+        },
+        onCancel: hoistedMocks.mockOnCancel,
+        isRunning: false,
+      });
+
+      renderWithQueryClient(<RunResultPane />);
+
+      const goToCheckButton = screen.getByRole("button", {
+        name: /Go to Check/i,
+      });
+      expect(goToCheckButton).toBeInTheDocument();
+      expect(goToCheckButton).not.toBeDisabled();
+
+      expect(
+        screen.queryByRole("button", { name: /Add to Checklist/i }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/js/src/components/run/__tests__/RunResultPane.test.tsx
+++ b/js/src/components/run/__tests__/RunResultPane.test.tsx
@@ -109,6 +109,8 @@ function MockRunResultPane({
   const disableShare = featureToggles?.disableShare ?? false;
   const disableUpdateChecklist =
     featureToggles?.disableUpdateChecklist ?? false;
+  const checklistPermissionDenied =
+    featureToggles?.checklistPermissionDenied ?? false;
   const csvExport = { canExportCSV: true };
 
   const isQuery =
@@ -252,8 +254,10 @@ function MockRunResultPane({
                 )),
         ]),
       // Add to Checklist button
-      !disableUpdateChecklist &&
-        (checkId
+      // Hide when disabled for non-permission reasons; show disabled with tooltip for permission denial
+      disableUpdateChecklist && !checklistPermissionDenied
+        ? null
+        : checkId && !checklistPermissionDenied
           ? React.createElement(
               "button",
               {
@@ -267,11 +271,15 @@ function MockRunResultPane({
               "button",
               {
                 key: "add-to-checklist",
-                disabled: !run?.run_id || !run?.result || !!error,
+                disabled:
+                  !run?.run_id ||
+                  !run?.result ||
+                  !!error ||
+                  checklistPermissionDenied,
                 onClick: onAddToChecklist,
               },
               "Add to Checklist",
-            )),
+            ),
       // Close button
       React.createElement(
         "button",
@@ -1068,6 +1076,23 @@ describe("RunResultPane", () => {
       expect(
         screen.queryByRole("button", { name: /Add to Checklist/i }),
       ).not.toBeInTheDocument();
+    });
+
+    it("shows disabled button with tooltip when checklistPermissionDenied", () => {
+      hoistedMocks.useRecceInstanceContext.mockReturnValue({
+        featureToggles: {
+          disableUpdateChecklist: true,
+          checklistPermissionDenied: true,
+        },
+      });
+
+      renderWithQueryClient(<RunResultPane />);
+
+      const addButton = screen.getByRole("button", {
+        name: /Add to Checklist/i,
+      });
+      expect(addButton).toBeInTheDocument();
+      expect(addButton).toBeDisabled();
     });
   });
 

--- a/recce/server.py
+++ b/recce/server.py
@@ -525,6 +525,7 @@ class RecceInstanceInfoOut(BaseModel):
     session_id: Optional[str] = None
     organization_name: Optional[str] = None
     web_url: Optional[str] = None
+    user_role: Optional[str] = None
 
 
 @app.get("/api/instance-info", response_model=RecceInstanceInfoOut, response_model_exclude_none=True)


### PR DESCRIPTION
## Summary
- Adds viewer-role gating for all 4 "Add to Checklist" button locations — viewers see a **disabled button with a tooltip** explaining the permission restriction instead of buttons being hidden
- Adds **error handling** with toast notifications for check creation failures (403 shows specific permission message, other errors show generic message)
- Adds `user_role` field to OSS `RecceInstanceInfoOut` model (returns `None` for standalone OSS, populated by Cloud endpoint via DataRecce/recce-cloud-infra#1170)

## Changes

### Backend (Python)
- `recce/server.py`: Added `user_role: Optional[str]` to `RecceInstanceInfoOut` — always `None` in standalone OSS

### Frontend (TypeScript)
- `instanceInfo.ts`: Added `user_role` to `RecceInstanceInfo` type
- `types.ts`: Added `checklistPermissionDenied` to `RecceFeatureToggles`
- `RecceInstanceContext.tsx`: Sets `disableUpdateChecklist` + `checklistPermissionDenied` when `user_role === 'viewer'`
- `RunResultPane.tsx`: Disabled button with tooltip instead of hidden for permission-denied case
- `RunResultPaneOss.tsx`: Added try/catch with toast error handling, passes `checklistPermissionDenied` prop
- `RunList.tsx`: Added `disableAddToChecklist` prop — shows disabled icon with tooltip
- `RunListOss.tsx`: Passes both `hideAddToChecklist` (mode-based) and `disableAddToChecklist` (permission-based)
- `LineageViewTopBar.tsx`: Conditionally shows Add to Checklist section; disabled menu items with tooltip for viewers

## Depends on
- DataRecce/recce-cloud-infra#1170 (exposes `user_role` from cloud instance-info endpoint)

## Test plan
- [x] TypeScript type check passes (`pnpm type:check`)
- [x] Biome lint passes (`pnpm lint`)
- [x] All 3641 frontend tests pass (`pnpm test`)
- [x] Python format + flake8 passes
- [x] Frontend build succeeds (`pnpm run build`)
- [ ] Manual test: viewer role sees disabled buttons with tooltip in all 4 locations
- [ ] Manual test: check creation failure shows toast with error message
- [ ] CI passes

Refs: DRC-3201

Generated with [Claude Code](https://claude.com/claude-code)