### PR TITLE
fix(ui): replace Fragment with array in Menu children

### DIFF
--- a/js/packages/ui/src/components/lineage/topbar/LineageViewTopBar.tsx
+++ b/js/packages/ui/src/components/lineage/topbar/LineageViewTopBar.tsx
@@ -775,67 +775,66 @@ export const LineageViewTopBar = ({
                   </MenuItem>
                 </SetupConnectionPopoverSlot>
 
-                {!featureToggles.disableUpdateChecklist ||
-                featureToggles.checklistPermissionDenied ? (
-                  <>
-                    <Divider />
-                    <ListSubheader
-                      sx={{ lineHeight: "32px", bgcolor: "transparent" }}
-                    >
-                      Add to Checklist
-                    </ListSubheader>
-                    <MuiTooltip
-                      title={
-                        featureToggles.checklistPermissionDenied
-                          ? "You don't have permission to add checks"
-                          : ""
-                      }
-                      placement="left"
-                    >
-                      <span>
-                        <MenuItem
-                          disabled={featureToggles.checklistPermissionDenied}
-                          onClick={() => {
-                            if (featureToggles.checklistPermissionDenied)
-                              return;
-                            onAddLineageDiffCheck?.(viewOptions.view_mode);
-                            handleActionsClose();
-                          }}
-                        >
-                          <ListItemIcon>
-                            <LineageDiffIcon fontSize="small" />
-                          </ListItemIcon>
-                          <ListItemText>Lineage Diff</ListItemText>
-                        </MenuItem>
-                      </span>
-                    </MuiTooltip>
-                    <MuiTooltip
-                      title={
-                        featureToggles.checklistPermissionDenied
-                          ? "You don't have permission to add checks"
-                          : ""
-                      }
-                      placement="left"
-                    >
-                      <span>
-                        <MenuItem
-                          disabled={featureToggles.checklistPermissionDenied}
-                          onClick={() => {
-                            if (featureToggles.checklistPermissionDenied)
-                              return;
-                            onAddSchemaDiffCheck?.();
-                            handleActionsClose();
-                          }}
-                        >
-                          <ListItemIcon>
-                            <SchemaDiffIcon fontSize="small" />
-                          </ListItemIcon>
-                          <ListItemText>Schema Diff</ListItemText>
-                        </MenuItem>
-                      </span>
-                    </MuiTooltip>
-                  </>
-                ) : null}
+                {(!featureToggles.disableUpdateChecklist ||
+                  featureToggles.checklistPermissionDenied) && [
+                  <Divider key="checklist-divider" />,
+                  <ListSubheader
+                    key="checklist-header"
+                    sx={{ lineHeight: "32px", bgcolor: "transparent" }}
+                  >
+                    Add to Checklist
+                  </ListSubheader>,
+                  <MuiTooltip
+                    key="add-lineage-diff"
+                    title={
+                      featureToggles.checklistPermissionDenied
+                        ? "You don't have permission to add checks"
+                        : ""
+                    }
+                    placement="left"
+                  >
+                    <span>
+                      <MenuItem
+                        disabled={featureToggles.checklistPermissionDenied}
+                        onClick={() => {
+                          if (featureToggles.checklistPermissionDenied) return;
+                          onAddLineageDiffCheck?.(viewOptions.view_mode);
+                          handleActionsClose();
+                        }}
+                      >
+                        <ListItemIcon>
+                          <LineageDiffIcon fontSize="small" />
+                        </ListItemIcon>
+                        <ListItemText>Lineage Diff</ListItemText>
+                      </MenuItem>
+                    </span>
+                  </MuiTooltip>,
+                  <MuiTooltip
+                    key="add-schema-diff"
+                    title={
+                      featureToggles.checklistPermissionDenied
+                        ? "You don't have permission to add checks"
+                        : ""
+                    }
+                    placement="left"
+                  >
+                    <span>
+                      <MenuItem
+                        disabled={featureToggles.checklistPermissionDenied}
+                        onClick={() => {
+                          if (featureToggles.checklistPermissionDenied) return;
+                          onAddSchemaDiffCheck?.();
+                          handleActionsClose();
+                        }}
+                      >
+                        <ListItemIcon>
+                          <SchemaDiffIcon fontSize="small" />
+                        </ListItemIcon>
+                        <ListItemText>Schema Diff</ListItemText>
+                      </MenuItem>
+                    </span>
+                  </MuiTooltip>,
+                ]}
               </Menu>
             </Box>
           </ControlItem>


### PR DESCRIPTION
## Summary
- MUI Menu doesn't accept Fragment as a child, causing console errors
- Replaced `<>...</>` with a keyed array `[...]` for the checklist section in the Actions dropdown

## Test plan
- [ ] Open lineage view, click Actions dropdown — checklist items render correctly
- [ ] Console is free of the "Menu component doesn't accept a Fragment" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)