### PR TITLE
fix(cll): handle compiled SQL referencing unresolved parents (#1354)

### DIFF
--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -1542,6 +1542,31 @@ class DbtAdapter(BaseAdapter):
             schema[table_name] = columns
         return schema
 
+    @staticmethod
+    def _resolve_compiled_table(table_id_map: dict, manifest, table_name: str) -> Optional[str]:
+        """Resolve a table name from compiled SQL to a parent unique_id.
+
+        Tries the pre-built map (from depends_on.nodes) first, then falls back
+        to a project-wide alias/identifier scan so models referenced via raw
+        SQL or stale compiled_code still resolve. Returns None if no match —
+        the caller should skip the dependency rather than raise.
+        """
+        key = table_name.lower()
+        if key in table_id_map:
+            return table_id_map[key]
+
+        for unique_id, manifest_node in manifest.nodes.items():
+            candidate = getattr(manifest_node, "alias", None) or manifest_node.name
+            if candidate and candidate.lower() == key:
+                return unique_id
+
+        for unique_id, manifest_src in manifest.sources.items():
+            candidate = getattr(manifest_src, "identifier", None) or manifest_src.name
+            if candidate and candidate.lower() == key:
+                return unique_id
+
+        return None
+
     @lru_cache(maxsize=128)
     def get_cll_cached(self, node_id: str, base: Optional[bool] = False) -> Optional[CllData]:
         cll_tracker = CLLPerformanceTracking()
@@ -1703,8 +1728,19 @@ class DbtAdapter(BaseAdapter):
         # parent map for node
         depends_on = set(parent_list)
         for d in m2c:
-            parent_key = f"{table_id_map[d.node.lower()]}_{d.column}"
-            depends_on.add(parent_key)
+            parent_id = self._resolve_compiled_table(table_id_map, manifest, d.node)
+            if parent_id is None:
+                # Compiled SQL references a table that isn't in depends_on.nodes
+                # and doesn't match any model/source in the project (e.g. raw
+                # SQL with a hard-coded relation, stale compiled_code, or a
+                # macro that emits direct table names). Skip rather than 500.
+                logger.warning(
+                    "[cll] %s: skipping unresolved parent %r in compiled SQL",
+                    node_id,
+                    d.node,
+                )
+                continue
+            depends_on.add(f"{parent_id}_{d.column}")
         cll_data.parent_map[node_id] = depends_on
 
         # parent map for columns
@@ -1713,8 +1749,10 @@ class DbtAdapter(BaseAdapter):
             column_id = f"{node.id}_{name}"
             if name in c2c_map:
                 for d in c2c_map[name].depends_on:
-                    parent_key = f"{table_id_map[d.node.lower()]}_{d.column}"
-                    depends_on.add(parent_key)
+                    parent_id = self._resolve_compiled_table(table_id_map, manifest, d.node)
+                    if parent_id is None:
+                        continue
+                    depends_on.add(f"{parent_id}_{d.column}")
                 column.transformation_type = c2c_map[name].transformation_type
             cll_data.parent_map[column_id] = set(depends_on)
 

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -1542,29 +1542,51 @@ class DbtAdapter(BaseAdapter):
             schema[table_name] = columns
         return schema
 
+    # Resource types that produce database relations (and can therefore be
+    # legitimate parents in compiled SQL). Excludes test/analysis nodes whose
+    # `name` could otherwise alias-collide with a real model.
+    _RELATION_RESOURCE_TYPES = frozenset({"model", "seed", "snapshot"})
+
     @staticmethod
     def _resolve_compiled_table(table_id_map: dict, manifest, table_name: str) -> Optional[str]:
         """Resolve a table name from compiled SQL to a parent unique_id.
 
         Tries the pre-built map (from depends_on.nodes) first, then falls back
-        to a project-wide alias/identifier scan so models referenced via raw
-        SQL or stale compiled_code still resolve. Returns None if no match —
-        the caller should skip the dependency rather than raise.
+        to a project-wide alias/identifier scan over relation-producing nodes
+        (model/seed/snapshot) and sources, so models referenced via raw SQL or
+        stale compiled_code still resolve. Returns None when no match OR when
+        more than one node/source matches — picking arbitrarily on ambiguity
+        would silently produce incorrect lineage, mirroring the existing
+        `has_alias_collision` safeguard on the depends_on-derived map.
+
+        On a successful project-wide resolution, the result is memoized into
+        ``table_id_map`` so repeated lookups for the same name in the same
+        ``get_cll_cached`` call are O(1) instead of O(N) per scan.
         """
         key = table_name.lower()
         if key in table_id_map:
             return table_id_map[key]
 
+        matches: List[str] = []
         for unique_id, manifest_node in manifest.nodes.items():
+            if getattr(manifest_node, "resource_type", None) not in DbtAdapter._RELATION_RESOURCE_TYPES:
+                continue
             candidate = getattr(manifest_node, "alias", None) or manifest_node.name
             if candidate and candidate.lower() == key:
-                return unique_id
+                matches.append(unique_id)
+                if len(matches) > 1:
+                    return None  # ambiguous — bail early
 
         for unique_id, manifest_src in manifest.sources.items():
             candidate = getattr(manifest_src, "identifier", None) or manifest_src.name
             if candidate and candidate.lower() == key:
-                return unique_id
+                matches.append(unique_id)
+                if len(matches) > 1:
+                    return None
 
+        if len(matches) == 1:
+            table_id_map[key] = matches[0]
+            return matches[0]
         return None
 
     @lru_cache(maxsize=128)
@@ -1725,20 +1747,21 @@ class DbtAdapter(BaseAdapter):
         cll_data.nodes[node.id] = node
         cll_data.columns = {f"{node.id}_{col.name}": col for col in node.columns.values()}
 
+        # Collect unresolved parent names across both node-level and column-
+        # level dependency loops, then log once per node. Compiled SQL may
+        # reference tables that aren't in depends_on.nodes and don't match any
+        # model/source in the project (raw SQL with a hard-coded relation,
+        # stale compiled_code, or a macro emitting direct table names). Skip
+        # those rather than 500. Dedup avoids log spam when the same unresolved
+        # name appears across many column dependencies.
+        unresolved: Set[str] = set()
+
         # parent map for node
         depends_on = set(parent_list)
         for d in m2c:
             parent_id = self._resolve_compiled_table(table_id_map, manifest, d.node)
             if parent_id is None:
-                # Compiled SQL references a table that isn't in depends_on.nodes
-                # and doesn't match any model/source in the project (e.g. raw
-                # SQL with a hard-coded relation, stale compiled_code, or a
-                # macro that emits direct table names). Skip rather than 500.
-                logger.warning(
-                    "[cll] %s: skipping unresolved parent %r in compiled SQL",
-                    node_id,
-                    d.node,
-                )
+                unresolved.add(d.node)
                 continue
             depends_on.add(f"{parent_id}_{d.column}")
         cll_data.parent_map[node_id] = depends_on
@@ -1751,10 +1774,18 @@ class DbtAdapter(BaseAdapter):
                 for d in c2c_map[name].depends_on:
                     parent_id = self._resolve_compiled_table(table_id_map, manifest, d.node)
                     if parent_id is None:
+                        unresolved.add(d.node)
                         continue
                     depends_on.add(f"{parent_id}_{d.column}")
                 column.transformation_type = c2c_map[name].transformation_type
             cll_data.parent_map[column_id] = set(depends_on)
+
+        if unresolved:
+            logger.warning(
+                "[cll] %s: skipping unresolved parents %s in compiled SQL",
+                node_id,
+                sorted(unresolved),
+            )
 
         cll_tracker.end_column_lineage()
         log_performance("column level lineage per node", cll_tracker.to_dict())

--- a/tests/adapter/dbt_adapter/test_dbt_cll.py
+++ b/tests/adapter/dbt_adapter/test_dbt_cll.py
@@ -399,6 +399,171 @@ def test_cll_with_compiled_code_alias_collision_falls_back(dbt_test_helper):
     )
 
 
