### PR TITLE
fix(mcp): accept session_id env var for cloud MCP validation

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -2561,7 +2561,9 @@ def mcp_server(state_file, sse, host, port, **kwargs):
     handle_debug_flag(**kwargs)
     patch_derived_args(kwargs)
     is_cloud_mcp = kwargs.get("cloud", False)
-    cloud_session = kwargs.pop("cloud_session", None)
+    # DRC-3383: also accept the session_id env var (RECCE_SESSION_ID) — patch_derived_args()
+    # already promotes session_id to cloud=True, so the validation must honor the same source.
+    cloud_session = kwargs.pop("cloud_session", None) or kwargs.get("session_id")
 
     if is_cloud_mcp and not cloud_session:
         console.print("[[red]Error[/red]] --session is required when using --cloud with recce mcp-server.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -345,6 +345,32 @@ class TestCommandMCPServer(TestCase):
         assert "single_env" not in call_kwargs
         assert "Base artifacts not found" not in result.output
 
+    @patch("asyncio.run")
+    @patch("recce.mcp_server.run_mcp_server", new_callable=MagicMock)
+    @patch("recce.config.RecceConfig")
+    @patch("recce.util.api_token.prepare_api_token", return_value="token-abc")
+    def test_cmd_mcp_server_session_id_env_var_satisfies_cloud_session(
+        self, mock_prepare_api_token, mock_recce_config, mock_run_mcp_server, mock_asyncio_run
+    ):
+        # DRC-3383 regression: the AI-summary entrypoint invokes `recce mcp-server --sse`
+        # with RECCE_SESSION_ID set in the environment. patch_derived_args() promotes
+        # session_id to cloud=True, so the new --session validation must accept the
+        # session_id env var as the session source — otherwise the CLI exits before
+        # the MCP server starts.
+        with patch.object(Path, "is_dir", return_value=False):
+            result = self.runner.invoke(
+                cli_command_mcp_server,
+                ["--sse"],
+                env={"RECCE_SESSION_ID": "sess-from-env"},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "--session is required" not in result.output
+        mock_run_mcp_server.assert_called_once()
+        call_kwargs = mock_run_mcp_server.call_args.kwargs
+        assert call_kwargs["cloud"] is True
+        assert call_kwargs["session"] == "sess-from-env"
+
 
 def test_cli_shows_update_available_warning():
     """CLI should show update available warning when a newer version exists."""


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`/kind bug`

**What this PR does / why we need it**:

DRC-3345 added a new `--session` flag for cloud MCP mode and strict validation that errors when `--cloud` is set without `--session`. The legacy AI-summary entrypoint at `recce_instance_launcher/src/recce_ai_summary_entrypoint` invokes `recce mcp-server --sse` with `RECCE_SESSION_ID` set in the environment. Click binds that env var to `--session-id`, and `patch_derived_args()` then promotes `session_id` to `cloud=True`. With 1.48.0.dev0, this implicit-cloud path no longer satisfied the new check (`cloud_session` only reads from the explicit `--session` flag), so the CLI exited before MCP could start.

Effect in production: every AI-summary container started, `recce mcp-server` exited with `[Error] --session is required when using --cloud with recce mcp-server.`, the entrypoint timed out after 30 health-check attempts, and the GitLab/GitHub PR comment stuck on "Generating summary... Please wait." across all sessions for ~17 hours starting `2026-05-06 09:33 UTC` (right after 1.48.0.dev0 published and the launcher image rebuilt to pull it).

The fix: fall back to `session_id` when `cloud_session` is unset, so the new validation honors the same source of truth that `patch_derived_args()` already uses. Genuine misuse (`--cloud` with no session source at all) still errors out — the existing `test_cmd_mcp_server_cloud_requires_session` confirms.

```diff
- cloud_session = kwargs.pop("cloud_session", None)
+ cloud_session = kwargs.pop("cloud_session", None) or kwargs.get("session_id")
```

**Which issue(s) this PR fixes**:

Resolves DRC-3383

**Special notes for your reviewer**:

- Added `test_cmd_mcp_server_session_id_env_var_satisfies_cloud_session` as a regression test that reproduces the production failure (RED before fix, GREEN after).
- All 176 CLI/MCP tests pass; full suite 1185/1190 (5 pre-existing unrelated static-route failures need frontend build).
- After merge and 1.48.0.dev1 publishes to PyPI, the `recce-instance-launcher` image will auto-rebuild on `repository_dispatch` and pick up the fix. No recce-cloud-infra change required.

**Does this PR introduce a user-facing change?**:

\`\`\`release-note
Fix `recce mcp-server` exiting with "--session is required" when only the `RECCE_SESSION_ID` env var is provided. The validation now accepts either the explicit `--session` flag or the `RECCE_SESSION_ID`/`RECCE_SNAPSHOT_ID` env var (matching the existing `--session-id` behavior).
\`\`\`