### PR TITLE
fix(cloud): add S3v4 x-amz-meta-* headers to presigned URL uploads

### DIFF
--- a/recce/artifact.py
+++ b/recce/artifact.py
@@ -10,7 +10,7 @@ import requests
 from rich.console import Console
 
 from recce.git import commit_hash_from_branch, current_branch, hosting_repo
-from recce.state import s3_sse_c_headers
+from recce.state import s3_metadata_headers, s3_sse_c_headers
 from recce.util.recce_cloud import PresignedUrlMethod, RecceCloud
 
 
@@ -181,6 +181,7 @@ def upload_dbt_artifacts(target_path: str, branch: str, token: str, password: st
     headers = s3_sse_c_headers(password)
     if metadata:
         headers["x-amz-tagging"] = urlencode(metadata)
+        headers.update(s3_metadata_headers(metadata))
     response = requests.put(presigned_url, data=open(compress_file_path, "rb").read(), headers=headers)
     if response.status_code != 200:
         raise Exception({response.text})

--- a/recce/artifact.py
+++ b/recce/artifact.py
@@ -10,7 +10,7 @@ import requests
 from rich.console import Console
 
 from recce.git import commit_hash_from_branch, current_branch, hosting_repo
-from recce.state import s3_metadata_headers, s3_sse_c_headers
+from recce.state import normalize_s3_metadata, s3_metadata_headers, s3_sse_c_headers
 from recce.util.recce_cloud import PresignedUrlMethod, RecceCloud
 
 
@@ -180,10 +180,11 @@ def upload_dbt_artifacts(target_path: str, branch: str, token: str, password: st
 
     headers = s3_sse_c_headers(password)
     if metadata:
-        headers["x-amz-tagging"] = urlencode(metadata)
+        normalized = normalize_s3_metadata(metadata)
+        headers["x-amz-tagging"] = urlencode(normalized)
         headers.update(s3_metadata_headers(metadata))
     response = requests.put(presigned_url, data=open(compress_file_path, "rb").read(), headers=headers)
-    if response.status_code != 200:
+    if response.status_code not in (200, 204):
         raise Exception({response.text})
 
     # Clean up the compressed artifacts

--- a/recce/state/__init__.py
+++ b/recce/state/__init__.py
@@ -2,6 +2,7 @@ from .cloud import (
     CloudStateLoader,
     RecceCloudStateManager,
     RecceShareStateManager,
+    normalize_s3_metadata,
     s3_metadata_headers,
     s3_sse_c_headers,
 )
@@ -26,6 +27,7 @@ __all__ = [
     "CloudStateLoader",
     "FileStateLoader",
     "RecceStateMetadata",
+    "normalize_s3_metadata",
     "s3_metadata_headers",
     "s3_sse_c_headers",
     "GitRepoInfo",

--- a/recce/state/__init__.py
+++ b/recce/state/__init__.py
@@ -2,6 +2,7 @@ from .cloud import (
     CloudStateLoader,
     RecceCloudStateManager,
     RecceShareStateManager,
+    s3_metadata_headers,
     s3_sse_c_headers,
 )
 from .const import ErrorMessage
@@ -25,6 +26,7 @@ __all__ = [
     "CloudStateLoader",
     "FileStateLoader",
     "RecceStateMetadata",
+    "s3_metadata_headers",
     "s3_sse_c_headers",
     "GitRepoInfo",
     "PullRequestInfo",

--- a/recce/state/cloud.py
+++ b/recce/state/cloud.py
@@ -39,13 +39,23 @@ def s3_sse_c_headers(password: str) -> Dict[str, str]:
     }
 
 
+def normalize_s3_metadata(metadata: dict) -> Dict[str, str]:
+    """Normalize metadata values to strings for S3 headers.
+
+    Converts None to empty string and other values to str so that
+    x-amz-tagging and x-amz-meta-* headers use consistent values.
+    """
+    return {key: str(value) if value is not None else "" for key, value in metadata.items()}
+
+
 def s3_metadata_headers(metadata: dict) -> Dict[str, str]:
     """Build S3 x-amz-meta-* headers from metadata dict.
 
     S3v4 presigned URLs may include these in SignedHeaders,
     so the client must send them with matching values.
     """
-    return {f"x-amz-meta-{key}": str(value) if value is not None else "" for key, value in metadata.items()}
+    normalized = normalize_s3_metadata(metadata)
+    return {f"x-amz-meta-{key}": value for key, value in normalized.items()}
 
 
 class CloudStateLoader(RecceStateLoader):
@@ -473,7 +483,8 @@ class CloudStateLoader(RecceStateLoader):
         if password:
             headers.update(s3_sse_c_headers(password))
         if metadata:
-            headers["x-amz-tagging"] = urlencode(metadata)
+            normalized = normalize_s3_metadata(metadata)
+            headers["x-amz-tagging"] = urlencode(normalized)
             headers.update(s3_metadata_headers(metadata))
 
         with tempfile.NamedTemporaryFile() as tmp:
@@ -559,7 +570,8 @@ class RecceCloudStateManager:
         compress_passwd = self.cloud_options.get("password")
         headers = s3_sse_c_headers(compress_passwd)
         if metadata:
-            headers["x-amz-tagging"] = urlencode(metadata)
+            normalized = normalize_s3_metadata(metadata)
+            headers["x-amz-tagging"] = urlencode(normalized)
             headers.update(s3_metadata_headers(metadata))
         with tempfile.NamedTemporaryFile() as tmp:
             state.to_file(tmp.name, file_type=SupportedFileTypes.GZIP)

--- a/recce/state/cloud.py
+++ b/recce/state/cloud.py
@@ -39,6 +39,15 @@ def s3_sse_c_headers(password: str) -> Dict[str, str]:
     }
 
 
+def s3_metadata_headers(metadata: dict) -> Dict[str, str]:
+    """Build S3 x-amz-meta-* headers from metadata dict.
+
+    S3v4 presigned URLs may include these in SignedHeaders,
+    so the client must send them with matching values.
+    """
+    return {f"x-amz-meta-{key}": str(value) if value is not None else "" for key, value in metadata.items()}
+
+
 class CloudStateLoader(RecceStateLoader):
     def __init__(
         self,
@@ -465,6 +474,7 @@ class CloudStateLoader(RecceStateLoader):
             headers.update(s3_sse_c_headers(password))
         if metadata:
             headers["x-amz-tagging"] = urlencode(metadata)
+            headers.update(s3_metadata_headers(metadata))
 
         with tempfile.NamedTemporaryFile() as tmp:
             # Use the specified state to export to file
@@ -548,6 +558,9 @@ class RecceCloudStateManager:
 
         compress_passwd = self.cloud_options.get("password")
         headers = s3_sse_c_headers(compress_passwd)
+        if metadata:
+            headers["x-amz-tagging"] = urlencode(metadata)
+            headers.update(s3_metadata_headers(metadata))
         with tempfile.NamedTemporaryFile() as tmp:
             state.to_file(tmp.name, file_type=SupportedFileTypes.GZIP)
             response = requests.put(presigned_url, data=open(tmp.name, "rb").read(), headers=headers)

--- a/tests/state/test_cloud.py
+++ b/tests/state/test_cloud.py
@@ -788,5 +788,96 @@ class TestCloudStateLoader(unittest.TestCase):
         self.assertIs(result_state.pull_request, loader.pr_info)
 
 
+class TestS3HeaderHelpers(unittest.TestCase):
+
+    def test_normalize_s3_metadata_basic(self):
+        from recce.state.cloud import normalize_s3_metadata
+
+        result = normalize_s3_metadata({"commit": "abc123", "dbt_version": "1.8.9"})
+        self.assertEqual(result, {"commit": "abc123", "dbt_version": "1.8.9"})
+
+    def test_normalize_s3_metadata_none_values(self):
+        from recce.state.cloud import normalize_s3_metadata
+
+        result = normalize_s3_metadata({"commit": None, "dbt_version": "1.8.9"})
+        self.assertEqual(result, {"commit": "", "dbt_version": "1.8.9"})
+
+    def test_normalize_s3_metadata_int_values(self):
+        from recce.state.cloud import normalize_s3_metadata
+
+        result = normalize_s3_metadata({"total_checks": 5, "approved_checks": 3})
+        self.assertEqual(result, {"total_checks": "5", "approved_checks": "3"})
+
+    def test_normalize_s3_metadata_empty(self):
+        from recce.state.cloud import normalize_s3_metadata
+
+        self.assertEqual(normalize_s3_metadata({}), {})
+
+    def test_s3_metadata_headers_basic(self):
+        from recce.state.cloud import s3_metadata_headers
+
+        result = s3_metadata_headers({"commit": "abc123", "dbt_version": "1.8.9"})
+        self.assertEqual(
+            result,
+            {
+                "x-amz-meta-commit": "abc123",
+                "x-amz-meta-dbt_version": "1.8.9",
+            },
+        )
+
+    def test_s3_metadata_headers_none_values(self):
+        from recce.state.cloud import s3_metadata_headers
+
+        result = s3_metadata_headers({"commit": None, "dbt_version": "1.8.9"})
+        self.assertEqual(
+            result,
+            {
+                "x-amz-meta-commit": "",
+                "x-amz-meta-dbt_version": "1.8.9",
+            },
+        )
+
+    def test_s3_metadata_headers_empty(self):
+        from recce.state.cloud import s3_metadata_headers
+
+        self.assertEqual(s3_metadata_headers({}), {})
+
+
+class TestUploadIncludesMetaHeaders(unittest.TestCase):
+
+    @patch("recce.state.cloud.CheckDAO")
+    @patch("requests.put")
+    def test_export_state_to_github_sends_meta_headers(self, mock_put, mock_check_dao):
+        """Verify _upload_state_to_url includes x-amz-meta-* headers when metadata is provided."""
+        mock_pr_info = Mock()
+        mock_pr_info.id = "123"
+        mock_pr_info.repository = "owner/repo"
+
+        loader = CloudStateLoader(cloud_options={"api_token": "token"})
+        loader.catalog = "github"
+        loader.pr_info = mock_pr_info
+        loader.cloud_options = {"password": "test_pass"}
+        loader.state = RecceState()
+
+        mock_check_dao.return_value.status.return_value = {"total": 5, "approved": 3}
+
+        loader.recce_cloud = Mock()
+        loader.recce_cloud.get_presigned_url_by_github_repo.return_value = "http://presigned.url"
+        loader.recce_cloud.get_artifact_metadata.return_value = {"etag": "test_etag"}
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_put.return_value = mock_response
+
+        loader._export_state_to_github()
+
+        # Verify x-amz-meta-* headers were included in the PUT request
+        call_kwargs = mock_put.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+        self.assertEqual(headers["x-amz-meta-total_checks"], "5")
+        self.assertEqual(headers["x-amz-meta-approved_checks"], "3")
+        self.assertIn("x-amz-tagging", headers)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

Recce Cloud switched to S3v4 presigned URL signing, which now includes `x-amz-meta-*` headers in `SignedHeaders`. The client was not sending these headers, causing S3 to reject uploads with `SignatureDoesNotMatch`.

This PR:
- Adds `s3_metadata_headers()` helper to build `x-amz-meta-{key}: {value}` headers from metadata dicts
- Applies it to all three S3 upload paths:
  - `artifact.py:upload_dbt_artifacts()` — dbt artifact upload
  - `cloud.py:CloudStateLoader._upload_state_to_url()` — state upload (server mode)
  - `cloud.py:RecceCloudStateManager._upload_state_to_recce_cloud()` — state upload (CLI), also adds missing `x-amz-tagging`

**Which issue(s) this PR fixes**:

Fixes DRC-3241

**Special notes for your reviewer**:

Root cause analysis from CI logs (run [24377641265](https://github.com/DataRecce/recce/actions/runs/24377641265)):
- The S3 `CanonicalRequest` in the error shows `x-amz-meta-commit:` and `x-amz-meta-dbt_version:` with **empty values** (client doesn't send them)
- The presigned URL's `X-Amz-SignedHeaders` includes these headers, meaning the server signed them with actual metadata values
- Mismatch between signed values and actual (empty) values → `SignatureDoesNotMatch`
- Last passing run was April 13; first failure April 14 — consistent with a server-side S3v4 migration

**Does this PR introduce a user-facing change?**:

NONE