### PR TITLE
fix(mcp): restore cloud-snapshot mode for Recce Summary agent (DRC-3384)

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -2559,18 +2559,47 @@ def mcp_server(state_file, sse, host, port, **kwargs):
     RecceConfig(config_file=kwargs.get("config"))
 
     handle_debug_flag(**kwargs)
-    patch_derived_args(kwargs)
-    is_cloud_mcp = kwargs.get("cloud", False)
-    # DRC-3383: also accept the session_id env var (RECCE_SESSION_ID) — patch_derived_args()
-    # already promotes session_id to cloud=True, so the validation must honor the same source.
-    cloud_session = kwargs.pop("cloud_session", None) or kwargs.get("session_id")
 
-    if is_cloud_mcp and not cloud_session:
+    # Three MCP server modes:
+    #
+    # - cloud-session  (public)   `--cloud --session <id>`
+    #     CloudBackend proxies tool calls to a live Recce Cloud session instance
+    #     (POST /api/v2/sessions/{id}/instance to spawn, then runs/queries against
+    #     the live session). Exposed to end users.
+    #
+    # - cloud-snapshot (internal) `RECCE_SESSION_ID` / `RECCE_SNAPSHOT_ID` env
+    #     CloudStateLoader downloads the session's state file from S3 and the
+    #     server runs as a local MCP against that frozen snapshot. Used by the
+    #     Recce Summary agent (the AI-summary backend inside Recce Cloud) — it
+    #     boots an MCP server pointed at a finished session's state to generate
+    #     summaries. Not intended for end users; the env-var entrypoint is what
+    #     keeps the contract with the Summary agent stable.
+    #
+    # - local         (default)   no flags / no env
+    #     Local MCP from local dbt artifacts (and optional state file).
+    #
+    # We must capture the explicit --cloud / --session flags BEFORE running
+    # patch_derived_args — that helper promotes session_id (which Click also
+    # reads from RECCE_SESSION_ID) to cloud=True for the legacy snapshot path,
+    # and after that we can no longer tell explicit-cloud-session apart from
+    # env-driven snapshot mode.
+    cloud_session = kwargs.pop("cloud_session", None)
+    explicit_cloud = kwargs.get("cloud", False)
+    is_cloud_session = explicit_cloud or bool(cloud_session)
+
+    patch_derived_args(kwargs)
+
+    if explicit_cloud and not cloud_session:
         console.print("[[red]Error[/red]] --session is required when using --cloud with recce mcp-server.")
         exit(1)
-    if cloud_session and not is_cloud_mcp:
+    if cloud_session and not explicit_cloud:
         console.print("[[red]Error[/red]] --cloud is required when using --session with recce mcp-server.")
         exit(1)
+
+    # cloud-snapshot: cloud=True was set by patch_derived_args via
+    # RECCE_SESSION_ID/RECCE_SNAPSHOT_ID env (Recce Summary agent invocation),
+    # but the user didn't pass --cloud --session.
+    is_cloud_snapshot = kwargs.get("cloud", False) and not is_cloud_session
 
     # Prepare API token
     try:
@@ -2580,9 +2609,9 @@ def mcp_server(state_file, sse, host, port, **kwargs):
         show_invalid_api_token_message()
         exit(1)
 
-    # Create state loader using shared function when running local MCP with a state file.
-    # Cloud MCP proxies to a spawned Recce Cloud instance and must not load local context/state.
-    if not is_cloud_mcp and state_file:
+    # cloud-session skips local context entirely (CloudBackend handles everything).
+    # Otherwise load a state file if provided locally OR via cloud snapshot.
+    if not is_cloud_session and (state_file or is_cloud_snapshot):
         state_loader = create_state_loader_by_args(state_file, **kwargs)
         kwargs["state_loader"] = state_loader
 
@@ -2590,10 +2619,8 @@ def mcp_server(state_file, sse, host, port, **kwargs):
     # When target-base/ doesn't exist, fall back to single-env mode: set
     # target_base_path = target_path so both envs load the same artifacts,
     # making all diffs show no changes. The MCP server adds _warning to responses.
-    # Skipped in cloud mode and when the user hasn't pointed at a dbt project — in
-    # the latter case the server will start unconfigured and the agent flips it via
-    # the set_backend MCP tool.
-    if not is_cloud_mcp:
+    # Skipped in cloud-session and cloud-snapshot modes — they bring their own state.
+    if not is_cloud_session and not is_cloud_snapshot:
         project_dir_path = Path(kwargs.get("project_dir") or "./")
         target_path = project_dir_path.joinpath(Path(kwargs.get("target_path", "target")))
         target_base_path = project_dir_path.joinpath(Path(kwargs.get("target_base_path", "target-base")))
