### PR TITLE
fix(ci): read version from recce/VERSION for manual nightly UI release

### DIFF
--- a/.github/workflows/release-ui.yaml
+++ b/.github/workflows/release-ui.yaml
@@ -193,11 +193,13 @@ jobs:
               echo "npm_tag=latest" >> $GITHUB_OUTPUT
             fi
           else
-            # Manual dispatch - use input version or package.json
+            # Manual dispatch - use input version or recce/VERSION
             if [[ -n "${{ inputs.version }}" ]]; then
               npm_version="${{ inputs.version }}"
             else
-              npm_version=$(node -p "require('./package.json').version")
+              # Read base version from recce/VERSION (e.g., "1.44.0.dev0" -> "1.44.0")
+              python_version=$(cat "${GITHUB_WORKSPACE}/recce/VERSION")
+              npm_version=$(echo "$python_version" | sed -E 's/\.dev[0-9]*$//')
             fi
 
             if [[ "${{ steps.release_type.outputs.type }}" == "nightly" ]]; then


### PR DESCRIPTION
## Summary
- Fix manual `workflow_dispatch` Nightly release of `@datarecce/ui` reading version from `package.json` (hardcoded `0.2.1`) instead of `recce/VERSION`
- Now reads `recce/VERSION` and strips `.devN` suffix to derive the base semver, matching the automated nightly path behavior

## Test plan
- [ ] Manually trigger the release-ui workflow with Nightly type and no version input — verify it produces a version based on `recce/VERSION` (e.g., `1.44.0-nightly.YYYYMMDD`) instead of `0.2.1-nightly.YYYYMMDD`

Closes DRC-3214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Kent Huang <kent@infuseai.io>