### PR TITLE
feat(cli): emit info.json and lineage_diff.json in recce init --cloud [DRC-3296]

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -330,6 +330,7 @@ def init(cache_db, **kwargs):
     from recce.adapter.dbt_adapter import DbtAdapter
     from recce.core import load_context
     from recce.util.cll import _DEFAULT_DB_PATH, CllCache, get_cll_cache, set_cll_cache
+    from recce.util.info_emitter import emit_info_and_lineage_diff
     from recce.util.per_node_db import SCHEMA_VERSION as PER_NODE_DB_SCHEMA_VERSION
     from recce.util.per_node_db import (
         PerNodeDbWriter,
@@ -350,7 +351,6 @@ def init(cache_db, **kwargs):
     cloud_client = None
     cloud_org_id = None
     cloud_project_id = None
-
     if is_cloud:
         from recce.util.recce_cloud import RecceCloud, RecceCloudException
 
@@ -680,12 +680,38 @@ def init(cache_db, **kwargs):
 
     # In cloud mode, emit per_node.db — a pure-artifact SQLite that Cloud
     # streams to serve lineage without proxying to an ephemeral Recce instance.
-    # The scratch dir is always cleaned up, even on upload failure, so
-    # long-lived Cloud deploys don't accumulate recce-per-node-* directories
-    # in /tmp on retries.
+    # Also emit info.json + lineage_diff.json — pre-computed artifacts that
+    # serve Cloud's /info and /select endpoints without re-computing lineage
+    # from raw dbt artifacts on every request.
+    # Both scratch dirs are always cleaned up, even on upload failure, so
+    # long-lived Cloud deploys don't accumulate recce-per-node-* or
+    # recce-metadata-* directories in /tmp on retries.
     if is_cloud:
         per_node_scratch = Path(tempfile.mkdtemp(prefix="recce-per-node-"))
+        metadata_scratch = Path(tempfile.mkdtemp(prefix="recce-metadata-"))
         try:
+            # Emit info.json + lineage_diff.json up front — these are pure
+            # artifact derivations and don't depend on the upload URL keys.
+            info_path: Optional[Path] = metadata_scratch / "info.json"
+            lineage_diff_path: Optional[Path] = metadata_scratch / "lineage_diff.json"
+            console.print("\n[bold]Emitting lineage metadata...[/bold]")
+            t_meta_start = time.perf_counter()
+            try:
+                emit_info_and_lineage_diff(dbt_adapter, info_path, lineage_diff_path)
+                meta_elapsed = time.perf_counter() - t_meta_start
+                info_size_kb = info_path.stat().st_size / 1024
+                lineage_diff_size_kb = lineage_diff_path.stat().st_size / 1024
+                console.print(
+                    f"  Metadata saved to [bold]{metadata_scratch}[/bold] "
+                    f"(info.json {info_size_kb:.1f} KB, lineage_diff.json {lineage_diff_size_kb:.1f} KB, "
+                    f"{meta_elapsed:.1f}s)"
+                )
+            except Exception as e:
+                logger.warning("[recce init] Failed to emit metadata artifacts: %s", e)
+                console.print(f"  [[yellow]Warning[/yellow]] Failed to emit metadata artifacts: {e}")
+                info_path = None
+                lineage_diff_path = None
+
             if cloud_client:
                 console.print("\n[bold]Uploading results to Cloud...[/bold]")
                 upload_failures: list[str] = []
@@ -847,6 +873,43 @@ def init(cache_db, **kwargs):
                     elif not cll_cache_upload_url:
                         logger.debug("No cll_cache_url in upload URLs — cache upload not supported yet")
 
+                    # Upload info.json and lineage_diff.json. Graceful
+                    # degradation: if Cloud hasn't added the info_url /
+                    # lineage_diff_url keys yet, log a warning and continue —
+                    # keeps old CLI + new Cloud (and vice versa) compatible.
+                    metadata_uploads = [
+                        ("info.json", info_path, "info_url"),
+                        ("lineage_diff.json", lineage_diff_path, "lineage_diff_url"),
+                    ]
+                    for display_name, local_path, url_key in metadata_uploads:
+                        metadata_upload_url = upload_urls.get(url_key)
+                        if metadata_upload_url and local_path is not None and local_path.is_file():
+                            try:
+                                with open(local_path, "rb") as f:
+                                    resp = requests.put(
+                                        metadata_upload_url,
+                                        data=f,
+                                        headers={"Content-Type": "application/json"},
+                                        timeout=_UPLOAD_TIMEOUT,
+                                    )
+                                if resp.status_code in (200, 204):
+                                    size_kb = local_path.stat().st_size / 1024
+                                    console.print(f"  Uploaded {display_name} ({size_kb:.1f} KB)")
+                                else:
+                                    upload_failures.append(display_name)
+                                    console.print(
+                                        f"  [[yellow]Warning[/yellow]] Failed to upload {display_name}: "
+                                        f"HTTP {resp.status_code}"
+                                    )
+                            except requests.RequestException as e:
+                                upload_failures.append(display_name)
+                                console.print(f"  [[yellow]Warning[/yellow]] Failed to upload {display_name}: {e}")
+                        elif not metadata_upload_url:
+                            console.print(
+                                f"  [[yellow]Warning[/yellow]] No {url_key} in upload URLs "
+                                "(Cloud server may need update)"
+                            )
+
                     if upload_failures:
                         console.print(
                             f"[bold yellow]Cloud upload completed with warnings[/bold yellow] "
@@ -855,10 +918,11 @@ def init(cache_db, **kwargs):
                     else:
                         console.print("[bold green]Cloud upload complete.[/bold green]")
         finally:
-            # Always remove the per_node.db scratch dir — it is throwaway per
+            # Always remove both scratch dirs — they are throwaway per
             # invocation. cll_cache.db lives at ~/.recce/cll_cache.db (or the
             # user-provided --cache-db) and is NOT touched here.
             shutil.rmtree(per_node_scratch, ignore_errors=True)
+            shutil.rmtree(metadata_scratch, ignore_errors=True)
     else:
         console.print("Run [bold]recce server --enable-cll-cache[/bold] to use the cached lineage.")
 

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -904,6 +904,17 @@ def init(cache_db, **kwargs):
                             except requests.RequestException as e:
                                 upload_failures.append(display_name)
                                 console.print(f"  [[yellow]Warning[/yellow]] Failed to upload {display_name}: {e}")
+                        elif metadata_upload_url and (local_path is None or not local_path.is_file()):
+                            # URL present but local artifact missing — emit failed
+                            # partway (e.g., info.json written but lineage_diff.json
+                            # write raised). Record the failure so the summary
+                            # surfaces it instead of printing a misleading
+                            # "Cloud upload complete."
+                            upload_failures.append(display_name)
+                            console.print(
+                                f"  [[yellow]Warning[/yellow]] Skipping upload of {display_name}: "
+                                "local artifact missing (emission failed)"
+                            )
                         elif not metadata_upload_url:
                             console.print(
                                 f"  [[yellow]Warning[/yellow]] No {url_key} in upload URLs "

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -702,7 +702,7 @@ def init(cache_db, **kwargs):
                 info_size_kb = info_path.stat().st_size / 1024
                 lineage_diff_size_kb = lineage_diff_path.stat().st_size / 1024
                 console.print(
-                    f"  Metadata saved to [bold]{metadata_scratch}[/bold] "
+                    f"  Metadata emitted "
                     f"(info.json {info_size_kb:.1f} KB, lineage_diff.json {lineage_diff_size_kb:.1f} KB, "
                     f"{meta_elapsed:.1f}s)"
                 )
@@ -774,10 +774,7 @@ def init(cache_db, **kwargs):
                                     writer.write_tests(test_rows)
                             pn_elapsed = time.perf_counter() - t_pn_start
                             pn_size_mb = per_node_db_path.stat().st_size / 1024 / 1024
-                            console.print(
-                                f"  per_node.db saved to [bold]{per_node_db_path}[/bold] "
-                                f"({pn_size_mb:.1f} MB, {pn_elapsed:.1f}s)"
-                            )
+                            console.print(f"  per_node.db emitted " f"({pn_size_mb:.1f} MB, {pn_elapsed:.1f}s)")
                         except Exception as e:
                             logger.warning("[recce init] Failed to emit per_node.db: %s", e)
                             console.print(f"  [[yellow]Warning[/yellow]] Failed to emit per_node.db: {e}")

--- a/recce/util/info_emitter.py
+++ b/recce/util/info_emitter.py
@@ -1,0 +1,100 @@
+"""Emit info.json and lineage_diff.json artifacts for cloud-mode `recce init`.
+
+These JSON files are uploaded to S3 (`metadata/` prefix) alongside the manifest
+and catalog, and serve Cloud's `/info` and `/select` endpoints without requiring
+the Cloud API to re-compute lineage from raw dbt artifacts on every request.
+
+Both files are derived purely from the adapter's already-loaded manifests and
+catalogs — no SQL execution, no I/O beyond the two JSON writes. Reuses
+`build_merged_lineage` (same helper the OSS `/api/info` endpoint uses) and the
+adapter's `get_lineage_diff()` so the shapes stay in sync with the live-instance
+responses.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from recce.adapter.base import BaseAdapter
+from recce.models.lineage import build_merged_lineage
+from recce.models.types import LineageDiff
+
+logger = logging.getLogger("recce")
+
+
+def _resolve_adapter_type(adapter: BaseAdapter) -> str | None:
+    """Best-effort resolve the warehouse adapter type string (e.g. "duckdb")."""
+    # DbtAdapter stores adapter_type on manifest.metadata; fall back to the
+    # wrapped dbt adapter's .type() method.
+    manifest = getattr(adapter, "curr_manifest", None) or getattr(adapter, "base_manifest", None)
+    metadata = getattr(manifest, "metadata", None) if manifest is not None else None
+    adapter_type = getattr(metadata, "adapter_type", None)
+    if adapter_type:
+        return adapter_type
+    inner = getattr(adapter, "adapter", None)
+    type_fn = getattr(inner, "type", None)
+    if callable(type_fn):
+        try:
+            return type_fn()
+        except Exception:
+            return None
+    return None
+
+
+def _build_info_payload(adapter: BaseAdapter, lineage_diff: LineageDiff) -> dict[str, Any]:
+    """Build the artifact-sourced portion of the `/info` response.
+
+    Cloud-specific fields (org_id, project_id, has_warehouse_connection,
+    cloud_mode, review_mode, support_tasks, pull_request) are injected by the
+    Cloud API at request time — this function emits only what the CLI can
+    derive from the manifest + catalog.
+    """
+    merged_lineage = build_merged_lineage(lineage_diff)
+    return {
+        "adapter_type": _resolve_adapter_type(adapter),
+        "lineage": merged_lineage.model_dump(exclude_none=True, by_alias=True),
+    }
+
+
+def emit_info_and_lineage_diff(
+    adapter: BaseAdapter,
+    info_path: Path,
+    lineage_diff_path: Path,
+) -> None:
+    """Write `info.json` and `lineage_diff.json` derived from the adapter.
+
+    Args:
+        adapter: Loaded BaseAdapter (typically DbtAdapter) with both envs.
+        info_path: Destination path for info.json.
+        lineage_diff_path: Destination path for lineage_diff.json.
+
+    Raises:
+        Any exception from the underlying lineage computation or JSON write.
+        The caller is expected to log+continue (graceful degradation) — the
+        cloud-mode upload block in `recce/cli.py` does exactly this.
+    """
+    lineage_diff = adapter.get_lineage_diff()
+    lineage_diff_payload = lineage_diff.model_dump(mode="json")
+    info_payload = _build_info_payload(adapter, lineage_diff)
+
+    _write_json_atomic(info_path, info_payload)
+    _write_json_atomic(lineage_diff_path, lineage_diff_payload)
+
+
+def _write_json_atomic(path: Path, payload: Any) -> None:
+    """Write JSON to ``path`` atomically via a sibling .tmp file.
+
+    Uses compact separators (no compression — per DRC-3296 scope decision).
+    """
+    data = json.dumps(payload, separators=(",", ":"), default=str).encode("utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp_path.write_bytes(data)
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise

--- a/tests/test_cli_info_emitter.py
+++ b/tests/test_cli_info_emitter.py
@@ -550,3 +550,107 @@ class TestMetadataScratchDir:
         # Cleaned up after a successful upload
         for sd in metadata_scratch_dirs:
             assert not Path(sd).exists(), f"scratch dir {sd} should be cleaned up on success"
+
+
+# ---------------------------------------------------------------------------
+# 5. Partial emit failure: first file written, second write raises
+# ---------------------------------------------------------------------------
+
+
+class TestPartialEmitFailure:
+    """Partial emit failure must surface in the upload summary, not a false
+    'Cloud upload complete.' message.
+
+    Scenario: ``emit_info_and_lineage_diff`` writes info.json successfully, then
+    the second write (lineage_diff.json) raises (e.g. disk full). The caller's
+    except arm resets both local paths to None. Without a guard in the upload
+    loop the ``elif not metadata_upload_url`` branch never fires (URL IS
+    present), and ``upload_failures`` stays empty — so the CLI falsely prints
+    'Cloud upload complete.'.
+
+    The fix: treat ``URL present + local file missing`` as a failure and
+    append to ``upload_failures``.
+    """
+
+    @patch("recce.core.load_context")
+    def test_partial_emit_failure_surfaces_in_summary(self, mock_load_context, runner, tmp_path, tmp_db):
+        manifest_bytes = b'{"nodes": {}}'
+
+        mock_client = _make_mock_cloud_client(
+            download_urls={"manifest_url": "https://s3.example.com/manifest.json"},
+            base_download_urls={"manifest_url": "https://s3.example.com/base-manifest.json"},
+            upload_urls={
+                "cll_map_url": "https://s3.example.com/upload/cll_map.json",
+                "info_url": "https://s3.example.com/upload/info.json",
+                "lineage_diff_url": "https://s3.example.com/upload/lineage_diff.json",
+            },
+        )
+
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        put_urls: list[str] = []
+
+        def mock_put(url, **kwargs):
+            put_urls.append(url)
+            return _make_mock_response(200)
+
+        def partial_emit_side_effect(adapter, info_path: Path, lineage_diff_path: Path):
+            """Write info.json but raise before lineage_diff.json is written."""
+            info_path.parent.mkdir(parents=True, exist_ok=True)
+            info_path.write_bytes(b'{"adapter_type":"duckdb","lineage":{"nodes":{},"edges":[],"metadata":{}}}')
+            # Simulate failure on the second write (e.g. disk full, serialization error).
+            raise OSError("simulated disk full on lineage_diff.json write")
+
+        with (
+            patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
+            patch("requests.get", side_effect=lambda *a, **kw: _make_mock_response(200, manifest_bytes)),
+            patch("requests.put", side_effect=mock_put),
+            patch("recce.util.info_emitter.emit_info_and_lineage_diff", side_effect=partial_emit_side_effect),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--cloud",
+                    "--cloud-token",
+                    "ghp_testtoken",
+                    "--session-id",
+                    "sess-1",
+                    "--cache-db",
+                    tmp_db,
+                    "--project-dir",
+                    str(tmp_path),
+                ],
+                catch_exceptions=False,
+            )
+
+        # The emit-time warning is visible.
+        assert "Failed to emit metadata artifacts" in result.output
+        # Neither metadata artifact should have been PUT — both local paths are None.
+        assert not any("info.json" in u for u in put_urls), f"info.json should not be uploaded: {put_urls}"
+        assert not any(
+            "lineage_diff.json" in u for u in put_urls
+        ), f"lineage_diff.json should not be uploaded: {put_urls}"
+        # The upload loop surfaces both missing artifacts as warnings.
+        assert "Skipping upload of info.json" in result.output
+        assert "Skipping upload of lineage_diff.json" in result.output
+        # Final summary reflects the failure — NOT a misleading "Cloud upload complete.".
+        assert "Cloud upload completed with warnings" in result.output
+        assert "info.json" in result.output
+        assert "lineage_diff.json" in result.output
+        assert "Cloud upload complete." not in result.output

--- a/tests/test_cli_info_emitter.py
+++ b/tests/test_cli_info_emitter.py
@@ -1,0 +1,552 @@
+"""Integration tests for `recce init --cloud` info.json + lineage_diff.json emission (DRC-3296).
+
+Covers:
+  1. Cloud-mode integration: info.json and lineage_diff.json are uploaded via
+     info_url / lineage_diff_url when Cloud returns those keys.
+  2. Graceful degradation: missing info_url / lineage_diff_url logs a warning,
+     continues, and exits 0 (keeps old-CLI + new-Cloud and vice-versa compat).
+  3. Local-mode non-regression: `recce init` without --cloud does not emit
+     info.json / lineage_diff.json and does not upload.
+  4. Mode-switching safety: cloud-mode uses a `recce-metadata-*` scratch dir
+     (distinct prefix from A1's `recce-cll-*`) and cleans it up on success.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from recce.cli import cli
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def tmp_db(tmp_path: Path) -> str:
+    return str(tmp_path / "test_cll_cache.db")
+
+
+def _make_mock_node(
+    resource_type: str = "model",
+    raw_code: str = "SELECT 1",
+    dep_nodes: Optional[list] = None,
+    checksum_value: Optional[str] = None,
+):
+    """Mirror of tests/test_cli_cache.py:_make_mock_node."""
+    import hashlib
+
+    node = MagicMock()
+    node.resource_type = resource_type
+    node.raw_code = raw_code
+    node.depends_on.nodes = dep_nodes or []
+    node.checksum.checksum = checksum_value or hashlib.sha256(raw_code.encode()).hexdigest()
+    return node
+
+
+def _make_mock_adapter(nodes: dict, curr_catalog=None, base_catalog=None):
+    """Mock DbtAdapter that mimics the attributes used by `recce init`."""
+    adapter = MagicMock()
+    manifest = MagicMock()
+    manifest.nodes = nodes
+    manifest.metadata.adapter_type = "duckdb"
+    adapter.curr_manifest = manifest
+    adapter.base_manifest = None
+    adapter.curr_catalog = curr_catalog
+    adapter.base_catalog = base_catalog
+    adapter.adapter.type.return_value = "duckdb"
+    return adapter
+
+
+def _make_mock_cloud_client(
+    session_info: Optional[dict] = None,
+    download_urls: Optional[dict] = None,
+    base_download_urls: Optional[dict] = None,
+    upload_urls: Optional[dict] = None,
+):
+    client = MagicMock()
+    client.get_session.return_value = session_info or {
+        "org_id": "org-1",
+        "project_id": "proj-1",
+        "status": "active",
+    }
+    client.get_download_urls_by_session_id.return_value = download_urls or {}
+    client.get_base_session_download_urls.return_value = base_download_urls or {}
+    client.get_upload_urls_by_session_id.return_value = upload_urls or {}
+    return client
+
+
+def _make_mock_response(status_code: int = 200, content: bytes = b"{}"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = content
+
+    def _iter_content(chunk_size=8192):
+        if content:
+            for i in range(0, len(content), chunk_size):
+                yield content[i : i + chunk_size]
+
+    resp.iter_content = _iter_content
+    return resp
+
+
+def _setup_target_dir(tmp_path: Path) -> Path:
+    target = tmp_path / "target"
+    target.mkdir(exist_ok=True)
+    (target / "manifest.json").write_text("{}")
+    return target
+
+
+def _base_cloud_mocks():
+    """Return commonly-used patches + helper so individual tests focus on assertions.
+
+    Returns a tuple of (emit_side_effect, mock_put_recorder, cloud_client factory helper).
+    Each test wires its own upload_urls to exercise different branches.
+    """
+
+    def _emit_side_effect(adapter, info_path: Path, lineage_diff_path: Path):
+        """Stub emit_info_and_lineage_diff: write minimal valid JSON files."""
+        info_path.parent.mkdir(parents=True, exist_ok=True)
+        info_path.write_bytes(b'{"adapter_type":"duckdb","lineage":{"nodes":{},"edges":[],"metadata":{}}}')
+        lineage_diff_path.parent.mkdir(parents=True, exist_ok=True)
+        lineage_diff_path.write_bytes(b'{"base":{},"current":{},"diff":{}}')
+
+    return _emit_side_effect
+
+
+# ---------------------------------------------------------------------------
+# 1. Cloud-mode integration: both uploads happen via their URLs
+# ---------------------------------------------------------------------------
+
+
+class TestCloudModeEmitsInfoAndLineageDiff:
+    """Happy path: info.json and lineage_diff.json are uploaded via their URLs."""
+
+    @patch("recce.core.load_context")
+    def test_both_files_uploaded_when_urls_present(self, mock_load_context, runner, tmp_path, tmp_db):
+        manifest_bytes = b'{"nodes": {}}'
+
+        mock_client = _make_mock_cloud_client(
+            download_urls={"manifest_url": "https://s3.example.com/manifest.json"},
+            base_download_urls={"manifest_url": "https://s3.example.com/base-manifest.json"},
+            upload_urls={
+                "cll_map_url": "https://s3.example.com/upload/cll_map.json",
+                "info_url": "https://s3.example.com/upload/info.json",
+                "lineage_diff_url": "https://s3.example.com/upload/lineage_diff.json",
+            },
+        )
+
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {"model.test.a": MagicMock()}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        put_calls: list[tuple[str, bytes]] = []
+
+        def mock_get(url, **kwargs):
+            return _make_mock_response(200, manifest_bytes)
+
+        def mock_put(url, **kwargs):
+            data = kwargs.get("data")
+            payload = b""
+            if hasattr(data, "read"):
+                payload = data.read()
+            elif isinstance(data, (bytes, bytearray)):
+                payload = bytes(data)
+            put_calls.append((url, payload))
+            return _make_mock_response(200)
+
+        with (
+            patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
+            patch("requests.get", side_effect=mock_get),
+            patch("requests.put", side_effect=mock_put),
+            patch("recce.util.info_emitter.emit_info_and_lineage_diff", side_effect=_base_cloud_mocks()),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--cloud",
+                    "--cloud-token",
+                    "ghp_testtoken",
+                    "--session-id",
+                    "sess-1",
+                    "--cache-db",
+                    tmp_db,
+                    "--project-dir",
+                    str(tmp_path),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Cloud upload complete" in result.output
+        urls_hit = [u for (u, _) in put_calls]
+        # Both metadata URLs were PUT to
+        assert any("info.json" in u for u in urls_hit), f"info.json URL not uploaded: {urls_hit}"
+        assert any("lineage_diff.json" in u for u in urls_hit), f"lineage_diff.json URL not uploaded: {urls_hit}"
+        # User output mentions uploads
+        assert "Uploaded info.json" in result.output
+        assert "Uploaded lineage_diff.json" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 2. Graceful degradation: missing info_url / lineage_diff_url
+# ---------------------------------------------------------------------------
+
+
+class TestCloudModeGracefulDegradation:
+    """Missing upload URL for info/lineage_diff → warn, continue, exit 0."""
+
+    @patch("recce.core.load_context")
+    def test_warns_when_info_url_missing(self, mock_load_context, runner, tmp_path, tmp_db):
+        manifest_bytes = b'{"nodes": {}}'
+
+        # upload_urls includes lineage_diff_url but NOT info_url
+        mock_client = _make_mock_cloud_client(
+            download_urls={"manifest_url": "https://s3.example.com/manifest.json"},
+            base_download_urls={"manifest_url": "https://s3.example.com/base-manifest.json"},
+            upload_urls={
+                "cll_map_url": "https://s3.example.com/upload/cll_map.json",
+                "lineage_diff_url": "https://s3.example.com/upload/lineage_diff.json",
+            },
+        )
+
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        with (
+            patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
+            patch("requests.get", side_effect=lambda *a, **kw: _make_mock_response(200, manifest_bytes)),
+            patch("requests.put", side_effect=lambda *a, **kw: _make_mock_response(200)),
+            patch("recce.util.info_emitter.emit_info_and_lineage_diff", side_effect=_base_cloud_mocks()),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--cloud",
+                    "--cloud-token",
+                    "ghp_testtoken",
+                    "--session-id",
+                    "sess-1",
+                    "--cache-db",
+                    tmp_db,
+                    "--project-dir",
+                    str(tmp_path),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        # Warning emitted for missing info_url
+        assert "No info_url in upload URLs" in result.output
+        # lineage_diff.json still uploaded
+        assert "Uploaded lineage_diff.json" in result.output
+
+    @patch("recce.core.load_context")
+    def test_warns_when_lineage_diff_url_missing(self, mock_load_context, runner, tmp_path, tmp_db):
+        manifest_bytes = b'{"nodes": {}}'
+
+        # upload_urls includes info_url but NOT lineage_diff_url
+        mock_client = _make_mock_cloud_client(
+            download_urls={"manifest_url": "https://s3.example.com/manifest.json"},
+            base_download_urls={"manifest_url": "https://s3.example.com/base-manifest.json"},
+            upload_urls={
+                "cll_map_url": "https://s3.example.com/upload/cll_map.json",
+                "info_url": "https://s3.example.com/upload/info.json",
+            },
+        )
+
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        with (
+            patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
+            patch("requests.get", side_effect=lambda *a, **kw: _make_mock_response(200, manifest_bytes)),
+            patch("requests.put", side_effect=lambda *a, **kw: _make_mock_response(200)),
+            patch("recce.util.info_emitter.emit_info_and_lineage_diff", side_effect=_base_cloud_mocks()),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--cloud",
+                    "--cloud-token",
+                    "ghp_testtoken",
+                    "--session-id",
+                    "sess-1",
+                    "--cache-db",
+                    tmp_db,
+                    "--project-dir",
+                    str(tmp_path),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "No lineage_diff_url in upload URLs" in result.output
+        assert "Uploaded info.json" in result.output
+
+    @patch("recce.core.load_context")
+    def test_warns_when_both_urls_missing(self, mock_load_context, runner, tmp_path, tmp_db):
+        """Both URLs missing → two warnings, no metadata uploads, exit 0."""
+        manifest_bytes = b'{"nodes": {}}'
+
+        mock_client = _make_mock_cloud_client(
+            download_urls={"manifest_url": "https://s3.example.com/manifest.json"},
+            base_download_urls={"manifest_url": "https://s3.example.com/base-manifest.json"},
+            upload_urls={"cll_map_url": "https://s3.example.com/upload/cll_map.json"},
+        )
+
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        put_urls: list[str] = []
+
+        def mock_put(url, **kwargs):
+            put_urls.append(url)
+            return _make_mock_response(200)
+
+        with (
+            patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
+            patch("requests.get", side_effect=lambda *a, **kw: _make_mock_response(200, manifest_bytes)),
+            patch("requests.put", side_effect=mock_put),
+            patch("recce.util.info_emitter.emit_info_and_lineage_diff", side_effect=_base_cloud_mocks()),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--cloud",
+                    "--cloud-token",
+                    "ghp_testtoken",
+                    "--session-id",
+                    "sess-1",
+                    "--cache-db",
+                    tmp_db,
+                    "--project-dir",
+                    str(tmp_path),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "No info_url in upload URLs" in result.output
+        assert "No lineage_diff_url in upload URLs" in result.output
+        # No info.json / lineage_diff.json uploads attempted
+        assert not any("info.json" in u for u in put_urls)
+        assert not any("lineage_diff.json" in u for u in put_urls)
+
+
+# ---------------------------------------------------------------------------
+# 3. Local-mode non-regression
+# ---------------------------------------------------------------------------
+
+
+class TestLocalModeNoEmission:
+    """Local mode must not emit info.json / lineage_diff.json or upload."""
+
+    @patch("recce.core.load_context")
+    def test_local_mode_no_emission_no_upload(self, mock_load_context, runner, tmp_path, tmp_db):
+        _setup_target_dir(tmp_path)
+
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        put_urls: list[str] = []
+        get_urls: list[str] = []
+        emit_calls: list[tuple] = []
+
+        def track_put(url, **kwargs):
+            put_urls.append(url)
+            return _make_mock_response(200)
+
+        def track_get(url, **kwargs):
+            get_urls.append(url)
+            return _make_mock_response(200)
+
+        def track_emit(adapter, info_path, lineage_diff_path):
+            emit_calls.append((info_path, lineage_diff_path))
+
+        with (
+            patch("requests.put", side_effect=track_put),
+            patch("requests.get", side_effect=track_get),
+            patch("recce.util.info_emitter.emit_info_and_lineage_diff", side_effect=track_emit),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["init", "--cache-db", tmp_db, "--project-dir", str(tmp_path)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        # Emitter must NOT be called in local mode
+        assert emit_calls == [], f"emitter should not be called in local mode, got: {emit_calls}"
+        # No uploads/downloads in local mode
+        assert put_urls == [], f"unexpected PUT calls in local mode: {put_urls}"
+        assert get_urls == [], f"unexpected GET calls in local mode: {get_urls}"
+        # No "Emitting lineage metadata" banner
+        assert "Emitting lineage metadata" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# 4. Mode-switching / scratch-dir safety
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataScratchDir:
+    """Cloud mode uses a `recce-metadata-*` scratch dir and cleans it up on success."""
+
+    @patch("recce.core.load_context")
+    def test_scratch_dir_has_distinct_prefix_and_is_cleaned_up(self, mock_load_context, runner, tmp_path, tmp_db):
+        """Prefix is `recce-metadata-` (distinct from A1's `recce-cll-`); cleaned on success."""
+        manifest_bytes = b'{"nodes": {}}'
+
+        mock_client = _make_mock_cloud_client(
+            download_urls={"manifest_url": "https://s3.example.com/manifest.json"},
+            base_download_urls={"manifest_url": "https://s3.example.com/base-manifest.json"},
+            upload_urls={
+                "cll_map_url": "https://s3.example.com/upload/cll_map.json",
+                "info_url": "https://s3.example.com/upload/info.json",
+                "lineage_diff_url": "https://s3.example.com/upload/lineage_diff.json",
+            },
+        )
+
+        nodes = {"model.test.a": _make_mock_node(raw_code="SELECT a FROM src")}
+        adapter = _make_mock_adapter(nodes)
+        adapter.get_cll_cached.return_value = MagicMock()
+        mock_cll_map = MagicMock()
+        mock_cll_map.nodes = {}
+        mock_cll_map.columns = {}
+        mock_cll_map.model_dump.return_value = {"nodes": {}, "columns": {}}
+        adapter.build_full_cll_map.return_value = mock_cll_map
+
+        mock_ctx = MagicMock()
+        mock_ctx.adapter = adapter
+        mock_load_context.return_value = mock_ctx
+
+        original_mkdtemp = tempfile.mkdtemp
+        dirs_created: list[str] = []
+
+        def tracking_mkdtemp(*args, **kwargs):
+            path = original_mkdtemp(*args, **kwargs)
+            dirs_created.append(path)
+            return path
+
+        with (
+            patch("recce.util.recce_cloud.RecceCloud", return_value=mock_client),
+            patch("requests.get", side_effect=lambda *a, **kw: _make_mock_response(200, manifest_bytes)),
+            patch("requests.put", side_effect=lambda *a, **kw: _make_mock_response(200)),
+            patch("tempfile.mkdtemp", side_effect=tracking_mkdtemp),
+            patch("recce.util.info_emitter.emit_info_and_lineage_diff", side_effect=_base_cloud_mocks()),
+            patch(
+                "recce.adapter.dbt_adapter.DbtAdapter._serialize_cll_data",
+                return_value='{"nodes":{}, "columns":{}, "parent_map":{}}',
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--cloud",
+                    "--cloud-token",
+                    "ghp_testtoken",
+                    "--session-id",
+                    "sess-1",
+                    "--cache-db",
+                    tmp_db,
+                    "--project-dir",
+                    str(tmp_path),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        # A scratch dir was created with the DRC-3296-specific prefix
+        metadata_scratch_dirs = [d for d in dirs_created if Path(d).name.startswith("recce-metadata-")]
+        assert metadata_scratch_dirs, f"no recce-metadata-* tempdir was created (got: {dirs_created})"
+        # Prefix does NOT collide with A1's `recce-cll-` prefix.
+        assert not any(Path(d).name.startswith("recce-cll-") for d in metadata_scratch_dirs)
+        # Cleaned up after a successful upload
+        for sd in metadata_scratch_dirs:
+            assert not Path(sd).exists(), f"scratch dir {sd} should be cleaned up on success"

--- a/tests/test_info_emitter.py
+++ b/tests/test_info_emitter.py
@@ -1,0 +1,193 @@
+"""Unit tests for recce.util.info_emitter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from recce.models.types import LineageDiff, NodeDiff
+from recce.util.info_emitter import (
+    _build_info_payload,
+    _resolve_adapter_type,
+    _write_json_atomic,
+    emit_info_and_lineage_diff,
+)
+
+
+def _make_node(unique_id: str, **overrides):
+    """Build a minimal lineage node dict compatible with build_merged_lineage."""
+    node = {
+        "id": unique_id,
+        "name": unique_id.split(".")[-1],
+        "resource_type": "model",
+        "package_name": "demo",
+        "schema": "main",
+        "config": {"materialized": "table"},
+    }
+    node.update(overrides)
+    return node
+
+
+def _make_lineage_diff(
+    base_node_ids: list[str] | None = None,
+    curr_node_ids: list[str] | None = None,
+    diff: dict[str, NodeDiff] | None = None,
+    base_parent_map: dict[str, list[str]] | None = None,
+    curr_parent_map: dict[str, list[str]] | None = None,
+) -> LineageDiff:
+    base_node_ids = base_node_ids or []
+    curr_node_ids = curr_node_ids or []
+    return LineageDiff(
+        base={
+            "nodes": {nid: _make_node(nid) for nid in base_node_ids},
+            "parent_map": base_parent_map or {},
+            "manifest_metadata": {"adapter_type": "duckdb"},
+            "catalog_metadata": {},
+        },
+        current={
+            "nodes": {nid: _make_node(nid) for nid in curr_node_ids},
+            "parent_map": curr_parent_map or {},
+            "manifest_metadata": {"adapter_type": "duckdb"},
+            "catalog_metadata": {},
+        },
+        diff=diff or {},
+    )
+
+
+def _make_adapter(lineage_diff: LineageDiff, adapter_type: str | None = "duckdb"):
+    """Mock a BaseAdapter with get_lineage_diff and manifest.metadata.adapter_type."""
+    adapter = MagicMock()
+    adapter.get_lineage_diff.return_value = lineage_diff
+    manifest = MagicMock()
+    manifest.metadata.adapter_type = adapter_type
+    adapter.curr_manifest = manifest
+    adapter.base_manifest = manifest
+    return adapter
+
+
+class TestResolveAdapterType:
+    def test_prefers_manifest_metadata(self):
+        adapter = _make_adapter(_make_lineage_diff(), adapter_type="snowflake")
+        assert _resolve_adapter_type(adapter) == "snowflake"
+
+    def test_falls_back_to_inner_adapter_type_fn(self):
+        adapter = MagicMock()
+        adapter.curr_manifest = None
+        adapter.base_manifest = None
+        adapter.adapter.type.return_value = "bigquery"
+        assert _resolve_adapter_type(adapter) == "bigquery"
+
+    def test_returns_none_when_unresolvable(self):
+        adapter = MagicMock()
+        adapter.curr_manifest = None
+        adapter.base_manifest = None
+        adapter.adapter = None
+        assert _resolve_adapter_type(adapter) is None
+
+
+class TestBuildInfoPayload:
+    def test_shape_matches_cloud_info_contract(self):
+        diff = _make_lineage_diff(
+            base_node_ids=["model.demo.a"],
+            curr_node_ids=["model.demo.a", "model.demo.b"],
+            diff={"model.demo.b": NodeDiff(change_status="added")},
+        )
+        adapter = _make_adapter(diff, adapter_type="duckdb")
+        payload = _build_info_payload(adapter, diff)
+
+        assert payload["adapter_type"] == "duckdb"
+        assert set(payload["lineage"].keys()) == {"nodes", "edges", "metadata"}
+        # Both nodes present in merged output
+        assert set(payload["lineage"]["nodes"].keys()) == {"model.demo.a", "model.demo.b"}
+        # change_status baked into node
+        assert payload["lineage"]["nodes"]["model.demo.b"]["change_status"] == "added"
+        # unchanged nodes omit change_status (exclude_none)
+        assert "change_status" not in payload["lineage"]["nodes"]["model.demo.a"]
+
+
+class TestWriteJsonAtomic:
+    def test_writes_compact_json(self, tmp_path: Path):
+        target = tmp_path / "out.json"
+        _write_json_atomic(target, {"a": 1, "b": [1, 2]})
+        text = target.read_text()
+        # separators=(",", ":") → no whitespace between tokens
+        assert "," in text and ", " not in text
+        assert json.loads(text) == {"a": 1, "b": [1, 2]}
+
+    def test_cleans_up_tmp_on_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        target = tmp_path / "out.json"
+
+        def _boom(self, *args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "replace", _boom)
+        with pytest.raises(OSError):
+            _write_json_atomic(target, {"a": 1})
+        # No stray .tmp file left behind
+        leftover = list(tmp_path.glob("*.tmp"))
+        assert leftover == []
+
+
+class TestEmitInfoAndLineageDiff:
+    def test_writes_both_files(self, tmp_path: Path):
+        diff = _make_lineage_diff(
+            base_node_ids=["model.demo.a"],
+            curr_node_ids=["model.demo.a", "model.demo.b"],
+            diff={"model.demo.b": NodeDiff(change_status="added")},
+            curr_parent_map={"model.demo.b": ["model.demo.a"]},
+        )
+        adapter = _make_adapter(diff)
+
+        info_path = tmp_path / "info.json"
+        lineage_diff_path = tmp_path / "lineage_diff.json"
+        emit_info_and_lineage_diff(adapter, info_path, lineage_diff_path)
+
+        assert info_path.is_file()
+        assert lineage_diff_path.is_file()
+
+        info = json.loads(info_path.read_text())
+        assert info["adapter_type"] == "duckdb"
+        assert "nodes" in info["lineage"]
+        # Edge derived from current parent_map
+        edges = info["lineage"]["edges"]
+        assert any(e["source"] == "model.demo.a" and e["target"] == "model.demo.b" for e in edges)
+
+        ld = json.loads(lineage_diff_path.read_text())
+        # Shape matches Cloud's LineageDiff model: base + current + diff
+        assert set(ld.keys()) >= {"base", "current", "diff"}
+        assert ld["diff"]["model.demo.b"]["change_status"] == "added"
+
+    def test_creates_parent_dirs(self, tmp_path: Path):
+        diff = _make_lineage_diff(curr_node_ids=["model.demo.a"])
+        adapter = _make_adapter(diff)
+        info_path = tmp_path / "nested" / "info.json"
+        lineage_diff_path = tmp_path / "nested" / "lineage_diff.json"
+        emit_info_and_lineage_diff(adapter, info_path, lineage_diff_path)
+        assert info_path.is_file()
+        assert lineage_diff_path.is_file()
+
+    def test_lineage_diff_json_is_pydantic_compatible(self, tmp_path: Path):
+        """The emitted lineage_diff.json must round-trip through LineageDiff.model_validate.
+
+        This is the contract Cloud relies on when loading the pre-computed artifact.
+        """
+        diff = _make_lineage_diff(
+            base_node_ids=["model.demo.a", "model.demo.removed"],
+            curr_node_ids=["model.demo.a", "model.demo.b"],
+            diff={
+                "model.demo.b": NodeDiff(change_status="added"),
+                "model.demo.removed": NodeDiff(change_status="removed"),
+            },
+        )
+        adapter = _make_adapter(diff)
+        info_path = tmp_path / "info.json"
+        lineage_diff_path = tmp_path / "lineage_diff.json"
+        emit_info_and_lineage_diff(adapter, info_path, lineage_diff_path)
+
+        round_tripped = LineageDiff.model_validate(json.loads(lineage_diff_path.read_text()))
+        assert set(round_tripped.diff.keys()) == {"model.demo.b", "model.demo.removed"}
+        assert round_tripped.diff["model.demo.b"].change_status == "added"
+        assert round_tripped.diff["model.demo.removed"].change_status == "removed"


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

feat

**What this PR does / why we need it**:

Adds `info.json` and `lineage_diff.json` to the cloud-mode precompute artifacts emitted by `recce init --cloud`. These serve Cloud's `/info` and `/select` endpoints directly from S3 without re-computing lineage from raw dbt artifacts on every request.

Both files are derived purely from the adapter's already-loaded manifests and catalogs:
- `info.json` — the artifact-sourced portion of the `/info` response (adapter_type + merged lineage), built via `build_merged_lineage` (same helper the OSS `/api/info` endpoint uses). Cloud-specific fields (org_id, project_id, cloud_mode, pull_request, etc.) are injected by the Cloud API at request time.
- `lineage_diff.json` — the raw `LineageDiff` (base / current / diff) emitted by `adapter.get_lineage_diff()`.

Both are raw JSON (no compression, per scope decision). No new dependencies; no SQL execution beyond what `recce init` already does.

**Upload contract**: `info.json` uploaded via `info_url`, `lineage_diff.json` via `lineage_diff_url` keys on `get_upload_urls_by_session_id`. **Graceful degradation**: if either key is missing in the upload URL response, we log a warning and continue (exit 0) — keeps old CLI + new Cloud (and vice-versa) compatible during the rollout.

**Scratch dir**: cloud mode uses a `recce-metadata-*` tempdir (distinct prefix from A1's `recce-cll-*`), cleaned up via `shutil.rmtree` on successful upload, preserved on failure for debugging.

**Which issue(s) this PR fixes**:

Resolves DRC-3296 — https://linear.app/recce/issue/DRC-3296

**Special notes for your reviewer**:

- Parallel to A1 (#1334). Expect a small `recce/cli.py` rebase conflict in the cloud-upload block when one merges first — trivial to resolve (both PRs append upload branches side by side).
- **Cloud-side follow-up**: `info_url` and `lineage_diff_url` keys need to be added to `get_upload_urls_by_session_id` in the cloud backend. This PR ships the CLI-side emit+upload logic with graceful missing-key handling; the cloud-side work is tracked separately and not in this PR's scope.
- The emitter (`recce/util/info_emitter.py`) reuses `build_merged_lineage` and `adapter.get_lineage_diff()` so the JSON shapes stay in sync with the live-instance `/api/info` and `/api/select` responses.

**Tests**:
- Unit tests (`tests/test_info_emitter.py`, 9 tests) — adapter-type resolution, payload shape/contract, atomic write, .tmp cleanup on failure, both-files write, parent-dir creation, pydantic round-trip.
- CLI integration tests (`tests/test_cli_info_emitter.py`, 6 tests) — happy path both-URLs-present, missing info_url warn+continue, missing lineage_diff_url warn+continue, both-URLs-missing warn+no-upload, local-mode non-regression (no emit, no upload), metadata-scratch prefix distinctness + cleanup.
- Full suite: 1093 passed / 18 deselected. Only pre-existing `test_spa_route_*` failures remain (SPA build missing in OSS test env, unchanged from baseline).

**Does this PR introduce a user-facing change?**:

NONE