@@ -2606,17 +2633,35 @@ def mcp_server(state_file, sse, host, port, **kwargs):
             )
             console.print("To enable diffing: dbt docs generate --target-path target-base")
 
+    # Don't let env-derived cloud=True trigger run_mcp_server's CloudBackend branch
+    # — cloud-snapshot runs as a local MCP against the downloaded state file.
+    if not is_cloud_session:
+        kwargs["cloud"] = False
+
     try:
-        if sse:
-            console.print(f"Starting Recce MCP Server in HTTP/SSE mode on {host}:{port}...")
-            console.print(f"SSE endpoint: http://{host}:{port}/sse")
-        elif is_cloud_mcp:
-            console.print("Starting Recce MCP Server in cloud stdio mode...")
+        if is_cloud_session:
+            if sse:
+                console.print(f"Starting Recce MCP Server in cloud-session HTTP/SSE mode on {host}:{port}...")
+                console.print(f"SSE endpoint: http://{host}:{port}/sse")
+            else:
+                console.print("Starting Recce MCP Server in cloud-session stdio mode...")
+        elif is_cloud_snapshot:
+            session_label = kwargs.get("session_id") or kwargs.get("share_url")
+            console.print(f"Loading Recce state from cloud snapshot ({session_label})...")
+            if sse:
+                console.print(f"Starting Recce MCP Server in cloud-snapshot HTTP/SSE mode on {host}:{port}...")
+                console.print(f"SSE endpoint: http://{host}:{port}/sse")
+            else:
+                console.print("Starting Recce MCP Server in cloud-snapshot stdio mode...")
         else:
-            console.print(
-                "Starting Recce MCP Server in stdio mode "
-                "(use the set_backend MCP tool to switch local/cloud at runtime)..."
-            )
+            if sse:
+                console.print(f"Starting Recce MCP Server in HTTP/SSE mode on {host}:{port}...")
+                console.print(f"SSE endpoint: http://{host}:{port}/sse")
+            else:
+                console.print(
+                    "Starting Recce MCP Server in stdio mode "
+                    "(use the set_backend MCP tool to switch local/cloud at runtime)..."
+                )
 
         # Run the server (stdio or SSE based on --sse flag)
         asyncio.run(run_mcp_server(sse=sse, host=host, port=port, session=cloud_session, **kwargs))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -347,16 +347,24 @@ class TestCommandMCPServer(TestCase):
 
     @patch("asyncio.run")
     @patch("recce.mcp_server.run_mcp_server", new_callable=MagicMock)
+    @patch("recce.cli.create_state_loader_by_args")
     @patch("recce.config.RecceConfig")
     @patch("recce.util.api_token.prepare_api_token", return_value="token-abc")
