### PR TITLE
fix(profile): handle empty tables in profile_diff

### DIFF
--- a/recce/tasks/profile.py
+++ b/recce/tasks/profile.py
@@ -41,18 +41,25 @@ PROFILE_COLUMN_JINJA_TEMPLATE = r"""
 
 {# General Agg ------------------------------------------- #}
 {%- set agg_row_count = 'cast(count(*) as ' ~ dbt.type_bigint() ~ ')' -%}
+{# Wrap count(*) denominators in nullif so empty tables yield NULL proportions
+   instead of raising a database "division by zero" error. #}
 {%- set agg_not_null_proportion =
         'sum(case when ' ~ adapter.quote(column_name) ~ ' is null '
         ~ 'then 0 '
         ~ 'else 1 end) / '
-        ~ 'cast(count(*) as ' ~ dbt.type_numeric() ~ ')'
+        ~ 'nullif(cast(count(*) as ' ~ dbt.type_numeric() ~ '), 0)'
 -%}
 {%- set agg_distinct_proportion =
         'count(distinct ' ~ adapter.quote(column_name) ~') / '
-        ~ 'cast(count(*) as ' ~ dbt.type_numeric() ~ ')'
+        ~ 'nullif(cast(count(*) as ' ~ dbt.type_numeric() ~ '), 0)'
 -%}
 {%- set agg_distinct_count = 'count(distinct ' ~ adapter.quote(column_name) ~ ')' -%}
-{%- set agg_is_unique =      'count(distinct ' ~ adapter.quote(column_name) ~ ') = count(*)' -%}
+{# is_unique is undefined on an empty table — emit null rather than vacuously
+   "0 = 0 = true". #}
+{%- set agg_is_unique =
+        'case when count(*) = 0 then null '
+        ~ 'else count(distinct ' ~ adapter.quote(column_name) ~ ') = count(*) end'
+-%}
 {%- set agg_min =            'cast(null as ' ~ dbt.type_string() ~ ')' -%}
 {%- set agg_max =            'cast(null as ' ~ dbt.type_string() ~ ')' -%}
 {%- set agg_avg =            'cast(null as ' ~ dbt.type_numeric() ~ ')' -%}

--- a/tests/tasks/test_profile.py
+++ b/tests/tasks/test_profile.py
@@ -56,6 +56,49 @@ def test_profile_diff_with_selected_columns(dbt_test_helper):
     assert len(run_result.base.data) == 2
 
 
+# Empty table has no rows — the SQL used to divide by count(*) and fail with
+# "division by zero". After the nullif() fix, an empty side produces one row
+# per column with row_count=0 and NULL proportions.
+csv_data_empty = """
+        customer_id,name,age
+        """
+
+
+def test_profile_diff_current_empty(dbt_test_helper):
+    dbt_test_helper.create_model("customers", csv_data_base, csv_data_empty)
+    params = dict(model="customers")
+    task = ProfileDiffTask(params)
+    run_result = task.execute()
+
+    # Still returns a row per column on both sides.
+    assert len(run_result.base.data) == 3
+    assert len(run_result.current.data) == 3
+
+    # Row counts are populated: base has 3, current has 0.
+    def _row_count(df, col_name):
+        col_names = [c.name for c in df.columns]
+        idx_name = col_names.index("column_name")
+        idx_rc = col_names.index("row_count")
+        for row in df.data:
+            if row[idx_name] == col_name:
+                return row[idx_rc]
+        return None
+
+    assert _row_count(run_result.base, "customer_id") == 3
+    assert _row_count(run_result.current, "customer_id") == 0
+
+
+def test_profile_diff_both_empty(dbt_test_helper):
+    dbt_test_helper.create_model("customers", csv_data_empty, csv_data_empty)
+    params = dict(model="customers")
+    task = ProfileDiffTask(params)
+    run_result = task.execute()
+
+    # No crash; one row per column on each side.
+    assert len(run_result.base.data) == 3
+    assert len(run_result.current.data) == 3
+
+
 def test_validator():
     from recce.tasks.profile import ProfileCheckValidator
 


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

bug

**What this PR does / why we need it**:

Fixes `profile_diff` when a model has zero rows on one side. The generated SQL divided by `count(*)`, so an empty table raised a database "division by zero" error (Snowflake 100051), which Recce surfaced as the confusing message "No profile diff result due to the model is empty."

An empty model on one side is useful diagnostic information — the user should see `row_count` go from K to 0, not an opaque error.

Changes in `recce/tasks/profile.py`:
- Wrap the two `count(*)` denominators (`not_null_proportion`, `distinct_proportion`) in `nullif(..., 0)` so empty tables yield `NULL` proportions instead of dividing by zero.
- Wrap `is_unique` in `case when count(*) = 0 then null else ... end` so it doesn't vacuously return `TRUE` on zero rows.

Adds two tests in `tests/tasks/test_profile.py`: `test_profile_diff_current_empty` and `test_profile_diff_both_empty`.

**Which issue(s) this PR fixes**:

None linked.

**Special notes for your reviewer**:

- Discovered against Snowflake on `order_returns` (181 base → 0 current). Verified manually on Snowflake jaffle_shop with this branch.
- The Snowflake 100051 error handler at `recce/tasks/profile.py` becomes a safety net after this change — kept as-is.
- All 8 tests in `tests/tasks/test_profile.py` pass against DuckDB (6 existing + 2 new).

**Does this PR introduce a user-facing change?**:

Yes — profile diff now renders row counts and NULL proportions when a model is empty on one side, instead of failing with "No profile diff result due to the model is empty."

```release-note
Fix profile diff to handle empty tables: emit NULL proportions instead of failing with a divide-by-zero error when a model has zero rows on one side.
```
