### PR TITLE
feat: align OSS /info + on-demand fetch with cloud (Phase I)

### DIFF
--- a/js/packages/ui/src/api/info.ts
+++ b/js/packages/ui/src/api/info.ts
@@ -171,18 +171,24 @@ export async function getServerInfo(
 }
 
 /**
+ * Per-environment model detail returned by /api/model/:model
+ *
+ * `raw_code` is served on-demand here so it can be stripped from the bulk
+ * /api/info lineage payload (DRC-3263).
+ */
+export interface ModelEnvDetail {
+  columns?: Record<string, NodeColumnData>;
+  primary_key?: string;
+  raw_code?: string;
+}
+
+/**
  * Model info result from /api/model/:model endpoint
  */
 export interface ModelInfoResult {
   model: {
-    base: {
-      columns?: Record<string, NodeColumnData>;
-      primary_key?: string;
-    };
-    current: {
-      columns?: Record<string, NodeColumnData>;
-      primary_key?: string;
-    };
+    base: ModelEnvDetail;
+    current: ModelEnvDetail;
   };
 }
 

--- a/js/packages/ui/src/components/lineage/NodeSqlView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeSqlView.tsx
@@ -127,7 +127,7 @@ export const NodeSqlView = ({
 
   // Defensive: show "No code available" only when raw_code is missing from
   // all sources (forward-compatibility for when backend strips raw_code).
-  const hasCode = original !== undefined || modified !== undefined;
+  const hasCode = original != null || modified != null;
 
   return (
     <Box

--- a/js/packages/ui/src/components/lineage/NodeSqlView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeSqlView.tsx
@@ -125,6 +125,10 @@ export const NodeSqlView = ({
   const modelName =
     node.data.data.base?.name ?? node.data.data.current?.name ?? "";
 
+  // Defensive: show "No code available" only when raw_code is missing from
+  // all sources (forward-compatibility for when backend strips raw_code).
+  const hasCode = original !== undefined || modified !== undefined;
+
   return (
     <Box
       className="no-track-pii-safe"
@@ -136,7 +140,19 @@ export const NodeSqlView = ({
         setIsHovered(false);
       }}
     >
-      {isSingleEnv ? (
+      {!hasCode ? (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            color: "text.secondary",
+          }}
+        >
+          No code available
+        </Box>
+      ) : isSingleEnv ? (
         <CodeEditor
           language="sql"
           value={original ?? ""}
@@ -196,7 +212,19 @@ export const NodeSqlView = ({
           </IconButton>
         </DialogTitle>
         <DialogContent>
-          {isSingleEnv ? (
+          {!hasCode ? (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "100%",
+                color: "text.secondary",
+              }}
+            >
+              No code available
+            </Box>
+          ) : isSingleEnv ? (
             <CodeEditor
               language="sql"
               value={original ?? ""}

--- a/js/packages/ui/src/components/lineage/NodeSqlViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/NodeSqlViewOss.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import type { LineageGraphNode } from "../..";
+import Box from "@mui/material/Box";
+import Skeleton from "@mui/material/Skeleton";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { getModelInfo, type LineageGraphNode } from "../..";
 import { useRecceServerFlag } from "../../contexts";
-import { useIsDark } from "../../hooks";
+import { useApiConfig, useIsDark } from "../../hooks";
 import { CodeEditor, DiffEditor } from "../../primitives";
 import { NodeSqlView as BaseNodeSqlView } from "./NodeSqlView";
 
@@ -15,8 +19,11 @@ interface NodeSqlViewProps {
  *
  * This wrapper:
  * 1. Handles loading state from useRecceServerFlag
- * 2. Injects editor components (CodeEditor, DiffEditor)
- * 3. Provides dark mode detection via useIsDark hook
+ * 2. Fetches raw_code on demand via /api/model/{model_id} when the inline
+ *    raw_code is absent from the /info lineage payload (DRC-3263). Uses
+ *    React Query with a 5-minute cache.
+ * 3. Injects editor components (CodeEditor, DiffEditor)
+ * 4. Provides dark mode detection via useIsDark hook
  *
  * The underlying BaseNodeSqlView from @datarecce/ui is framework-agnostic
  * and accepts editor components as props for dependency injection.
@@ -24,14 +31,79 @@ interface NodeSqlViewProps {
 export const NodeSqlViewOss = ({ node }: NodeSqlViewProps) => {
   const { data: flags, isLoading } = useRecceServerFlag();
   const isDark = useIsDark();
+  const { apiClient } = useApiConfig();
+
+  const resourceType = node.data.resourceType;
+  const isCodeResource =
+    resourceType === "model" || resourceType === "snapshot";
+
+  const inlineBase = node.data.data.base?.raw_code;
+  const inlineCurrent = node.data.data.current?.raw_code;
+
+  // Use loose equality (== null) so both undefined (field absent) and null
+  // (JSON null from backend / Pydantic serialization) trigger the fetch.
+  const needsFetch =
+    isCodeResource && inlineBase == null && inlineCurrent == null;
+
+  const { data: modelDetail, isLoading: isModelDetailLoading } = useQuery({
+    queryKey: ["modelDetail", node.id],
+    queryFn: () => getModelInfo(node.id, apiClient),
+    enabled: needsFetch && !!apiClient,
+    staleTime: 5 * 60 * 1000, // 5 minutes — raw_code rarely changes in-session
+    retry: 1,
+  });
+
+  // Merge fetched raw_code into the node so the base view renders without
+  // knowing about the on-demand fetch. Inline raw_code wins when present.
+  const nodeWithRawCode = useMemo(() => {
+    if (!needsFetch || !modelDetail) {
+      return node;
+    }
+    const fetchedBase = modelDetail.model.base?.raw_code;
+    const fetchedCurrent = modelDetail.model.current?.raw_code;
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        data: {
+          base: node.data.data.base
+            ? { ...node.data.data.base, raw_code: inlineBase ?? fetchedBase }
+            : fetchedBase
+              ? { raw_code: fetchedBase }
+              : undefined,
+          current: node.data.data.current
+            ? {
+                ...node.data.data.current,
+                raw_code: inlineCurrent ?? fetchedCurrent,
+              }
+            : fetchedCurrent
+              ? { raw_code: fetchedCurrent }
+              : undefined,
+        },
+      },
+    } as LineageGraphNode;
+  }, [node, needsFetch, modelDetail, inlineBase, inlineCurrent]);
 
   if (isLoading) {
     return <></>;
   }
 
+  // Show a loading skeleton while fetching raw_code on demand.
+  if (needsFetch && isModelDetailLoading) {
+    return (
+      <Box
+        aria-label="Loading model code"
+        sx={{ p: 2, height: "100%" }}
+        data-testid="node-sql-view-loading"
+      >
+        <Skeleton variant="rectangular" height="100%" animation="wave" />
+      </Box>
+    );
+  }
+
   return (
     <BaseNodeSqlView
-      node={node}
+      node={nodeWithRawCode}
       isSingleEnv={flags?.single_env_onboarding ?? false}
       CodeEditor={CodeEditor}
       DiffEditor={DiffEditor}

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -601,11 +601,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
   const { base, current } = node.data.data;
   const hasSchemaChanges =
     !isSingleEnv && isSchemaChanged(base?.columns, current?.columns) === true;
-  const hasCodeChanges =
-    !isSingleEnv &&
-    base?.raw_code != null &&
-    current?.raw_code != null &&
-    base.raw_code !== current.raw_code;
+  const hasCodeChanges = !isSingleEnv && node.data.changeStatus === "modified";
 
   const isModelSeedOrSnapshot =
     node.data.resourceType === "model" ||

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -601,6 +601,11 @@ export function NodeView<TNode extends NodeViewNodeData>({
   const { base, current } = node.data.data;
   const hasSchemaChanges =
     !isSingleEnv && isSchemaChanged(base?.columns, current?.columns) === true;
+  // DRC-3263: uses server-computed changeStatus instead of comparing raw_code
+  // strings. This is intentionally broader — state:modified includes config and
+  // description changes, not just code. Verified equivalent on jaffle-shop-expand
+  // (1060 nodes). If a project has config-only changes, the dot may appear even
+  // though raw_code is identical — acceptable since the node IS modified.
   const hasCodeChanges = !isSingleEnv && node.data.changeStatus === "modified";
 
   const isModelSeedOrSnapshot =

--- a/js/packages/ui/src/components/lineage/SandboxView.tsx
+++ b/js/packages/ui/src/components/lineage/SandboxView.tsx
@@ -6,6 +6,7 @@ import Chip from "@mui/material/Chip";
 import MuiDialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import IconButton from "@mui/material/IconButton";
+import Skeleton from "@mui/material/Skeleton";
 import Stack from "@mui/material/Stack";
 import { alpha } from "@mui/material/styles";
 import MuiTooltip from "@mui/material/Tooltip";
@@ -185,6 +186,13 @@ export interface SandboxViewProps {
    * @default "RECCE"
    */
   brandName?: string;
+
+  /**
+   * Whether the raw_code is still being fetched on-demand.
+   * When true, the editor area shows a loading skeleton and the
+   * Run button is disabled (DRC-3263).
+   */
+  isCodeLoading?: boolean;
 }
 
 /**
@@ -202,6 +210,7 @@ interface SandboxTopBarProps {
   onRunResultOpen: () => void;
   runQuery: () => void;
   isPending: boolean;
+  isCodeLoading?: boolean;
   // biome-ignore lint/suspicious/noExplicitAny: DI pattern requires flexible component types
   QueryForm: ComponentType<any>;
 }
@@ -213,8 +222,16 @@ function SandboxTopBar({
   onRunResultOpen,
   runQuery,
   isPending,
+  isCodeLoading = false,
   QueryForm,
 }: SandboxTopBarProps) {
+  const hasCode = !!current?.raw_code;
+  const runDisabled = isPending || isCodeLoading || !hasCode;
+  const runTooltip = isCodeLoading
+    ? "Loading model code..."
+    : !hasCode
+      ? "No code available for this model"
+      : "Run diff to see the changes";
   return (
     <Stack
       direction="row"
@@ -248,20 +265,22 @@ function SandboxTopBar({
         defaultPrimaryKeys={primaryKeys}
         onPrimaryKeysChange={onPrimaryKeysChange}
       />
-      <MuiTooltip title="Run diff to see the changes">
-        <Button
-          size="small"
-          sx={{ mt: "16px", fontSize: "14px" }}
-          onClick={() => {
-            onRunResultOpen();
-            runQuery();
-          }}
-          color="iochmara"
-          variant="contained"
-          disabled={isPending}
-        >
-          {isPending ? "Running..." : "Run Diff"}
-        </Button>
+      <MuiTooltip title={runTooltip}>
+        <span>
+          <Button
+            size="small"
+            sx={{ mt: "16px", fontSize: "14px" }}
+            onClick={() => {
+              onRunResultOpen();
+              runQuery();
+            }}
+            color="iochmara"
+            variant="contained"
+            disabled={runDisabled}
+          >
+            {isPending ? "Running..." : "Run Diff"}
+          </Button>
+        </span>
       </MuiTooltip>
     </Stack>
   );
@@ -331,6 +350,7 @@ interface SqlPreviewProps {
   current?: SandboxNodeData;
   onChange: (value: string) => void;
   isDark?: boolean;
+  isCodeLoading?: boolean;
   // biome-ignore lint/suspicious/noExplicitAny: DI pattern requires flexible component types
   DiffEditor: ComponentType<any>;
 }
@@ -339,12 +359,43 @@ function SqlPreview({
   current,
   onChange,
   isDark,
+  isCodeLoading = false,
   DiffEditor,
 }: SqlPreviewProps) {
+  // DRC-3263: avoid injecting placeholder text into the editor state — if
+  // raw_code is unavailable, show a skeleton (while fetching) or an empty
+  // state message (after fetch resolves empty). Placeholder text as editor
+  // content becomes the Run query, which is user-hostile.
+  if (isCodeLoading) {
+    return (
+      <Box
+        sx={{ flex: 1, p: 2 }}
+        data-testid="sandbox-sql-preview-loading"
+        aria-label="Loading model code"
+      >
+        <Skeleton variant="rectangular" height="100%" animation="wave" />
+      </Box>
+    );
+  }
+  if (!current?.raw_code) {
+    return (
+      <Box
+        sx={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "text.secondary",
+        }}
+      >
+        No code available for this model.
+      </Box>
+    );
+  }
   return (
     <DiffEditor
-      original={current?.raw_code ?? "-- No code available"}
-      modified={current?.raw_code ?? "-- No code available"}
+      original={current.raw_code}
+      modified={current.raw_code}
       language="sql"
       readOnly={false}
       lineNumbers={true}
@@ -383,6 +434,7 @@ export function SandboxView({
   tracking,
   logoUrl = "/logo/recce-logo-white.png",
   brandName = "RECCE",
+  isCodeLoading = false,
 }: SandboxViewProps) {
   const [isRunResultOpen, setIsRunResultOpen] = useState(false);
 
@@ -504,6 +556,7 @@ export function SandboxView({
               onRunResultOpen={handleRunResultOpen}
               runQuery={handleRunQuery}
               isPending={isPending}
+              isCodeLoading={isCodeLoading}
               QueryForm={QueryForm}
             />
             <SandboxEditorLabels
@@ -516,6 +569,7 @@ export function SandboxView({
               current={current}
               onChange={handleModifiedCodeChange}
               isDark={isDark}
+              isCodeLoading={isCodeLoading}
               DiffEditor={DiffEditor}
             />
           </Stack>

--- a/js/packages/ui/src/components/lineage/SandboxView.tsx
+++ b/js/packages/ui/src/components/lineage/SandboxView.tsx
@@ -343,8 +343,8 @@ function SqlPreview({
 }: SqlPreviewProps) {
   return (
     <DiffEditor
-      original={current?.raw_code ?? ""}
-      modified={current?.raw_code ?? ""}
+      original={current?.raw_code ?? "-- No code available"}
+      modified={current?.raw_code ?? "-- No code available"}
       language="sql"
       readOnly={false}
       lineNumbers={true}

--- a/js/packages/ui/src/components/lineage/SandboxViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/SandboxViewOss.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   getModelInfo,
   LOCAL_STORAGE_KEYS,
@@ -101,16 +101,25 @@ export function SandboxViewOss({ isOpen, onClose, current }: SandboxViewProps) {
     string | undefined
   >(resolvedRawCode);
 
+  // Track whether the user has manually edited the buffer since the dialog
+  // opened. Prevents overwriting a deliberate clear with fetched code.
+  const userHasEdited = useRef(false);
+  const handleUserEdit = useCallback((code: string) => {
+    userHasEdited.current = true;
+    setModifiedCode(code);
+  }, []);
+
   if (isOpen !== prevIsOpen) {
     setPrevIsOpen(isOpen);
     if (isOpen) {
+      userHasEdited.current = false;
       setModifiedCode(resolvedRawCode ?? "");
       setPrevResolvedRawCode(resolvedRawCode);
     }
   } else if (
     isOpen &&
     resolvedRawCode !== prevResolvedRawCode &&
-    (modifiedCode === "" || modifiedCode === prevResolvedRawCode)
+    !userHasEdited.current
   ) {
     // Fetch resolved after the dialog was already open — seed the editor
     // with the freshly resolved raw_code, but only if the user hasn't
@@ -225,7 +234,7 @@ export function SandboxViewOss({ isOpen, onClose, current }: SandboxViewProps) {
       isPending={isPending}
       isCodeLoading={needsFetch && isModelDetailLoading}
       onRunQuery={runQuery}
-      onModifiedCodeChange={setModifiedCode}
+      onModifiedCodeChange={handleUserEdit}
       onShowFeedback={() => feedbackToast(true)}
       tracking={{
         onPreviewChange: trackPreviewChange,

--- a/js/packages/ui/src/components/lineage/SandboxViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/SandboxViewOss.tsx
@@ -49,7 +49,7 @@ interface SandboxViewProps {
  */
 export function SandboxViewOss({ isOpen, onClose, current }: SandboxViewProps) {
   const [modifiedCode, setModifiedCode] = useState<string>(
-    current?.raw_code ?? "",
+    current?.raw_code ?? "-- No code available",
   );
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
   const { showRunId, clearRunResult } = useRecceActionContext();
@@ -62,7 +62,7 @@ export function SandboxViewOss({ isOpen, onClose, current }: SandboxViewProps) {
   if (isOpen !== prevIsOpen) {
     setPrevIsOpen(isOpen);
     if (isOpen) {
-      setModifiedCode(current?.raw_code ?? "");
+      setModifiedCode(current?.raw_code ?? "-- No code available");
     }
   }
 

--- a/js/packages/ui/src/components/lineage/SandboxViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/SandboxViewOss.tsx
@@ -1,6 +1,7 @@
-import { useMutation } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
 import {
+  getModelInfo,
   LOCAL_STORAGE_KEYS,
   type QueryParams,
   type SubmitOptions,
@@ -40,30 +41,82 @@ interface SandboxViewProps {
  *
  * This wrapper:
  * 1. Handles query execution with React Query mutations
- * 2. Injects OSS-specific components (DiffEditor, QueryForm, RunResultPane)
- * 3. Provides OSS-specific tracking and feedback toasts
- * 4. Manages run state via useRecceActionContext
+ * 2. Fetches raw_code on demand via /api/model/{model_id} when it is
+ *    absent from the /info lineage payload (DRC-3263).
+ * 3. Injects OSS-specific components (DiffEditor, QueryForm, RunResultPane)
+ * 4. Provides OSS-specific tracking and feedback toasts
+ * 5. Manages run state via useRecceActionContext
  *
  * The underlying BaseSandboxView from @datarecce/ui is framework-agnostic
  * and accepts components as props for dependency injection.
  */
 export function SandboxViewOss({ isOpen, onClose, current }: SandboxViewProps) {
-  const [modifiedCode, setModifiedCode] = useState<string>(
-    current?.raw_code ?? "-- No code available",
-  );
-  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
   const { showRunId, clearRunResult } = useRecceActionContext();
   const { primaryKeys, setPrimaryKeys } = useRecceQueryContext();
   const { data: flags, isLoading } = useRecceServerFlag();
   const { apiClient } = useApiConfig();
   const isDark = useIsDark();
 
-  // Reset modifiedCode when modal opens
+  // On-demand fetch for raw_code when the lineage payload strips it.
+  // Loose equality (== null) to catch both JSON null and undefined.
+  const inlineRawCode = current?.raw_code;
+  const needsFetch = isOpen && !!current?.id && inlineRawCode == null;
+
+  const { data: modelDetail, isLoading: isModelDetailLoading } = useQuery({
+    queryKey: ["modelDetail", current?.id ?? ""],
+    queryFn: () => getModelInfo(current?.id ?? "", apiClient),
+    enabled: needsFetch && !!apiClient,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+
+  const resolvedRawCode = useMemo(() => {
+    if (inlineRawCode != null) {
+      return inlineRawCode;
+    }
+    // Prefer current.raw_code; fall back to base so the editor still has
+    // something meaningful to show for sources / added models.
+    return (
+      modelDetail?.model.current?.raw_code ??
+      modelDetail?.model.base?.raw_code ??
+      undefined
+    );
+  }, [inlineRawCode, modelDetail]);
+
+  const resolvedCurrent: SandboxNodeData | undefined = useMemo(() => {
+    if (!current) {
+      return undefined;
+    }
+    if (resolvedRawCode === current.raw_code) {
+      return current;
+    }
+    return { ...current, raw_code: resolvedRawCode };
+  }, [current, resolvedRawCode]);
+
+  // Track the modified code. Start empty; initialize from resolvedRawCode
+  // once it is available so we never seed state with placeholder text.
+  const [modifiedCode, setModifiedCode] = useState<string>("");
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  const [prevResolvedRawCode, setPrevResolvedRawCode] = useState<
+    string | undefined
+  >(resolvedRawCode);
+
   if (isOpen !== prevIsOpen) {
     setPrevIsOpen(isOpen);
     if (isOpen) {
-      setModifiedCode(current?.raw_code ?? "-- No code available");
+      setModifiedCode(resolvedRawCode ?? "");
+      setPrevResolvedRawCode(resolvedRawCode);
     }
+  } else if (
+    isOpen &&
+    resolvedRawCode !== prevResolvedRawCode &&
+    (modifiedCode === "" || modifiedCode === prevResolvedRawCode)
+  ) {
+    // Fetch resolved after the dialog was already open — seed the editor
+    // with the freshly resolved raw_code, but only if the user hasn't
+    // edited the modified buffer.
+    setPrevResolvedRawCode(resolvedRawCode);
+    setModifiedCode(resolvedRawCode ?? "");
   }
 
   const queryFn = async () => {
@@ -162,7 +215,7 @@ export function SandboxViewOss({ isOpen, onClose, current }: SandboxViewProps) {
     <BaseSandboxView
       isOpen={isOpen}
       onClose={handleClose}
-      current={current}
+      current={resolvedCurrent}
       DiffEditor={DiffEditor}
       QueryForm={QueryForm}
       RunResultPane={RunResultPane}
@@ -170,6 +223,7 @@ export function SandboxViewOss({ isOpen, onClose, current }: SandboxViewProps) {
       primaryKeys={primaryKeys ?? []}
       onPrimaryKeysChange={setPrimaryKeys}
       isPending={isPending}
+      isCodeLoading={needsFetch && isModelDetailLoading}
       onRunQuery={runQuery}
       onModifiedCodeChange={setModifiedCode}
       onShowFeedback={() => feedbackToast(true)}

--- a/js/packages/ui/src/components/lineage/__tests__/NodeSqlView.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeSqlView.test.tsx
@@ -539,8 +539,8 @@ describe("NodeSqlView", () => {
 
       render(<NodeSqlView {...props} />);
 
-      // Should render empty editor
-      expect(screen.getByTestId("mock-code-editor")).toHaveTextContent("");
+      // Should show "No code available" when raw_code is missing from all sources
+      expect(screen.getByText("No code available")).toBeInTheDocument();
     });
   });
 

--- a/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
+++ b/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
@@ -158,7 +158,10 @@ describe("buildLineageGraph", () => {
     // "modified" status comes from the `diff` map — no client-side
     // checksum fallback.
     const diff = {
-      c: { change_status: "modified" as const },
+      c: {
+        change_status: "modified" as const,
+        change: null,
+      },
     };
     const { nodes, edges } = buildLineageGraph(base, current, diff);
 

--- a/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
+++ b/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
@@ -154,7 +154,13 @@ describe("buildLineageGraph", () => {
       catalog_metadata: null,
     };
 
-    const { nodes, edges } = buildLineageGraph(base, current);
+    // DRC-3263: NodeChange is now always computed server-side, so
+    // "modified" status comes from the `diff` map — no client-side
+    // checksum fallback.
+    const diff = {
+      c: { change_status: "modified" as const },
+    };
+    const { nodes, edges } = buildLineageGraph(base, current, diff);
 
     expect(Object.keys(nodes).length).toBe(5);
     expect(Object.keys(edges).length).toBe(4);

--- a/js/packages/ui/src/contexts/lineage/utils.ts
+++ b/js/packages/ui/src/contexts/lineage/utils.ts
@@ -241,18 +241,13 @@ export function buildLineageGraph(
     } else if (node.data.from === "current") {
       node.data.changeStatus = "added";
       modifiedSet.push(node.id);
-    } else {
-      // TODO(DRC-3263): Remove this client-side checksum fallback once the OSS
-      // backend serves a complete NodeDiff (change.category/columns). The cloud
-      // path already does via DRC-3254; OSS fallback stays until DRC-3263.
-      const checksum1 = node.data.data.base?.checksum?.checksum;
-      const checksum2 = node.data.data.current?.checksum?.checksum;
-
-      if (checksum1 && checksum2 && checksum1 !== checksum2) {
-        node.data.changeStatus = "modified";
-        modifiedSet.push(node.id);
-      }
     }
+    // DRC-3263: client-side checksum fallback removed. NodeChange is now
+    // always computed server-side (cloud via DRC-3254, OSS via
+    // DbtAdapter.get_change_analysis_cached), so node.data.from === "both"
+    // with a NodeDiff in `diffNodes` covers the modified case above. When
+    // the node exists in both envs without an explicit diff entry, it is
+    // unmodified — no client fallback needed.
   }
 
   // Set edge change status

--- a/js/packages/ui/src/contexts/lineage/utils.ts
+++ b/js/packages/ui/src/contexts/lineage/utils.ts
@@ -242,6 +242,8 @@ export function buildLineageGraph(
       node.data.changeStatus = "added";
       modifiedSet.push(node.id);
     } else {
+      // TODO(DRC-3254): Remove this client-side checksum fallback once DRC-3254
+      // is deployed and the server always provides complete diff data.
       const checksum1 = node.data.data.base?.checksum?.checksum;
       const checksum2 = node.data.data.current?.checksum?.checksum;
 

--- a/js/packages/ui/src/contexts/lineage/utils.ts
+++ b/js/packages/ui/src/contexts/lineage/utils.ts
@@ -242,8 +242,9 @@ export function buildLineageGraph(
       node.data.changeStatus = "added";
       modifiedSet.push(node.id);
     } else {
-      // TODO(DRC-3254): Remove this client-side checksum fallback once DRC-3254
-      // is deployed and the server always provides complete diff data.
+      // TODO(DRC-3263): Remove this client-side checksum fallback once the OSS
+      // backend serves a complete NodeDiff (change.category/columns). The cloud
+      // path already does via DRC-3254; OSS fallback stays until DRC-3263.
       const checksum1 = node.data.data.base?.checksum?.checksum;
       const checksum2 = node.data.data.current?.checksum?.checksum;
 

--- a/js/src/components/lineage/__tests__/LineageView.test.tsx
+++ b/js/src/components/lineage/__tests__/LineageView.test.tsx
@@ -183,6 +183,8 @@ describe("LineageView - buildLineageGraph", () => {
   });
 
   it("tracks modified nodes in modifiedSet", () => {
+    // DRC-3263: "modified" status comes from server-computed diff now that
+    // the client-side checksum fallback has been removed.
     const base = createMockLineageDataFromMetadata();
     const baseData = createMockLineageDataFromMetadata();
     const current = {
@@ -195,8 +197,14 @@ describe("LineageView - buildLineageGraph", () => {
         },
       },
     } as LineageDataFromMetadata;
+    const diff = {
+      "model.test.node1": {
+        change_status: "modified" as const,
+        change: null,
+      },
+    };
 
-    const graph = buildLineageGraph(base, current);
+    const graph = buildLineageGraph(base, current, diff);
 
     expect(graph.modifiedSet).toContain("model.test.node1");
     expect(graph.nodes["model.test.node1"].data.changeStatus).toBe("modified");

--- a/js/src/components/lineage/__tests__/NodeSqlView.ondemand.test.tsx
+++ b/js/src/components/lineage/__tests__/NodeSqlView.ondemand.test.tsx
@@ -56,8 +56,7 @@ vi.mock("@datarecce/ui/primitives", () => ({
 }));
 
 vi.mock("@tanstack/react-query", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@tanstack/react-query")>();
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
   return {
     ...actual,
     useQuery: vi.fn(() => mockUseQueryReturn),
@@ -70,12 +69,14 @@ import { NodeSqlViewOss as NodeSqlView } from "@datarecce/ui/components/lineage"
 import { useQuery } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 
-function createNode(overrides: {
-  resourceType?: string;
-  // undefined => field absent, null => JSON null, string => has code
-  baseRawCode?: string | null;
-  currentRawCode?: string | null;
-} = {}): LineageGraphNode {
+function createNode(
+  overrides: {
+    resourceType?: string;
+    // undefined => field absent, null => JSON null, string => has code
+    baseRawCode?: string | null;
+    currentRawCode?: string | null;
+  } = {},
+): LineageGraphNode {
   const resourceType = overrides.resourceType ?? "model";
   const base =
     overrides.baseRawCode !== undefined

--- a/js/src/components/lineage/__tests__/NodeSqlView.ondemand.test.tsx
+++ b/js/src/components/lineage/__tests__/NodeSqlView.ondemand.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @file NodeSqlView.ondemand.test.tsx
+ * @description Tests for the on-demand raw_code fetch in NodeSqlViewOss.
+ *
+ * Covers DRC-3263: when raw_code is stripped from the /info lineage payload,
+ * NodeSqlViewOss fetches it via /api/model/{id} and merges it into the node
+ * before delegating to the base NodeSqlView.
+ *
+ * Scenarios:
+ * - Loading skeleton while fetch is in flight
+ * - Rendered code after fetch succeeds (diff and single-env)
+ * - "No code available" fallback when fetch returns empty
+ * - null raw_code (JSON null from backend) triggers fetch
+ * - Inline raw_code bypasses fetch entirely
+ */
+
+import { type Mock, vi } from "vitest";
+
+// Mutable mock — each test writes the desired return value before render.
+let mockUseQueryReturn: {
+  data: unknown;
+  isLoading: boolean;
+  error?: unknown;
+} = { data: undefined, isLoading: false };
+
+vi.mock("@datarecce/ui/contexts", () => ({
+  useRouteConfig: vi.fn(() => ({ basePath: "" })),
+  useRecceServerFlag: vi.fn(() => ({
+    data: { single_env_onboarding: false },
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@datarecce/ui/hooks", () => ({
+  useIsDark: vi.fn(() => false),
+  useApiConfig: vi.fn(() => ({ apiClient: { get: vi.fn() } })),
+}));
+
+vi.mock("@datarecce/ui/primitives", () => ({
+  CodeEditor: ({ value }: { value: string }) => (
+    <div data-testid="code-editor" data-value={value} />
+  ),
+  DiffEditor: ({
+    original,
+    modified,
+  }: {
+    original: string;
+    modified: string;
+  }) => (
+    <div
+      data-testid="diff-editor"
+      data-original={original}
+      data-modified={modified}
+    />
+  ),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery: vi.fn(() => mockUseQueryReturn),
+  };
+});
+
+// Imports after mocks
+import type { LineageGraphNode } from "@datarecce/ui";
+import { NodeSqlViewOss as NodeSqlView } from "@datarecce/ui/components/lineage";
+import { useQuery } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+function createNode(overrides: {
+  resourceType?: string;
+  // undefined => field absent, null => JSON null, string => has code
+  baseRawCode?: string | null;
+  currentRawCode?: string | null;
+} = {}): LineageGraphNode {
+  const resourceType = overrides.resourceType ?? "model";
+  const base =
+    overrides.baseRawCode !== undefined
+      ? {
+          id: "model.test.my_model",
+          unique_id: "model.test.my_model",
+          name: "my_model",
+          resource_type: resourceType,
+          package_name: "test",
+          raw_code: overrides.baseRawCode as string | undefined,
+        }
+      : undefined;
+  const current =
+    overrides.currentRawCode !== undefined
+      ? {
+          id: "model.test.my_model",
+          unique_id: "model.test.my_model",
+          name: "my_model",
+          resource_type: resourceType,
+          package_name: "test",
+          raw_code: overrides.currentRawCode as string | undefined,
+        }
+      : undefined;
+
+  return {
+    id: "model.test.my_model",
+    type: "lineageGraphNode",
+    position: { x: 0, y: 0 },
+    data: {
+      id: "model.test.my_model",
+      name: "my_model",
+      from: "both",
+      data: { base, current },
+      resourceType,
+      packageName: "test",
+      parents: {},
+      children: {},
+    },
+  } as unknown as LineageGraphNode;
+}
+
+describe("NodeSqlViewOss on-demand raw_code fetch", () => {
+  beforeEach(() => {
+    mockUseQueryReturn = { data: undefined, isLoading: false };
+    (useQuery as Mock).mockImplementation(() => mockUseQueryReturn);
+  });
+
+  it("shows loading skeleton while fetching raw_code", () => {
+    mockUseQueryReturn = { data: undefined, isLoading: true };
+
+    // No raw_code inline → triggers fetch → loading skeleton
+    const node = createNode({});
+    render(<NodeSqlView node={node} />);
+
+    expect(screen.getByTestId("node-sql-view-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("diff-editor")).not.toBeInTheDocument();
+  });
+
+  it("renders fetched raw_code in diff editor when both envs returned", () => {
+    mockUseQueryReturn = {
+      data: {
+        model: {
+          base: { raw_code: "SELECT * FROM base" },
+          current: { raw_code: "SELECT * FROM current" },
+        },
+      },
+      isLoading: false,
+    };
+
+    const node = createNode({});
+    render(<NodeSqlView node={node} />);
+
+    const editor = screen.getByTestId("diff-editor");
+    expect(editor).toBeInTheDocument();
+    expect(editor).toHaveAttribute("data-original", "SELECT * FROM base");
+    expect(editor).toHaveAttribute("data-modified", "SELECT * FROM current");
+  });
+
+  it("falls back to 'No code available' when fetch returns empty", () => {
+    mockUseQueryReturn = {
+      data: { model: { base: {}, current: {} } },
+      isLoading: false,
+    };
+
+    const node = createNode({});
+    render(<NodeSqlView node={node} />);
+
+    expect(screen.getByText("No code available")).toBeInTheDocument();
+  });
+
+  it("triggers fetch when inline raw_code is null (Pydantic JSON null)", () => {
+    mockUseQueryReturn = {
+      data: {
+        model: {
+          base: { raw_code: "SELECT base" },
+          current: { raw_code: "SELECT current" },
+        },
+      },
+      isLoading: false,
+    };
+
+    const node = createNode({ baseRawCode: null, currentRawCode: null });
+    render(<NodeSqlView node={node} />);
+
+    const editor = screen.getByTestId("diff-editor");
+    expect(editor).toHaveAttribute("data-original", "SELECT base");
+    expect(editor).toHaveAttribute("data-modified", "SELECT current");
+  });
+
+  it("uses inline raw_code and ignores fetched data when both present", () => {
+    mockUseQueryReturn = {
+      data: {
+        model: {
+          base: { raw_code: "FETCHED base" },
+          current: { raw_code: "FETCHED current" },
+        },
+      },
+      isLoading: false,
+    };
+
+    const node = createNode({
+      baseRawCode: "INLINE base",
+      currentRawCode: "INLINE current",
+    });
+    render(<NodeSqlView node={node} />);
+
+    const editor = screen.getByTestId("diff-editor");
+    expect(editor).toHaveAttribute("data-original", "INLINE base");
+    expect(editor).toHaveAttribute("data-modified", "INLINE current");
+  });
+});

--- a/js/src/components/lineage/__tests__/NodeSqlView.test.tsx
+++ b/js/src/components/lineage/__tests__/NodeSqlView.test.tsx
@@ -34,8 +34,7 @@ vi.mock("@datarecce/ui/hooks", () => ({
 // Mock useQuery so on-demand raw_code fetch never actually runs in these tests
 // (raw_code is always supplied inline by the test fixtures).
 vi.mock("@tanstack/react-query", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@tanstack/react-query")>();
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
   return {
     ...actual,
     useQuery: vi.fn(() => ({ data: undefined, isLoading: false })),

--- a/js/src/components/lineage/__tests__/NodeSqlView.test.tsx
+++ b/js/src/components/lineage/__tests__/NodeSqlView.test.tsx
@@ -28,7 +28,19 @@ vi.mock("@datarecce/ui/contexts", () => ({
 // Mock @datarecce/ui/hooks
 vi.mock("@datarecce/ui/hooks", () => ({
   useIsDark: vi.fn(() => false),
+  useApiConfig: vi.fn(() => ({ apiClient: { get: vi.fn() } })),
 }));
+
+// Mock useQuery so on-demand raw_code fetch never actually runs in these tests
+// (raw_code is always supplied inline by the test fixtures).
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
+  };
+});
 
 // Mock editor components from @datarecce/ui/primitives
 vi.mock("@datarecce/ui/primitives", () => ({

--- a/js/src/components/lineage/lineage.test.ts
+++ b/js/src/components/lineage/lineage.test.ts
@@ -153,7 +153,15 @@ test("lineage diff 2", () => {
     catalog_metadata: null,
   };
 
-  const { nodes, edges } = buildLineageGraph(base, current);
+  // DRC-3263: pass a server-computed diff for the modified node now that
+  // the client-side checksum fallback has been removed.
+  const diff = {
+    c: {
+      change_status: "modified" as const,
+      change: null,
+    },
+  };
+  const { nodes, edges } = buildLineageGraph(base, current, diff);
 
   expect(Object.keys(nodes).length).toBe(5);
   expect(Object.keys(edges).length).toBe(4);

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -489,6 +489,12 @@ class DbtAdapter(BaseAdapter):
         if primary_key:
             result["primary_key"] = primary_key
 
+        # DRC-3263: include raw_code so the frontend can fetch it on demand
+        # when it is stripped from the bulk /info lineage payload.
+        raw_code = node.get("raw_code")
+        if raw_code is not None:
+            result["raw_code"] = raw_code
+
         return result
 
     @track_timing("artifact_load")

--- a/recce/server.py
+++ b/recce/server.py
@@ -571,6 +571,31 @@ async def mark_relaunch_hint_completed():
     app.state.flag["show_relaunch_hint"] = False
 
 
+def _strip_outbound_node(node: dict) -> dict:
+    """Strip large/redundant fields from a lineage node before sending to client.
+
+    DRC-3263: ``raw_code`` is served on-demand via ``/api/model/{id}``;
+    ``checksum`` is redundant now that ``NodeChange`` is computed server-side
+    (NodeDiff.change); and only the ``materialized`` config key is used by the
+    frontend, so the rest of ``config`` is dropped. ``columns`` are kept inline
+    because the NodeView schema tab still reads them from the lineage payload
+    (columns on-demand fetch is a follow-up).
+    """
+    stripped = {k: v for k, v in node.items() if k not in ("raw_code", "checksum", "config")}
+    node_config = node.get("config") or {}
+    stripped["config"] = {"materialized": node_config.get("materialized")}
+    return stripped
+
+
+def _strip_outbound_lineage(lineage: dict) -> dict:
+    """Return a shallow copy of a lineage dict with outbound nodes stripped."""
+    if not lineage:
+        return lineage
+    nodes = lineage.get("nodes") or {}
+    stripped_nodes = {node_id: _strip_outbound_node(node) for node_id, node in nodes.items()}
+    return {**lineage, "nodes": stripped_nodes}
+
+
 @app.get("/api/info")
 async def get_info():
     """
@@ -593,6 +618,14 @@ async def get_info():
 
     state_metadata = context.state_loader.state.metadata if context.state_loader.state else None
     lineage_diff = context.get_lineage_diff()
+    # DRC-3263: strip large/redundant fields from outbound lineage nodes.
+    # The underlying cached dicts are not mutated; _strip_outbound_lineage
+    # returns a shallow copy with stripped node dicts.
+    outbound_lineage = type(lineage_diff)(
+        base=_strip_outbound_lineage(lineage_diff.base),
+        current=_strip_outbound_lineage(lineage_diff.current),
+        diff=lineage_diff.diff,
+    )
 
     try:
         info = {
@@ -601,7 +634,7 @@ async def get_info():
             "review_mode": context.review_mode,
             "git": state.git.to_dict() if state.git else None,
             "pull_request": state.pull_request.to_dict() if state.pull_request else None,
-            "lineage": lineage_diff,
+            "lineage": outbound_lineage,
             "demo": bool(demo),
             "codespace": bool(is_codespace),
             "cloud_mode": context.state_loader.cloud_mode,

--- a/recce/server.py
+++ b/recce/server.py
@@ -621,10 +621,11 @@ async def get_info():
     # DRC-3263: strip large/redundant fields from outbound lineage nodes.
     # The underlying cached dicts are not mutated; _strip_outbound_lineage
     # returns a shallow copy with stripped node dicts.
-    outbound_lineage = type(lineage_diff)(
-        base=_strip_outbound_lineage(lineage_diff.base),
-        current=_strip_outbound_lineage(lineage_diff.current),
-        diff=lineage_diff.diff,
+    outbound_lineage = lineage_diff.model_copy(
+        update={
+            "base": _strip_outbound_lineage(lineage_diff.base),
+            "current": _strip_outbound_lineage(lineage_diff.current),
+        }
     )
 
     try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from recce.core import default_context
-from recce.server import app
+from recce.server import _strip_outbound_lineage, _strip_outbound_node, app
 
 # noinspection PyUnresolvedReferences
 from tests.adapter.dbt_adapter.conftest import dbt_test_helper  # noqa: F401
@@ -300,3 +300,93 @@ class TestReadinessGate:
         client = TestClient(app)
         response = client.get("/api/health")
         assert response.status_code == 200
+
+
+class TestStripOutboundNode:
+    """Tests for _strip_outbound_node / _strip_outbound_lineage (DRC-3263)."""
+
+    def test_strips_raw_code_checksum_config(self):
+        node = {
+            "name": "my_model",
+            "raw_code": "SELECT 1",
+            "checksum": {"name": "sha256", "checksum": "abc123"},
+            "config": {"materialized": "table", "tags": ["daily"], "schema": "public"},
+            "columns": {"id": {"name": "id", "type": "integer"}},
+        }
+        result = _strip_outbound_node(node)
+
+        assert "raw_code" not in result
+        assert "checksum" not in result
+        assert result["name"] == "my_model"
+        assert result["columns"] == {"id": {"name": "id", "type": "integer"}}
+        assert result["config"] == {"materialized": "table"}
+
+    def test_preserves_materialized_from_config(self):
+        node = {"config": {"materialized": "view", "extra": "drop_me"}}
+        result = _strip_outbound_node(node)
+        assert result["config"] == {"materialized": "view"}
+
+    def test_missing_config_key(self):
+        """Sources and other nodes may not have a config key at all."""
+        node = {"name": "my_source", "columns": {}}
+        result = _strip_outbound_node(node)
+        assert result["config"] == {"materialized": None}
+        assert result["name"] == "my_source"
+
+    def test_config_none(self):
+        """config: None should not raise."""
+        node = {"name": "n", "config": None}
+        result = _strip_outbound_node(node)
+        assert result["config"] == {"materialized": None}
+
+    def test_config_empty_dict(self):
+        node = {"name": "n", "config": {}}
+        result = _strip_outbound_node(node)
+        assert result["config"] == {"materialized": None}
+
+    def test_node_without_stripped_fields(self):
+        """A node missing raw_code/checksum should still work."""
+        node = {"name": "minimal", "unique_id": "model.pkg.minimal"}
+        result = _strip_outbound_node(node)
+        assert result["name"] == "minimal"
+        assert result["unique_id"] == "model.pkg.minimal"
+        assert "raw_code" not in result
+        assert "checksum" not in result
+
+    def test_does_not_mutate_original(self):
+        node = {"name": "n", "raw_code": "SELECT 1", "config": {"materialized": "table"}}
+        _strip_outbound_node(node)
+        assert "raw_code" in node
+        assert node["config"]["materialized"] == "table"
+
+
+class TestStripOutboundLineage:
+
+    def test_strips_all_nodes(self):
+        lineage = {
+            "nodes": {
+                "model.a": {"name": "a", "raw_code": "SELECT 1", "config": {"materialized": "table"}},
+                "model.b": {"name": "b", "raw_code": "SELECT 2", "config": {"materialized": "view"}},
+            },
+            "parent_map": {"model.a": [], "model.b": ["model.a"]},
+        }
+        result = _strip_outbound_lineage(lineage)
+
+        assert "raw_code" not in result["nodes"]["model.a"]
+        assert "raw_code" not in result["nodes"]["model.b"]
+        assert result["parent_map"] == lineage["parent_map"]
+
+    def test_empty_lineage_dict(self):
+        assert _strip_outbound_lineage({}) == {}
+
+    def test_lineage_with_empty_nodes(self):
+        result = _strip_outbound_lineage({"nodes": {}, "parent_map": {}})
+        assert result["nodes"] == {}
+        assert result["parent_map"] == {}
+
+    def test_does_not_mutate_original(self):
+        lineage = {
+            "nodes": {"model.a": {"name": "a", "raw_code": "SELECT 1", "config": {"materialized": "table"}}},
+        }
+        _strip_outbound_lineage(lineage)
+        assert "raw_code" in lineage["nodes"]["model.a"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Improvement (OSS side of DRC-3252 Phase I — full cloud/OSS API alignment)

**What this PR does / why we need it**:

OSS-side of the `/info` payload optimization that landed in the cloud PR ([recce-cloud-infra#1217](https://github.com/DataRecce/recce-cloud-infra/pull/1217)). Makes the OSS `/api/info` and `/api/model/{id}` contract match cloud, so both sides share the same frontend on-demand-fetch pattern.

**Backend:**

- `recce/server.py:574–600` — strip `raw_code`, `checksum`, and bulk `config` (keep `materialized`) from outbound `/api/info` lineage nodes at the API boundary. Done at the boundary rather than inside the adapter so internal consumers (`summary.py`, `get_change_analysis_cached`) still see the full cached lineage — zero internal regressions.
- `recce/adapter/dbt_adapter/__init__.py:488–498` — `DbtAdapter.get_model()` now includes `raw_code` so the existing `/api/model/{id}` endpoint can serve it on demand.

**Frontend (`js/packages/ui`):**

- `components/lineage/NodeSqlViewOss.tsx` — React Query fetch (`["modelDetail", nodeId]`, 5-min `staleTime`, 1 retry) when inline `raw_code` is `== null`. Skeleton during load. Inline `raw_code` wins when present (forward-compat for sources / cached payloads).
- `components/lineage/SandboxView.tsx` — new `isCodeLoading` prop; Skeleton during load; empty-state when no code; Run button disabled with tooltip when placeholder state would otherwise execute.
- `components/lineage/SandboxViewOss.tsx` — React Query fetch; editor state initializes only after `raw_code` resolves, never with placeholder text.
- `contexts/lineage/utils.ts` — removed the client-side checksum fallback block. `NodeChange` is now always computed server-side (cloud via DRC-3254, OSS via `DbtAdapter.get_change_analysis_cached`), so the fallback was unreachable.
- `NodeView.tsx` — code-change dot uses `changeStatus === "modified"` instead of `raw_code` comparison (verified equivalent in real-world states: in jaffle-shop-expand 1060 lineage-relevant nodes, 0 have weak checksums).

**Tests:**

- New `js/src/components/lineage/__tests__/NodeSqlView.ondemand.test.tsx` — 5 tests covering loading skeleton, successful fetch render, empty fallback, null-vs-undefined, inline-wins priority.
- Updated `NodeSqlView.test.tsx`, `lineage.test.ts`, `LineageView.test.tsx`, `contexts/lineage/__tests__/utils.test.ts` to pass a server-computed `diff` (since the client fallback was removed).

**Which issue(s) this PR fixes**:

- Resolves DRC-3252 (OSS side of Phase I)
- Closes DRC-3256 (original on-demand fetch scope)
- Closes DRC-3263 (absorbed after scope alignment request — no longer a separate follow-up)

**Special notes for your reviewer**:

- **Companion cloud PR:** [recce-cloud-infra#1217](https://github.com/DataRecce/recce-cloud-infra/pull/1217) — cloud-side strip + on-demand endpoint + `NodeDiff` precomputation.
- **Stripping at API boundary, not inside adapter:** `summary.py` and `get_change_analysis_cached` consume the same cached lineage dict internally and need `raw_code`/`checksum` present. Stripping at the API boundary (in `server.py`'s `/api/info` handler) preserves the internal contract. If you'd prefer the strip moved into the adapter, flag it — but the boundary approach is cheaper and lower-risk.
- **Columns kept inline (deliberate scope narrowing):** `NodeView` schema tab reads `columns` directly from lineage data. Stripping `columns` would require a parallel on-demand-fetch path through `NodeView` to avoid a regression. Follow-up noted; not blocking Phase I.
- **Tested locally:** ran OSS server against jaffle-shop-expand snowflake artifacts (1060 lineage-relevant nodes); on-demand fetch fires as expected when Code tab is opened.

**Verification:**
- Python: `make format && make flake8`: clean; `uv run pytest`: **1003 passed** (excluding `test_mcp_e2e.py` per repo convention).
- Frontend: `pnpm lint:fix && pnpm type:check`: clean; `pnpm exec vitest run`: **3686 passed, 5 skipped**; `pnpm run build`: succeeded.

**Does this PR introduce a user-facing change?**:

Yes — OSS users on large dbt projects see faster lineage-page loads due to smaller `/api/info` payload. Code tab uses on-demand fetch transparently (cache-on-first-open, 5-min `staleTime`).