-    def test_cmd_mcp_server_session_id_env_var_satisfies_cloud_session(
-        self, mock_prepare_api_token, mock_recce_config, mock_run_mcp_server, mock_asyncio_run
+    def test_cmd_mcp_server_cloud_snapshot_mode_via_env_var(
+        self,
+        mock_prepare_api_token,
+        mock_recce_config,
+        mock_create_state_loader,
+        mock_run_mcp_server,
+        mock_asyncio_run,
     ):
-        # DRC-3383 regression: the AI-summary entrypoint invokes `recce mcp-server --sse`
-        # with RECCE_SESSION_ID set in the environment. patch_derived_args() promotes
-        # session_id to cloud=True, so the new --session validation must accept the
-        # session_id env var as the session source — otherwise the CLI exits before
-        # the MCP server starts.
+        # cloud-snapshot mode (used by the Recce Summary agent):
+        # `recce mcp-server --sse` with RECCE_SESSION_ID in the environment runs
+        # as a LOCAL MCP backed by a snapshot state file downloaded from S3, NOT
+        # as a live cloud-session via CloudBackend.
+        mock_state_loader = MagicMock()
+        mock_create_state_loader.return_value = mock_state_loader
+
         with patch.object(Path, "is_dir", return_value=False):
             result = self.runner.invoke(
                 cli_command_mcp_server,
@@ -365,11 +373,40 @@ class TestCommandMCPServer(TestCase):
             )
 
         assert result.exit_code == 0, result.output
-        assert "--session is required" not in result.output
+        # Snapshot mode: state loader created with cloud-derived options
+        mock_create_state_loader.assert_called_once()
+        mock_run_mcp_server.assert_called_once()
+        call_kwargs = mock_run_mcp_server.call_args.kwargs
+        # Cloud-live branch must NOT fire — env var is snapshot mode
+        assert call_kwargs["cloud"] is False
+        assert call_kwargs["session"] is None
+        assert call_kwargs["state_loader"] is mock_state_loader
+
+    @patch("asyncio.run")
+    @patch("recce.mcp_server.run_mcp_server", new_callable=MagicMock)
+    @patch("recce.cli.create_state_loader_by_args")
+    @patch("recce.config.RecceConfig")
+    @patch("recce.util.api_token.prepare_api_token", return_value="token-abc")
+    def test_cmd_mcp_server_cloud_session_mode_skips_state_loader(
+        self,
+        mock_prepare_api_token,
+        mock_recce_config,
+        mock_create_state_loader,
+        mock_run_mcp_server,
+        mock_asyncio_run,
+    ):
+        # cloud-session mode (public): explicit --cloud --session uses CloudBackend
+        # to proxy a live session — no state loader, no local context.
+        with patch.object(Path, "is_dir", return_value=False):
+            result = self.runner.invoke(cli_command_mcp_server, ["--cloud", "--session", "sess-explicit"])
+
+        assert result.exit_code == 0, result.output
+        mock_create_state_loader.assert_not_called()
         mock_run_mcp_server.assert_called_once()
         call_kwargs = mock_run_mcp_server.call_args.kwargs
         assert call_kwargs["cloud"] is True
-        assert call_kwargs["session"] == "sess-from-env"
+        assert call_kwargs["session"] == "sess-explicit"
+        assert "state_loader" not in call_kwargs
 
 
 def test_cli_shows_update_available_warning():


### PR DESCRIPTION
## Summary

`recce mcp-server` had collapsed two distinct cloud paths into a single live `CloudBackend` branch. With `RECCE_SESSION_ID` in the environment (the contract used by the Recce Summary agent), the server tried to spawn a live cloud instance via `POST /api/v2/sessions/{id}/instance` and 401'd before MCP could start — breaking GitLab summary generation in production (DRC-3384).

This PR splits `mcp-server` into three explicit modes:

| Mode | Inputs | Behavior |
|---|---|---|
| **cloud-session** (public) | `--cloud --session <id>` | `CloudBackend` proxies tool calls to a live Recce Cloud session |
| **cloud-snapshot** (internal) | `RECCE_SESSION_ID` / `RECCE_SNAPSHOT_ID` env | `CloudStateLoader` downloads state file from S3, served as a local MCP. Used by the Recce Summary agent. |
| **local** (default) | none | Local MCP from local artifacts/state |

## Root cause

`patch_derived_args()` promotes `session_id` (which Click reads from `RECCE_SESSION_ID` via the hidden `--session-id` option) to `cloud=True`. After e7b7f815 added `CloudBackend`, the env-driven flag also routed into the live-session branch — but the Recce Summary agent only has snapshot artifacts, not a running cloud instance, so the spawn call 401'd.

## Fix

- Capture explicit `--cloud` / `--session` flags **before** `patch_derived_args()` so explicit cloud-session can still be told apart from env-driven cloud-snapshot afterward.
- Route cloud-snapshot through `create_state_loader_by_args` (legacy path) and reset `kwargs[\"cloud\"] = False` before `run_mcp_server` so it does not take the `CloudBackend` branch.
- Distinct startup banners per mode for diagnosability.

## Test plan

- [x] `tests/test_cli.py::TestCommandMCPServer` — all 6 tests pass
  - new `test_cmd_mcp_server_cloud_snapshot_mode_via_env_var`: `RECCE_SESSION_ID` → state loader, no live spawn
  - new `test_cmd_mcp_server_cloud_session_mode_skips_state_loader`: `--cloud --session` → `CloudBackend`, no state loader
- [x] Full `tests/test_cli.py` suite passes (21 tests)
- [ ] Manual verification: `recce mcp-server --sse --debug` with `RECCE_SESSION_ID` set should print `Loading Recce state from cloud snapshot (...)` and start an SSE server (no `POST /instance` call)
- [ ] Manual verification: `recce mcp-server --cloud --session <id>` still spawns a live cloud session

## Related

- Linear: [DRC-3384](https://linear.app/recce/issue/DRC-3384/recce-gitlab-summary-generation-hits-401-auth-error-at-cloud-session)
- Regressed by: e7b7f815 (`feat(mcp): add cloud-mode support for recce mcp-server`, DRC-3345)
- Partial earlier fix: e3687abc (DRC-3383) — accepted env-var session_id but routed it to the wrong branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)