### PR TITLE
perf(cll): reuse existing cached manifests instead of recreating per node

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -887,8 +887,8 @@ class DbtAdapter(BaseAdapter):
         base = lineage_diff.base
         current = lineage_diff.current
 
-        base_manifest = as_manifest(self.get_manifest(True))
-        curr_manifest = as_manifest(self.get_manifest(False))
+        base_manifest = self.previous_state.manifest
+        curr_manifest = self.manifest
         breaking_perf_tracker.record_checkpoint("manifest")
 
         def ref_func(*args):
@@ -1125,7 +1125,11 @@ class DbtAdapter(BaseAdapter):
                     cll_data_one = self._deserialize_cll_data(cached_json)
                     node_cache_hits += 1
                 except Exception as e:
-                    logger.debug("[cll cache] corrupted entry for %s, recomputing: %s", node_id, e)
+                    logger.debug(
+                        "[cll cache] corrupted entry for %s, recomputing: %s",
+                        node_id,
+                        e,
+                    )
                     cached_json = None
 
             if not cached_json:
@@ -1133,7 +1137,11 @@ class DbtAdapter(BaseAdapter):
                 try:
                     cll_data_one = deepcopy(self.get_cll_cached(node_id, base=False))
                 except Exception as e:
-                    logger.debug("[cll cache] computation failed for %s, skipping: %s", node_id, e)
+                    logger.debug(
+                        "[cll cache] computation failed for %s, skipping: %s",
+                        node_id,
+                        e,
+                    )
                     continue
                 if cll_data_one is None:
                     continue
@@ -1415,7 +1423,11 @@ class DbtAdapter(BaseAdapter):
                     if node_diff is not None and node_diff.change is not None:
                         extra_node_ids.add(nid)
                         if no_cll:
-                            if node_diff.change.category in ["breaking", "partial_breaking", "unknown"]:
+                            if node_diff.change.category in [
+                                "breaking",
+                                "partial_breaking",
+                                "unknown",
+                            ]:
                                 anchor_node_ids.add(nid)
                         else:
                             if node_diff.change.category in ["breaking", "unknown"]:
@@ -1433,7 +1445,11 @@ class DbtAdapter(BaseAdapter):
                 if node_diff is not None and node_diff.change is not None:
                     extra_node_ids.add(node_id)
                     if no_cll:
-                        if node_diff.change.category in ["breaking", "partial_breaking", "unknown"]:
+                        if node_diff.change.category in [
+                            "breaking",
+                            "partial_breaking",
+                            "unknown",
+                        ]:
                             anchor_node_ids.add(node_id)
                     else:
                         if node_diff.change.category in ["breaking", "unknown"]:
@@ -1543,7 +1559,7 @@ class DbtAdapter(BaseAdapter):
                 cll_data.parent_map[column_id] = set()
             return cll_data
 
-        manifest = as_manifest(self.get_manifest(base))
+        manifest = self.manifest if base is False else self.previous_state.manifest
         catalog = self.curr_catalog if base is False else self.base_catalog
         resource_type = node.resource_type
         if resource_type not in {"model", "seed", "source", "snapshot"}:
@@ -1662,7 +1678,7 @@ class DbtAdapter(BaseAdapter):
             if pre_compiled:
                 compiled_sql = pre_compiled
             else:
-                compiled_sql = self.generate_sql(raw_code, base=base, context=jinja_context, provided_manifest=manifest)
+                compiled_sql = self.generate_sql(raw_code, base=base, context=jinja_context)
             dialect = self.adapter.type()
             if self.get_manifest(base).metadata.adapter_type is not None:
                 dialect = self.get_manifest(base).metadata.adapter_type
@@ -1720,7 +1736,12 @@ class DbtAdapter(BaseAdapter):
                 columns = {}
                 for col_name, col_metadata in catalog.nodes[unique_id].columns.items():
                     column_id = f"{unique_id}_{col_name}"
