### PR TITLE
fix(ui): move @fontsource import from library to app entry point

### DIFF
--- a/js/app/layout.tsx
+++ b/js/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import "@fontsource/montserrat/800.css";
 import "./global.css";
 import Providers from "@datarecce/ui/components/app/Providers";
 import { GoogleTagManager } from "@next/third-parties/google";

--- a/js/packages/ui/src/components/app/MainLayout.tsx
+++ b/js/packages/ui/src/components/app/MainLayout.tsx
@@ -7,7 +7,6 @@
 
 "use client";
 
-import "@fontsource/montserrat/800.css";
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 import { usePathname } from "next/navigation";

--- a/js/packages/ui/tsdown.config.ts
+++ b/js/packages/ui/tsdown.config.ts
@@ -71,11 +71,6 @@ export default defineConfig({
     // Next.js packages are provided by the consuming application
     /^next\//,
     "next",
-    // Font packages — app-level concern, not bundled in library CSS.
-    // Without this, tsdown collects @font-face declarations into dist/style.css
-    // with relative url() paths to .woff2 files that don't exist in dist/,
-    // breaking downstream Next.js builds that import the CSS.
-    /^@fontsource\//,
     // CodeMirror packages
     /^@codemirror\//,
     // react-markdown and remark/unified ecosystem use Node.js built-ins (vfile uses path, process, url)


### PR DESCRIPTION
## Summary

- Removes `import "@fontsource/montserrat/800.css"` from `MainLayout.tsx` (library component)
- Adds the import to `js/app/layout.tsx` (OSS app entry point)
- Reverts the `@fontsource` tsdown external from PR #1298 (no longer needed)

## Root Cause

PR #1298 externalized `@fontsource` in tsdown to prevent broken font `url()` paths in `dist/style.css`. However, `external` causes tsdown to **preserve** the `import "@fontsource/montserrat/800.css"` statement in the output JS — meaning every consuming app must have `@fontsource/montserrat` installed. Recce Cloud does not (it uses `next/font/google` instead), so the Docker build fails with `Module not found: Can't resolve '@fontsource/montserrat/800.css'`.

The correct fix: font loading is an app-level concern, not a library concern. Each consuming app provides its own Montserrat font:
- **Recce OSS**: `@fontsource/montserrat` in `app/layout.tsx` (this PR)
- **Recce Cloud**: `next/font/google` in `app/layout.tsx` (already in place)

## Verification

After `pnpm build` in `@datarecce/ui`:
- `dist/style.css`: zero `@font-face` / `montserrat` / `.woff` references
- `dist/*.js`: zero `@fontsource` import statements
- Schema CSS classes (`row-added`, `row-removed`, `row-changed`) still present

## Test plan

- [x] `pnpm build` succeeds for `@datarecce/ui`
- [x] No `@fontsource` references in any `dist/` output
- [x] Schema row highlighting CSS intact
- [ ] Recce OSS app builds and Montserrat font loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
