### PR TITLE
fix(lineage): make impacted-column snapshot trigger sidebar re-render

### DIFF
--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -475,8 +475,14 @@ export function PrivateLineageView(
 
   // Guard: auto-trigger impact analysis only once per mount
   const impactAtStartupFired = useRef(false);
-  const impactedNodeIdsRef = useRef<Set<string>>(new Set());
-  const impactedColumnIdsRef = useRef<Set<string>>(new Set());
+  // State (not refs) so downstream memos re-render when impact CLL populates the
+  // snapshot; a ref mutation would leave SchemaView latched on the initial empty Set.
+  const [impactedNodeIds, setImpactedNodeIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [impactedColumnIds, setImpactedColumnIds] = useState<Set<string>>(
+    new Set(),
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Intentionally only run when lineageGraph changes (initial load/refetch).
   useLayoutEffect(() => {
@@ -621,8 +627,8 @@ export function PrivateLineageView(
       // Snapshot impacted sets during impact analysis so they stay stable
       // when the user clicks a column (which returns column-scoped CLL data).
       if (impacted && cllInput?.change_analysis && !cllInput?.column) {
-        impactedNodeIdsRef.current = impacted.nodeIds;
-        impactedColumnIdsRef.current = impacted.columnIds;
+        setImpactedNodeIds(impacted.nodeIds);
+        setImpactedColumnIds(impacted.columnIds);
       }
 
       // Track lineage view render
@@ -911,8 +917,8 @@ export function PrivateLineageView(
 
     // Snapshot impacted node and column IDs during impact analysis (see layout effect).
     if (impacted && !cllInput2?.column) {
-      impactedNodeIdsRef.current = impacted.nodeIds;
-      impactedColumnIdsRef.current = impacted.columnIds;
+      setImpactedNodeIds(impacted.nodeIds);
+      setImpactedColumnIds(impacted.columnIds);
     }
 
     // Track lineage view render
@@ -1141,8 +1147,8 @@ export function PrivateLineageView(
     selectParentNodes,
     selectChildNodes,
     deselect,
-    impactedNodeIds: impactedNodeIdsRef.current,
-    impactedColumnIds: impactedColumnIdsRef.current,
+    impactedNodeIds,
+    impactedColumnIds,
     isNodeHighlighted: (nodeId: string) => highlighted.has(nodeId),
     isNodeSelected: (nodeId: string) => selectedNodeIds.has(nodeId),
     isEdgeHighlighted: (source, target) => {

--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -105,6 +105,7 @@ import {
 import {
   useLineageCopyToClipboard,
   useNavToCheck,
+  usePublishedImpactSets,
   useResizeObserver,
   useTrackLineageRender,
 } from "./hooks";
@@ -475,14 +476,11 @@ export function PrivateLineageView(
 
   // Guard: auto-trigger impact analysis only once per mount
   const impactAtStartupFired = useRef(false);
-  // State (not refs) so downstream memos re-render when impact CLL populates the
-  // snapshot; a ref mutation would leave SchemaView latched on the initial empty Set.
-  const [impactedNodeIds, setImpactedNodeIds] = useState<Set<string>>(
-    new Set(),
-  );
-  const [impactedColumnIds, setImpactedColumnIds] = useState<Set<string>>(
-    new Set(),
-  );
+  const {
+    impactedNodeIds,
+    impactedColumnIds,
+    publish: publishImpactSets,
+  } = usePublishedImpactSets();
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Intentionally only run when lineageGraph changes (initial load/refetch).
   useLayoutEffect(() => {
@@ -627,8 +625,7 @@ export function PrivateLineageView(
       // Snapshot impacted sets during impact analysis so they stay stable
       // when the user clicks a column (which returns column-scoped CLL data).
       if (impacted && cllInput?.change_analysis && !cllInput?.column) {
-        setImpactedNodeIds(impacted.nodeIds);
-        setImpactedColumnIds(impacted.columnIds);
+        publishImpactSets(impacted);
       }
 
       // Track lineage view render
@@ -917,8 +914,7 @@ export function PrivateLineageView(
 
     // Snapshot impacted node and column IDs during impact analysis (see layout effect).
     if (impacted && !cllInput2?.column) {
-      setImpactedNodeIds(impacted.nodeIds);
-      setImpactedColumnIds(impacted.columnIds);
+      publishImpactSets(impacted);
     }
 
     // Track lineage view render

--- a/js/packages/ui/src/components/lineage/hooks/index.ts
+++ b/js/packages/ui/src/components/lineage/hooks/index.ts
@@ -1,5 +1,6 @@
 // Hooks for LineageView components
 export { useLineageCopyToClipboard } from "./useLineageCopyToClipboard";
 export { useNavToCheck } from "./useNavToCheck";
+export { usePublishedImpactSets } from "./usePublishedImpactSets";
 export { useResizeObserver } from "./useResizeObserver";
 export { useTrackLineageRender } from "./useTrackLineageRender";

--- a/js/packages/ui/src/components/lineage/hooks/usePublishedImpactSets.test.tsx
+++ b/js/packages/ui/src/components/lineage/hooks/usePublishedImpactSets.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Regression test for CLL sidebar race (PR #1315).
+ *
+ * The publishing mechanism for impacted node/column sets MUST use React state,
+ * not a ref. A ref mutation does not trigger a re-render, so downstream memos
+ * (notably SchemaView's `impactedColumns`) latch onto the initial empty Set
+ * and never refresh when async impact-CLL analysis resolves.
+ *
+ * If someone refactors this back to `useRef`, these tests fail.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { usePublishedImpactSets } from "./usePublishedImpactSets";
+
+describe("usePublishedImpactSets", () => {
+  it("starts with empty node and column sets", () => {
+    const { result } = renderHook(() => usePublishedImpactSets());
+
+    expect(result.current.impactedNodeIds.size).toBe(0);
+    expect(result.current.impactedColumnIds.size).toBe(0);
+  });
+
+  it("publishing new sets changes the returned identity (triggers re-render)", () => {
+    // This is the core regression assertion. With a ref-based implementation,
+    // result.current would be frozen at the first render's snapshot and the
+    // new Sets would never surface to consumers.
+    const { result } = renderHook(() => usePublishedImpactSets());
+
+    const initialNodeIds = result.current.impactedNodeIds;
+    const initialColumnIds = result.current.impactedColumnIds;
+
+    act(() => {
+      result.current.publish({
+        nodeIds: new Set(["model.test.orders"]),
+        columnIds: new Set(["model.test.orders.status"]),
+      });
+    });
+
+    expect(result.current.impactedNodeIds).not.toBe(initialNodeIds);
+    expect(result.current.impactedColumnIds).not.toBe(initialColumnIds);
+    expect(result.current.impactedNodeIds.has("model.test.orders")).toBe(true);
+    expect(
+      result.current.impactedColumnIds.has("model.test.orders.status"),
+    ).toBe(true);
+  });
+
+  it("each publish exposes a fresh Set identity so useMemo dependencies re-fire", () => {
+    // Simulates the SchemaView consumer: a useMemo keyed on impactedColumnIds.
+    // If the hook re-publishes with new content, the memo must see a new
+    // reference and re-run. Mutating a ref in place would break this contract.
+    const { result } = renderHook(() => usePublishedImpactSets());
+
+    act(() => {
+      result.current.publish({
+        nodeIds: new Set(["a"]),
+        columnIds: new Set(["a.x"]),
+      });
+    });
+    const first = result.current.impactedColumnIds;
+
+    act(() => {
+      result.current.publish({
+        nodeIds: new Set(["a", "b"]),
+        columnIds: new Set(["a.x", "b.y"]),
+      });
+    });
+    const second = result.current.impactedColumnIds;
+
+    expect(second).not.toBe(first);
+    expect(second.size).toBe(2);
+  });
+});

--- a/js/packages/ui/src/components/lineage/hooks/usePublishedImpactSets.ts
+++ b/js/packages/ui/src/components/lineage/hooks/usePublishedImpactSets.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from "react";
+
+export interface ImpactSets {
+  nodeIds: Set<string>;
+  columnIds: Set<string>;
+}
+
+export interface UsePublishedImpactSetsResult {
+  impactedNodeIds: Set<string>;
+  impactedColumnIds: Set<string>;
+  publish: (sets: ImpactSets) => void;
+}
+
+// State (not refs) so downstream memos re-render when impact CLL populates the
+// snapshot. A ref mutation would leave SchemaView latched on the initial empty
+// Set. See PR #1315 for the race this guards against.
+export function usePublishedImpactSets(): UsePublishedImpactSetsResult {
+  const [impactedNodeIds, setImpactedNodeIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [impactedColumnIds, setImpactedColumnIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const publish = useCallback((sets: ImpactSets) => {
+    setImpactedNodeIds(sets.nodeIds);
+    setImpactedColumnIds(sets.columnIds);
+  }, []);
+
+  return { impactedNodeIds, impactedColumnIds, publish };
+}


### PR DESCRIPTION
## Summary

- Promotes `impactedNodeIdsRef` / `impactedColumnIdsRef` from `useRef` to `useState` in `LineageViewOss` so downstream memos — notably `SchemaView`'s `impactedColumns` — re-render when whole-graph impact CLL finishes populating the snapshot.
- Previously a ref mutation meant `SchemaView` latched onto the initial empty `Set()`; if the user opened the schema sidebar while the impact CLL was in flight, amber highlights never appeared once the data resolved.
- Behavior preserved: the snapshot still "freezes" across column navigation (a column-scoped fetch only writes when the snapshot is still empty or when impact analysis completes without a `column` scope).

## Context

Race diagnosed via Playwright + injected logs:
- `impactedColumnIdsRef` starts empty; writes at `LineageViewOss.tsx:625` / `:915` are guarded by `!cllInput?.column`.
- `SchemaView.tsx:232` reads `lineageViewContext.impactedColumnIds` (which pointed at `impactedColumnIdsRef.current`) inside a `useMemo`. Because refs don't trigger re-renders, the memo never re-ran when impact CLL populated the set after an open sidebar.

With a 5 s delay simulated on the impact-analysis fetch (before fix):
- `SV:frozen-size=0` @ +1354ms (sidebar blank)
- `ref-update` @ +6010ms (ref filled, but no re-render)
- Sidebar stays blank indefinitely.

After fix (verified against Snowflake-backed jaffle_shop, `change_analysis=true`, 46 impacted columns):
- State setter fires when impact CLL resolves → context Provider re-renders → `SchemaView`'s `useMemo` re-runs → amber paints on `orders.STATUS` and all downstream-impacted columns.

## Test plan

- [x] `pnpm type:check` clean
- [x] `pnpm lint:fix` clean
- [x] `pnpm test` — 3664 passed, 5 skipped
- [x] Manual verification: Snowflake `jaffle_shop`, `--new-cll-experience --impact-at-startup`, sidebar shows amber on impacted columns (`orders.STATUS`, `customers.FULL_NAME` downstream, etc.) both on patient load and during a simulated 5 s CLL delay.

## User-facing changes

- Schema sidebar now reliably shows amber highlights on columns impacted by upstream breaking changes, even when opened mid-fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)