### PR TITLE
fix(valuediff): quote column identifiers in generated SQL

### DIFF
--- a/recce/tasks/valuediff.py
+++ b/recce/tasks/valuediff.py
@@ -35,8 +35,11 @@ class ValueDiffMixin:
             if len(primary_key) == 0:
                 raise RecceException("Primary key cannot be empty")
             sql_template = r"""
-            {%- set column_list = primary_key %}
-            {%- set columns_csv = column_list | join(', ') %}
+            {%- set quoted_cols = [] %}
+            {%- for col in primary_key %}
+                {%- do quoted_cols.append(adapter.quote(col)) %}
+            {%- endfor %}
+            {%- set columns_csv = quoted_cols | join(', ') %}
 
             with validation_errors as (
                 select
@@ -128,7 +131,7 @@ class ValueDiffTask(Task, ValueDiffMixin):
 
         {%- for field in primary_keys -%}
             {%- do fields.append(
-                "coalesce(cast(" ~ field ~ " as " ~ dbt.type_string() ~ "), '" ~ default_null_value  ~"')"
+                "coalesce(cast(" ~ adapter.quote(field) ~ " as " ~ dbt.type_string() ~ "), '" ~ default_null_value  ~"')"
             ) -%}
 
             {%- if not loop.last %}
@@ -146,19 +149,21 @@ class ValueDiffTask(Task, ValueDiffMixin):
             select {{ _pk }} as _pk, * from {{ curr_relation }}
         ),
 
+        {%- set _quoted_col = adapter.quote(column_to_compare) -%}
+
         joined as (
             select
                 coalesce(a_query._pk, b_query._pk) as _pk,
-                a_query.{{ column_to_compare }} as a_query_value,
-                b_query.{{ column_to_compare }} as b_query_value,
+                a_query.{{ _quoted_col }} as a_query_value,
+                b_query.{{ _quoted_col }} as b_query_value,
                 case
-                    when a_query.{{ column_to_compare }} = b_query.{{ column_to_compare }} then 'perfect match'
-                    when a_query.{{ column_to_compare }} is null and b_query.{{ column_to_compare }} is null then 'both are null'
+                    when a_query.{{ _quoted_col }} = b_query.{{ _quoted_col }} then 'perfect match'
+                    when a_query.{{ _quoted_col }} is null and b_query.{{ _quoted_col }} is null then 'both are null'
                     when a_query._pk is null then 'missing from {{ a_relation_name }}'
                     when b_query._pk is null then 'missing from {{ b_relation_name }}'
-                    when a_query.{{ column_to_compare }} is null then 'value is null in {{ a_relation_name }} only'
-                    when b_query.{{ column_to_compare }} is null then 'value is null in {{ b_relation_name }} only'
-                    when a_query.{{ column_to_compare }} != b_query.{{ column_to_compare }} then 'values do not match'
+                    when a_query.{{ _quoted_col }} is null then 'value is null in {{ a_relation_name }} only'
+                    when b_query.{{ _quoted_col }} is null then 'value is null in {{ b_relation_name }} only'
+                    when a_query.{{ _quoted_col }} != b_query.{{ _quoted_col }} then 'values do not match'
                     else 'unknown' -- this should never happen
                 end as match_status
             from a_query
@@ -377,10 +382,19 @@ class ValueDiffDetailTask(Task, ValueDiffMixin):
                 columns.insert(0, primary_key)
 
         sql_template = r"""
