### PR TITLE
fix(api): rename /api/model/ to /api/models/ for cloud compatibility

### DIFF
--- a/js/packages/storybook/.storybook/mocks/handlers.ts
+++ b/js/packages/storybook/.storybook/mocks/handlers.ts
@@ -94,9 +94,9 @@ function createModelInfoResponse(
  * MSW request handlers for Recce API endpoints
  */
 export const handlers = [
-  // Handler for /api/model/:model endpoint
+  // Handler for /api/models/:model endpoint
   // Used by useModelColumns hook when columns aren't available in context
-  http.get("/api/model/:model", ({ params }) => {
+  http.get("/api/models/:model", ({ params }) => {
     const model = params.model as string;
     const response = createModelInfoResponse(model);
 

--- a/js/packages/ui/src/api/info.ts
+++ b/js/packages/ui/src/api/info.ts
@@ -202,7 +202,7 @@ export async function getServerInfo(
 }
 
 /**
- * Per-environment model detail returned by /api/model/:model
+ * Per-environment model detail returned by /api/models/:model
  *
  * `raw_code` is served on-demand here so it can be stripped from the bulk
  * /api/info lineage payload (DRC-3263).
@@ -214,7 +214,7 @@ export interface ModelEnvDetail {
 }
 
 /**
- * Model info result from /api/model/:model endpoint
+ * Model info result from /api/models/:model endpoint
  */
 export interface ModelInfoResult {
   model: {
@@ -231,7 +231,7 @@ export async function getModelInfo(
   client: ApiClient,
 ): Promise<ModelInfoResult> {
   const response = await client.get<never, ApiResponse<ModelInfoResult>>(
-    `/api/model/${model}`,
+    `/api/models/${model}`,
   );
   return response.data;
 }

--- a/js/packages/ui/src/components/lineage/NodeSqlViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/NodeSqlViewOss.tsx
@@ -18,7 +18,7 @@ interface NodeSqlViewProps {
  *
  * This wrapper:
  * 1. Handles loading state from useRecceServerFlag
- * 2. Fetches raw_code on demand via /api/model/{model_id}. Uses
+ * 2. Fetches raw_code on demand via /api/models/{model_id}. Uses
  *    React Query with a 5-minute cache.
  * 3. Injects editor components (CodeEditor, DiffEditor)
  * 4. Provides dark mode detection via useIsDark hook

--- a/js/packages/ui/src/components/lineage/SandboxViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/SandboxViewOss.tsx
@@ -41,7 +41,7 @@ interface SandboxViewProps {
  *
  * This wrapper:
  * 1. Handles query execution with React Query mutations
- * 2. Fetches raw_code on demand via /api/model/{model_id} when it is
+ * 2. Fetches raw_code on demand via /api/models/{model_id} when it is
  *    absent from the /info lineage payload (DRC-3263).
  * 3. Injects OSS-specific components (DiffEditor, QueryForm, RunResultPane)
  * 4. Provides OSS-specific tracking and feedback toasts

--- a/js/src/components/lineage/__tests__/NodeSqlView.ondemand.test.tsx
+++ b/js/src/components/lineage/__tests__/NodeSqlView.ondemand.test.tsx
@@ -3,7 +3,7 @@
  * @description Tests for the on-demand raw_code fetch in NodeSqlViewOss.
  *
  * Covers DRC-3263: when raw_code is stripped from the /info lineage payload,
- * NodeSqlViewOss fetches it via /api/model/{id} and merges it into the node
+ * NodeSqlViewOss fetches it via /api/models/{id} and merges it into the node
  * before delegating to the base NodeSqlView.
  *
  * Scenarios:

--- a/recce/server.py
+++ b/recce/server.py
@@ -693,7 +693,7 @@ async def select_nodes(input: SelectNodesInput):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@app.get("/api/model/{model_id}")
+@app.get("/api/models/{model_id}")
 async def get_columns(model_id: str):
     context = default_context()
     try:


### PR DESCRIPTION
## Summary

- Renames the model detail endpoint from `/api/model/{model_id}` to `/api/models/{model_id}` (singular → plural)
- Updates all frontend references in `getModelInfo()`, MSW mock handlers, and JSDoc comments

## Problem

DRC-3260 introduced on-demand model detail fetching — clicking a node in the lineage view now calls `getModelInfo()` which hits `/api/model/{model_id}`.

In Recce Cloud, the `ApiProvider` middleware rewrites `/api` → `/v2/sessions/{id}`, producing:
```
/v2/sessions/{id}/model/{model_id}   ← singular "model"
```

But the cloud API endpoint is registered as:
```
/v2/sessions/{id}/models/{model_id}  ← plural "models"
```

This one-character mismatch (`model` vs `models`) caused a **404 on every node click** in the cloud lineage view. The issue never surfaced before DRC-3260 because columns were inline in the lineage payload — `getModelInfo` was never called from the lineage view.

## Fix

Rename the OSS endpoint to use the plural form, aligning with the cloud API route convention (`/sessions/{session_id}/models/{model_id}`).

## Test plan

- [x] Verified locally with `make start` — node clicks load columns and code correctly
- [ ] OSS standalone: click model nodes in lineage view, verify columns and SQL load
- [ ] Cloud mode: click model nodes, verify no 404 in network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
