### PR TITLE
refactor(api): strip raw_code from /api/cll payload

### DIFF
--- a/recce/models/types.py
+++ b/recce/models/types.py
@@ -230,7 +230,11 @@ class CllNode(BaseModel):
     name: str
     package_name: str
     resource_type: str
-    raw_code: Optional[str] = None
+    # raw_code is populated from the manifest for server-side CLL computation
+    # (see DbtAdapter.get_cll_cached) but is excluded from serialization — no
+    # frontend consumer reads it off a CLL-sourced node, and it bloats the
+    # /api/cll payload significantly.
+    raw_code: Optional[str] = Field(default=None, exclude=True)
     source_name: Optional[str] = None
 
     # change analysis

--- a/tests/adapter/dbt_adapter/test_dbt_cll.py
+++ b/tests/adapter/dbt_adapter/test_dbt_cll.py
@@ -77,6 +77,37 @@ def assert_cll_contain_columns(cll_data: CllData, columns):
         assert column[1] == cll_data.columns[column_key].name, f"Column {column[1]} name mismatch"
 
 
+def test_cll_response_excludes_raw_code(dbt_test_helper, disable_cll_cache):
+    """The /api/cll payload must not contain raw_code on any node — it bloats the
+    response and no frontend consumer reads it off a CLL-sourced node. Server-side
+    code may still read the attribute off CllNode in memory."""
+    import json
+
+    from recce.server import CllOutput
+
+    dbt_test_helper.create_model(
+        "model1", unique_id="model.model1", curr_sql="select 1 as c", curr_columns={"c": "int"}
+    )
+    dbt_test_helper.create_model(
+        "model2",
+        unique_id="model.model2",
+        curr_sql='select c from {{ ref("model1") }} where c > 0',
+        curr_columns={"c": "int"},
+        depends_on=["model.model1"],
+    )
+    adapter: DbtAdapter = dbt_test_helper.context.adapter
+
+    # In-memory CllNode still has raw_code populated for server-side CLL compute
+    cll_node, _ = adapter.get_cll_node("model.model1")
+    assert cll_node.raw_code == "select 1 as c"
+
+    # But the serialized /api/cll response must not contain raw_code
+    cll = adapter.get_cll()
+    payload = json.loads(CllOutput(current=cll).model_dump_json())
+    for node_id, node in payload["current"]["nodes"].items():
+        assert "raw_code" not in node, f"raw_code leaked into /api/cll response for {node_id}"
+
+
 def test_cll_basic(dbt_test_helper, disable_cll_cache):
     dbt_test_helper.create_model(
         "model1", unique_id="model.model1", curr_sql="select 1 as c", curr_columns={"c": "int"}

--- a/tests/util/test_cll_cache.py
+++ b/tests/util/test_cll_cache.py
@@ -366,7 +366,8 @@ class TestSerializationRoundTrip(unittest.TestCase):
             assert rest_node.name == orig_node.name
             assert rest_node.package_name == orig_node.package_name
             assert rest_node.resource_type == orig_node.resource_type
-            assert rest_node.raw_code == orig_node.raw_code
+            # raw_code is deliberately excluded from CllNode serialization
+            assert rest_node.raw_code is None
             assert rest_node.source_name == orig_node.source_name
 
         # Columns
@@ -564,7 +565,8 @@ class TestCacheVsFreshEquivalence(unittest.TestCase):
             assert fn.name == cn.name
             assert fn.package_name == cn.package_name
             assert fn.resource_type == cn.resource_type
-            assert fn.raw_code == cn.raw_code
+            # raw_code is excluded from serialization, so cached copy is always None
+            assert cn.raw_code is None
             assert fn.source_name == cn.source_name
 
         # Columns


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

refactor / payload optimization

**What this PR does / why we need it**:

Strips `raw_code` from the `/api/cll` response payload. `CllNode.raw_code` is populated from the dbt manifest for server-side CLL computation (read in `DbtAdapter.get_cll_cached` on two paths) but is read by zero frontend consumers off a CLL-sourced node — frontend only reads `raw_code` from `/api/models/{id}` responses (NodeSqlView, SandboxView, SandboxViewOss).

This mirrors the precedent set by `/info` (lineage diff), which already strips `raw_code`, `config`, `columns`, `checksum` in `recce-cloud-infra`'s `api_server/core/lineage/diff.py`.

Implementation: mark `raw_code: Optional[str] = Field(default=None, exclude=True)` on `CllNode`. `exclude=True` applies to every `model_dump`, so the field is dropped from both the FastAPI response and the SQLite CLL cache payload, while the in-memory attribute remains available for the two server-side reads.

Cloud's `/cll` endpoint is a passthrough (S3 map fast path + OSS proxy fallback), so fixing OSS fixes both.

**Which issue(s) this PR fixes**:

N/A — payload optimization task.

**Special notes for your reviewer**:

- Two existing assertions in `tests/util/test_cll_cache.py` asserted `raw_code` round-trips through the CLL cache. Updated to assert `raw_code is None` after deserialization — this is the new intended contract (the cache stores post-computation `CllData` and no consumer reads raw_code from cached entries).
- New test `test_cll_response_excludes_raw_code` serializes via `CllOutput.model_dump_json()` (exactly what FastAPI uses with `response_model=CllOutput`) and asserts no node carries `raw_code`. Also positively asserts the in-memory attribute is still populated.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```