+def test_cll_with_compiled_code_unknown_parent_does_not_500(dbt_test_helper):
+    """Regression for #1354: compiled SQL referencing a table not in depends_on.nodes
+    and not matching any model/source in the project must not raise KeyError.
+
+    Calls get_cll_cached directly to bypass build_full_cll_map's blanket
+    exception swallow — that's the path that produced the user's 500.
+    """
+    dbt_test_helper.create_model(
+        "model1", unique_id="model.model1", curr_sql="select 1 as c", curr_columns={"c": "int"}
+    )
+    dbt_test_helper.create_model(
+        "model2",
+        unique_id="model.model2",
+        curr_sql='select c from {{ ref("model1") }}',
+        curr_columns={"c": "int"},
+        depends_on=["model.model1"],
+    )
+    adapter: DbtAdapter = dbt_test_helper.context.adapter
+    # compiled_code references a table that exists in the warehouse but is
+    # NOT registered as a dbt ref/source. Mirrors the issue reporter's
+    # `connect_appointment_totals` / `connect_login_counts` symptoms.
+    _set_compiled_code(
+        adapter,
+        "model.model2",
+        "select model1.c " 'from "main"."model1" ' 'join "main"."ghost_table" on model1.c = ghost_table.c',
+    )
+
+    # Must not raise. Known parent edge survives; ghost_table is dropped.
+    cll_data = adapter.get_cll_cached("model.model2")
+    assert cll_data is not None
+    column_id = build_column_key("model.model2", "c")
+    parents = cll_data.parent_map.get(column_id) or set()
+    assert build_column_key("model.model1", "c") in parents
+    # Ghost table must not appear as a parent in any form
+    assert not any("ghost_table" in p for p in parents)
+
+
+def test_cll_with_compiled_code_unknown_parent_falls_back_to_project_lookup(dbt_test_helper):
+    """Regression for #1354: compiled SQL may reference a real model in the
+    project that's missing from this node's depends_on.nodes (raw SQL ref,
+    stale compiled_code, custom macro). The fallback project-wide alias scan
+    should resolve it.
+    """
+    dbt_test_helper.create_model(
+        "model1", unique_id="model.model1", curr_sql="select 1 as c", curr_columns={"c": "int"}
+    )
+    # other_model exists in the project but is NOT in model2's depends_on
+    dbt_test_helper.create_model(
+        "other_model",
+        unique_id="model.other_model",
+        curr_sql="select 1 as c",
+        curr_columns={"c": "int"},
+    )
+    dbt_test_helper.create_model(
+        "model2",
+        unique_id="model.model2",
+        # depends_on only lists model.model1, but compiled_code references
+        # other_model directly (raw SQL).
+        curr_sql='select model1.c from {{ ref("model1") }}',
+        curr_columns={"c": "int"},
+        depends_on=["model.model1"],
+    )
+    adapter: DbtAdapter = dbt_test_helper.context.adapter
+    _set_compiled_code(
+        adapter,
+        "model.model2",
+        "select model1.c " 'from "main"."model1" ' 'join "main"."other_model" on model1.c = other_model.c',
+    )
+
+    # Must not raise. The fallback resolves "other_model" via project-wide scan.
+    cll_data = adapter.get_cll_cached("model.model2")
+    assert cll_data is not None
+    # other_model is referenced in the JOIN — it shows up in the node-level
+    # parent_map (m2c), not the selected-column c2c_map.
+    node_parents = cll_data.parent_map.get("model.model2") or set()
+    assert build_column_key("model.other_model", "c") in node_parents
+    # The selected column 'c' still lineages back to model1.c
+    column_id = build_column_key("model.model2", "c")
+    column_parents = cll_data.parent_map.get(column_id) or set()
+    assert build_column_key("model.model1", "c") in column_parents
+
+
+def test_cll_with_compiled_code_unknown_parent_alias_fallback(dbt_test_helper):
+    """Regression for #1354: project-wide fallback must respect custom aliases
+    (the reporter's `generate_alias_name` macro produces e.g. `vw_<name>`).
+    """
+
+    def patch_alias(node):
+        node["alias"] = "vw_intermediate"
+
+    dbt_test_helper.create_model(
+        "model1", unique_id="model.model1", curr_sql="select 1 as c", curr_columns={"c": "int"}
+    )
+    # An "intermediate view" with a vw_ alias, NOT in model2's depends_on
+    dbt_test_helper.create_model(
+        "intermediate",
+        unique_id="model.intermediate",
+        curr_sql="select 1 as c",
+        curr_columns={"c": "int"},
+        patch_func=patch_alias,
+    )
+    dbt_test_helper.create_model(
+        "model2",
+        unique_id="model.model2",
+        curr_sql='select c from {{ ref("model1") }}',
+        curr_columns={"c": "int"},
+        depends_on=["model.model1"],
+    )
+    adapter: DbtAdapter = dbt_test_helper.context.adapter
+    _set_compiled_code(
+        adapter,
+        "model.model2",
+        "select model1.c " 'from "main"."model1" ' 'join "main"."vw_intermediate" on model1.c = vw_intermediate.c',
+    )
+
+    cll_data = adapter.get_cll_cached("model.model2")
+    assert cll_data is not None
+    # vw_intermediate is referenced in the JOIN — node-level parent_map.
+    node_parents = cll_data.parent_map.get("model.model2") or set()
+    # Fallback must match by alias (`vw_intermediate`), not by model name.
+    assert build_column_key("model.intermediate", "c") in node_parents
+
+
+def test_resolve_compiled_table(dbt_test_helper):
+    """_resolve_compiled_table: pre-built map first, then project-wide fallback,
+    then None for unknown."""
+
+    def patch_alias(node):
+        node["alias"] = "vw_intermediate"
+
+    dbt_test_helper.create_model(
+        "model1", unique_id="model.model1", curr_sql="select 1 as c", curr_columns={"c": "int"}
+    )
+    dbt_test_helper.create_model(
+        "intermediate",
+        unique_id="model.intermediate",
+        curr_sql="select 1 as c",
+        curr_columns={"c": "int"},
+        patch_func=patch_alias,
+    )
+    dbt_test_helper.create_source(
+        "src", "tbl", unique_id="source.src.tbl", curr_csv="id\n1\n", curr_columns={"id": "int"}
+    )
+
+    adapter: DbtAdapter = dbt_test_helper.context.adapter
+    from recce.adapter.dbt_adapter import as_manifest
+
+    manifest = as_manifest(adapter.get_manifest(base=False))
+
+    # Pre-built map wins (priority over project scan)
+    table_id_map = {"model1": "model.model1"}
+    assert adapter._resolve_compiled_table(table_id_map, manifest, "model1") == "model.model1"
+    # Case-insensitive match against the map
+    assert adapter._resolve_compiled_table(table_id_map, manifest, "MODEL1") == "model.model1"
+
+    # Falls back to project-wide alias scan
+    assert adapter._resolve_compiled_table({}, manifest, "vw_intermediate") == "model.intermediate"
+
+    # Falls back to source identifier
+    assert adapter._resolve_compiled_table({}, manifest, "tbl") == "source.src.tbl"
+
+    # Unknown table → None (no exception)
+    assert adapter._resolve_compiled_table({}, manifest, "ghost_table") is None
+
+
 def test_seed(dbt_test_helper, disable_cll_cache):
     csv_data_curr = """
     customer_id,name,age

--- a/tests/adapter/dbt_adapter/test_dbt_cll.py
+++ b/tests/adapter/dbt_adapter/test_dbt_cll.py
@@ -554,14 +554,75 @@ def test_resolve_compiled_table(dbt_test_helper):
     # Case-insensitive match against the map
     assert adapter._resolve_compiled_table(table_id_map, manifest, "MODEL1") == "model.model1"
 
-    # Falls back to project-wide alias scan
-    assert adapter._resolve_compiled_table({}, manifest, "vw_intermediate") == "model.intermediate"
+    # Falls back to project-wide alias scan, and memoizes the result
+    table_id_map = {}
+    assert adapter._resolve_compiled_table(table_id_map, manifest, "vw_intermediate") == "model.intermediate"
+    assert table_id_map.get("vw_intermediate") == "model.intermediate"
 
     # Falls back to source identifier
     assert adapter._resolve_compiled_table({}, manifest, "tbl") == "source.src.tbl"
 
     # Unknown table → None (no exception)
     assert adapter._resolve_compiled_table({}, manifest, "ghost_table") is None
+
+
+def test_resolve_compiled_table_skips_non_relation_resource_types():
+    """Project-wide fallback must not match non-relation manifest nodes (e.g.
+    tests, analyses) — only model/seed/snapshot nodes produce database
+    relations. We use a lightweight stub manifest because dbt's ModelNode
+    rejects resource_type values outside its Literal type.
+    """
+    from types import SimpleNamespace
+
+    manifest = SimpleNamespace(
+        nodes={
+            "model.real": SimpleNamespace(resource_type="model", alias=None, name="real"),
+            # Test/analysis nodes whose names alias-collide with a real reference
+            "test.ghost_table": SimpleNamespace(resource_type="test", alias=None, name="ghost_table"),
+            "analysis.also_ghost": SimpleNamespace(resource_type="analysis", alias=None, name="also_ghost"),
+        },
+        sources={},
+    )
+
+    # Model resolves
+    assert DbtAdapter._resolve_compiled_table({}, manifest, "real") == "model.real"
+    # Test and analysis nodes are filtered out
+    assert DbtAdapter._resolve_compiled_table({}, manifest, "ghost_table") is None
+    assert DbtAdapter._resolve_compiled_table({}, manifest, "also_ghost") is None
+
+
+def test_resolve_compiled_table_returns_none_on_ambiguous_alias(dbt_test_helper):
+    """Two project models sharing the same alias must NOT silently resolve to
+    one of them — that would produce incorrect lineage. Return None so the
+    caller skips the dependency, mirroring the has_alias_collision safeguard
+    on the depends_on-derived map.
+    """
+
+    def patch_alias(node):
+        node["alias"] = "shared_alias"
+
+    dbt_test_helper.create_model(
+        "stg_orders",
+        unique_id="model.pkg1.stg_orders",
+        curr_sql="select 1 as id",
+        curr_columns={"id": "int"},
+        patch_func=patch_alias,
+    )
+    dbt_test_helper.create_model(
+        "raw_orders",
+        unique_id="model.pkg2.raw_orders",
+        curr_sql="select 1 as id",
+        curr_columns={"id": "int"},
+        patch_func=patch_alias,
+    )
+
+    adapter: DbtAdapter = dbt_test_helper.context.adapter
+    from recce.adapter.dbt_adapter import as_manifest
+
+    manifest = as_manifest(adapter.get_manifest(base=False))
+
+    # Two nodes share alias "shared_alias" — ambiguous, must not resolve.
+    assert adapter._resolve_compiled_table({}, manifest, "shared_alias") is None
 
 
 def test_seed(dbt_test_helper, disable_cll_cache):


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

bug

**What this PR does / why we need it**:

Fixes a 500 from `/api/cll` (`KeyError` in `get_cll_cached`) when a model's compiled SQL references a table that isn't in its `depends_on.nodes`.

The pre-compiled CLL path builds `table_id_map` from `depends_on.nodes` only and asserts every parent table sqlglot reports back must be a key in that map. That assumption breaks for several real-world cases:

1. **Hard-coded SQL references** (`select … from analytics.foo` instead of `{{ ref('foo') }}`) — appear in compiled SQL but not `depends_on.nodes`.
2. **Stale `compiled_code`** in `manifest.json`.
3. **Custom macros** that emit direct table identifiers.

The reporter's project also uses a `generate_alias_name` macro that prepends `vw_` to intermediate views — the alias mapping itself works (e.g. `vw_connect_int_unique_dealers` resolves), but other parents (e.g. `connect_appointment_totals`, `connect_login_counts`) aren't in `depends_on.nodes` and trigger the crash.

**Changes**

- New `_resolve_compiled_table(table_id_map, manifest, table_name)` helper in `recce/adapter/dbt_adapter/__init__.py`. Tries the pre-built parent map first (fast path), then a project-wide scan over `manifest.nodes` (alias / name) and `manifest.sources` (identifier / name). Returns `None` if nothing matches.
- Replace both `table_id_map[d.node.lower()]` lookups in `get_cll_cached` (node-level `m2c` and column-level `c2c_map` loops) with the helper. Unresolved parents are skipped with a `logger.warning` instead of raising.
- Regression tests in `tests/adapter/dbt_adapter/test_dbt_cll.py` calling `get_cll_cached` directly (the path that produced the 500 — `build_full_cll_map` swallows exceptions, masking the bug):
  - `test_cll_with_compiled_code_unknown_parent_does_not_500`: ghost table reference → no exception, ghost dropped, real parents preserved.
  - `test_cll_with_compiled_code_unknown_parent_falls_back_to_project_lookup`: project-wide fallback resolves a real model missing from `depends_on`.
  - `test_cll_with_compiled_code_unknown_parent_alias_fallback`: fallback respects custom aliases (e.g. reporter's `vw_*` prefix).
  - `test_resolve_compiled_table`: unit test for the helper covering map-hit, alias-fallback, source-fallback, and unknown-returns-None.

I confirmed the regression tests fail against the unpatched code with the exact `KeyError` from the issue (e.g. `KeyError: 'ghost_table'`) before applying the fix, then pass post-fix. All 47 tests in `test_dbt_cll.py` pass; full `tests/adapter` suite (54) passes.

**Which issue(s) this PR fixes**:

Fixes #1354

**Special notes for your reviewer**:

- The behavior change is graceful degradation: unresolved table references in compiled SQL no longer 500 but are silently skipped (with a warning logged via `uvicorn` logger). For affected users this means partial lineage in the UI rather than a broken page — preferable to a hard failure, and consistent with the pattern already used a few lines above for sqlglot parse failures (`return _apply_all_columns(node, "unknown")`).
- The project-wide fallback is O(n) over manifest nodes per unresolved reference. It's only invoked on the unresolved branch, which is rare. If profiling shows hot-path regressions in larger projects, we can memoize per-manifest.
- Did NOT change the Jinja fallback path's parallel lookup (line 1716 in the original code, equivalent line post-fix). It already uses the same map but is populated lazily by `ref_func`/`source_func` so it's less likely to trip — but technically still vulnerable if compiled output (post-Jinja) contains hard-coded names. Worth a follow-up but out of scope for this fix.

**Does this PR introduce a user-facing change?**:

```release-note
Fix 500 error from /api/cll when a model's compiled SQL references a table that isn't tracked in its depends_on.nodes (e.g. raw SQL references, stale compiled_code, custom macros). Unresolved references now degrade gracefully with a partial lineage instead of failing the request.
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01SFLmgJ5YXeGTL2ULVM1vQT)_