### PR TITLE
chore(docs): relax Co-Authored-By trailer in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ When asked to "publish ui" or "release ui package":
 
 ## Commit and PR Workflow
 
-**Commits:** Always use `--signoff` and include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+**Commits:** Always use `--signoff` and include a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer (version pin optional — if included, use the current model)
 
 **PRs:** Follow `.github/PULL_REQUEST_TEMPLATE.md`:
 - PR checklist (tests, DCO)


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

chore / docs

**What this PR does / why we need it**:

Relaxes the commit convention line in `CLAUDE.md`. It currently pins `Co-Authored-By: Claude Opus 4.6`, which goes stale every time the model version bumps (we're shipping under Opus 4.7 today, and this line was last updated when 4.6 was current). Drop the version pin and mark it optional so the rule stays valid as models evolve.

Before:
```
**Commits:** Always use `--signoff` and include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
```

After:
```
**Commits:** Always use `--signoff` and include a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer (version pin optional — if included, use the current model)
```

`AGENTS.md` already omits the version pin (see "Sign off commits: \`git commit -s\`" — no Co-Authored-By guidance at all). This brings CLAUDE.md closer in spirit: required attribution, unpinned version.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Trivial one-line doc change. No code, no behavior, no tests to run.

**Does this PR introduce a user-facing change?**:

\`\`\`release-note
NONE
\`\`\`