-                    col = CllColumn(id=column_id, name=col_name, table_id=unique_id, type=col_metadata.type)
+                    col = CllColumn(
+                        id=column_id,
+                        name=col_name,
+                        table_id=unique_id,
+                        type=col_metadata.type,
+                    )
                     columns[col_name] = col
                 node.columns = columns
 
@@ -1735,7 +1756,12 @@ class DbtAdapter(BaseAdapter):
                 columns = {}
                 for col_name, col_metadata in catalog.sources[unique_id].columns.items():
                     column_id = f"{unique_id}_{col_name}"
-                    col = CllColumn(id=column_id, name=col_name, table_id=unique_id, type=col_metadata.type)
+                    col = CllColumn(
+                        id=column_id,
+                        name=col_name,
+                        table_id=unique_id,
+                        type=col_metadata.type,
+                    )
                     columns[col_name] = col
                 node.columns = columns
 

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -887,7 +887,6 @@ class DbtAdapter(BaseAdapter):
         base = lineage_diff.base
         current = lineage_diff.current
 
-        base_manifest = self.previous_state.manifest
         curr_manifest = self.manifest
         breaking_perf_tracker.record_checkpoint("manifest")
 
@@ -940,13 +939,13 @@ class DbtAdapter(BaseAdapter):
 
                 base_sql = self.generate_sql(
                     base_node.get("raw_code"),
+                    base=True,
                     context=jinja_context,
-                    provided_manifest=base_manifest,
                 )
                 curr_sql = self.generate_sql(
                     curr_node.get("raw_code"),
+                    base=False,
                     context=jinja_context,
-                    provided_manifest=curr_manifest,
                 )
                 base_schema = _get_schema(base)
                 curr_schema = _get_schema(current)

--- a/tests/adapter/dbt_adapter/test_dbt_cll.py
+++ b/tests/adapter/dbt_adapter/test_dbt_cll.py
@@ -201,12 +201,17 @@ def _set_compiled_code(adapter, node_id, compiled_code, base=False):
 
     The test helper's set_artifacts round-trips through writable_manifest() which
     strips compiled_code. This helper patches it back directly on both the
-    WritableManifest and the Manifest used by the adapter.
+    WritableManifest and the resolved Manifest used by the adapter.
     """
     writable = adapter.curr_manifest if not base else adapter.base_manifest
     if node_id in writable.nodes:
         writable.nodes[node_id].compiled_code = compiled_code
         writable.nodes[node_id].compiled = True
+
+    resolved = adapter.manifest if not base else adapter.previous_state.manifest
+    if node_id in resolved.nodes:
+        resolved.nodes[node_id].compiled_code = compiled_code
+        resolved.nodes[node_id].compiled = True
 
 
 def test_cll_with_compiled_code(dbt_test_helper):


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Performance fix

**What this PR does / why we need it**:

`get_cll_cached()` and `get_change_analysis_cached()` called `as_manifest()` on every invocation. `as_manifest()` calls `Manifest.from_writable_manifest()` — a heavy dbt operation that processes all seeds and nodes.

On a 1466-model project (SnapTravel), `build_full_cll_map()` triggered hundreds of redundant conversions for non-model nodes (sources, exposures) that weren't in the per-node SQLite cache. This made Phase 5 ("Building full CLL map") take **15.5 minutes** for what should be a fast cache-read pass.

The adapter already maintains resolved manifests: `self.manifest` (current) and `self.previous_state.manifest` (base). This PR reuses them instead of recreating per node.

`generate_sql()` still creates fresh manifests since `process_node()` mutates them.

**Which issue(s) this PR fixes**:

Resolves DRC-3243

**Special notes for your reviewer**:

The bulk of the diff is `black` reformatting (line wrapping). The actual logical changes are 3 lines:
1. `get_change_analysis_cached`: use `self.previous_state.manifest` / `self.manifest`
2. `get_cll_cached`: use `self.manifest if base is False else self.previous_state.manifest`
3. `get_cll_cached` Jinja path: don't pass cached manifest to `generate_sql` (it mutates)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
