### PR TITLE
fix(ui): export dist/style.css for downstream CSS imports

### DIFF
--- a/js/packages/ui/package.json
+++ b/js/packages/ui/package.json
@@ -60,6 +60,9 @@
     "./styles": {
       "default": "./dist/styles.css"
     },
+    "./dist/style.css": {
+      "default": "./dist/style.css"
+    },
     "./utils": {
       "types": "./dist/utils.d.ts",
       "import": "./dist/utils.js",


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix (package export)

**What this PR does / why we need it**:

Add `./dist/style.css` to the `exports` field in `@datarecce/ui` package.json.

The `tsdown` build extracts component CSS (including schema row highlighting classes like `.row-added`, `.row-removed`, `.row-changed`) to `dist/style.css`, but it was not listed in the exports map. Downstream consumers (recce-cloud) that use `@import "@datarecce/ui/dist/style.css"` fail because Node.js/bundler export enforcement blocks unlisted paths.

Follows the same pattern as `@xyflow/react` which exports `"./dist/style.css": "./dist/style.css"`.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

One-line change to package.json exports field. No code logic changes.

**Does this PR introduce a user-facing change?**:

NONE

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)