### PR TITLE
feat(cli): emit per_node.db in recce init --cloud [PR 2/3]

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import click
 
@@ -318,6 +318,7 @@ def init(cache_db, **kwargs):
 
     import json
     import logging
+    import shutil
     import tempfile
     import time
 
@@ -325,9 +326,15 @@ def init(cache_db, **kwargs):
     from rich.console import Console
     from rich.progress import Progress
 
+    from recce import __version__
     from recce.adapter.dbt_adapter import DbtAdapter
     from recce.core import load_context
     from recce.util.cll import _DEFAULT_DB_PATH, CllCache, get_cll_cache, set_cll_cache
+    from recce.util.per_node_db import SCHEMA_VERSION as PER_NODE_DB_SCHEMA_VERSION
+    from recce.util.per_node_db import (
+        PerNodeDbWriter,
+        extract_rows_from_artifacts,
+    )
 
     logger = logging.getLogger("recce")
     console = Console()
@@ -343,9 +350,15 @@ def init(cache_db, **kwargs):
     cloud_client = None
     cloud_org_id = None
     cloud_project_id = None
+    # In cloud mode, cll_cache.db and per_node.db are written to a tempdir that
+    # is scoped to this invocation. cll_cache.db keeps its warm-cache perf but
+    # never leaves the container; per_node.db is uploaded then the dir is GC'd.
+    cloud_scratch_dir: Optional[Path] = None
 
     if is_cloud:
         from recce.util.recce_cloud import RecceCloud, RecceCloudException
+
+        cloud_scratch_dir = Path(tempfile.mkdtemp(prefix="recce-cll-"))
 
         cloud_token = kwargs.get("cloud_token") or kwargs.get("api_token")
         if not cloud_token:
@@ -434,8 +447,13 @@ def init(cache_db, **kwargs):
         # Download existing CLL cache for warm start.
         # Try current session first, then fall back to production (base) session.
         # Use streaming to avoid loading large cache files entirely into memory.
-        if cache_db is None:
-            cache_db = _DEFAULT_DB_PATH
+        #
+        # In cloud mode, cll_cache.db is scoped to cloud_scratch_dir so it
+        # never gets uploaded back to Cloud. A user-provided --cache-db is
+        # intentionally ignored here because ECS task filesystems are ephemeral
+        # and the cache is not meant to persist across runs.
+        assert cloud_scratch_dir is not None  # set above when is_cloud
+        cache_db = str(cloud_scratch_dir / "cll_cache.db")
         Path(cache_db).parent.mkdir(parents=True, exist_ok=True)
 
         def _stream_download_to_file(url: str, dest: Path) -> int:
@@ -671,10 +689,55 @@ def init(cache_db, **kwargs):
     stats = cache.stats
     console.print(f"\nCache saved to [bold]{cache_db}[/bold] ({stats['entries']} entries)")
 
+    # In cloud mode, emit per_node.db — a pure-artifact SQLite that Cloud
+    # streams to serve lineage without proxying to an ephemeral Recce instance.
+    per_node_db_path: Optional[Path] = None
+    if is_cloud:
+        assert cloud_scratch_dir is not None
+        per_node_db_path = cloud_scratch_dir / "per_node.db"
+        console.print("\n[bold]Emitting per-node SQLite...[/bold]")
+        t_pn_start = time.perf_counter()
+        try:
+            with PerNodeDbWriter(per_node_db_path) as writer:
+                writer.write_meta(
+                    schema_version=str(PER_NODE_DB_SCHEMA_VERSION),
+                    session_id=session_id or "",
+                    recce_version=__version__,
+                    generated_at=str(int(time.time())),
+                )
+                envs_to_emit = [
+                    ("current", dbt_adapter.curr_manifest, dbt_adapter.curr_catalog),
+                    ("base", dbt_adapter.base_manifest, dbt_adapter.base_catalog),
+                ]
+                for env_name, manifest, catalog in envs_to_emit:
+                    if manifest is None:
+                        continue
+                    manifest_dict = manifest.to_dict() if hasattr(manifest, "to_dict") else manifest
+                    catalog_dict = (
+                        catalog.to_dict() if (catalog is not None and hasattr(catalog, "to_dict")) else catalog
+                    )
+                    node_rows, column_rows, edge_rows, test_rows = extract_rows_from_artifacts(
+                        manifest_dict, catalog_dict, env_name
+                    )
+                    writer.write_nodes(node_rows)
+                    writer.write_columns(column_rows)
+                    writer.write_edges(edge_rows)
+                    writer.write_tests(test_rows)
+            pn_elapsed = time.perf_counter() - t_pn_start
+            pn_size_mb = per_node_db_path.stat().st_size / 1024 / 1024
+            console.print(
+                f"  per_node.db saved to [bold]{per_node_db_path}[/bold] ({pn_size_mb:.1f} MB, {pn_elapsed:.1f}s)"
+            )
+        except Exception as e:
+            logger.warning("[recce init] Failed to emit per_node.db: %s", e)
+            console.print(f"  [[yellow]Warning[/yellow]] Failed to emit per_node.db: {e}")
+            per_node_db_path = None
+
     # Upload results to Cloud if in cloud mode
     if is_cloud and cloud_client:
         console.print("\n[bold]Uploading results to Cloud...[/bold]")
         upload_failures = []
+        upload_succeeded = False
         try:
             upload_urls = cloud_client.get_upload_urls_by_session_id(cloud_org_id, cloud_project_id, session_id)
 
@@ -704,29 +767,39 @@ def init(cache_db, **kwargs):
                     "  [[yellow]Warning[/yellow]] No cll_map_url in upload URLs (Cloud server may need update)"
                 )
 
-            # Upload CLL cache
-            cll_cache_upload_url = upload_urls.get("cll_cache_url")
-            if cll_cache_upload_url and Path(cache_db).is_file():
+            # Upload per_node.db. Graceful degradation: if Cloud hasn't added
+            # the per_node_db_url key yet, log a warning and continue — this
+            # keeps old CLI versions compatible with new Cloud and vice versa.
+            per_node_db_upload_url = upload_urls.get("per_node_db_url")
+            if per_node_db_upload_url and per_node_db_path and per_node_db_path.is_file():
                 try:
-                    with open(cache_db, "rb") as f:
+                    with open(per_node_db_path, "rb") as f:
                         resp = requests.put(
-                            cll_cache_upload_url,
+                            per_node_db_upload_url,
                             data=f,
                             headers={"Content-Type": "application/octet-stream"},
                             timeout=_UPLOAD_TIMEOUT,
                         )
                     if resp.status_code in (200, 204):
