### PR TITLE
feat(ci): auto-trigger bump @datarecce/ui in recce-cloud-infra

### DIFF
--- a/.github/workflows/release-ui.yaml
+++ b/.github/workflows/release-ui.yaml
@@ -330,6 +330,7 @@ jobs:
       - uses: actions/create-github-app-token@v2
         id: app-token
         if: steps.check_artifact.outputs.skip != 'true' && steps.patch_version.outputs.npm_tag == 'latest'
+        continue-on-error: true
         with:
           app-id: ${{ secrets.RECCE_ACTION_BOT_APP_ID }}
           private-key: ${{ secrets.RECCE_ACTION_BOT_PRIVATE_KEY }}
@@ -337,17 +338,18 @@ jobs:
 
       - name: Trigger Bump @datarecce/ui in recce-cloud-infra
         id: dispatch
-        if: steps.check_artifact.outputs.skip != 'true' && steps.patch_version.outputs.npm_tag == 'latest'
+        if: steps.check_artifact.outputs.skip != 'true' && steps.patch_version.outputs.npm_tag == 'latest' && steps.app-token.outcome == 'success'
         continue-on-error: true
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: 'bump-recce-ui.yml'
           repo: 'DataRecce/recce-cloud-infra'
+          ref: 'main'
           inputs: '{ "version": "${{ steps.patch_version.outputs.version }}" }'
           token: '${{ steps.app-token.outputs.token }}'
 
       - name: Handle dispatch failure
-        if: steps.dispatch.outcome == 'failure'
+        if: steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure'
         run: |
           echo "::warning::Failed to trigger Bump @datarecce/ui workflow in recce-cloud-infra"
           echo "::warning::Please manually trigger the bump at: https://github.com/DataRecce/recce-cloud-infra/actions/workflows/bump-recce-ui.yml"

--- a/.github/workflows/release-ui.yaml
+++ b/.github/workflows/release-ui.yaml
@@ -326,3 +326,29 @@ jobs:
             echo "npm install @datarecce/ui@${version}" >> $GITHUB_STEP_SUMMARY
           fi
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        if: steps.check_artifact.outputs.skip != 'true' && steps.patch_version.outputs.npm_tag == 'latest'
+        with:
+          app-id: ${{ secrets.RECCE_ACTION_BOT_APP_ID }}
+          private-key: ${{ secrets.RECCE_ACTION_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Trigger Bump @datarecce/ui in recce-cloud-infra
+        id: dispatch
+        if: steps.check_artifact.outputs.skip != 'true' && steps.patch_version.outputs.npm_tag == 'latest'
+        continue-on-error: true
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: 'bump-recce-ui.yml'
+          repo: 'DataRecce/recce-cloud-infra'
+          inputs: '{ "version": "${{ steps.patch_version.outputs.version }}" }'
+          token: '${{ steps.app-token.outputs.token }}'
+
+      - name: Handle dispatch failure
+        if: steps.dispatch.outcome == 'failure'
+        run: |
+          echo "::warning::Failed to trigger Bump @datarecce/ui workflow in recce-cloud-infra"
+          echo "::warning::Please manually trigger the bump at: https://github.com/DataRecce/recce-cloud-infra/actions/workflows/bump-recce-ui.yml"
+          echo "::warning::Use version: ${{ steps.patch_version.outputs.version }}"


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

CI / Infrastructure

**What this PR does / why we need it**:

After a successful **official** (non-nightly) npm publish of `@datarecce/ui`, automatically triggers the `Bump @datarecce/ui` workflow in `DataRecce/recce-cloud-infra` via `benc-uk/workflow-dispatch@v1`. This removes the manual step of going to recce-cloud-infra and dispatching the bump workflow each time we cut an official release.

- Uses the existing GitHub App token (`RECCE_ACTION_BOT`) — no new secrets needed
- Only triggers for official releases (`npm_tag == 'latest'`), nightly builds are skipped
- Follows the same dispatch pattern used in `nightly.yaml` and `release.yaml`
- Graceful failure handling: warns with manual trigger link instead of failing the release

**Which issue(s) this PR fixes**:

Fixes DRC-3240

**Special notes for your reviewer**:

The `if` guard on the `app-token` step is intentional — unlike `nightly.yaml`/`release.yaml` which use separate jobs for dispatch, this is inline in the `build-and-publish` job and needs to skip token generation for nightly builds.

**Does this PR introduce a user-facing change?**:

NONE