### PR TITLE
fix(lineage): dedupe /api/models/{id} fetch on node click

### DIFF
--- a/js/packages/ui/src/hooks/__tests__/useModelColumns.test.tsx
+++ b/js/packages/ui/src/hooks/__tests__/useModelColumns.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * @file useModelColumns.test.tsx
+ * @description Tests for the useModelColumns hook (DRC-3343).
+ *
+ * Verifies:
+ * - The hook resolves columns + primary_key from the /api/models/{id} payload.
+ * - When useModelColumns and a sibling useQuery({queryKey: ["modelDetail", id]})
+ *   mount under one QueryClient, only ONE network request fires
+ *   (regression guard for DRC-3343, where the panel double-fetched).
+ * - The hook returns isLoading=false when no model resolves (matches the
+ *   prior hook contract).
+ */
+
+import { vi } from "vitest";
+
+// ============================================================================
+// Mocks - MUST be set up before imports
+// ============================================================================
+
+const mockApiClient = {
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+};
+
+const mockGetModelInfo = vi.fn();
+
+vi.mock("../../api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api")>();
+  return {
+    ...actual,
+    getModelInfo: (...args: unknown[]) => mockGetModelInfo(...args),
+  };
+});
+
+const mockUseLineageGraphContext = vi.fn();
+vi.mock("../../contexts/lineage", () => ({
+  useLineageGraphContext: () => mockUseLineageGraphContext(),
+}));
+
+vi.mock("../../providers", () => ({
+  useApiConfigOptional: () => ({ apiClient: mockApiClient }),
+}));
+
+// ============================================================================
+// Imports
+// ============================================================================
+
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useModelColumns } from "../useModelColumns";
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+const NODE_ID = "model.test.my_model";
+const MODEL_NAME = "my_model";
+
+const lineageNode = {
+  id: NODE_ID,
+  data: { id: NODE_ID, name: MODEL_NAME },
+};
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const fakeModelInfo = {
+  model: {
+    base: {
+      columns: { id: { name: "id", type: "INT" } },
+      primary_key: "id",
+    },
+    current: {
+      columns: {
+        id: { name: "id", type: "INT" },
+        name: { name: "name", type: "TEXT" },
+      },
+      primary_key: "id",
+    },
+  },
+};
+
+describe("useModelColumns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetModelInfo.mockReset();
+    mockUseLineageGraphContext.mockReturnValue({
+      lineageGraph: { nodes: [lineageNode] },
+    });
+  });
+
+  it("resolves columns and primaryKey from /api/models/{id}", async () => {
+    mockGetModelInfo.mockResolvedValue(fakeModelInfo);
+
+    const { result } = renderHook(() => useModelColumns(MODEL_NAME), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGetModelInfo).toHaveBeenCalledTimes(1);
+    expect(mockGetModelInfo).toHaveBeenCalledWith(NODE_ID, mockApiClient);
+    expect(result.current.columns.map((c) => c.name)).toEqual(["id", "name"]);
+    expect(result.current.primaryKey).toBe("id");
+    expect(result.current.error).toBe(null);
+  });
+
+  it("dedupes the /api/models/{id} fetch when a sibling useQuery shares the cache key (DRC-3343)", async () => {
+    mockGetModelInfo.mockResolvedValue(fakeModelInfo);
+
+    // One QueryClient shared by both hooks — the dedupe under test.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    // Sibling query in the same render — same shape NodeViewOss uses today.
+    const useBothQueries = () => {
+      const cols = useModelColumns(MODEL_NAME);
+      const sibling = useQuery({
+        queryKey: ["modelDetail", NODE_ID],
+        queryFn: () => mockGetModelInfo(NODE_ID, mockApiClient),
+        staleTime: 5 * 60 * 1000,
+      });
+      return { cols, sibling };
+    };
+
+    const { result } = renderHook(useBothQueries, { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.cols.isLoading).toBe(false);
+      expect(result.current.sibling.isLoading).toBe(false);
+    });
+
+    // Critical assertion: ONE network call across both hooks.
+    expect(mockGetModelInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns isLoading=false and no fetch when model is undefined", () => {
+    const { result } = renderHook(() => useModelColumns(undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.columns).toEqual([]);
+    expect(result.current.primaryKey).toBeUndefined();
+    expect(mockGetModelInfo).not.toHaveBeenCalled();
+  });
+
+  it("surfaces fetch errors as Error instances", async () => {
+    mockGetModelInfo.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useModelColumns(MODEL_NAME), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe("boom");
+  });
+});

