### PR TITLE
feat: make raw_code usage defensive for on-demand fetch

### DIFF
--- a/js/packages/ui/src/components/lineage/NodeSqlView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeSqlView.tsx
@@ -125,6 +125,10 @@ export const NodeSqlView = ({
   const modelName =
     node.data.data.base?.name ?? node.data.data.current?.name ?? "";
 
+  // Defensive: show "No code available" only when raw_code is missing from
+  // all sources (forward-compatibility for when backend strips raw_code).
+  const hasCode = original !== undefined || modified !== undefined;
+
   return (
     <Box
       className="no-track-pii-safe"
@@ -136,7 +140,19 @@ export const NodeSqlView = ({
         setIsHovered(false);
       }}
     >
-      {isSingleEnv ? (
+      {!hasCode ? (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            color: "text.secondary",
+          }}
+        >
+          No code available
+        </Box>
+      ) : isSingleEnv ? (
         <CodeEditor
           language="sql"
           value={original ?? ""}
@@ -196,7 +212,19 @@ export const NodeSqlView = ({
           </IconButton>
         </DialogTitle>
         <DialogContent>
-          {isSingleEnv ? (
+          {!hasCode ? (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "100%",
+                color: "text.secondary",
+              }}
+            >
+              No code available
+            </Box>
+          ) : isSingleEnv ? (
             <CodeEditor
               language="sql"
               value={original ?? ""}

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -601,11 +601,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
   const { base, current } = node.data.data;
   const hasSchemaChanges =
     !isSingleEnv && isSchemaChanged(base?.columns, current?.columns) === true;
-  const hasCodeChanges =
-    !isSingleEnv &&
-    base?.raw_code != null &&
-    current?.raw_code != null &&
-    base.raw_code !== current.raw_code;
+  const hasCodeChanges = !isSingleEnv && node.data.changeStatus === "modified";
 
   const isModelSeedOrSnapshot =
     node.data.resourceType === "model" ||

--- a/js/packages/ui/src/components/lineage/SandboxView.tsx
+++ b/js/packages/ui/src/components/lineage/SandboxView.tsx
@@ -343,8 +343,8 @@ function SqlPreview({
 }: SqlPreviewProps) {
   return (
     <DiffEditor
-      original={current?.raw_code ?? ""}
-      modified={current?.raw_code ?? ""}
+      original={current?.raw_code ?? "-- No code available"}
+      modified={current?.raw_code ?? "-- No code available"}
       language="sql"
       readOnly={false}
       lineNumbers={true}

--- a/js/packages/ui/src/components/lineage/SandboxViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/SandboxViewOss.tsx
@@ -49,7 +49,7 @@ interface SandboxViewProps {
  */
 export function SandboxViewOss({ isOpen, onClose, current }: SandboxViewProps) {
   const [modifiedCode, setModifiedCode] = useState<string>(
-    current?.raw_code ?? "",
+    current?.raw_code ?? "-- No code available",
   );
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
   const { showRunId, clearRunResult } = useRecceActionContext();
@@ -62,7 +62,7 @@ export function SandboxViewOss({ isOpen, onClose, current }: SandboxViewProps) {
   if (isOpen !== prevIsOpen) {
     setPrevIsOpen(isOpen);
     if (isOpen) {
-      setModifiedCode(current?.raw_code ?? "");
+      setModifiedCode(current?.raw_code ?? "-- No code available");
     }
   }
 

--- a/js/packages/ui/src/components/lineage/__tests__/NodeSqlView.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeSqlView.test.tsx
@@ -539,8 +539,8 @@ describe("NodeSqlView", () => {
 
       render(<NodeSqlView {...props} />);
 
-      // Should render empty editor
-      expect(screen.getByTestId("mock-code-editor")).toHaveTextContent("");
+      // Should show "No code available" when raw_code is missing from all sources
+      expect(screen.getByText("No code available")).toBeInTheDocument();
     });
   });
 

--- a/js/packages/ui/src/contexts/lineage/utils.ts
+++ b/js/packages/ui/src/contexts/lineage/utils.ts
@@ -242,6 +242,8 @@ export function buildLineageGraph(
       node.data.changeStatus = "added";
       modifiedSet.push(node.id);
     } else {
+      // TODO(DRC-3254): Remove this client-side checksum fallback once DRC-3254
+      // is deployed and the server always provides complete diff data.
       const checksum1 = node.data.data.base?.checksum?.checksum;
       const checksum2 = node.data.data.current?.checksum?.checksum;
 


### PR DESCRIPTION
## Summary

Make all `raw_code` consumers handle the case where it's missing from lineage data, preparing for Phase I field stripping (DRC-3255).

- `NodeView.tsx`: Replace `raw_code` comparison with `changeStatus === "modified"` for code-change dot
- `NodeSqlView.tsx`: Show "No code available" when `raw_code` is undefined (both base and current)
- `SandboxViewOss.tsx` / `SandboxView.tsx`: Use `"-- No code available"` fallback
- `utils.ts`: Added TODO comment for checksum fallback removal (DRC-3254)

**Backward-compatible:** Works with both old `/info` (raw_code present) and new `/info` (raw_code stripped).

## Test plan

- [x] All 3681 tests pass
- [x] Lint clean, type check clean
- [ ] Manual: verify Code tab shows code when raw_code is present (current behavior)

Resolves DRC-3256

🤖 Generated with [Claude Code](https://claude.com/claude-code)