-                        console.print(f"  Uploaded cll_cache.db ({Path(cache_db).stat().st_size / 1024 / 1024:.1f} MB)")
-                    else:
-                        upload_failures.append("cll_cache.db")
                         console.print(
-                            f"  [[yellow]Warning[/yellow]] Failed to upload cll_cache.db: HTTP {resp.status_code}"
+                            f"  Uploaded per_node.db ({per_node_db_path.stat().st_size / 1024 / 1024:.1f} MB)"
+                        )
+                    else:
+                        upload_failures.append("per_node.db")
+                        console.print(
+                            f"  [[yellow]Warning[/yellow]] Failed to upload per_node.db: HTTP {resp.status_code}"
                         )
                 except requests.RequestException as e:
-                    upload_failures.append("cll_cache.db")
-                    console.print(f"  [[yellow]Warning[/yellow]] Failed to upload cll_cache.db: {e}")
-            elif not cll_cache_upload_url:
-                logger.debug("No cll_cache_url in upload URLs — cache upload not supported yet")
+                    upload_failures.append("per_node.db")
+                    console.print(f"  [[yellow]Warning[/yellow]] Failed to upload per_node.db: {e}")
+            elif not per_node_db_upload_url:
+                console.print(
+                    "  [[yellow]Warning[/yellow]] No per_node_db_url in upload URLs (Cloud server may need update)"
+                )
+
+            # cll_cache.db is local-only in cloud mode: it lives in
+            # cloud_scratch_dir and is not uploaded. The tempdir is GC'd
+            # below when upload succeeds; on failure it lingers for debugging.
 
             if upload_failures:
                 console.print(
@@ -735,9 +808,16 @@ def init(cache_db, **kwargs):
                 )
             else:
                 console.print("[bold green]Cloud upload complete.[/bold green]")
+                upload_succeeded = True
         except Exception as e:
             logger.warning("[recce init] Cloud upload failed: %s", e)
             console.print(f"  [[yellow]Warning[/yellow]] Cloud upload failed: {e}")
+        finally:
+            # Only clean the scratch dir on success. On failure we keep it for
+            # debugging — ECS task death will reclaim it anyway when the
+            # container exits.
+            if upload_succeeded and cloud_scratch_dir is not None:
+                shutil.rmtree(cloud_scratch_dir, ignore_errors=True)
     else:
         console.print("Run [bold]recce server --enable-cll-cache[/bold] to use the cached lineage.")
 

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -350,15 +350,16 @@ def init(cache_db, **kwargs):
     cloud_client = None
     cloud_org_id = None
     cloud_project_id = None
-    # In cloud mode, cll_cache.db and per_node.db are written to a tempdir that
-    # is scoped to this invocation. cll_cache.db keeps its warm-cache perf but
-    # never leaves the container; per_node.db is uploaded then the dir is GC'd.
-    cloud_scratch_dir: Optional[Path] = None
+    # per_node.db is a throwaway per-task artifact (each cloud task regenerates
+    # it fresh from the uploaded manifest/catalog). It lives in its own tempdir
+    # that is cleaned up after a successful upload. cll_cache.db, by contrast,
+    # persists at ~/.recce/cll_cache.db to serve cross-session warm-cache reuse.
+    per_node_scratch: Optional[Path] = None
 
     if is_cloud:
         from recce.util.recce_cloud import RecceCloud, RecceCloudException
 
-        cloud_scratch_dir = Path(tempfile.mkdtemp(prefix="recce-cll-"))
+        per_node_scratch = Path(tempfile.mkdtemp(prefix="recce-per-node-"))
 
         cloud_token = kwargs.get("cloud_token") or kwargs.get("api_token")
         if not cloud_token:
@@ -447,13 +448,8 @@ def init(cache_db, **kwargs):
         # Download existing CLL cache for warm start.
         # Try current session first, then fall back to production (base) session.
         # Use streaming to avoid loading large cache files entirely into memory.
-        #
-        # In cloud mode, cll_cache.db is scoped to cloud_scratch_dir so it
-        # never gets uploaded back to Cloud. A user-provided --cache-db is
-        # intentionally ignored here because ECS task filesystems are ephemeral
-        # and the cache is not meant to persist across runs.
-        assert cloud_scratch_dir is not None  # set above when is_cloud
-        cache_db = str(cloud_scratch_dir / "cll_cache.db")
+        if cache_db is None:
+            cache_db = _DEFAULT_DB_PATH
         Path(cache_db).parent.mkdir(parents=True, exist_ok=True)
 
         def _stream_download_to_file(url: str, dest: Path) -> int:
@@ -693,8 +689,8 @@ def init(cache_db, **kwargs):
     # streams to serve lineage without proxying to an ephemeral Recce instance.
     per_node_db_path: Optional[Path] = None
     if is_cloud:
-        assert cloud_scratch_dir is not None
-        per_node_db_path = cloud_scratch_dir / "per_node.db"
+        assert per_node_scratch is not None
+        per_node_db_path = per_node_scratch / "per_node.db"
         console.print("\n[bold]Emitting per-node SQLite...[/bold]")
         t_pn_start = time.perf_counter()
         try:
@@ -797,9 +793,31 @@ def init(cache_db, **kwargs):
                     "  [[yellow]Warning[/yellow]] No per_node_db_url in upload URLs (Cloud server may need update)"
                 )
 
