### PR TITLE
fix(ui): exclude @fontsource from tsdown externals

### DIFF
--- a/js/packages/ui/package.json
+++ b/js/packages/ui/package.json
@@ -122,11 +122,15 @@
     "*.css"
   ],
   "peerDependencies": {
+    "@fontsource/montserrat": "^5.0.0",
     "@sentry/react": "^10.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@fontsource/montserrat": {
+      "optional": true
+    },
     "@sentry/react": {
       "optional": true
     }

--- a/js/packages/ui/tsdown.config.ts
+++ b/js/packages/ui/tsdown.config.ts
@@ -71,6 +71,11 @@ export default defineConfig({
     // Next.js packages are provided by the consuming application
     /^next\//,
     "next",
+    // Font packages — app-level concern, not bundled in library CSS.
+    // Without this, tsdown collects @font-face declarations into dist/style.css
+    // with relative url() paths to .woff2 files that don't exist in dist/,
+    // breaking downstream Next.js builds that import the CSS.
+    /^@fontsource\//,
     // CodeMirror packages
     /^@codemirror\//,
     // react-markdown and remark/unified ecosystem use Node.js built-ins (vfile uses path, process, url)

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -379,6 +379,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
+      '@fontsource/montserrat':
+        specifier: ^5.0.0
+        version: 5.2.8
       '@hello-pangea/dnd':
         specifier: ^18.0.0
         version: 18.0.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
## Summary

- Adds `@fontsource` to tsdown's `external` list in the UI package build config
- This prevents tsdown from collecting `@fontsource/montserrat/800.css` `@font-face` declarations into `dist/style.css`
- The collected font CSS referenced `./files/montserrat-*.woff2` files that don't exist in `dist/`, breaking downstream Next.js builds (recce-cloud-infra) with "Module not found" errors

## Context

PR #1297 exported `dist/style.css` so recce-cloud-infra could import schema row highlighting CSS. But `dist/style.css` is a tsdown artifact that bundles ALL CSS encountered during compilation — including Montserrat font CSS from `MainLayout.tsx`. The font `@font-face` declarations have relative `url()` paths to `.woff2` files that are never copied to `dist/files/`, causing the downstream build to fail.

The `@fontsource` import in `MainLayout.tsx` is an app-level concern (the consuming app should provide its own fonts). Other app-level CSS packages like `@xyflow/react` are already externalized for the same reason.

## Test plan

- [x] `pnpm build` succeeds
- [x] `dist/style.css` has zero `@font-face` / `montserrat` / `.woff` references
- [x] Schema CSS classes (`row-added`, `row-removed`, `row-changed`, etc.) still present in `dist/style.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
