### PR TITLE
feat(ci): add staging cloud smoke test

### DIFF
--- a/.github/workflows/integration-tests-cloud.yaml
+++ b/.github/workflows/integration-tests-cloud.yaml
@@ -13,6 +13,18 @@ on:
     paths-ignore:
       - "js/**"
       - "recce/data/**"
+  schedule:
+    - cron: '0 19 * * 0,1,2,3,4' # run at 3 AM (UTC + 8) every working day, after nightly build
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Cloud environment to test against'
+        type: choice
+        required: true
+        options:
+          - production
+          - staging
+        default: production
 
 # Explicitly limit permissions for pull_request_target
 permissions:
@@ -20,10 +32,27 @@ permissions:
   pull-requests: read
 
 jobs:
-  # First job: Check if the PR author has write permission
+  resolve-environment:
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.resolve.outputs.environment }}
+    steps:
+      - name: Resolve target environment
+        id: resolve
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "environment=staging"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "environment=${{ inputs.environment }}"
+          else
+            echo "environment=production"
+          fi >> $GITHUB_OUTPUT
+
+  # Check if the PR author has write permission
   # This job runs in the privileged context but doesn't checkout untrusted code
   authorize:
-    if: github.actor != 'dependabot[bot]'
+    needs: resolve-environment
+    if: needs.resolve-environment.outputs.environment == 'production' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     outputs:
       authorized: ${{ steps.check.outputs.authorized }}
@@ -46,10 +75,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Second job: Run the actual tests only if authorized
+  # Production cloud smoke test
   smoke-test-cloud:
-    needs: authorize
-    if: needs.authorize.outputs.authorized == 'true'
+    needs: [resolve-environment, authorize]
+    if: needs.resolve-environment.outputs.environment == 'production' && needs.authorize.outputs.authorized == 'true'
     concurrency:
       group: smoke-test-cloud
       cancel-in-progress: false
@@ -91,3 +120,48 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RECCE_CLOUD_TOKEN }}
           RECCE_STATE_PASSWORD: ${{ vars.RECCE_STATE_PASSWORD }}
+
+  # Staging cloud smoke test - runs daily after nightly build
+  smoke-test-cloud-staging:
+    needs: resolve-environment
+    if: needs.resolve-environment.outputs.environment == 'staging'
+    concurrency:
+      group: smoke-test-cloud-staging
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        include:
+          - python-version: "3.11"
+            dbt-version: "1.8"
+          - python-version: "3.13"
+            dbt-version: "latest"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install Recce and dbt
+        run: |
+          uv venv
+          uv sync --no-dev --python ${{ matrix.python-version }}
+          if [ "${{ matrix.dbt-version }}" == "latest" ]; then
+            uv pip install dbt-core dbt-duckdb
+          else
+            uv pip install dbt-core~=${{ matrix.dbt-version }}.0 dbt-duckdb~=${{ matrix.dbt-version }}.0
+          fi
+
+      - name: Run smoke test - dbt (staging)
+        run: |
+          source .venv/bin/activate
+          ./integration_tests/dbt/smoke_test_cloud.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.RECCE_CLOUD_TOKEN_STAGING }}
+          RECCE_STATE_PASSWORD: ${{ vars.RECCE_STATE_PASSWORD }}
+          RECCE_CLOUD_API_HOST: ${{ vars.RECCE_CLOUD_API_HOST_STAGING }}

--- a/.github/workflows/integration-tests-cloud.yaml
+++ b/.github/workflows/integration-tests-cloud.yaml
@@ -26,7 +26,7 @@ on:
           - staging
         default: production
 
-# Explicitly limit permissions for pull_request_target
+# Explicitly limit permissions
 permissions:
   contents: read
   pull-requests: read
@@ -41,12 +41,12 @@ jobs:
         id: resolve
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            echo "environment=staging"
+            echo "environment=staging" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "environment=${{ inputs.environment }}"
+            echo "environment=${{ inputs.environment }}" >> "$GITHUB_OUTPUT"
           else
-            echo "environment=production"
-          fi >> $GITHUB_OUTPUT
+            echo "environment=production" >> "$GITHUB_OUTPUT"
+          fi
 
   # Check if the PR author has write permission
   # This job runs in the privileged context but doesn't checkout untrusted code

--- a/.github/workflows/integration-tests-cloud.yaml
+++ b/.github/workflows/integration-tests-cloud.yaml
@@ -165,3 +165,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RECCE_CLOUD_TOKEN_STAGING }}
           RECCE_STATE_PASSWORD: ${{ vars.RECCE_STATE_PASSWORD }}
           RECCE_CLOUD_API_HOST: ${{ vars.RECCE_CLOUD_API_HOST_STAGING }}
+
+  notify-staging-failure:
+    needs: smoke-test-cloud-staging
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL_DEV" \
+            -H 'Content-type: application/json' \
+            -d "{
+              \"text\": \":red_circle: Staging cloud smoke test failed\",
+              \"blocks\": [
+                {
+                  \"type\": \"section\",
+                  \"text\": {
+                    \"type\": \"mrkdwn\",
+                    \"text\": \":red_circle: *Staging Cloud Smoke Test Failed*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>\"
+                  }
+                }
+              ]
+            }"
+        env:
+          SLACK_WEBHOOK_URL_DEV: ${{ secrets.SLACK_WEBHOOK_URL_DEV }}


### PR DESCRIPTION
## Summary
- Add daily scheduled staging cloud smoke test that runs after the nightly build (3 AM UTC+8)
- Add `workflow_dispatch` trigger with environment selector (production/staging) for manual runs
- Use `resolve-environment` job to cleanly route between production and staging tests

## Required GitHub Settings
- **Secret**: `RECCE_CLOUD_TOKEN_STAGING` — auth token for staging cloud
- **Variable**: `RECCE_CLOUD_API_HOST_STAGING` — staging cloud API URL

## Test plan
- [ ] Verify push/PR triggers only run production smoke test (unchanged behavior)
- [ ] Verify scheduled trigger only runs staging smoke test
- [ ] Verify manual dispatch with "production" runs production test
- [ ] Verify manual dispatch with "staging" runs staging test
- [ ] Configure `RECCE_CLOUD_TOKEN_STAGING` secret and `RECCE_CLOUD_API_HOST_STAGING` variable in repo settings

Resolves: DRC-3244

🤖 Generated with [Claude Code](https://claude.com/claude-code)