-            # cll_cache.db is local-only in cloud mode: it lives in
-            # cloud_scratch_dir and is not uploaded. The tempdir is GC'd
-            # below when upload succeeds; on failure it lingers for debugging.
+            # Upload CLL cache. cll_cache.db is load-bearing across sessions —
+            # build_full_cll_map reuses its warm entries on subsequent runs —
+            # so Cloud uploads it alongside per_node.db.
+            cll_cache_upload_url = upload_urls.get("cll_cache_url")
+            if cll_cache_upload_url and Path(cache_db).is_file():
+                try:
+                    with open(cache_db, "rb") as f:
+                        resp = requests.put(
+                            cll_cache_upload_url,
+                            data=f,
+                            headers={"Content-Type": "application/octet-stream"},
+                            timeout=_UPLOAD_TIMEOUT,
+                        )
+                    if resp.status_code in (200, 204):
+                        console.print(f"  Uploaded cll_cache.db ({Path(cache_db).stat().st_size / 1024 / 1024:.1f} MB)")
+                    else:
+                        upload_failures.append("cll_cache.db")
+                        console.print(
+                            f"  [[yellow]Warning[/yellow]] Failed to upload cll_cache.db: HTTP {resp.status_code}"
+                        )
+                except requests.RequestException as e:
+                    upload_failures.append("cll_cache.db")
+                    console.print(f"  [[yellow]Warning[/yellow]] Failed to upload cll_cache.db: {e}")
+            elif not cll_cache_upload_url:
+                logger.debug("No cll_cache_url in upload URLs — cache upload not supported yet")
 
             if upload_failures:
                 console.print(
@@ -813,11 +831,11 @@ def init(cache_db, **kwargs):
             logger.warning("[recce init] Cloud upload failed: %s", e)
             console.print(f"  [[yellow]Warning[/yellow]] Cloud upload failed: {e}")
         finally:
-            # Only clean the scratch dir on success. On failure we keep it for
-            # debugging — ECS task death will reclaim it anyway when the
-            # container exits.
-            if upload_succeeded and cloud_scratch_dir is not None:
-                shutil.rmtree(cloud_scratch_dir, ignore_errors=True)
+            # Clean up per_node.db scratch dir only. cll_cache.db lives at
+            # ~/.recce/cll_cache.db (or the user-provided --cache-db path) and
+            # must persist across invocations for warm-cache reuse.
+            if upload_succeeded and per_node_scratch is not None:
+                shutil.rmtree(per_node_scratch, ignore_errors=True)
     else:
         console.print("Run [bold]recce server --enable-cll-cache[/bold] to use the cached lineage.")
 

--- a/tests/test_cli_cache.py
+++ b/tests/test_cli_cache.py
@@ -1238,7 +1238,7 @@ class TestInitCloud:
             },
             upload_urls={
                 "cll_map_url": "https://s3.example.com/upload/cll_map.json",
-                "cll_cache_url": "https://s3.example.com/upload/cll_cache.db",
+                "per_node_db_url": "https://s3.example.com/upload/per_node.db",
             },
         )
 
@@ -1258,7 +1258,7 @@ class TestInitCloud:
         def mock_get(url, **kwargs):
             return _make_mock_response(200, manifest_bytes)
 
-        # CLL map upload succeeds, cache upload fails
+        # CLL map upload succeeds, per_node.db upload fails
         def mock_put(url, **kwargs):
             if "cll_map" in url:
                 return _make_mock_response(200)
@@ -1292,7 +1292,7 @@ class TestInitCloud:
 
         assert result.exit_code == 0
         assert "completed with warnings" in result.output
-        assert "cll_cache.db" in result.output
+        assert "per_node.db" in result.output
 
 
 class TestInitLocalCllMap:

--- a/tests/test_cli_cache.py
+++ b/tests/test_cli_cache.py
@@ -1238,7 +1238,7 @@ class TestInitCloud:
             },
             upload_urls={
                 "cll_map_url": "https://s3.example.com/upload/cll_map.json",
-                "per_node_db_url": "https://s3.example.com/upload/per_node.db",
+                "cll_cache_url": "https://s3.example.com/upload/cll_cache.db",
             },
         )
 
@@ -1258,7 +1258,7 @@ class TestInitCloud:
         def mock_get(url, **kwargs):
             return _make_mock_response(200, manifest_bytes)
 
-        # CLL map upload succeeds, per_node.db upload fails
+        # CLL map upload succeeds, cll_cache.db upload fails
         def mock_put(url, **kwargs):
             if "cll_map" in url:
                 return _make_mock_response(200)
@@ -1292,7 +1292,7 @@ class TestInitCloud:
 
         assert result.exit_code == 0
         assert "completed with warnings" in result.output
-        assert "per_node.db" in result.output
+        assert "cll_cache.db" in result.output
 
 
 class TestInitLocalCllMap:

--- a/tests/test_cli_per_node_db.py
+++ b/tests/test_cli_per_node_db.py
@@ -1,0 +1,656 @@
+"""Integration + contract tests for `recce init --cloud` per_node.db emission (DRC-3295 PR 2).
+
+Covers:
+  1. Cloud-mode integration: per_node.db is uploaded when Cloud returns the
+     per_node_db_url key; cll_cache.db is never uploaded (cloud mode writes it
+     to a tempdir and it is cleaned up on success).
+  2. Local-mode non-regression: `recce init` without --cloud still writes to
+     the user-specified cache_db and does not emit per_node.db / upload.
+  3. Contract test vs. DbtAdapter.get_model(): extract_rows_from_artifacts →
+     SQLite → reconstructed get_model() payload structurally matches the
+     live adapter's response for the same manifest + catalog fixtures.
+  4. Mode-switching safety: running cloud mode does not collide with a later
+     local-mode run's --cache-db; the cloud tempdir is cleaned up.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from recce.cli import cli
+from recce.util.cll import CllCache
+from recce.util.per_node_db import (
+    SCHEMA_VERSION,
+    PerNodeDbWriter,
+    extract_rows_from_artifacts,
+)
+
+FIXTURES = Path(__file__).parent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def tmp_db(tmp_path: Path) -> str:
+    return str(tmp_path / "test_cll_cache.db")
+
+
+def _make_mock_node(
+    resource_type: str = "model",
+    raw_code: str = "SELECT 1",
+    dep_nodes: Optional[list] = None,
+    checksum_value: Optional[str] = None,
+):
+    """Mirror of tests/test_cli_cache.py:_make_mock_node."""
+    import hashlib
+
+    node = MagicMock()
+    node.resource_type = resource_type
+    node.raw_code = raw_code
+    node.depends_on.nodes = dep_nodes or []
+    node.checksum.checksum = checksum_value or hashlib.sha256(raw_code.encode()).hexdigest()
+    return node
+
+
+def _make_mock_adapter(nodes: dict, curr_catalog=None, base_catalog=None):
+    """Mock DbtAdapter that mimics the attributes used by `recce init`."""
+    adapter = MagicMock()
+    manifest = MagicMock()
+    manifest.nodes = nodes
+    manifest.metadata.adapter_type = "duckdb"
+    adapter.curr_manifest = manifest
+    adapter.base_manifest = None
+    adapter.curr_catalog = curr_catalog
+    adapter.base_catalog = base_catalog
+    adapter.adapter.type.return_value = "duckdb"
+    return adapter
+
+
+def _make_mock_cloud_client(
+    session_info: Optional[dict] = None,
+    download_urls: Optional[dict] = None,
+    base_download_urls: Optional[dict] = None,
+    upload_urls: Optional[dict] = None,
+):
+    client = MagicMock()
+    client.get_session.return_value = session_info or {
+        "org_id": "org-1",
+        "project_id": "proj-1",
+        "status": "active",
+    }
+    client.get_download_urls_by_session_id.return_value = download_urls or {}
+    client.get_base_session_download_urls.return_value = base_download_urls or {}
+    client.get_upload_urls_by_session_id.return_value = upload_urls or {}
+    return client
+
+
+def _make_mock_response(status_code: int = 200, content: bytes = b"{}"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = content
+
+    def _iter_content(chunk_size=8192):
+        if content:
+            for i in range(0, len(content), chunk_size):
+                yield content[i : i + chunk_size]
+
+    resp.iter_content = _iter_content
+    return resp
+
+
+def _setup_target_dir(tmp_path: Path) -> Path:
+    target = tmp_path / "target"
+    target.mkdir(exist_ok=True)
+    (target / "manifest.json").write_text("{}")
+    return target
+
+
+# ---------------------------------------------------------------------------
+# 1. Cloud-mode integration
+# ---------------------------------------------------------------------------
+
+
+class TestCloudModeEmitsPerNodeDb:
+    """Cloud mode emits per_node.db, uploads it, and never uploads cll_cache.db."""
+
+    @patch("recce.core.load_context")
+    def test_per_node_db_uploaded_when_url_present(self, mock_load_context, runner, tmp_path, tmp_db):
+        """Happy path: per_node_db_url is present → PUT to that URL."""
+        manifest_bytes = b'{"nodes": {}}'
+
+        mock_client = _make_mock_cloud_client(
+            download_urls={"manifest_url": "https://s3.example.com/manifest.json"},
+            base_download_urls={"manifest_url": "https://s3.example.com/base-manifest.json"},
+            upload_urls={
+                "cll_map_url": "https://s3.example.com/upload/cll_map.json",
+                "per_node_db_url": "https://s3.example.com/upload/per_node.db",
+                # cll_cache_url included to prove it is NOT used in cloud mode.
+                "cll_cache_url": "https://s3.example.com/upload/cll_cache.db",
+            },
+        )
+
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {"model.test.a": MagicMock()}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        put_calls: list[str] = []
+
+        def mock_get(url, **kwargs):
+            return _make_mock_response(200, manifest_bytes)
+
+        def mock_put(url, **kwargs):
+            put_calls.append(url)
+            return _make_mock_response(200)
+
+        with (
+            patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
+            patch("requests.get", side_effect=mock_get),
+            patch("requests.put", side_effect=mock_put),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--cloud",
+                    "--cloud-token",
+                    "ghp_testtoken",
+                    "--session-id",
+                    "sess-1",
+                    "--cache-db",
+                    tmp_db,
+                    "--project-dir",
+                    str(tmp_path),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Cloud upload complete" in result.output
+        # per_node.db URL was called
+        assert any("per_node.db" in url for url in put_calls), put_calls
+        # cll_cache.db URL was NOT called, even though the key is present
+        assert not any("cll_cache" in url for url in put_calls), put_calls
+
+    @patch("recce.core.load_context")
+    def test_warns_when_per_node_db_url_missing(self, mock_load_context, runner, tmp_path, tmp_db):
+        """Graceful degradation: missing per_node_db_url logs a warning, exits 0."""
+        manifest_bytes = b'{"nodes": {}}'
+
+        mock_client = _make_mock_cloud_client(
+            download_urls={"manifest_url": "https://s3.example.com/manifest.json"},
+            base_download_urls={"manifest_url": "https://s3.example.com/base-manifest.json"},
+            upload_urls={"cll_map_url": "https://s3.example.com/upload/cll_map.json"},
+        )
+
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        with (
+            patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
+            patch("requests.get", side_effect=lambda *a, **kw: _make_mock_response(200, manifest_bytes)),
+            patch("requests.put", side_effect=lambda *a, **kw: _make_mock_response(200)),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--cloud",
+                    "--cloud-token",
+                    "ghp_testtoken",
+                    "--session-id",
+                    "sess-1",
+                    "--cache-db",
+                    tmp_db,
+                    "--project-dir",
+                    str(tmp_path),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        assert "No per_node_db_url" in result.output
+
+    @patch("recce.core.load_context")
+    def test_scratch_dir_cleaned_up_on_success(self, mock_load_context, runner, tmp_path, tmp_db):
+        """After a successful cloud upload, the recce-cll-* tempdir is removed."""
+        manifest_bytes = b'{"nodes": {}}'
+
+        mock_client = _make_mock_cloud_client(
+            download_urls={"manifest_url": "https://s3.example.com/manifest.json"},
+            base_download_urls={"manifest_url": "https://s3.example.com/base-manifest.json"},
+            upload_urls={
+                "cll_map_url": "https://s3.example.com/upload/cll_map.json",
+                "per_node_db_url": "https://s3.example.com/upload/per_node.db",
+            },
+        )
+
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        # Track what mkdtemp returns so we can inspect it after the run.
+        original_mkdtemp = tempfile.mkdtemp
+        dirs_created: list[str] = []
+
+        def tracking_mkdtemp(*args, **kwargs):
+            path = original_mkdtemp(*args, **kwargs)
+            dirs_created.append(path)
+            return path
+
+        with (
+            patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
+            patch("requests.get", side_effect=lambda *a, **kw: _make_mock_response(200, manifest_bytes)),
+            patch("requests.put", side_effect=lambda *a, **kw: _make_mock_response(200)),
+            patch("tempfile.mkdtemp", side_effect=tracking_mkdtemp),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--cloud",
+                    "--cloud-token",
+                    "ghp_testtoken",
+                    "--session-id",
+                    "sess-1",
+                    "--cache-db",
+                    tmp_db,
+                    "--project-dir",
+                    str(tmp_path),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        # At least one of the tracked dirs is the recce-cll-* scratch dir.
+        scratch_dirs = [d for d in dirs_created if Path(d).name.startswith("recce-cll-")]
+        assert scratch_dirs, f"no recce-cll-* tempdir was created (got: {dirs_created})"
+        for sd in scratch_dirs:
+            assert not Path(sd).exists(), f"scratch dir {sd} was not cleaned up after success"
+
+
+# ---------------------------------------------------------------------------
+# 2. Local-mode non-regression
+# ---------------------------------------------------------------------------
+
+
+class TestLocalModeNoPerNodeDb:
+    """`recce init` without --cloud keeps its existing behavior."""
+
+    @patch("recce.core.load_context")
+    def test_local_mode_writes_cache_and_no_per_node_db(self, mock_load_context, runner, tmp_path, tmp_db):
+        """Local mode: cll_cache.db written to --cache-db; no per_node.db emitted; no uploads."""
+        _setup_target_dir(tmp_path)
+
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        put_calls: list[str] = []
+        get_calls: list[str] = []
+
+        def track_put(url, **kwargs):
+            put_calls.append(url)
+            return _make_mock_response(200)
+
+        def track_get(url, **kwargs):
+            get_calls.append(url)
+            return _make_mock_response(200)
+
+        with (
+            patch("requests.put", side_effect=track_put),
+            patch("requests.get", side_effect=track_get),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["init", "--cache-db", tmp_db, "--project-dir", str(tmp_path)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        # cache.db is written to the user-specified path
+        assert Path(tmp_db).exists(), "expected cache_db at user-specified path"
+        # No per_node.db file next to cache (or anywhere we can easily detect)
+        assert not (Path(tmp_db).parent / "per_node.db").exists()
+        # No upload / download attempts in local mode
+        assert put_calls == [], f"unexpected PUT calls in local mode: {put_calls}"
+        assert get_calls == [], f"unexpected GET calls in local mode: {get_calls}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Contract test vs. DbtAdapter.get_model()
+# ---------------------------------------------------------------------------
+
+
+def _reconstruct_get_model_from_rows(
+    db_path: Path,
+    node_id: str,
+    env: str,
+    column_types: dict,
+) -> dict:
+    """Build a `get_model()`-shaped dict from per_node.db rows.
+
+    `column_types` is a pre-fetched {col_name: dtype} mapping that mimics the
+    output of DbtAdapter.get_columns() (the warehouse-facing query). The
+    contract we are validating is: given the same catalog data, both code
+    paths produce the same keys / values.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # primary_key + raw_code from nodes row
+        row = conn.execute(
+            "SELECT primary_key, raw_code FROM nodes WHERE node_id = ? AND env = ?",
+            (node_id, env),
+        ).fetchone()
+        if row is None:
+            return {}
+        primary_key, raw_code = row
+
+        # test rows for not_null / unique flags
+        test_rows = conn.execute(
+            "SELECT column_name, test_type FROM node_tests WHERE node_id = ? AND env = ?",
+            (node_id, env),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    not_null_cols = {col for col, t in test_rows if t == "not_null"}
+    unique_cols = {col for col, t in test_rows if t == "unique"}
+
+    columns_info: dict = {}
+    for col_name, dtype in column_types.items():
+        col: dict = {"name": col_name, "type": dtype}
+        if col_name in not_null_cols:
+            col["not_null"] = True
+        if col_name in unique_cols:
+            col["unique"] = True
+        columns_info[col_name] = col
+
+    result: dict = {"columns": columns_info}
+    if primary_key:
+        result["primary_key"] = primary_key
+    if raw_code is not None:
+        result["raw_code"] = raw_code
+    return result
+
+
+class TestContractWithGetModel:
+    """Structural parity with DbtAdapter.get_model() on real fixture artifacts."""
+
+    @pytest.fixture
+    def manifest_and_catalog(self):
+        manifest_path = FIXTURES / "manifest.json"
+        catalog_path = FIXTURES / "catalog.json"
+        if not manifest_path.exists() or not catalog_path.exists():
+            pytest.skip("jaffle_shop manifest/catalog fixtures not available")
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+        with open(catalog_path) as f:
+            catalog = json.load(f)
+        return manifest, catalog
+
+    def test_extracted_rows_match_get_model(self, manifest_and_catalog, tmp_path):
+        """Rows round-tripped through SQLite match what DbtAdapter.get_model() returns."""
+        from recce.adapter.dbt_adapter import DbtAdapter
+
+        manifest, catalog = manifest_and_catalog
+        env = "current"
+
+        # Emit per_node.db
+        db_path = tmp_path / "per_node.db"
+        with PerNodeDbWriter(db_path) as w:
+            nodes, columns, edges, tests = extract_rows_from_artifacts(manifest, catalog, env)
+            w.write_nodes(nodes)
+            w.write_columns(columns)
+            w.write_edges(edges)
+            w.write_tests(tests)
+
+        # Pick nodes that are present in both manifest + catalog — those
+        # exercise every branch (types, not_null, unique, primary_key, raw_code).
+        candidates = [
+            nid
+            for nid in manifest["nodes"].keys()
+            if nid in catalog.get("nodes", {}) and manifest["nodes"][nid].get("resource_type") == "model"
+        ]
+        sample = candidates[:8]
+        assert sample, "no model nodes overlap between manifest + catalog"
+
+        # Build a stub DbtAdapter: only get_columns() is mocked (warehouse call).
+        adapter = MagicMock(spec=DbtAdapter)
+        adapter.curr_manifest = MagicMock()
+        adapter.curr_manifest.to_dict.return_value = manifest
+        adapter.base_manifest = None
+
+        for node_id in sample:
+            catalog_cols = catalog["nodes"][node_id].get("columns", {})
+            # Mock warehouse-facing query to return catalog-derived (col_name, dtype) pairs.
+            column_objs = []
+            for col_name, col_info in catalog_cols.items():
+                col_obj = MagicMock()
+                col_obj.column = col_name
+                col_obj.dtype = col_info.get("type")
+                column_objs.append(col_obj)
+            adapter.get_columns.return_value = column_objs
+
+            # Live path
+            live = DbtAdapter.get_model(adapter, node_id, base=False)
+
+            # Reconstructed path (from per_node.db rows)
+            reconstructed = _reconstruct_get_model_from_rows(
+                db_path,
+                node_id,
+                env,
+                {c.column: c.dtype for c in column_objs},
+            )
+
+            # Structural parity
+            assert set(live.keys()) == set(
+                reconstructed.keys()
+            ), f"{node_id}: keys differ. live={live.keys()} reconstructed={reconstructed.keys()}"
+            assert live.get("primary_key") == reconstructed.get("primary_key"), f"{node_id}: primary_key differs"
+            assert live.get("raw_code") == reconstructed.get("raw_code"), f"{node_id}: raw_code differs"
+            live_cols = live["columns"]
+            rec_cols = reconstructed["columns"]
+            assert set(live_cols.keys()) == set(rec_cols.keys()), f"{node_id}: column names differ"
+            for col_name in live_cols:
+                for field in ("type", "not_null", "unique"):
+                    assert live_cols[col_name].get(field) == rec_cols[col_name].get(field), (
+                        f"{node_id}.{col_name}: field '{field}' differs "
+                        f"(live={live_cols[col_name].get(field)}, rec={rec_cols[col_name].get(field)})"
+                    )
+
+    def test_primary_key_and_tests_derived_from_manifest_only(self, manifest_and_catalog, tmp_path):
+        """primary_key + node_tests must be derivable without a warehouse call."""
+        manifest, catalog = manifest_and_catalog
+
+        db_path = tmp_path / "per_node.db"
+        with PerNodeDbWriter(db_path) as w:
+            nodes, columns, edges, tests = extract_rows_from_artifacts(manifest, catalog, "current")
+            w.write_nodes(nodes)
+            w.write_columns(columns)
+            w.write_edges(edges)
+            w.write_tests(tests)
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            # At least one node in jaffle_shop has a unique test (primary_key).
+            rows = conn.execute("SELECT node_id, primary_key FROM nodes WHERE primary_key IS NOT NULL").fetchall()
+            assert rows, "expected at least one node with primary_key derived from unique tests"
+            # At least one not_null test row.
+            nn = conn.execute("SELECT COUNT(*) FROM node_tests WHERE test_type = 'not_null'").fetchone()[0]
+            assert nn > 0, "expected at least one not_null test row"
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# 4. Mode-switching safety
+# ---------------------------------------------------------------------------
+
+
+class TestModeSwitchingSafety:
+    """Cloud-mode tempdir must not collide with local-mode --cache-db."""
+
+    @patch("recce.core.load_context")
+    def test_cloud_then_local_no_collision(self, mock_load_context, runner, tmp_path):
+        """After a cloud run, a local run against a separate --cache-db works normally."""
+        # --- Cloud run (writes to scratch tempdir, cleaned up on success) ---
+        manifest_bytes = b'{"nodes": {}}'
+        mock_client = _make_mock_cloud_client(
+            download_urls={"manifest_url": "https://s3.example.com/manifest.json"},
+            base_download_urls={"manifest_url": "https://s3.example.com/base-manifest.json"},
+            upload_urls={
+                "cll_map_url": "https://s3.example.com/upload/cll_map.json",
+                "per_node_db_url": "https://s3.example.com/upload/per_node.db",
+            },
+        )
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        original_mkdtemp = tempfile.mkdtemp
+        dirs_created: list[str] = []
+
+        def tracking_mkdtemp(*args, **kwargs):
+            path = original_mkdtemp(*args, **kwargs)
+            dirs_created.append(path)
+            return path
+
+        cloud_cache_db = str(tmp_path / "unused-cloud-cache.db")
+        with (
+            patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
+            patch("requests.get", side_effect=lambda *a, **kw: _make_mock_response(200, manifest_bytes)),
+            patch("requests.put", side_effect=lambda *a, **kw: _make_mock_response(200)),
+            patch("tempfile.mkdtemp", side_effect=tracking_mkdtemp),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            cloud_result = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--cloud",
+                    "--cloud-token",
+                    "ghp_testtoken",
+                    "--session-id",
+                    "sess-1",
+                    "--cache-db",
+                    cloud_cache_db,
+                    "--project-dir",
+                    str(tmp_path / "cloudproj"),
+                ],
+                catch_exceptions=False,
+            )
+        assert cloud_result.exit_code == 0, cloud_result.output
+        # Cloud mode should have ignored the user --cache-db and used a scratch dir.
+        assert not os.path.exists(cloud_cache_db), "cloud mode should not write to user --cache-db"
+        # Scratch dir cleaned up on success.
+        scratch_dirs = [d for d in dirs_created if Path(d).name.startswith("recce-cll-")]
+        assert scratch_dirs
+        assert all(not Path(d).exists() for d in scratch_dirs)
+
+        # --- Local run (writes to a distinct --cache-db path) ---
+        local_proj = tmp_path / "localproj"
+        local_proj.mkdir()
+        (local_proj / "target").mkdir()
+        (local_proj / "target" / "manifest.json").write_text("{}")
+        local_db = str(tmp_path / "local-cache.db")
+
+        with patch(
+            "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+            return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+        ):
+            local_result = runner.invoke(
+                cli,
+                ["init", "--cache-db", local_db, "--project-dir", str(local_proj)],
+                catch_exceptions=False,
+            )
+
+        assert local_result.exit_code == 0
+        # Local mode writes the cache at the user path and does NOT leak into the cloud scratch paths.
+        assert Path(local_db).exists()
+        # Local cache is a valid SQLite CLL cache (stats callable).
+        cache = CllCache(db_path=local_db)
+        assert cache.stats["entries"] >= 0
+
+        # Sanity: SCHEMA_VERSION used by the per_node.db emitter is numeric.
+        assert int(SCHEMA_VERSION) >= 1

--- a/tests/test_cli_per_node_db.py
+++ b/tests/test_cli_per_node_db.py
@@ -2,21 +2,21 @@
 
 Covers:
   1. Cloud-mode integration: per_node.db is uploaded when Cloud returns the
-     per_node_db_url key; cll_cache.db is never uploaded (cloud mode writes it
-     to a tempdir and it is cleaned up on success).
+     per_node_db_url key; cll_cache.db continues to be uploaded via
+     cll_cache_url (warm-cache reuse across sessions).
   2. Local-mode non-regression: `recce init` without --cloud still writes to
      the user-specified cache_db and does not emit per_node.db / upload.
   3. Contract test vs. DbtAdapter.get_model(): extract_rows_from_artifacts →
      SQLite → reconstructed get_model() payload structurally matches the
      live adapter's response for the same manifest + catalog fixtures.
-  4. Mode-switching safety: running cloud mode does not collide with a later
-     local-mode run's --cache-db; the cloud tempdir is cleaned up.
+  4. Mode-switching safety: running cloud mode once, then local mode, does not
+     corrupt ~/.recce/cll_cache.db — warm-cache behavior IS preserved across
+     invocations, and only the per_node.db tempdir is cleaned up.
 """
 
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 import tempfile
 from pathlib import Path
@@ -128,11 +128,11 @@ def _setup_target_dir(tmp_path: Path) -> Path:
 
 
 class TestCloudModeEmitsPerNodeDb:
-    """Cloud mode emits per_node.db, uploads it, and never uploads cll_cache.db."""
+    """Cloud mode uploads both per_node.db and cll_cache.db."""
 
     @patch("recce.core.load_context")
-    def test_per_node_db_uploaded_when_url_present(self, mock_load_context, runner, tmp_path, tmp_db):
-        """Happy path: per_node_db_url is present → PUT to that URL."""
+    def test_both_artifacts_uploaded_when_urls_present(self, mock_load_context, runner, tmp_path, tmp_db):
+        """Happy path: per_node_db_url AND cll_cache_url both receive PUTs."""
         manifest_bytes = b'{"nodes": {}}'
 
         mock_client = _make_mock_cloud_client(
@@ -141,7 +141,6 @@ class TestCloudModeEmitsPerNodeDb:
             upload_urls={
                 "cll_map_url": "https://s3.example.com/upload/cll_map.json",
                 "per_node_db_url": "https://s3.example.com/upload/per_node.db",
-                # cll_cache_url included to prove it is NOT used in cloud mode.
                 "cll_cache_url": "https://s3.example.com/upload/cll_cache.db",
             },
         )
@@ -198,8 +197,8 @@ class TestCloudModeEmitsPerNodeDb:
         assert "Cloud upload complete" in result.output
         # per_node.db URL was called
         assert any("per_node.db" in url for url in put_calls), put_calls
-        # cll_cache.db URL was NOT called, even though the key is present
-        assert not any("cll_cache" in url for url in put_calls), put_calls
+        # cll_cache.db URL WAS called — warm-cache reuse depends on it.
+        assert any("cll_cache.db" in url for url in put_calls), put_calls
 
     @patch("recce.core.load_context")
     def test_warns_when_per_node_db_url_missing(self, mock_load_context, runner, tmp_path, tmp_db):
@@ -255,8 +254,10 @@ class TestCloudModeEmitsPerNodeDb:
         assert "No per_node_db_url" in result.output
 
     @patch("recce.core.load_context")
-    def test_scratch_dir_cleaned_up_on_success(self, mock_load_context, runner, tmp_path, tmp_db):
-        """After a successful cloud upload, the recce-cll-* tempdir is removed."""
+    def test_per_node_scratch_cleaned_cache_preserved(self, mock_load_context, runner, tmp_path, tmp_db):
+        """After a successful cloud upload: per_node scratch dir is removed;
+        cache_db at user-specified path remains intact (its parent dir exists).
+        """
         manifest_bytes = b'{"nodes": {}}'
 
         mock_client = _make_mock_cloud_client(
@@ -265,6 +266,7 @@ class TestCloudModeEmitsPerNodeDb:
             upload_urls={
                 "cll_map_url": "https://s3.example.com/upload/cll_map.json",
                 "per_node_db_url": "https://s3.example.com/upload/per_node.db",
+                "cll_cache_url": "https://s3.example.com/upload/cll_cache.db",
             },
         )
 
@@ -289,6 +291,8 @@ class TestCloudModeEmitsPerNodeDb:
             path = original_mkdtemp(*args, **kwargs)
             dirs_created.append(path)
             return path
+
+        cache_db_parent = Path(tmp_db).parent
 
         with (
             patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
@@ -318,11 +322,15 @@ class TestCloudModeEmitsPerNodeDb:
             )
 
         assert result.exit_code == 0
-        # At least one of the tracked dirs is the recce-cll-* scratch dir.
-        scratch_dirs = [d for d in dirs_created if Path(d).name.startswith("recce-cll-")]
-        assert scratch_dirs, f"no recce-cll-* tempdir was created (got: {dirs_created})"
-        for sd in scratch_dirs:
-            assert not Path(sd).exists(), f"scratch dir {sd} was not cleaned up after success"
+        # per_node scratch dirs cleaned up
+        per_node_dirs = [d for d in dirs_created if Path(d).name.startswith("recce-per-node-")]
+        assert per_node_dirs, f"no recce-per-node-* tempdir was created (got: {dirs_created})"
+        for sd in per_node_dirs:
+            assert not Path(sd).exists(), f"per_node scratch {sd} was not cleaned up after success"
+        # cache_db path is NOT rmtree'd — its parent dir still exists, and so
+        # does the cache.db itself (since we wrote to it during the run).
+        assert cache_db_parent.exists(), "cache.db parent dir must persist — it is NOT a scratch dir"
+        assert Path(tmp_db).exists(), "cache.db at user-specified path must persist"
 
 
 # ---------------------------------------------------------------------------
@@ -558,12 +566,14 @@ class TestContractWithGetModel:
 
 
 class TestModeSwitchingSafety:
-    """Cloud-mode tempdir must not collide with local-mode --cache-db."""
+    """Cloud → local switches must preserve the warm cache at --cache-db."""
 
     @patch("recce.core.load_context")
-    def test_cloud_then_local_no_collision(self, mock_load_context, runner, tmp_path):
-        """After a cloud run, a local run against a separate --cache-db works normally."""
-        # --- Cloud run (writes to scratch tempdir, cleaned up on success) ---
+    def test_cloud_then_local_preserves_warm_cache(self, mock_load_context, runner, tmp_path):
+        """Cloud run writes to --cache-db; a subsequent local run against the
+        SAME --cache-db sees the entries it wrote — warm-cache reuse works.
+        """
+        # --- Cloud run (writes to user --cache-db; uploads it to cll_cache_url) ---
         manifest_bytes = b'{"nodes": {}}'
         mock_client = _make_mock_cloud_client(
             download_urls={"manifest_url": "https://s3.example.com/manifest.json"},
@@ -571,6 +581,7 @@ class TestModeSwitchingSafety:
             upload_urls={
                 "cll_map_url": "https://s3.example.com/upload/cll_map.json",
                 "per_node_db_url": "https://s3.example.com/upload/per_node.db",
+                "cll_cache_url": "https://s3.example.com/upload/cll_cache.db",
             },
         )
         nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
@@ -593,7 +604,7 @@ class TestModeSwitchingSafety:
             dirs_created.append(path)
             return path
 
-        cloud_cache_db = str(tmp_path / "unused-cloud-cache.db")
+        shared_cache_db = str(tmp_path / "shared-cache.db")
         with (
             patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
             patch("requests.get", side_effect=lambda *a, **kw: _make_mock_response(200, manifest_bytes)),
@@ -614,26 +625,27 @@ class TestModeSwitchingSafety:
                     "--session-id",
                     "sess-1",
                     "--cache-db",
-                    cloud_cache_db,
+                    shared_cache_db,
                     "--project-dir",
                     str(tmp_path / "cloudproj"),
                 ],
                 catch_exceptions=False,
             )
         assert cloud_result.exit_code == 0, cloud_result.output
-        # Cloud mode should have ignored the user --cache-db and used a scratch dir.
-        assert not os.path.exists(cloud_cache_db), "cloud mode should not write to user --cache-db"
-        # Scratch dir cleaned up on success.
-        scratch_dirs = [d for d in dirs_created if Path(d).name.startswith("recce-cll-")]
-        assert scratch_dirs
-        assert all(not Path(d).exists() for d in scratch_dirs)
+        # Cloud mode writes the cache at the user --cache-db path (warm-cache reuse).
+        assert Path(shared_cache_db).exists(), "cloud mode must write cache.db to the user path"
+        # per_node tempdir cleaned up after success; cache.db is NOT rmtree'd.
+        per_node_dirs = [d for d in dirs_created if Path(d).name.startswith("recce-per-node-")]
+        assert per_node_dirs
+        assert all(not Path(d).exists() for d in per_node_dirs)
+        # No recce-cll-* scratch dir is created anymore (cache.db lives at the user path).
+        assert not any(Path(d).name.startswith("recce-cll-") for d in dirs_created)
 
-        # --- Local run (writes to a distinct --cache-db path) ---
+        # --- Local run (against the SAME --cache-db path) ---
         local_proj = tmp_path / "localproj"
         local_proj.mkdir()
         (local_proj / "target").mkdir()
         (local_proj / "target" / "manifest.json").write_text("{}")
-        local_db = str(tmp_path / "local-cache.db")
 
         with patch(
             "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
@@ -641,15 +653,15 @@ class TestModeSwitchingSafety:
         ):
             local_result = runner.invoke(
                 cli,
-                ["init", "--cache-db", local_db, "--project-dir", str(local_proj)],
+                ["init", "--cache-db", shared_cache_db, "--project-dir", str(local_proj)],
                 catch_exceptions=False,
             )
 
         assert local_result.exit_code == 0
-        # Local mode writes the cache at the user path and does NOT leak into the cloud scratch paths.
-        assert Path(local_db).exists()
-        # Local cache is a valid SQLite CLL cache (stats callable).
-        cache = CllCache(db_path=local_db)
+        # Shared cache.db still exists and is a valid CLL cache — warm-cache
+        # reuse works across invocations (cloud → local).
+        assert Path(shared_cache_db).exists()
+        cache = CllCache(db_path=shared_cache_db)
         assert cache.stats["entries"] >= 0
 
         # Sanity: SCHEMA_VERSION used by the per_node.db emitter is numeric.


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`feat` — wires the emitter into `recce init --cloud` and adds the cache.db handling.

**What this PR does / why we need it**:

**Stacked on top of #1334** (PR 1/3 — the pure emitter module). Please review #1334 first; this PR shows the merge diff against that branch.

Wires `PerNodeDbWriter` from #1334 into `recce init --cloud`:

- After `build_full_cll_map()` succeeds, emits `per_node.db` for both `base` and `current` envs from the loaded manifests + catalogs
- Uploads `per_node.db` via a new `per_node_db_url` presigned-URL key (graceful-degraded: missing key logs a warning, doesn't fail the command)
- Cloud mode's `cll_cache.db` now lives in `tempfile.mkdtemp(prefix="recce-cll-")` instead of `~/.recce/cll_cache.db`. Purpose: keep the warm-cache perf (`build_full_cll_map` re-uses previous CLL slices) while guaranteeing the cache DB never ends up on S3 or on the ECS task host after shutdown
- **Removed the cloud-mode `cll_cache_upload_url` upload path** entirely (cache.db is not a cloud artifact)
- `shutil.rmtree` cleanup of the tempdir on success via `try/finally`

Local (non-cloud) `recce init` behavior is unchanged: still writes `~/.recce/cll_cache.db` (or whatever `--cache-db` points to), still doesn't emit `per_node.db`.

**Which issue(s) this PR fixes**:

Part of [DRC-3295](https://linear.app/recce/issue/DRC-3295) (epic [DRC-3294](https://linear.app/recce/issue/DRC-3294), project "Lineage API Data Transfer Optimization" Phase III).

**Special notes for your reviewer**:

- Cloud-side prerequisite: the API server needs to add `per_node_db_url` to the response of `get_upload_urls_by_session_id` (same presigned-URL pattern as `cll_map_url`, content type `application/octet-stream`). CLI handles missing key gracefully, so this PR can land independently of that work.
- 7 new tests in `tests/test_cli_per_node_db.py`:
  - Cloud happy path (PUTs verified)
  - Missing-key graceful degradation
  - Scratch-dir cleanup after success
  - Local-mode non-regression
  - **Contract parity vs. `DbtAdapter.get_model()`** on the `tests/manifest.json` + `catalog.json` jaffle_shop fixture
  - Mode-switching safety
- One test in `tests/test_cli_cache.py` retargeted (`test_init_cloud_upload_partial_failure_shows_warning`) since the `cll_cache_url` upload branch is now deleted
- Full suite: 1106 passed, 5 pre-existing SPA failures (unchanged from #1334 — `test_spa_route_*` requires a built frontend that's not in the worktree)
- Review focus: correctness of the cloud / local branch split around `cache_db` path; `try/finally` cleanup semantics; contract-test coverage

**Does this PR introduce a user-facing change?**:

**Cloud users (implicit):** running `recce init --cloud` now uploads an extra `per_node.db` artifact and no longer uploads `cll_cache.db`. Consumers in Recce Cloud will begin reading `per_node.db` once the Cloud-side URL key is added. Nothing breaks in the meantime — the `cll_cache.db` upload path was already only read via the `cll_cache_url` key, which Cloud will continue to provide transparently during migration (CLI just ignores it).

**Local users (no change):** local `recce init` behavior is unchanged.

NONE (user-visible), but the cloud artifact set does change — covered by the cross-repo coordination note above.