-                       with a_query as (select {{ columns | join (',\n') }}
+                       {%- set _quoted_cols = [] -%}
+                       {%- for col in columns -%}
+                           {%- do _quoted_cols.append(adapter.quote(col)) -%}
+                       {%- endfor -%}
+                       {%- set _quoted_pks = [] -%}
+                       {%- for pk in primary_keys -%}
+                           {%- do _quoted_pks.append(adapter.quote(pk)) -%}
+                       {%- endfor -%}
+
+                       with a_query as (select {{ _quoted_cols | join (',\n') }}
                        from {{ base_relation }}
                            ), b_query as (
-                       select {{ columns | join (',\n') }}
+                       select {{ _quoted_cols | join (',\n') }}
                        from {{ curr_relation }}
                            ), a_intersect_b as (
                        select *
@@ -421,7 +435,7 @@ class ValueDiffDetailTask(Task, ValueDiffMixin):
                        select *
                        from all_records
                        where not (in_a and in_b)
-                       order by {{ primary_keys | join (',\n') }}, in_a desc, in_b desc
+                       order by {{ _quoted_pks | join (',\n') }}, in_a desc, in_b desc
                            limit {{ limit }}
                        """
 

--- a/tests/tasks/test_valuediff.py
+++ b/tests/tasks/test_valuediff.py
@@ -344,6 +344,70 @@ def test_value_diff_skips_column_named_column_name(dbt_test_helper):
 # causing type conversion errors during SQL execution.
 
 
+def test_value_diff_digit_starting_column(dbt_test_helper):
+    """Test that columns starting with digits are properly quoted in SQL.
+
+    Regression test for GitHub #1311 / DRC-3247: column names like '47_1_TransId'
+    must be quoted in generated SQL, otherwise the parser reads '47' as a numeric
+    literal and fails.
+    """
+    csv_data_base = """
+        47_1_TransId,name,age
+        1,Alice,30
+        2,Bob,25
+        """
+
+    csv_data_curr = """
+        47_1_TransId,name,age
+        1,Alice,31
+        2,Bob,25
+        """
+
+    dbt_test_helper.create_model("digit_col", csv_data_base, csv_data_curr)
+
+    # ValueDiffTask with digit-starting primary key
+    params = {"model": "digit_col", "primary_key": ["47_1_TransId"]}
+    task = ValueDiffTask(params)
+    run_result = task.execute()
+    assert run_result.summary.total == 2
+    assert run_result.summary.added == 0
+    assert run_result.summary.removed == 0
+
+    # ValueDiffDetailTask with digit-starting primary key
+    task = ValueDiffDetailTask(params)
+    run_result = task.execute()
+    # Row 1 has age change (30 -> 31), should appear as 2 detail rows
+    assert len(run_result.data) == 2
+
+
+def test_value_diff_digit_starting_composite_key(dbt_test_helper):
+    """Test composite primary key with digit-starting columns."""
+    csv_data_base = """
+        47_1_TransId,2nd_key,value
+        1,A,100
+        2,B,200
+        """
+
+    csv_data_curr = """
+        47_1_TransId,2nd_key,value
+        1,A,100
+        2,B,250
+        """
+
+    dbt_test_helper.create_model("digit_composite", csv_data_base, csv_data_curr)
+
+    params = {"model": "digit_composite", "primary_key": ["47_1_TransId", "2nd_key"]}
+    task = ValueDiffTask(params)
+    run_result = task.execute()
+    assert run_result.summary.total == 2
+    assert run_result.summary.added == 0
+    assert run_result.summary.removed == 0
+
+    task = ValueDiffDetailTask(params)
+    run_result = task.execute()
+    assert len(run_result.data) == 2
+
+
 # =============================================================================
 # Validator Tests
 # =============================================================================


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

Column names starting with digits (e.g. `47_1_TransId`) caused SQL compilation errors on Snowflake because they were interpolated bare into Jinja SQL templates. The SQL parser reads leading digits as a numeric literal and fails on the remainder:

```
SQL compilation error:
syntax error line 4 at position 17 unexpected 'as'.
```

This PR adds `adapter.quote()` to all column identifier interpolations in value diff SQL templates, matching the pattern already used in `profile.py`. The fix covers:

- `_verify_primary_key` composite key validation
- Surrogate key field in `coalesce(cast(...))` expression
- Column comparison in the `joined` CTE (summary query)
- Column list and primary key list in the detail query

**Which issue(s) this PR fixes**:

Closes #1311
Resolves DRC-3247

**Special notes for your reviewer**:

- Line 175 (`'{{ column_to_compare }}'`) is intentionally left unquoted — it's a string literal for the `column_name` output field, not a SQL identifier reference
- Same quoting gap exists in `top_k.py` and `histogram.py` — those should be addressed in a follow-up
- All 1034 non-server tests pass; the 5 `test_server.py` failures are pre-existing (missing frontend build artifacts)

**Does this PR introduce a user-facing change?**:

Value diff now works correctly with column names that require SQL quoting (e.g. columns starting with digits like `47_1_TransId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)