--- a/js/packages/ui/src/hooks/index.ts
+++ b/js/packages/ui/src/hooks/index.ts
@@ -44,7 +44,6 @@ export { useFeedbackCollectionToast } from "./useFeedbackCollectionToast";
 export { useGuideToast } from "./useGuideToast";
 export { useIsDark } from "./useIsDark";
 export {
-  extractColumns,
   type UseModelColumnsReturn,
   unionColumns,
   useModelColumns,

--- a/js/packages/ui/src/hooks/useModelColumns.tsx
+++ b/js/packages/ui/src/hooks/useModelColumns.tsx
@@ -4,37 +4,13 @@
  * Combines data from lineage graph context with API calls for column details.
  */
 
+import { useQuery } from "@tanstack/react-query";
 import _ from "lodash";
-import { useCallback, useEffect, useState } from "react";
+import { useMemo } from "react";
 import { getModelInfo, type NodeColumnData } from "../api";
-import {
-  type LineageGraphNode,
-  useLineageGraphContext,
-} from "../contexts/lineage";
+import { useLineageGraphContext } from "../contexts/lineage";
 import type { ApiClient } from "../lib/fetchClient";
 import { useApiConfigOptional } from "../providers";
-
-/**
- * Stable empty array used when inline column data is unavailable.
- * Must be a module-level constant — a `[]` literal inside a hook body
- * creates a new reference every render, breaking the `prevNodeColumns`
- * identity check and causing an infinite re-render loop.
- */
-const EMPTY_COLUMNS: NodeColumnData[] = [];
-
-/**
- * Extract columns from a lineage graph node.
- *
- * After DRC-3260, inline column data is no longer available on the graph node.
- * This function always returns an empty array; the API fetch path in
- * useModelColumns provides the actual column data.
- *
- * @deprecated Kept for backward compatibility. Will be removed once all
- * callers migrate to on-demand API fetch.
- */
-export function extractColumns(_node: LineageGraphNode): NodeColumnData[] {
-  return EMPTY_COLUMNS;
-}
 
 /**
  * Create a union of base and current columns by name.
@@ -72,8 +48,12 @@ export interface UseModelColumnsReturn {
 /**
  * Hook to fetch model column information.
  *
- * This hook combines data from the lineage graph context (if available)
- * with API calls to get detailed column information for a model.
+ * This hook resolves the lineage node by `model` name and fetches the model
+ * detail (columns + primary_key) via TanStack Query. The query key
+ * `["modelDetail", node.id]` and `staleTime` are deliberately aligned with
+ * the `useQuery` calls in NodeViewOss / NodeSqlViewOss / SandboxViewOss /
+ * SchemaDiffView / SchemaSummary so that all consumers share a single cache
+ * entry and a single in-flight request per node (DRC-3343).
  *
  * @param model - The model name to fetch columns for
  * @param client - Axios instance for API calls (optional - will use context if not provided)
@@ -105,71 +85,55 @@ export function useModelColumns(
     },
   });
 
-  // After DRC-3260, inline column data is no longer on the graph node.
-  // Always use the API fetch path below.
-  // IMPORTANT: uses module-level EMPTY_COLUMNS for referential stability —
-  // a `[]` literal here caused infinite re-render (new ref every render).
-  const nodeColumns = EMPTY_COLUMNS;
+  const enabled = !!apiClient && !!node?.id;
 
-  const [columns, setColumns] = useState<NodeColumnData[]>([]);
-  const [primaryKey, setPrimaryKey] = useState<string>();
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [error, setError] = useState<Error | null>(null);
-  const [prevNodeColumns, setPrevNodeColumns] = useState<NodeColumnData[]>([]);
-  const [prevNodeId, setPrevNodeId] = useState(node?.id);
-
-  // After DRC-3260, primary_key is no longer inline on the graph node.
-  // The API fetch path below provides it.
-  const nodePrimaryKey = undefined;
-
-  const fetchData = useCallback(async () => {
-    if (!node || !apiClient) {
-      return;
-    }
-    try {
-      const data = await getModelInfo(node.id, apiClient);
-      const modelInfo = data.model;
-      if (!modelInfo.base.columns || !modelInfo.current.columns) {
-        setColumns([]);
-        setIsLoading(false);
-        return;
+  // Shares cache + in-flight request with NodeViewOss / NodeSqlViewOss /
+  // SandboxViewOss / SchemaDiffView / SchemaSummary, all of which use the
+  // same ["modelDetail", node.id] queryKey and staleTime.
+  const {
+    data,
+    isLoading: queryLoading,
+    error: queryError,
+  } = useQuery({
+    queryKey: ["modelDetail", node?.id],
+    queryFn: () => {
+      // `enabled` guarantees both `node?.id` and `apiClient` are defined
+      // before this function runs.
+      if (!node?.id || !apiClient) {
+        throw new Error("useModelColumns: missing node id or api client");
       }
-      setPrimaryKey(modelInfo.current.primary_key);
-      const baseColumns = Object.values(modelInfo.base.columns);
-      const currentColumns = Object.values(modelInfo.current.columns);
-      setColumns(unionColumns(baseColumns, currentColumns));
-      setIsLoading(false);
-    } catch (err) {
-      setError(err as Error);
-      setIsLoading(false);
-    }
-  }, [node, apiClient]);
+      return getModelInfo(node.id, apiClient);
+    },
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
 
-  // Adjust state during render when node changes
-  if (nodeColumns !== prevNodeColumns || node?.id !== prevNodeId) {
-    setPrevNodeColumns(nodeColumns);
-    setPrevNodeId(node?.id);
-
-    if (nodeColumns.length > 0) {
-      setColumns(nodeColumns);
-      setPrimaryKey(nodePrimaryKey);
-      setIsLoading(false);
-    } else if (node?.id === undefined) {
-      setColumns([]);
-      setIsLoading(false);
+  const { columns, primaryKey } = useMemo(() => {
+    const modelInfo = data?.model;
+    if (!modelInfo?.base.columns || !modelInfo.current.columns) {
+      return {
+        columns: [] as NodeColumnData[],
+        primaryKey: modelInfo?.current.primary_key,
+      };
     }
-    // Note: fetchData case is handled separately in effect below
-  }
+    const baseColumns = Object.values(modelInfo.base.columns);
+    const currentColumns = Object.values(modelInfo.current.columns);
+    return {
+      columns: unionColumns(baseColumns, currentColumns),
+      primaryKey: modelInfo.current.primary_key,
+    };
+  }, [data]);
 
-  // Fetch data effect - only runs when we need to fetch
-  useEffect(() => {
-    if (nodeColumns.length === 0 && node?.id !== undefined) {
-      fetchData().catch((e: unknown) => {
-        // error is already handled in fetchData()
-        console.error(e);
-      });
-    }
-  }, [fetchData, node?.id]);
+  // When the query is disabled (no model resolved or no api client), match
+  // the prior hook contract of returning isLoading=false rather than the
+  // TanStack default of true.
+  const isLoading = enabled ? queryLoading : false;
+
+  const error = queryError
+    ? queryError instanceof Error
+      ? queryError
+      : new Error(String(queryError))
+    : null;
 
   return { columns, primaryKey, isLoading, error };
 }

--- a/js/packages/ui/src/index.ts
+++ b/js/packages/ui/src/index.ts
@@ -177,7 +177,6 @@ export type {
 export {
   CheckContextAdapter,
   defaultSqlQuery,
-  extractColumns,
   IGNORE_SCREENSHOT_CLASS,
   LineageGraphAdapter,
   QueryContextAdapter,


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

bug fix

**What this PR does / why we need it**:

`NodeViewOss` (the panel that opens on lineage node click) was firing `GET /api/models/{id}` **twice** in parallel for the same model. Two co-located fetchers raced for the same payload:

1. `NodeViewOss.tsx:117` — `useQuery({ queryKey: ["modelDetail", node.id], staleTime: 5 * 60 * 1000 })`
2. `useModelColumns(node.data.name)` — a hand-rolled `useEffect` + `useState` flow that called `getModelInfo` directly, bypassing TanStack Query (no cache key, no in-flight dedupe).

This rewrites `useModelColumns` to use `useQuery` with the same `["modelDetail", node.id]` key and the same 5-minute `staleTime`. Two consumers of the same key on the same render tree → one network request.

`NodeSqlViewOss`, `SandboxViewOss`, `SchemaDiffView`, and `SchemaSummary` already use the same `["modelDetail", id]` key, so this dedupes for **all five** consumers — not just `NodeViewOss`.

Also drops dead exports (`EMPTY_COLUMNS`, `extractColumns`) — grep found zero external consumers.

**Which issue(s) this PR fixes**:

Resolves DRC-3343

**Special notes for your reviewer**:

- The hook's public API (`{ columns, primaryKey, isLoading, error }`) is preserved. Field shapes unchanged.
- One subtle behavior tightening: when the hook is called with no `apiClient` resolvable, the old code returned `isLoading=true` forever (the `fetchData` early-return left state stuck); the new code returns `isLoading=false` via TanStack's `enabled` flag. That's strictly an improvement, not a regression.
- New regression test `js/packages/ui/src/hooks/__tests__/useModelColumns.test.tsx`: under one `QueryClient`, `useModelColumns(model)` plus a sibling `useQuery({queryKey: ["modelDetail", id]})` together → exactly **one** `getModelInfo` call.
- Verification run: \`pnpm lint:fix\`, \`pnpm type:check\`, \`pnpm test\` (156 files, 3703 pass, 0 fail).

**Does this PR introduce a user-facing change?**:

NONE