### PR TITLE
feat(cll): surface downstream impact of whole-model changes (DRC-3341)

### DIFF
--- a/js/packages/storybook/stories/lineage/WholeModelImpact.stories.tsx
+++ b/js/packages/storybook/stories/lineage/WholeModelImpact.stories.tsx
@@ -1,0 +1,517 @@
+import { SchemaLegend } from "@datarecce/ui/components";
+import type { LineageNodeProps } from "@datarecce/ui/primitives";
+import { LineageNode, ScreenshotDataGrid } from "@datarecce/ui/primitives";
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { createRow, getRowClass, schemaColumns } from "../schema/fixtures";
+
+/**
+ * @file WholeModelImpact.stories.tsx
+ * @description Visual coverage for the `--downstream-of-breaking` feature
+ * (DRC-3341). Captain reviews these stories to verify each whole-model
+ * treatment renders distinctly:
+ *
+ * - AC-1 — downstream-only whole-model impact (amber wash + amber badge +
+ *   "downstream of <ancestor>" header).
+ * - AC-2 — column-only impact vs whole-model impact, side by side, plus
+ *   the both-apply case where the existing per-row `!` glyph stacks on
+ *   top of the wash.
+ * - AC-4 — whole-model-changed source (brown wash + brown badge +
+ *   source-flavored header), and the "source-also-downstream" case
+ *   (Q11 — source wins; brown treatment dominates).
+ *
+ * Stories render the presentational primitives directly (LineageNode +
+ * a hand-built wash/header pattern that mirrors SchemaView). This avoids
+ * pulling SchemaView's full context graph into Storybook.
+ */
+
+const GRID_STYLE = {
+  blockSize: "auto",
+  maxHeight: "100%",
+  overflow: "auto",
+  fontSize: "10pt",
+  borderWidth: 1,
+} as const;
+
+// ============================================================================
+// Hand-built fixtures mirroring SchemaView's wash + header
+// ============================================================================
+
+interface SidebarFixtureProps {
+  /** Node display name for column-headers in the demo. */
+  modelName: string;
+  /** Brown (source) or amber (downstream-only) treatment. */
+  variant: "source" | "impacted";
+  /** Header text. Use the spec-exact phrasings. */
+  headerText: string;
+  /** Optional title attribute on the header (Q7 — shown when the
+   *  generic-pluralization fallback fires). */
+  headerTitle?: string;
+  /** Schema rows to render under the header. Stack the existing `!`
+   *  glyph on top of the wash for the "Case 3" demo (Q5 of the spec). */
+  rows: ReturnType<typeof createRow>[];
+}
+
+/**
+ * Hand-built reproduction of SchemaView's wash + header. Mirrors the
+ * sx props in `SchemaView.tsx` so a captain comparing this story to a
+ * live `recce server` reads "the same thing twice."
+ */
+function SidebarFixture({
+  modelName,
+  variant,
+  headerText,
+  headerTitle,
+  rows,
+}: SidebarFixtureProps) {
+  const isSource = variant === "source";
+  return (
+    <Box
+      className="cll-experience"
+      data-testid={
+        isSource ? "whole-model-source-wash" : "whole-model-impact-wash"
+      }
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: 360,
+        width: 420,
+        border: 1,
+        borderColor: "divider",
+        backgroundColor: isSource
+          ? "var(--schema-color-changed)"
+          : "var(--schema-color-impacted)",
+        boxShadow: isSource
+          ? "inset 4px 0 0 var(--schema-color-changed-accent)"
+          : "inset 4px 0 0 var(--schema-color-impacted-accent)",
+      }}
+    >
+      <Box
+        title={headerTitle}
+        data-testid={
+          isSource ? "whole-model-source-header" : "whole-model-impact-header"
+        }
+        sx={{
+          px: 1,
+          py: 0.75,
+          fontSize: "0.75rem",
+          fontWeight: 600,
+          color: isSource
+            ? "var(--schema-badge-changed-fg, rgb(160 100 0))"
+            : "var(--schema-badge-impacted-fg, rgb(146 64 14))",
+          borderBottom: isSource
+            ? "1px solid var(--schema-color-changed-accent)"
+            : "1px solid var(--schema-color-impacted-accent)",
+        }}
+      >
+        {headerText}
+      </Box>
+
+      <Box sx={{ px: 1, py: 0.5, fontSize: "0.7rem", opacity: 0.7 }}>
+        Schema for <strong>{modelName}</strong>
+      </Box>
+      <SchemaLegend />
+      <ScreenshotDataGrid
+        style={GRID_STYLE}
+        columns={schemaColumns}
+        rows={rows}
+        rowHeight={35}
+        getRowClass={getRowClass}
+        className="rdg-light no-track-pii-safe cll-experience"
+      />
+    </Box>
+  );
+}
+
+// ============================================================================
+// Lineage node demo helpers
+// ============================================================================
+
+function NodeFixture(props: { label: string } & Partial<LineageNodeProps>) {
+  const { label, ...rest } = props;
+  const baseProps: LineageNodeProps = {
+    id: `model.${label}`,
+    data: {
+      label,
+      resourceType: "model",
+      changeStatus: "unchanged",
+    },
+    newCllExperience: true,
+    hasParents: true,
+    hasChildren: true,
+    ...rest,
+  };
+  return (
+    <Box
+      sx={{
+        width: 320,
+        // Hide ReactFlow handles — they're irrelevant in static stories.
+        "& .react-flow__handle": { display: "none" },
+      }}
+    >
+      <LineageNode {...baseProps} />
+    </Box>
+  );
+}
+
+// ============================================================================
+// Schema row fixtures
+// ============================================================================
+
+const baseRows = [
+  createRow({
+    name: "id",
+    baseIndex: 1,
+    currentIndex: 1,
+    baseType: "INTEGER",
+    currentType: "INTEGER",
+  }),
+  createRow({
+    name: "customer_id",
+    baseIndex: 2,
+    currentIndex: 2,
+    baseType: "INTEGER",
+    currentType: "INTEGER",
+  }),
+  createRow({
+    name: "ordered_at",
+    baseIndex: 3,
+    currentIndex: 3,
+    baseType: "TIMESTAMP",
+    currentType: "TIMESTAMP",
+  }),
+  createRow({
+    name: "total",
+    baseIndex: 4,
+    currentIndex: 4,
+    baseType: "DECIMAL(12,2)",
+    currentType: "DECIMAL(12,2)",
+  }),
+];
+
+// Rows for the source-of-its-own-change demo: a real SQL-level change is
+// expressed as `definitionChanged: true` on the row that the user edited.
+const sourceRows = [
+  createRow({
+    name: "id",
+    baseIndex: 1,
+    currentIndex: 1,
+    baseType: "INTEGER",
+    currentType: "INTEGER",
+  }),
+  createRow({
+    name: "customer_id",
+    baseIndex: 2,
+    currentIndex: 2,
+    baseType: "INTEGER",
+    currentType: "INTEGER",
+    definitionChanged: true,
+  }),
+  createRow({
+    name: "ordered_at",
+    baseIndex: 3,
+    currentIndex: 3,
+    baseType: "TIMESTAMP",
+    currentType: "TIMESTAMP",
+  }),
+  createRow({
+    name: "total",
+    baseIndex: 4,
+    currentIndex: 4,
+    baseType: "DECIMAL(12,2)",
+    currentType: "DECIMAL(12,2)",
+  }),
+];
+
+// ============================================================================
+// META
+// ============================================================================
+
+const meta: Meta = {
+  title: "Lineage/Whole-Model Impact (DRC-3341)",
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `Visual coverage for the \`--downstream-of-breaking\` feature.
+
+A captain reviews this story to confirm every whole-model state renders distinctly:
+
+- **Brown** (\`--schema-color-changed-*\` / \`--schema-badge-changed-*\`): the *source* of a whole-model change. Renders on the node that was actually edited.
+- **Amber** (\`--schema-color-impacted-*\` / \`--schema-badge-impacted-*\`): a downstream node where every column is potentially affected. Renders on every node in the source's downstream subtree.
+- **Source wins (Q11)**: a node that is both a source and downstream of another source renders in brown.
+
+The on-row \`!\` glyph (column-only impact) and the panel-wide wash (whole-model impact) compose without conflict — both are visible in the "Both apply" story.`,
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+// ============================================================================
+// AC-1 — Downstream-only whole-model impact
+// ============================================================================
+
+export const DownstreamOnly: Story = {
+  name: "AC-1: Downstream whole-model impact",
+  parameters: {
+    docs: {
+      description: {
+        story: `**AC-1.** \`fct_orders\` sits downstream of \`stg_orders\` (a model whose own SQL added a \`WHERE\` clause). Every column in \`fct_orders\` is now potentially affected.
+
+- Lineage node: amber "ALL" badge.
+- Sidebar: amber wash + "Whole-model impact — downstream of \`stg_orders\`" header.
+- Schema rows: clean (no \`!\` per-row glyphs — the wash carries the story).`,
+      },
+    },
+  },
+  render: () => (
+    <Stack direction="row" spacing={4} sx={{ alignItems: "flex-start" }}>
+      <Stack spacing={1}>
+        <Typography variant="caption">Lineage node</Typography>
+        <NodeFixture label="fct_orders" isWholeModelImpacted />
+      </Stack>
+      <Stack spacing={1}>
+        <Typography variant="caption">Sidebar</Typography>
+        <SidebarFixture
+          modelName="fct_orders"
+          variant="impacted"
+          headerText="Whole-model impact — downstream of stg_orders"
+          rows={baseRows}
+        />
+      </Stack>
+    </Stack>
+  ),
+};
+
+// ============================================================================
+// AC-2 — Column-only vs whole-model vs both
+// ============================================================================
+
+export const ColumnOnlyVsWholeModelVsBoth: Story = {
+  name: "AC-2: Column-only vs whole-model vs both",
+  parameters: {
+    docs: {
+      description: {
+        story: `**AC-2.** Three sidebars side by side. A captain confirms the three states read as distinct:
+
+- **Column-only impact** (left): one row gets the existing \`!\` glyph. No wash. No header.
+- **Whole-model impact** (middle): wash + header. No per-row \`!\` (the wash covers it).
+- **Both apply** (right): wash + header AND the per-row \`!\` glyph for the column on the column-level path. Different mechanisms (background vs row-glyph) compose without color collision (Q5).`,
+      },
+    },
+  },
+  render: () => {
+    // For the "column-only" case we render the rows on a normal (no-wash)
+    // SchemaView shape, mark a single row as impacted with the row-impacted
+    // class via getRowClass. Easiest path: use the existing fixture's row
+    // class for `definitionChanged` — that's `row-changed`, brown — which
+    // is the wrong vocabulary. Instead, simulate row-level impact by
+    // adding `__status: "impacted"` and a custom getRowClass.
+    const columnOnlyRows = baseRows.map((r, i) =>
+      i === 2 ? { ...r, isImpacted: true } : r,
+    );
+    const bothAppliesRows = baseRows.map((r, i) =>
+      i === 2 ? { ...r, isImpacted: true } : r,
+    );
+    const customGetRowClass = (params: { data?: { isImpacted?: boolean } }) => {
+      if (params.data?.isImpacted) return "row-impacted row-selectable";
+      return "row-normal";
+    };
+
+    return (
+      <Stack
+        direction="row"
+        spacing={3}
+        sx={{ alignItems: "flex-start", flexWrap: "wrap" }}
+      >
+        <Stack spacing={1}>
+          <Typography variant="subtitle2">Column-only impact</Typography>
+          <Box
+            sx={{
+              width: 380,
+              height: 320,
+              border: 1,
+              borderColor: "divider",
+              display: "flex",
+              flexDirection: "column",
+            }}
+            className="cll-experience"
+          >
+            <Box sx={{ px: 1, py: 0.5, fontSize: "0.7rem", opacity: 0.7 }}>
+              Schema for <strong>dim_customer_state</strong>
+            </Box>
+            <SchemaLegend />
+            <ScreenshotDataGrid
+              style={GRID_STYLE}
+              columns={schemaColumns}
+              rows={columnOnlyRows}
+              rowHeight={35}
+              getRowClass={customGetRowClass}
+              className="rdg-light no-track-pii-safe cll-experience"
+            />
+          </Box>
+        </Stack>
+
+        <Stack spacing={1}>
+          <Typography variant="subtitle2">Whole-model impact only</Typography>
+          <SidebarFixture
+            modelName="fct_orders"
+            variant="impacted"
+            headerText="Whole-model impact — downstream of stg_orders"
+            rows={baseRows}
+          />
+        </Stack>
+
+        <Stack spacing={1}>
+          <Typography variant="subtitle2">
+            Both apply (wash + per-row !)
+          </Typography>
+          <Box sx={{ position: "relative" }}>
+            <SidebarFixture
+              modelName="dim_customer_state"
+              variant="impacted"
+              headerText="Whole-model impact — downstream of stg_orders"
+              rows={bothAppliesRows}
+            />
+          </Box>
+        </Stack>
+      </Stack>
+    );
+  },
+};
+
+// ============================================================================
+// AC-4 — Source-only and source-also-downstream
+// ============================================================================
+
+export const SourceAndSourceWins: Story = {
+  name: "AC-4: Source-only and source-also-downstream",
+  parameters: {
+    docs: {
+      description: {
+        story: `**AC-4.** Two source cases side by side:
+
+- **Source only** (left): \`stg_orders\` had its own \`WHERE\` clause edit. No upstream whole-model change. Brown badge + brown wash + "Whole-model change in this model" header.
+- **Source also downstream of another source** (right) — Q11 "source wins": \`fct_orders\` has its own \`GROUP BY\` edit AND sits downstream of \`stg_orders\` (also breaking). The source treatment dominates: brown badge + brown wash + source-flavored header. The "also downstream of \`stg_orders\`" line is an optional secondary annotation per the spec.`,
+      },
+    },
+  },
+  render: () => (
+    <Stack
+      direction="row"
+      spacing={3}
+      sx={{ alignItems: "flex-start", flexWrap: "wrap" }}
+    >
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">Source only</Typography>
+        <NodeFixture
+          label="stg_orders"
+          isBreakingSource
+          data={{
+            label: "stg_orders",
+            resourceType: "model",
+            changeStatus: "modified",
+          }}
+        />
+        <SidebarFixture
+          modelName="stg_orders"
+          variant="source"
+          headerText="Whole-model change in this model"
+          rows={sourceRows}
+        />
+      </Stack>
+
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">
+          Source also downstream (Q11)
+        </Typography>
+        <NodeFixture
+          label="fct_orders"
+          isBreakingSource
+          // isWholeModelImpacted is false here even though fct_orders is
+          // downstream of stg_orders — GraphNodeOss zeroes it out when
+          // isBreakingSource is true (source wins).
+          data={{
+            label: "fct_orders",
+            resourceType: "model",
+            changeStatus: "modified",
+          }}
+        />
+        <SidebarFixture
+          modelName="fct_orders"
+          variant="source"
+          headerText="Whole-model change in this model"
+          rows={sourceRows}
+        />
+        <Typography
+          variant="caption"
+          sx={{ color: "text.secondary", maxWidth: 420 }}
+        >
+          (Optional secondary annotation per Q11: "also downstream of
+          stg_orders". Not implemented in v1; the source treatment alone covers
+          the AC.)
+        </Typography>
+      </Stack>
+    </Stack>
+  ),
+};
+
+// ============================================================================
+// Multi-ancestor formatting (Q7) — bonus coverage
+// ============================================================================
+
+export const MultiAncestorHeader: Story = {
+  name: "Q7: Multi-ancestor header formatting",
+  parameters: {
+    docs: {
+      description: {
+        story: `**Q7 — multiple closest ancestors.** The sidebar header lists every co-equal upstream whole-model-changed ancestor up to a length cap.
+
+- 1 ancestor → "Whole-model impact — downstream of \`a\`"
+- 2–3 ancestors that fit → "Whole-model impact — downstream of \`a\`, \`b\`, \`c\`"
+- >3 ancestors OR joined > 60 chars → falls back to "Whole-model impact — downstream of multiple changes"; full list available via the header's \`title\` tooltip.`,
+      },
+    },
+  },
+  render: () => (
+    <Stack spacing={2}>
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">Single ancestor</Typography>
+        <SidebarFixture
+          modelName="fct_orders"
+          variant="impacted"
+          headerText="Whole-model impact — downstream of stg_orders"
+          rows={baseRows}
+        />
+      </Stack>
+
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">Two ancestors (fits)</Typography>
+        <SidebarFixture
+          modelName="fct_revenue"
+          variant="impacted"
+          headerText="Whole-model impact — downstream of stg_orders, stg_payments"
+          rows={baseRows}
+        />
+      </Stack>
+
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">
+          Generic fallback (&gt;3 ancestors or overflow)
+        </Typography>
+        <SidebarFixture
+          modelName="wide_revenue_summary"
+          variant="impacted"
+          headerText="Whole-model impact — downstream of multiple changes"
+          headerTitle="Closest upstream whole-model changes: stg_a, stg_b, stg_c, stg_d, stg_e"
+          rows={baseRows}
+        />
+      </Stack>
+    </Stack>
+  ),
+};

--- a/js/packages/storybook/stories/lineage/WholeModelImpact.stories.tsx
+++ b/js/packages/storybook/stories/lineage/WholeModelImpact.stories.tsx
@@ -13,18 +13,21 @@ import { createRow, getRowClass, schemaColumns } from "../schema/fixtures";
  * (DRC-3341). Captain reviews these stories to verify each whole-model
  * treatment renders distinctly:
  *
- * - AC-1 — downstream-only whole-model impact (amber wash + amber badge +
- *   "downstream of <ancestor>" header).
+ * - AC-1 — downstream-only whole-model impact (amber wash + amber "ALL"
+ *   badge in the panel header + "Whole-model impact" header line).
  * - AC-2 — column-only impact vs whole-model impact, side by side, plus
  *   the both-apply case where the existing per-row `!` glyph stacks on
  *   top of the wash.
- * - AC-4 — whole-model-changed source (brown wash + brown badge +
- *   source-flavored header), and the "source-also-downstream" case
- *   (Q11 — source wins; brown treatment dominates).
+ * - AC-4 — whole-model-changed source (brown wash + brown "ALL" badge +
+ *   "Whole-model change in this model" header), and the
+ *   "source-also-downstream" case (Q11 — source wins; brown treatment
+ *   dominates).
  *
- * Stories render the presentational primitives directly (LineageNode +
- * a hand-built wash/header pattern that mirrors SchemaView). This avoids
- * pulling SchemaView's full context graph into Storybook.
+ * The fixture mirrors NodeView's panel — wash on the broad container,
+ * "ALL" badge in the panel header next to the model name, header line
+ * sitting above the (mock) Tabs strip and a Schema grid below it.
+ * Multi-ancestor list is intentionally not surfaced in v1 (Q7 punt;
+ * see DRC-3341 spec).
  */
 
 const GRID_STYLE = {
@@ -36,71 +39,125 @@ const GRID_STYLE = {
 } as const;
 
 // ============================================================================
-// Hand-built fixtures mirroring SchemaView's wash + header
+// Hand-built fixtures mirroring NodeView's panel-level whole-model treatment
 // ============================================================================
 
-interface SidebarFixtureProps {
-  /** Node display name for column-headers in the demo. */
+interface PanelFixtureProps {
+  /** Node display name shown in the panel header. */
   modelName: string;
   /** Brown (source) or amber (downstream-only) treatment. */
   variant: "source" | "impacted";
-  /** Header text. Use the spec-exact phrasings. */
-  headerText: string;
-  /** Optional title attribute on the header (Q7 — shown when the
-   *  generic-pluralization fallback fires). */
-  headerTitle?: string;
-  /** Schema rows to render under the header. Stack the existing `!`
-   *  glyph on top of the wash for the "Case 3" demo (Q5 of the spec). */
+  /** Schema rows to render under the (mock) tab strip. */
   rows: ReturnType<typeof createRow>[];
 }
 
 /**
- * Hand-built reproduction of SchemaView's wash + header. Mirrors the
- * sx props in `SchemaView.tsx` so a captain comparing this story to a
- * live `recce server` reads "the same thing twice."
+ * Hand-built reproduction of NodeView's panel-level whole-model
+ * treatment. Rendering an actual `<NodeView>` here would require mocking
+ * a chunk of the lineage context graph; the wash/badge/header combo is
+ * small enough that a hand-built mock stays in sync without that cost.
+ *
+ * Layout mirrors NodeView:
+ * - Wash on the outer Box (covers the entire panel — would span Lineage
+ *   / Columns / Code tabs in the real view).
+ * - "ALL" badge inline with the model name in the header row.
+ * - Header line ("Whole-model impact" / "Whole-model change in this
+ *   model") sits between the action-buttons row and the (mock) tabs.
  */
-function SidebarFixture({
-  modelName,
-  variant,
-  headerText,
-  headerTitle,
-  rows,
-}: SidebarFixtureProps) {
+function PanelFixture({ modelName, variant, rows }: PanelFixtureProps) {
   const isSource = variant === "source";
+  const headerText = isSource
+    ? "Whole-model change in this model"
+    : "Whole-model impact";
   return (
     <Box
-      className="cll-experience"
       data-testid={
         isSource ? "whole-model-source-wash" : "whole-model-impact-wash"
       }
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: 360,
-        width: 420,
+        height: 480,
+        width: 460,
         border: 1,
         borderColor: "divider",
         backgroundColor: isSource
           ? "var(--schema-color-changed)"
           : "var(--schema-color-impacted)",
         boxShadow: isSource
-          ? "inset 4px 0 0 var(--schema-color-changed-accent)"
-          : "inset 4px 0 0 var(--schema-color-impacted-accent)",
+          ? "inset 6px 0 0 var(--schema-color-changed-accent)"
+          : "inset 6px 0 0 var(--schema-color-impacted-accent)",
       }}
     >
+      {/* Panel header row — model name + "ALL" badge + (mock) close affordance */}
+      <Stack direction="row" sx={{ alignItems: "center", px: 2, py: 1.5 }}>
+        <Stack
+          direction="row"
+          sx={{ alignItems: "center", gap: 1, minWidth: 0, flex: 1 }}
+        >
+          <Typography
+            variant="subtitle1"
+            sx={{
+              fontWeight: 600,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {modelName}
+          </Typography>
+          <Box
+            data-testid={
+              isSource ? "whole-model-source-badge" : "whole-model-impact-badge"
+            }
+            aria-label={isSource ? "whole-model change" : "whole-model impact"}
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: "0.65rem",
+              fontWeight: 700,
+              lineHeight: 1,
+              height: 18,
+              minWidth: 22,
+              px: 0.5,
+              borderRadius: "3px",
+              color: isSource ? "rgb(160 100 0)" : "rgb(146 64 14)",
+              backgroundColor: isSource
+                ? "rgb(255 173 21 / 0.25)"
+                : "rgb(252 211 77 / 0.35)",
+              border: `1px solid ${
+                isSource ? "rgb(212 133 11)" : "rgb(252 211 77)"
+              }`,
+              flexShrink: 0,
+            }}
+          >
+            ALL
+          </Box>
+        </Stack>
+        <Box sx={{ flexGrow: 1 }} />
+      </Stack>
+
+      {/* Mock action buttons row — placeholder so the header sits in the
+          right vertical position relative to the rest of the panel. */}
+      <Box sx={{ pl: 2, py: 1, fontSize: "0.7rem", color: "text.secondary" }}>
+        Diff (action buttons placeholder)
+      </Box>
+
+      {/* Whole-model header line — sits above the Tabs strip. */}
       <Box
-        title={headerTitle}
         data-testid={
           isSource ? "whole-model-source-header" : "whole-model-impact-header"
         }
         sx={{
-          px: 1,
+          px: 2,
           py: 0.75,
           fontSize: "0.75rem",
           fontWeight: 600,
-          color: isSource
-            ? "var(--schema-badge-changed-fg, rgb(160 100 0))"
-            : "var(--schema-badge-impacted-fg, rgb(146 64 14))",
+          color: isSource ? "rgb(160 100 0)" : "rgb(146 64 14)",
+          borderTop: isSource
+            ? "1px solid var(--schema-color-changed-accent)"
+            : "1px solid var(--schema-color-impacted-accent)",
           borderBottom: isSource
             ? "1px solid var(--schema-color-changed-accent)"
             : "1px solid var(--schema-color-impacted-accent)",
@@ -109,9 +166,25 @@ function SidebarFixture({
         {headerText}
       </Box>
 
-      <Box sx={{ px: 1, py: 0.5, fontSize: "0.7rem", opacity: 0.7 }}>
-        Schema for <strong>{modelName}</strong>
+      {/* Mock tabs strip — non-functional, just for visual context. */}
+      <Box
+        sx={{
+          display: "flex",
+          gap: 2,
+          px: 2,
+          py: 1,
+          fontSize: "0.7rem",
+          color: "text.secondary",
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
+        <span>Lineage</span>
+        <strong>Columns</strong>
+        <span>Code</span>
       </Box>
+
+      {/* Schema grid */}
       <SchemaLegend />
       <ScreenshotDataGrid
         style={GRID_STYLE}
@@ -243,7 +316,7 @@ A captain reviews this story to confirm every whole-model state renders distinct
 - **Amber** (\`--schema-color-impacted-*\` / \`--schema-badge-impacted-*\`): a downstream node where every column is potentially affected. Renders on every node in the source's downstream subtree.
 - **Source wins (Q11)**: a node that is both a source and downstream of another source renders in brown.
 
-The on-row \`!\` glyph (column-only impact) and the panel-wide wash (whole-model impact) compose without conflict — both are visible in the "Both apply" story.`,
+The wash + "ALL" badge + header line live on the NodeView panel, so the treatment spans every sidebar tab (Lineage / Columns / Code). The on-row \`!\` glyph (column-only impact) and the panel-wide wash (whole-model impact) compose without conflict — both are visible in the "Both apply" story.`,
       },
     },
   },
@@ -261,10 +334,10 @@ export const DownstreamOnly: Story = {
   parameters: {
     docs: {
       description: {
-        story: `**AC-1.** \`fct_orders\` sits downstream of \`stg_orders\` (a model whose own SQL added a \`WHERE\` clause). Every column in \`fct_orders\` is now potentially affected.
+        story: `**AC-1.** \`fct_orders\` sits downstream of a model whose own SQL added a \`WHERE\` clause. Every column in \`fct_orders\` is now potentially affected.
 
 - Lineage node: amber "ALL" badge.
-- Sidebar: amber wash + "Whole-model impact — downstream of \`stg_orders\`" header.
+- Sidebar panel: amber wash + amber "ALL" badge in the panel header + "Whole-model impact" header line above the tabs.
 - Schema rows: clean (no \`!\` per-row glyphs — the wash carries the story).`,
       },
     },
@@ -276,11 +349,10 @@ export const DownstreamOnly: Story = {
         <NodeFixture label="fct_orders" isWholeModelImpacted />
       </Stack>
       <Stack spacing={1}>
-        <Typography variant="caption">Sidebar</Typography>
-        <SidebarFixture
+        <Typography variant="caption">Sidebar panel</Typography>
+        <PanelFixture
           modelName="fct_orders"
           variant="impacted"
-          headerText="Whole-model impact — downstream of stg_orders"
           rows={baseRows}
         />
       </Stack>
@@ -297,21 +369,15 @@ export const ColumnOnlyVsWholeModelVsBoth: Story = {
   parameters: {
     docs: {
       description: {
-        story: `**AC-2.** Three sidebars side by side. A captain confirms the three states read as distinct:
+        story: `**AC-2.** Three sidebar panels side by side. A captain confirms the three states read as distinct:
 
 - **Column-only impact** (left): one row gets the existing \`!\` glyph. No wash. No header.
-- **Whole-model impact** (middle): wash + header. No per-row \`!\` (the wash covers it).
-- **Both apply** (right): wash + header AND the per-row \`!\` glyph for the column on the column-level path. Different mechanisms (background vs row-glyph) compose without color collision (Q5).`,
+- **Whole-model impact** (middle): wash + "ALL" badge + header. No per-row \`!\` (the wash covers it).
+- **Both apply** (right): wash + badge + header AND the per-row \`!\` glyph for the column on the column-level path. Different mechanisms (background vs row-glyph) compose without color collision (Q5).`,
       },
     },
   },
   render: () => {
-    // For the "column-only" case we render the rows on a normal (no-wash)
-    // SchemaView shape, mark a single row as impacted with the row-impacted
-    // class via getRowClass. Easiest path: use the existing fixture's row
-    // class for `definitionChanged` — that's `row-changed`, brown — which
-    // is the wrong vocabulary. Instead, simulate row-level impact by
-    // adding `__status: "impacted"` and a custom getRowClass.
     const columnOnlyRows = baseRows.map((r, i) =>
       i === 2 ? { ...r, isImpacted: true } : r,
     );
@@ -333,8 +399,8 @@ export const ColumnOnlyVsWholeModelVsBoth: Story = {
           <Typography variant="subtitle2">Column-only impact</Typography>
           <Box
             sx={{
-              width: 380,
-              height: 320,
+              width: 460,
+              height: 400,
               border: 1,
               borderColor: "divider",
               display: "flex",
@@ -342,8 +408,15 @@ export const ColumnOnlyVsWholeModelVsBoth: Story = {
             }}
             className="cll-experience"
           >
-            <Box sx={{ px: 1, py: 0.5, fontSize: "0.7rem", opacity: 0.7 }}>
-              Schema for <strong>dim_customer_state</strong>
+            <Box
+              sx={{
+                px: 2,
+                py: 1.5,
+                fontSize: "1rem",
+                fontWeight: 600,
+              }}
+            >
+              dim_customer_state
             </Box>
             <SchemaLegend />
             <ScreenshotDataGrid
@@ -359,10 +432,9 @@ export const ColumnOnlyVsWholeModelVsBoth: Story = {
 
         <Stack spacing={1}>
           <Typography variant="subtitle2">Whole-model impact only</Typography>
-          <SidebarFixture
+          <PanelFixture
             modelName="fct_orders"
             variant="impacted"
-            headerText="Whole-model impact — downstream of stg_orders"
             rows={baseRows}
           />
         </Stack>
@@ -371,14 +443,11 @@ export const ColumnOnlyVsWholeModelVsBoth: Story = {
           <Typography variant="subtitle2">
             Both apply (wash + per-row !)
           </Typography>
-          <Box sx={{ position: "relative" }}>
-            <SidebarFixture
-              modelName="dim_customer_state"
-              variant="impacted"
-              headerText="Whole-model impact — downstream of stg_orders"
-              rows={bothAppliesRows}
-            />
-          </Box>
+          <PanelFixture
+            modelName="dim_customer_state"
+            variant="impacted"
+            rows={bothAppliesRows}
+          />
         </Stack>
       </Stack>
     );
@@ -396,8 +465,8 @@ export const SourceAndSourceWins: Story = {
       description: {
         story: `**AC-4.** Two source cases side by side:
 
-- **Source only** (left): \`stg_orders\` had its own \`WHERE\` clause edit. No upstream whole-model change. Brown badge + brown wash + "Whole-model change in this model" header.
-- **Source also downstream of another source** (right) — Q11 "source wins": \`fct_orders\` has its own \`GROUP BY\` edit AND sits downstream of \`stg_orders\` (also breaking). The source treatment dominates: brown badge + brown wash + source-flavored header. The "also downstream of \`stg_orders\`" line is an optional secondary annotation per the spec.`,
+- **Source only** (left): \`stg_orders\` had its own \`WHERE\` clause edit. No upstream whole-model change. Brown badge on the node + brown wash + brown "ALL" badge in the panel header + "Whole-model change in this model" header.
+- **Source also downstream of another source** (right) — Q11 "source wins": \`fct_orders\` has its own \`GROUP BY\` edit AND sits downstream of \`stg_orders\` (also breaking). The source treatment dominates: brown badge + brown wash + brown "ALL" badge + source-flavored header.`,
       },
     },
   },
@@ -418,10 +487,9 @@ export const SourceAndSourceWins: Story = {
             changeStatus: "modified",
           }}
         />
-        <SidebarFixture
+        <PanelFixture
           modelName="stg_orders"
           variant="source"
-          headerText="Whole-model change in this model"
           rows={sourceRows}
         />
       </Stack>
@@ -434,83 +502,27 @@ export const SourceAndSourceWins: Story = {
           label="fct_orders"
           isBreakingSource
           // isWholeModelImpacted is false here even though fct_orders is
-          // downstream of stg_orders — GraphNodeOss zeroes it out when
-          // isBreakingSource is true (source wins).
+          // downstream of stg_orders — GraphNodeOss / NodeViewOss zero it
+          // out when isBreakingSource is true (source wins).
           data={{
             label: "fct_orders",
             resourceType: "model",
             changeStatus: "modified",
           }}
         />
-        <SidebarFixture
+        <PanelFixture
           modelName="fct_orders"
           variant="source"
-          headerText="Whole-model change in this model"
           rows={sourceRows}
         />
         <Typography
           variant="caption"
-          sx={{ color: "text.secondary", maxWidth: 420 }}
+          sx={{ color: "text.secondary", maxWidth: 460 }}
         >
           (Optional secondary annotation per Q11: "also downstream of
           stg_orders". Not implemented in v1; the source treatment alone covers
           the AC.)
         </Typography>
-      </Stack>
-    </Stack>
-  ),
-};
-
-// ============================================================================
-// Multi-ancestor formatting (Q7) — bonus coverage
-// ============================================================================
-
-export const MultiAncestorHeader: Story = {
-  name: "Q7: Multi-ancestor header formatting",
-  parameters: {
-    docs: {
-      description: {
-        story: `**Q7 — multiple closest ancestors.** The sidebar header lists every co-equal upstream whole-model-changed ancestor up to a length cap.
-
-- 1 ancestor → "Whole-model impact — downstream of \`a\`"
-- 2–3 ancestors that fit → "Whole-model impact — downstream of \`a\`, \`b\`, \`c\`"
-- >3 ancestors OR joined > 60 chars → falls back to "Whole-model impact — downstream of multiple changes"; full list available via the header's \`title\` tooltip.`,
-      },
-    },
-  },
-  render: () => (
-    <Stack spacing={2}>
-      <Stack spacing={1}>
-        <Typography variant="subtitle2">Single ancestor</Typography>
-        <SidebarFixture
-          modelName="fct_orders"
-          variant="impacted"
-          headerText="Whole-model impact — downstream of stg_orders"
-          rows={baseRows}
-        />
-      </Stack>
-
-      <Stack spacing={1}>
-        <Typography variant="subtitle2">Two ancestors (fits)</Typography>
-        <SidebarFixture
-          modelName="fct_revenue"
-          variant="impacted"
-          headerText="Whole-model impact — downstream of stg_orders, stg_payments"
-          rows={baseRows}
-        />
-      </Stack>
-
-      <Stack spacing={1}>
-        <Typography variant="subtitle2">
-          Generic fallback (&gt;3 ancestors or overflow)
-        </Typography>
-        <SidebarFixture
-          modelName="wide_revenue_summary"
-          variant="impacted"
-          headerText="Whole-model impact — downstream of multiple changes"
-          headerTitle="Closest upstream whole-model changes: stg_a, stg_b, stg_c, stg_d, stg_e"
-          rows={baseRows}
-        />
       </Stack>
     </Stack>
   ),

--- a/js/packages/storybook/stories/lineage/WholeModelImpact.stories.tsx
+++ b/js/packages/storybook/stories/lineage/WholeModelImpact.stories.tsx
@@ -519,3 +519,86 @@ export const SourceAndSourceWins: Story = {
     </Stack>
   ),
 };
+
+// ============================================================================
+// Additive-change badge — captain follow-up after AC-1..AC-4
+// ============================================================================
+
+export const AdditiveBadge: Story = {
+  name: "Additive: green ADD badge on the graph",
+  parameters: {
+    docs: {
+      description: {
+        story: `Captain follow-up after AC-1..AC-4: a model whose only change is additive (\`non_breaking\` — adds a column, leaves existing rows and column values untouched) deserves a graph-level signal that it's *safe*. Green "ADD" badge on the lineage node, no sidebar wash (the per-row green \`+\` glyph in the schema view already calls out the added column).
+
+Precedence: source (brown) > downstream (amber) > additive (green). If a model is additive AND under any whole-model treatment, the stronger badge wins.`,
+      },
+    },
+  },
+  render: () => (
+    <Stack
+      direction="row"
+      spacing={3}
+      sx={{ alignItems: "flex-start", flexWrap: "wrap" }}
+    >
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">Additive only</Typography>
+        <NodeFixture
+          label="stg_customers"
+          data={{
+            label: "stg_customers",
+            resourceType: "model",
+            changeStatus: "modified",
+          }}
+          showChangeAnalysis
+          changeCategory="non_breaking"
+        />
+        <Typography
+          variant="caption"
+          sx={{ color: "text.secondary", maxWidth: 320 }}
+        >
+          Green ADD badge: this model added a column. No upstream whole-model
+          change.
+        </Typography>
+      </Stack>
+
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">For comparison: source</Typography>
+        <NodeFixture
+          label="stg_orders"
+          isBreakingSource
+          data={{
+            label: "stg_orders",
+            resourceType: "model",
+            changeStatus: "modified",
+          }}
+        />
+        <Typography
+          variant="caption"
+          sx={{ color: "text.secondary", maxWidth: 320 }}
+        >
+          Brown ALL badge: this model's own change is whole-model.
+        </Typography>
+      </Stack>
+
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">For comparison: downstream</Typography>
+        <NodeFixture
+          label="fct_orders"
+          isWholeModelImpacted
+          data={{
+            label: "fct_orders",
+            resourceType: "model",
+            changeStatus: "unchanged",
+          }}
+        />
+        <Typography
+          variant="caption"
+          sx={{ color: "text.secondary", maxWidth: 320 }}
+        >
+          Amber ALL badge: downstream of a whole-model change.
+        </Typography>
+      </Stack>
+    </Stack>
+  ),
+};

--- a/js/packages/storybook/stories/lineage/WholeModelImpact.stories.tsx
+++ b/js/packages/storybook/stories/lineage/WholeModelImpact.stories.tsx
@@ -1,4 +1,7 @@
-import { SchemaLegend } from "@datarecce/ui/components";
+import {
+  SchemaLegend,
+  wholeModelTreatmentTokens,
+} from "@datarecce/ui/components";
 import type { LineageNodeProps } from "@datarecce/ui/primitives";
 import { LineageNode, ScreenshotDataGrid } from "@datarecce/ui/primitives";
 import Box from "@mui/material/Box";
@@ -66,6 +69,7 @@ interface PanelFixtureProps {
  */
 function PanelFixture({ modelName, variant, rows }: PanelFixtureProps) {
   const isSource = variant === "source";
+  const tokens = wholeModelTreatmentTokens(isSource ? "source" : "downstream");
   const headerText = isSource
     ? "Whole-model change in this model"
     : "Whole-model impact";
@@ -81,12 +85,8 @@ function PanelFixture({ modelName, variant, rows }: PanelFixtureProps) {
         width: 460,
         border: 1,
         borderColor: "divider",
-        backgroundColor: isSource
-          ? "var(--schema-color-changed)"
-          : "var(--schema-color-impacted)",
-        boxShadow: isSource
-          ? "inset 6px 0 0 var(--schema-color-changed-accent)"
-          : "inset 6px 0 0 var(--schema-color-impacted-accent)",
+        backgroundColor: tokens.washBg,
+        boxShadow: `inset 6px 0 0 ${tokens.washAccent}`,
       }}
     >
       {/* Panel header row — model name + "ALL" badge + (mock) close affordance */}
@@ -122,13 +122,9 @@ function PanelFixture({ modelName, variant, rows }: PanelFixtureProps) {
               minWidth: 22,
               px: 0.5,
               borderRadius: "3px",
-              color: isSource ? "rgb(160 100 0)" : "rgb(146 64 14)",
-              backgroundColor: isSource
-                ? "rgb(255 173 21 / 0.25)"
-                : "rgb(252 211 77 / 0.35)",
-              border: `1px solid ${
-                isSource ? "rgb(212 133 11)" : "rgb(252 211 77)"
-              }`,
+              color: tokens.fg,
+              backgroundColor: tokens.badgeBg,
+              border: `1px solid ${tokens.badgeBorder}`,
               flexShrink: 0,
             }}
           >
@@ -154,13 +150,9 @@ function PanelFixture({ modelName, variant, rows }: PanelFixtureProps) {
           py: 0.75,
           fontSize: "0.75rem",
           fontWeight: 600,
-          color: isSource ? "rgb(160 100 0)" : "rgb(146 64 14)",
-          borderTop: isSource
-            ? "1px solid var(--schema-color-changed-accent)"
-            : "1px solid var(--schema-color-impacted-accent)",
-          borderBottom: isSource
-            ? "1px solid var(--schema-color-changed-accent)"
-            : "1px solid var(--schema-color-impacted-accent)",
+          color: tokens.fg,
+          borderTop: `1px solid ${tokens.washAccent}`,
+          borderBottom: `1px solid ${tokens.washAccent}`,
         }}
       >
         {headerText}

--- a/js/packages/ui/src/api/flag.ts
+++ b/js/packages/ui/src/api/flag.ts
@@ -9,6 +9,11 @@ export interface RecceServerFlags {
   disable_cll_cache: boolean;
   impact_at_startup: boolean;
   new_cll_experience: boolean;
+  /**
+   * Highlight downstream models of a *breaking* change (red) distinctly from
+   * downstream of non-breaking changes (amber). Implies new_cll_experience.
+   */
+  downstream_of_breaking: boolean;
 }
 
 /**

--- a/js/packages/ui/src/components/index.ts
+++ b/js/packages/ui/src/components/index.ts
@@ -52,8 +52,16 @@ export type {
   LineageCanvasProps,
   LineageViewProps,
   LineageViewRef,
+  WholeModelTreatmentKind,
+  WholeModelTreatmentTokens,
 } from "./lineage";
-export { LineageCanvas, LineagePageOss, LineageView } from "./lineage";
+export {
+  LineageCanvas,
+  LineagePageOss,
+  LineageView,
+  wholeModelTreatmentKind,
+  wholeModelTreatmentTokens,
+} from "./lineage";
 // Notification components
 export type { NotificationProps } from "./notifications";
 export { LineageViewNotification } from "./notifications";

--- a/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
+++ b/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
@@ -297,13 +297,19 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
     cll,
     impactedNodeIds,
     wholeModelImpactedNodeIds,
+    breakingSourceNodeIds,
     newCllExperience,
     showColumnLevelLineage,
     setChangeAnalysisMode,
   } = useLineageViewContextSafe();
   const { isActionAvailable } = useLineageGraphContext();
   const isImpacted = newCllExperience ? impactedNodeIds.has(id) : false;
-  const isWholeModelImpacted = wholeModelImpactedNodeIds.has(id);
+  // Q11 — source wins. A node that is both a breaking source AND downstream
+  // of another breaking source classifies as a source. The badge color
+  // primitive in LineageNode reads `isBreakingSource` first.
+  const isBreakingSource = breakingSourceNodeIds.has(id);
+  const isWholeModelImpacted =
+    wholeModelImpactedNodeIds.has(id) && !isBreakingSource;
 
   // Computed state
   const changeCategory = cll?.current.nodes[id]
@@ -371,6 +377,7 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
       newCllExperience={newCllExperience}
       isImpacted={isImpacted}
       isWholeModelImpacted={isWholeModelImpacted}
+      isBreakingSource={isBreakingSource}
       // Interactive props
       interactive={interactive}
       selectMode={nodeSelectMode}

--- a/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
+++ b/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
@@ -296,12 +296,14 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
     viewOptions,
     cll,
     impactedNodeIds,
+    wholeModelImpactedNodeIds,
     newCllExperience,
     showColumnLevelLineage,
     setChangeAnalysisMode,
   } = useLineageViewContextSafe();
   const { isActionAvailable } = useLineageGraphContext();
   const isImpacted = newCllExperience ? impactedNodeIds.has(id) : false;
+  const isWholeModelImpacted = wholeModelImpactedNodeIds.has(id);
 
   // Computed state
   const changeCategory = cll?.current.nodes[id]
@@ -368,6 +370,7 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
       // New CLL experience props
       newCllExperience={newCllExperience}
       isImpacted={isImpacted}
+      isWholeModelImpacted={isWholeModelImpacted}
       // Interactive props
       interactive={interactive}
       selectMode={nodeSelectMode}

--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -149,7 +149,8 @@ function computeImpactedSets(
   nodeIds: Set<string>;
   columnIds: Set<string>;
   wholeModelImpactedNodeIds?: Set<string>;
-  wholeModelImpactCauseMap?: Map<string, string>;
+  breakingSourceNodeIds?: Set<string>;
+  wholeModelImpactCauseMap?: Map<string, Set<string>>;
 } {
   const columnIds = computeImpactedColumns(cll);
   const nodeIds = new Set<string>();
@@ -173,11 +174,12 @@ function computeImpactedSets(
   // Whole-model-impacted models also count as "impacted" for the broader
   // CLL highlight set — everything downstream of a breaking node has at
   // least all-columns affected.
-  for (const id of whole.nodeIds) nodeIds.add(id);
+  for (const id of whole.wholeModelImpactedNodeIds) nodeIds.add(id);
   return {
     nodeIds,
     columnIds,
-    wholeModelImpactedNodeIds: whole.nodeIds,
+    wholeModelImpactedNodeIds: whole.wholeModelImpactedNodeIds,
+    breakingSourceNodeIds: whole.breakingSourceNodeIds,
     wholeModelImpactCauseMap: whole.causeMap,
   };
 }
@@ -511,6 +513,7 @@ export function PrivateLineageView(
     impactedNodeIds,
     impactedColumnIds,
     wholeModelImpactedNodeIds,
+    breakingSourceNodeIds,
     wholeModelImpactCauseMap,
     publish: publishImpactSets,
   } = usePublishedImpactSets();
@@ -1220,6 +1223,7 @@ export function PrivateLineageView(
     impactedNodeIds,
     impactedColumnIds,
     wholeModelImpactedNodeIds,
+    breakingSourceNodeIds,
     wholeModelImpactCauseMap,
     isNodeHighlighted: (nodeId: string) => highlighted.has(nodeId),
     isNodeSelected: (nodeId: string) => selectedNodeIds.has(nodeId),

--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -92,6 +92,7 @@ import { ColumnLevelLineageControlOss } from "./ColumnLevelLineageControlOss";
 import { computeColumnLineage } from "./computeColumnLineage";
 import { computeImpactedColumns } from "./computeImpactedColumns";
 import { computeIsImpacted } from "./computeIsImpacted";
+import { computeWholeModelImpact } from "./computeWholeModelImpact";
 import {
   EXPLORE_MIN_ZOOM,
   edgeTypes,
@@ -134,11 +135,22 @@ export const MINIMAP_NODE_THRESHOLD = 500;
  *
  * The expensive part is `computeImpactedColumns` (DFS over parent_map), so we
  * run it once and thread the result into per-node checks.
+ *
+ * When `downstreamOfBreaking` is `true`, we additionally walk the lineage
+ * graph downstream from every breaking node and surface the result so
+ * consumers can paint the whole-model-impact treatment (sidebar wash, node
+ * mark, sidebar header).
  */
 function computeImpactedSets(
   lineageGraph: LineageGraph,
   cll: ColumnLineageData,
-): { nodeIds: Set<string>; columnIds: Set<string> } {
+  downstreamOfBreaking = false,
+): {
+  nodeIds: Set<string>;
+  columnIds: Set<string>;
+  wholeModelImpactedNodeIds?: Set<string>;
+  wholeModelImpactCauseMap?: Map<string, string>;
+} {
   const columnIds = computeImpactedColumns(cll);
   const nodeIds = new Set<string>();
   for (const nodeId of Object.keys(lineageGraph.nodes)) {
@@ -154,7 +166,20 @@ function computeImpactedSets(
       nodeIds.add(nodeId);
     }
   }
-  return { nodeIds, columnIds };
+  if (!downstreamOfBreaking) {
+    return { nodeIds, columnIds };
+  }
+  const whole = computeWholeModelImpact(lineageGraph, cll);
+  // Whole-model-impacted models also count as "impacted" for the broader
+  // CLL highlight set — everything downstream of a breaking node has at
+  // least all-columns affected.
+  for (const id of whole.nodeIds) nodeIds.add(id);
+  return {
+    nodeIds,
+    columnIds,
+    wholeModelImpactedNodeIds: whole.nodeIds,
+    wholeModelImpactCauseMap: whole.causeMap,
+  };
 }
 
 /**
@@ -485,8 +510,11 @@ export function PrivateLineageView(
   const {
     impactedNodeIds,
     impactedColumnIds,
+    wholeModelImpactedNodeIds,
+    wholeModelImpactCauseMap,
     publish: publishImpactSets,
   } = usePublishedImpactSets();
+  const downstreamOfBreaking = serverFlags?.downstream_of_breaking ?? false;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Intentionally only run when lineageGraph changes (initial load/refetch).
   useLayoutEffect(() => {
@@ -609,7 +637,7 @@ export function PrivateLineageView(
       // Compute impacted sets once; thread into ancestry to avoid redundant DFS.
       const impacted =
         newCllExperience && cll
-          ? computeImpactedSets(lineageGraph, cll)
+          ? computeImpactedSets(lineageGraph, cll, downstreamOfBreaking)
           : undefined;
 
       const [nodes, edges, nodeColumnSetMap] = await toReactFlow(lineageGraph, {
@@ -937,7 +965,7 @@ export function PrivateLineageView(
 
     const impacted =
       newCllExperience && cll
-        ? computeImpactedSets(lineageGraph, cll)
+        ? computeImpactedSets(lineageGraph, cll, downstreamOfBreaking)
         : undefined;
 
     const [newNodes, newEdges, newNodeColumnSetMap] = await toReactFlow(
@@ -1191,6 +1219,8 @@ export function PrivateLineageView(
     deselect,
     impactedNodeIds,
     impactedColumnIds,
+    wholeModelImpactedNodeIds,
+    wholeModelImpactCauseMap,
     isNodeHighlighted: (nodeId: string) => highlighted.has(nodeId),
     isNodeSelected: (nodeId: string) => selectedNodeIds.has(nodeId),
     isEdgeHighlighted: (source, target) => {

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -168,6 +168,22 @@ export interface NodeViewProps<
    */
   lineageTabContent?: ReactNode;
 
+  /**
+   * Whole-model treatment props (DRC-3341 / `--downstream-of-breaking`).
+   * When either is true, the entire NodeView panel renders with a wash
+   * (brown for source, amber for downstream-only impact), a header line
+   * naming the impact state, and an "ALL" badge next to the model name.
+   * The treatment spans every tab (Lineage / Columns / Code) so the
+   * reviewer never loses the impact context when switching tabs.
+   *
+   * Source wins (Q11 of the spec): a node that is both a source and
+   * downstream of another source must arrive here with `isBreakingSource`
+   * true and `isWholeModelImpactedDownstream` false. The two are not
+   * additive; the consumer is responsible for that exclusivity.
+   */
+  isBreakingSource?: boolean;
+  isWholeModelImpactedDownstream?: boolean;
+
   // =========================================================================
   // DEPENDENCY INJECTION: Components
   // =========================================================================
@@ -605,6 +621,8 @@ export function NodeView<TNode extends NodeViewNodeData>({
   featureToggles,
   modelDetail,
   lineageTabContent,
+  isBreakingSource = false,
+  isWholeModelImpactedDownstream = false,
   // Injected components
   SchemaView,
   SingleEnvSchemaView,
@@ -657,13 +675,44 @@ export function NodeView<TNode extends NodeViewNodeData>({
     },
   };
 
+  // Whole-model treatment (DRC-3341). Either flag triggers the wash +
+  // header + badge. The two are mutually exclusive — the consumer
+  // (NodeViewOss) zeroes `isWholeModelImpactedDownstream` out when
+  // `isBreakingSource` is true (Q11 — source wins). Reuses the existing
+  // `--schema-color-changed*` (brown) and `--schema-color-impacted*`
+  // (amber) tokens — no new color tokens introduced.
+  const showWholeModelTreatment =
+    isBreakingSource || isWholeModelImpactedDownstream;
+  const wholeModelHeaderText = isBreakingSource
+    ? "Whole-model change in this model"
+    : "Whole-model impact";
+
   return (
     <Box
       sx={{
         height: "100%",
         display: "flex",
         flexDirection: "column",
+        // Whole-model wash — covers the entire NodeView panel so the
+        // treatment is visible across every tab (Lineage / Columns / Code).
+        // Inset shadow on the left edge gives a slightly more prominent
+        // "this whole model is impacted" cue than v1's 4px stripe.
+        ...(isBreakingSource && {
+          backgroundColor: "var(--schema-color-changed)",
+          boxShadow: "inset 6px 0 0 var(--schema-color-changed-accent)",
+        }),
+        ...(isWholeModelImpactedDownstream && {
+          backgroundColor: "var(--schema-color-impacted)",
+          boxShadow: "inset 6px 0 0 var(--schema-color-impacted-accent)",
+        }),
       }}
+      data-testid={
+        isBreakingSource
+          ? "whole-model-source-wash"
+          : isWholeModelImpactedDownstream
+            ? "whole-model-impact-wash"
+            : undefined
+      }
     >
       {/* Header row: name + close button */}
       <Stack
@@ -672,16 +721,70 @@ export function NodeView<TNode extends NodeViewNodeData>({
           alignItems: "center",
         }}
       >
-        <Box sx={{ flex: "0 1 20%", p: 2 }}>
+        <Box
+          sx={{
+            flex: "0 1 20%",
+            p: 2,
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            minWidth: 0,
+          }}
+        >
           <Typography
             variant="subtitle1"
             className="no-track-pii-safe"
             sx={{
               fontWeight: 600,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
             }}
           >
             {node.data.name}
           </Typography>
+          {/* "ALL" badge — same primitive as the LineageNode graph badge,
+              colored brown for whole-model-changed sources and amber for
+              downstream-only whole-model impact. Visible regardless of the
+              currently active tab. */}
+          {showWholeModelTreatment && (
+            <Box
+              data-testid={
+                isBreakingSource
+                  ? "whole-model-source-badge"
+                  : "whole-model-impact-badge"
+              }
+              aria-label={
+                isBreakingSource ? "whole-model change" : "whole-model impact"
+              }
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: "0.65rem",
+                fontWeight: 700,
+                lineHeight: 1,
+                height: 18,
+                minWidth: 22,
+                px: 0.5,
+                borderRadius: "3px",
+                color: isBreakingSource
+                  ? "rgb(160 100 0)"
+                  : "rgb(146 64 14)",
+                backgroundColor: isBreakingSource
+                  ? "rgb(255 173 21 / 0.25)"
+                  : "rgb(252 211 77 / 0.35)",
+                border: `1px solid ${
+                  isBreakingSource
+                    ? "rgb(212 133 11)"
+                    : "rgb(252 211 77)"
+                }`,
+                flexShrink: 0,
+              }}
+            >
+              ALL
+            </Box>
+          )}
         </Box>
         <Box sx={{ flexGrow: 1 }} />
         {!isSingleEnv && isModelSeedOrSnapshot && (
@@ -739,6 +842,39 @@ export function NodeView<TNode extends NodeViewNodeData>({
               ConnectionPopoverWrapper={ConnectionPopoverWrapper}
             />
           )}
+        </Box>
+      )}
+      {/* Whole-model header — sits above the Tabs strip so it spans every
+          tab. Multi-ancestor list intentionally omitted in v1: it adds
+          visual noise without clear value. The closest upstream causes are
+          still computed and exposed via
+          `LineageViewContext.wholeModelImpactCauseMap` for future use
+          (e.g., a hover tooltip or expandable detail). See Q7 in the
+          DRC-3341 spec. */}
+      {showWholeModelTreatment && (
+        <Box
+          data-testid={
+            isBreakingSource
+              ? "whole-model-source-header"
+              : "whole-model-impact-header"
+          }
+          sx={{
+            px: 2,
+            py: 0.75,
+            fontSize: "0.75rem",
+            fontWeight: 600,
+            color: isBreakingSource
+              ? "rgb(160 100 0)"
+              : "rgb(146 64 14)",
+            borderTop: isBreakingSource
+              ? "1px solid var(--schema-color-changed-accent)"
+              : "1px solid var(--schema-color-impacted-accent)",
+            borderBottom: isBreakingSource
+              ? "1px solid var(--schema-color-changed-accent)"
+              : "1px solid var(--schema-color-impacted-accent)",
+          }}
+        >
+          {wholeModelHeaderText}
         </Box>
       )}
       {/* Content area: tabs for columns and code */}

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -18,6 +18,10 @@ import { IoClose } from "react-icons/io5";
 
 import type { NodeData } from "../../api/info";
 import { DisableTooltipMessages } from "../../constants";
+import {
+  wholeModelTreatmentKind,
+  wholeModelTreatmentTokens,
+} from "./wholeModelTreatment";
 
 // =============================================================================
 // TYPE DEFINITIONS
@@ -675,17 +679,21 @@ export function NodeView<TNode extends NodeViewNodeData>({
     },
   };
 
-  // Whole-model treatment (DRC-3341). Either flag triggers the wash +
-  // header + badge. The two are mutually exclusive — the consumer
-  // (NodeViewOss) zeroes `isWholeModelImpactedDownstream` out when
-  // `isBreakingSource` is true (Q11 — source wins). Reuses the existing
-  // `--schema-color-changed*` (brown) and `--schema-color-impacted*`
-  // (amber) tokens — no new color tokens introduced.
-  const showWholeModelTreatment =
-    isBreakingSource || isWholeModelImpactedDownstream;
-  const wholeModelHeaderText = isBreakingSource
-    ? "Whole-model change in this model"
-    : "Whole-model impact";
+  // Whole-model treatment (DRC-3341). Q11 source-wins is enforced upstream
+  // by NodeViewOss — at most one of the flags is true. The brown vs amber
+  // palette comes from `wholeModelTreatmentTokens` so every site that
+  // renders the wash / badge / header pulls from one place.
+  const treatmentKind = wholeModelTreatmentKind({
+    isBreakingSource,
+    isWholeModelImpactedDownstream,
+  });
+  const treatment = treatmentKind
+    ? wholeModelTreatmentTokens(treatmentKind)
+    : null;
+  const wholeModelHeaderText =
+    treatmentKind === "source"
+      ? "Whole-model change in this model"
+      : "Whole-model impact";
 
   return (
     <Box
@@ -693,23 +701,18 @@ export function NodeView<TNode extends NodeViewNodeData>({
         height: "100%",
         display: "flex",
         flexDirection: "column",
-        // Whole-model wash — covers the entire NodeView panel so the
-        // treatment is visible across every tab (Lineage / Columns / Code).
-        // Inset shadow on the left edge gives a slightly more prominent
-        // "this whole model is impacted" cue than v1's 4px stripe.
-        ...(isBreakingSource && {
-          backgroundColor: "var(--schema-color-changed)",
-          boxShadow: "inset 6px 0 0 var(--schema-color-changed-accent)",
-        }),
-        ...(isWholeModelImpactedDownstream && {
-          backgroundColor: "var(--schema-color-impacted)",
-          boxShadow: "inset 6px 0 0 var(--schema-color-impacted-accent)",
+        // Wash covers the entire NodeView so the treatment spans every tab
+        // (Lineage / Columns / Code). 6px inset accent on the left edge is
+        // slightly more prominent than the 4px stripe used in v1.
+        ...(treatment && {
+          backgroundColor: treatment.washBg,
+          boxShadow: `inset 6px 0 0 ${treatment.washAccent}`,
         }),
       }}
       data-testid={
-        isBreakingSource
+        treatmentKind === "source"
           ? "whole-model-source-wash"
-          : isWholeModelImpactedDownstream
+          : treatmentKind === "downstream"
             ? "whole-model-impact-wash"
             : undefined
       }
@@ -747,15 +750,17 @@ export function NodeView<TNode extends NodeViewNodeData>({
               colored brown for whole-model-changed sources and amber for
               downstream-only whole-model impact. Visible regardless of the
               currently active tab. */}
-          {showWholeModelTreatment && (
+          {treatment && (
             <Box
               data-testid={
-                isBreakingSource
+                treatmentKind === "source"
                   ? "whole-model-source-badge"
                   : "whole-model-impact-badge"
               }
               aria-label={
-                isBreakingSource ? "whole-model change" : "whole-model impact"
+                treatmentKind === "source"
+                  ? "whole-model change"
+                  : "whole-model impact"
               }
               sx={{
                 display: "inline-flex",
@@ -768,13 +773,9 @@ export function NodeView<TNode extends NodeViewNodeData>({
                 minWidth: 22,
                 px: 0.5,
                 borderRadius: "3px",
-                color: isBreakingSource ? "rgb(160 100 0)" : "rgb(146 64 14)",
-                backgroundColor: isBreakingSource
-                  ? "rgb(255 173 21 / 0.25)"
-                  : "rgb(252 211 77 / 0.35)",
-                border: `1px solid ${
-                  isBreakingSource ? "rgb(212 133 11)" : "rgb(252 211 77)"
-                }`,
+                color: treatment.fg,
+                backgroundColor: treatment.badgeBg,
+                border: `1px solid ${treatment.badgeBorder}`,
                 flexShrink: 0,
               }}
             >
@@ -847,10 +848,10 @@ export function NodeView<TNode extends NodeViewNodeData>({
           `LineageViewContext.wholeModelImpactCauseMap` for future use
           (e.g., a hover tooltip or expandable detail). See Q7 in the
           DRC-3341 spec. */}
-      {showWholeModelTreatment && (
+      {treatment && (
         <Box
           data-testid={
-            isBreakingSource
+            treatmentKind === "source"
               ? "whole-model-source-header"
               : "whole-model-impact-header"
           }
@@ -859,13 +860,9 @@ export function NodeView<TNode extends NodeViewNodeData>({
             py: 0.75,
             fontSize: "0.75rem",
             fontWeight: 600,
-            color: isBreakingSource ? "rgb(160 100 0)" : "rgb(146 64 14)",
-            borderTop: isBreakingSource
-              ? "1px solid var(--schema-color-changed-accent)"
-              : "1px solid var(--schema-color-impacted-accent)",
-            borderBottom: isBreakingSource
-              ? "1px solid var(--schema-color-changed-accent)"
-              : "1px solid var(--schema-color-impacted-accent)",
+            color: treatment.fg,
+            borderTop: `1px solid ${treatment.washAccent}`,
+            borderBottom: `1px solid ${treatment.washAccent}`,
           }}
         >
           {wholeModelHeaderText}

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -768,16 +768,12 @@ export function NodeView<TNode extends NodeViewNodeData>({
                 minWidth: 22,
                 px: 0.5,
                 borderRadius: "3px",
-                color: isBreakingSource
-                  ? "rgb(160 100 0)"
-                  : "rgb(146 64 14)",
+                color: isBreakingSource ? "rgb(160 100 0)" : "rgb(146 64 14)",
                 backgroundColor: isBreakingSource
                   ? "rgb(255 173 21 / 0.25)"
                   : "rgb(252 211 77 / 0.35)",
                 border: `1px solid ${
-                  isBreakingSource
-                    ? "rgb(212 133 11)"
-                    : "rgb(252 211 77)"
+                  isBreakingSource ? "rgb(212 133 11)" : "rgb(252 211 77)"
                 }`,
                 flexShrink: 0,
               }}
@@ -863,9 +859,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
             py: 0.75,
             fontSize: "0.75rem",
             fontWeight: 600,
-            color: isBreakingSource
-              ? "rgb(160 100 0)"
-              : "rgb(146 64 14)",
+            color: isBreakingSource ? "rgb(160 100 0)" : "rgb(146 64 14)",
             borderTop: isBreakingSource
               ? "1px solid var(--schema-color-changed-accent)"
               : "1px solid var(--schema-color-impacted-accent)",

--- a/js/packages/ui/src/components/lineage/NodeViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/NodeViewOss.tsx
@@ -132,6 +132,13 @@ export function NodeViewOss({
     () => computeLineageTabImpactSets(lineageViewCtx?.cll),
     [lineageViewCtx?.cll],
   );
+  // Whole-model treatment (DRC-3341). Q11 — source wins. A node that is
+  // both a breaking source AND downstream of another breaking source
+  // classifies as a source, so we zero out the downstream flag here.
+  const isBreakingSource = !!lineageViewCtx?.breakingSourceNodeIds.has(node.id);
+  const isWholeModelImpactedDownstream =
+    !!lineageViewCtx?.wholeModelImpactedNodeIds.has(node.id) &&
+    !isBreakingSource;
   const { singleEnv: isSingleEnvOnboarding, featureToggles } =
     useRecceInstanceContext();
   const { setSqlQuery, setPrimaryKeys } = useRecceQueryContext();
@@ -331,6 +338,8 @@ export function NodeViewOss({
       onCloseNode={onCloseNode}
       isSingleEnv={isSingleEnvOnboarding ?? false}
       featureToggles={featureToggles}
+      isBreakingSource={isBreakingSource}
+      isWholeModelImpactedDownstream={isWholeModelImpactedDownstream}
       modelDetail={(() => {
         if (!modelDetail) return undefined;
         const hasBase =

--- a/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
@@ -402,42 +402,61 @@ describe("LineageNode", () => {
   // ==========================================================================
 
   describe("change analysis", () => {
-    const changeCategories: ChangeCategory[] = [
-      "breaking",
-      "non_breaking",
-      "partial_breaking",
-      "unknown",
+    // Per DRC-3341 captain review: "Breaking" and "Partial Breaking"
+    // labels were dropped from the graph node. The "ALL" badge already
+    // carries the whole-model-change signal, and the per-row `~` / `!`
+    // glyphs carry the column-level signal. Only "Non Breaking"
+    // (additive) and "Unknown" (classifier failed) still render.
+    const labelledCategories: { category: ChangeCategory; label: string }[] = [
+      { category: "non_breaking", label: "Non Breaking" },
+      { category: "unknown", label: "Unknown" },
     ];
 
     it.each(
-      changeCategories,
-    )("shows %s category label when showChangeAnalysis is true", (category) => {
-      const labels: Record<ChangeCategory, string> = {
-        breaking: "Breaking",
-        non_breaking: "Non Breaking",
-        partial_breaking: "Partial Breaking",
-        unknown: "Unknown",
-      };
+      labelledCategories,
+    )(
+      "shows $category category label when showChangeAnalysis is true",
+      ({ category, label }) => {
+        const props = createMockNodeProps(
+          { showChangeAnalysis: true, changeCategory: category },
+          { label: "test" },
+        );
 
-      const props = createMockNodeProps(
-        { showChangeAnalysis: true, changeCategory: category },
-        { label: "test" },
-      );
+        render(<LineageNode {...props} />);
 
-      render(<LineageNode {...props} />);
+        expect(screen.getByText(label)).toBeInTheDocument();
+      },
+    );
 
-      expect(screen.getByText(labels[category])).toBeInTheDocument();
-    });
+    const unlabelledCategories: ChangeCategory[] = [
+      "breaking",
+      "partial_breaking",
+    ];
+
+    it.each(unlabelledCategories)(
+      "does not show category label for %s (carried by ALL badge / row glyphs)",
+      (category) => {
+        const props = createMockNodeProps(
+          { showChangeAnalysis: true, changeCategory: category },
+          { label: "test" },
+        );
+
+        render(<LineageNode {...props} />);
+
+        expect(screen.queryByText("Breaking")).not.toBeInTheDocument();
+        expect(screen.queryByText("Partial Breaking")).not.toBeInTheDocument();
+      },
+    );
 
     it("does not show category label when showChangeAnalysis is false", () => {
       const props = createMockNodeProps(
-        { showChangeAnalysis: false, changeCategory: "breaking" },
+        { showChangeAnalysis: false, changeCategory: "non_breaking" },
         { label: "test" },
       );
 
       render(<LineageNode {...props} />);
 
-      expect(screen.queryByText("Breaking")).not.toBeInTheDocument();
+      expect(screen.queryByText("Non Breaking")).not.toBeInTheDocument();
     });
   });
 

--- a/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
@@ -414,39 +414,38 @@ describe("LineageNode", () => {
 
     it.each(
       labelledCategories,
-    )(
-      "shows $category category label when showChangeAnalysis is true",
-      ({ category, label }) => {
-        const props = createMockNodeProps(
-          { showChangeAnalysis: true, changeCategory: category },
-          { label: "test" },
-        );
+    )("shows $category category label when showChangeAnalysis is true", ({
+      category,
+      label,
+    }) => {
+      const props = createMockNodeProps(
+        { showChangeAnalysis: true, changeCategory: category },
+        { label: "test" },
+      );
 
-        render(<LineageNode {...props} />);
+      render(<LineageNode {...props} />);
 
-        expect(screen.getByText(label)).toBeInTheDocument();
-      },
-    );
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
 
     const unlabelledCategories: ChangeCategory[] = [
       "breaking",
       "partial_breaking",
     ];
 
-    it.each(unlabelledCategories)(
-      "does not show category label for %s (carried by ALL badge / row glyphs)",
-      (category) => {
-        const props = createMockNodeProps(
-          { showChangeAnalysis: true, changeCategory: category },
-          { label: "test" },
-        );
+    it.each(
+      unlabelledCategories,
+    )("does not show category label for %s (carried by ALL badge / row glyphs)", (category) => {
+      const props = createMockNodeProps(
+        { showChangeAnalysis: true, changeCategory: category },
+        { label: "test" },
+      );
 
-        render(<LineageNode {...props} />);
+      render(<LineageNode {...props} />);
 
-        expect(screen.queryByText("Breaking")).not.toBeInTheDocument();
-        expect(screen.queryByText("Partial Breaking")).not.toBeInTheDocument();
-      },
-    );
+      expect(screen.queryByText("Breaking")).not.toBeInTheDocument();
+      expect(screen.queryByText("Partial Breaking")).not.toBeInTheDocument();
+    });
 
     it("does not show category label when showChangeAnalysis is false", () => {
       const props = createMockNodeProps(

--- a/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
@@ -402,41 +402,31 @@ describe("LineageNode", () => {
   // ==========================================================================
 
   describe("change analysis", () => {
-    // Per DRC-3341 captain review: "Breaking" and "Partial Breaking"
-    // labels were dropped from the graph node. The "ALL" badge already
-    // carries the whole-model-change signal, and the per-row `~` / `!`
-    // glyphs carry the column-level signal. Only "Additive" (the spec's
-    // UI term for `non_breaking`) and "Unknown" (classifier failed)
-    // still render.
-    const labelledCategories: { category: ChangeCategory; label: string }[] = [
-      { category: "non_breaking", label: "Additive" },
-      { category: "unknown", label: "Unknown" },
-    ];
-
-    it.each(
-      labelledCategories,
-    )("shows $category category label when showChangeAnalysis is true", ({
-      category,
-      label,
-    }) => {
+    // Per DRC-3341 captain review: "Breaking", "Partial Breaking", and
+    // "Additive" labels were dropped from the graph node — the brown ALL
+    // badge, per-row `~`/`!` glyphs, and green ADD badge carry those
+    // signals respectively. Only "Unknown" (classifier failed) still
+    // renders as a bottom-row label.
+    it("shows Unknown category label when showChangeAnalysis is true", () => {
       const props = createMockNodeProps(
-        { showChangeAnalysis: true, changeCategory: category },
+        { showChangeAnalysis: true, changeCategory: "unknown" },
         { label: "test" },
       );
 
       render(<LineageNode {...props} />);
 
-      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(screen.getByText("Unknown")).toBeInTheDocument();
     });
 
     const unlabelledCategories: ChangeCategory[] = [
       "breaking",
       "partial_breaking",
+      "non_breaking",
     ];
 
     it.each(
       unlabelledCategories,
-    )("does not show category label for %s (carried by ALL badge / row glyphs)", (category) => {
+    )("does not show category label for %s (carried by badge or row glyph)", (category) => {
       const props = createMockNodeProps(
         { showChangeAnalysis: true, changeCategory: category },
         { label: "test" },
@@ -446,17 +436,60 @@ describe("LineageNode", () => {
 
       expect(screen.queryByText("Breaking")).not.toBeInTheDocument();
       expect(screen.queryByText("Partial Breaking")).not.toBeInTheDocument();
+      expect(screen.queryByText("Additive")).not.toBeInTheDocument();
     });
 
     it("does not show category label when showChangeAnalysis is false", () => {
       const props = createMockNodeProps(
-        { showChangeAnalysis: false, changeCategory: "non_breaking" },
+        { showChangeAnalysis: false, changeCategory: "unknown" },
         { label: "test" },
       );
 
       render(<LineageNode {...props} />);
 
-      expect(screen.queryByText("Additive")).not.toBeInTheDocument();
+      expect(screen.queryByText("Unknown")).not.toBeInTheDocument();
+    });
+
+    it("renders the green ADD badge for non_breaking (additive) changes", () => {
+      const props = createMockNodeProps(
+        { changeCategory: "non_breaking" },
+        { label: "test" },
+      );
+
+      render(<LineageNode {...props} />);
+
+      const badge = screen.getByTestId("additive-change-badge");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent("ADD");
+    });
+
+    it("source/downstream badges win priority over additive when stacked", () => {
+      // Defensive — if a consumer ever passes both an additive category
+      // AND a whole-model flag, the brown/amber badge must still win.
+      const breakingProps = createMockNodeProps(
+        { changeCategory: "non_breaking", isBreakingSource: true },
+        { label: "src" },
+      );
+      const { unmount } = render(<LineageNode {...breakingProps} />);
+      expect(
+        screen.queryByTestId("additive-change-badge"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("whole-model-source-badge"),
+      ).toBeInTheDocument();
+      unmount();
+
+      const impactedProps = createMockNodeProps(
+        { changeCategory: "non_breaking", isWholeModelImpacted: true },
+        { label: "imp" },
+      );
+      render(<LineageNode {...impactedProps} />);
+      expect(
+        screen.queryByTestId("additive-change-badge"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("whole-model-impact-badge"),
+      ).toBeInTheDocument();
     });
   });
 

--- a/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
@@ -405,10 +405,11 @@ describe("LineageNode", () => {
     // Per DRC-3341 captain review: "Breaking" and "Partial Breaking"
     // labels were dropped from the graph node. The "ALL" badge already
     // carries the whole-model-change signal, and the per-row `~` / `!`
-    // glyphs carry the column-level signal. Only "Non Breaking"
-    // (additive) and "Unknown" (classifier failed) still render.
+    // glyphs carry the column-level signal. Only "Additive" (the spec's
+    // UI term for `non_breaking`) and "Unknown" (classifier failed)
+    // still render.
     const labelledCategories: { category: ChangeCategory; label: string }[] = [
-      { category: "non_breaking", label: "Non Breaking" },
+      { category: "non_breaking", label: "Additive" },
       { category: "unknown", label: "Unknown" },
     ];
 
@@ -455,7 +456,7 @@ describe("LineageNode", () => {
 
       render(<LineageNode {...props} />);
 
-      expect(screen.queryByText("Non Breaking")).not.toBeInTheDocument();
+      expect(screen.queryByText("Additive")).not.toBeInTheDocument();
     });
   });
 

--- a/js/packages/ui/src/components/lineage/__tests__/computeWholeModelImpact.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/computeWholeModelImpact.test.ts
@@ -64,18 +64,20 @@ describe("computeWholeModelImpact", () => {
     ]);
     const cll = makeCll([], ["a", "b", "c"]);
     const result = computeWholeModelImpact(graph as any, cll as any);
-    expect(result.nodeIds.size).toBe(0);
+    expect(result.wholeModelImpactedNodeIds.size).toBe(0);
+    expect(result.breakingSourceNodeIds.size).toBe(0);
     expect(result.causeMap.size).toBe(0);
   });
 
-  it("includes the breaking node itself as whole-model-impacted", () => {
+  it("includes the breaking node itself as whole-model-impacted and source", () => {
     const graph = makeGraph([["a", "b"]]);
     const cll = makeCll(["a"], ["a", "b"]);
     const result = computeWholeModelImpact(graph as any, cll as any);
-    expect(result.nodeIds.has("a")).toBe(true);
+    expect(result.wholeModelImpactedNodeIds.has("a")).toBe(true);
+    expect(result.breakingSourceNodeIds.has("a")).toBe(true);
     // The breaking node is its own cause — sidebar header reads the cause
     // and decides whether to phrase as "in this model" vs "downstream of X".
-    expect(result.causeMap.get("a")).toBe("a");
+    expect(result.causeMap.get("a")).toEqual(new Set(["a"]));
   });
 
   it("propagates whole-model impact to every downstream node (transitively)", () => {
@@ -87,14 +89,17 @@ describe("computeWholeModelImpact", () => {
     ]);
     const cll = makeCll(["a"], ["a", "b", "c", "d"]);
     const result = computeWholeModelImpact(graph as any, cll as any);
-    expect(result.nodeIds.has("a")).toBe(true);
-    expect(result.nodeIds.has("b")).toBe(true);
-    expect(result.nodeIds.has("c")).toBe(true);
-    expect(result.nodeIds.has("d")).toBe(true);
-    // All downstream nodes share the same cause (the only breaking ancestor).
-    expect(result.causeMap.get("b")).toBe("a");
-    expect(result.causeMap.get("c")).toBe("a");
-    expect(result.causeMap.get("d")).toBe("a");
+    expect(result.wholeModelImpactedNodeIds.has("a")).toBe(true);
+    expect(result.wholeModelImpactedNodeIds.has("b")).toBe(true);
+    expect(result.wholeModelImpactedNodeIds.has("c")).toBe(true);
+    expect(result.wholeModelImpactedNodeIds.has("d")).toBe(true);
+    // Only `a` is a source — the rest are downstream-only.
+    expect(result.breakingSourceNodeIds).toEqual(new Set(["a"]));
+    // All downstream nodes share the same single cause (the only breaking
+    // ancestor).
+    expect(result.causeMap.get("b")).toEqual(new Set(["a"]));
+    expect(result.causeMap.get("c")).toEqual(new Set(["a"]));
+    expect(result.causeMap.get("d")).toEqual(new Set(["a"]));
   });
 
   it("does not propagate whole-model impact to upstream of a breaking node", () => {
@@ -105,25 +110,46 @@ describe("computeWholeModelImpact", () => {
     ]);
     const cll = makeCll(["a"], ["up", "a", "down"]);
     const result = computeWholeModelImpact(graph as any, cll as any);
-    expect(result.nodeIds.has("up")).toBe(false);
-    expect(result.nodeIds.has("a")).toBe(true);
-    expect(result.nodeIds.has("down")).toBe(true);
+    expect(result.wholeModelImpactedNodeIds.has("up")).toBe(false);
+    expect(result.wholeModelImpactedNodeIds.has("a")).toBe(true);
+    expect(result.wholeModelImpactedNodeIds.has("down")).toBe(true);
   });
 
   it("picks the closest breaking ancestor when a node has multiple breaking upstreams", () => {
     // a (breaking) -> b (breaking) -> c
-    // BFS visits b at distance 1 from b *before* it would visit c at
-    // distance 2 from a, so c's cause should be b.
+    // BFS visits c at distance 1 from b (the closer breaking ancestor),
+    // not distance 2 from a.
     const graph = makeGraph([
       ["a", "b"],
       ["b", "c"],
     ]);
     const cll = makeCll(["a", "b"], ["a", "b", "c"]);
     const result = computeWholeModelImpact(graph as any, cll as any);
-    expect(result.causeMap.get("c")).toBe("b");
+    expect(result.causeMap.get("c")).toEqual(new Set(["b"]));
+    // Both a and b are sources of their own waves. Per Q11 (source wins),
+    // b classifies as a source even though it is also downstream of a.
+    expect(result.breakingSourceNodeIds).toEqual(new Set(["a", "b"]));
+    // b's own cause is itself (it is both impacted-by-a and a source).
+    expect(result.causeMap.get("b")).toEqual(new Set(["b"]));
   });
 
-  it("handles a diamond — both branches reach the join node", () => {
+  it("collects ALL closest breaking ancestors at the same BFS distance (Q7)", () => {
+    // a (breaking) -> c -> d
+    // b (breaking) -> c -> d
+    // c sees both `a` and `b` at distance 1 — the cause map for c (and
+    // therefore d, at distance 2) should list both ancestors.
+    const graph = makeGraph([
+      ["a", "c"],
+      ["b", "c"],
+      ["c", "d"],
+    ]);
+    const cll = makeCll(["a", "b"], ["a", "b", "c", "d"]);
+    const result = computeWholeModelImpact(graph as any, cll as any);
+    expect(result.causeMap.get("c")).toEqual(new Set(["a", "b"]));
+    expect(result.causeMap.get("d")).toEqual(new Set(["a", "b"]));
+  });
+
+  it("handles a diamond — both branches reach the join node from a single cause", () => {
     // a (breaking) -> b -> d
     // a            -> c -> d
     const graph = makeGraph([
@@ -134,7 +160,30 @@ describe("computeWholeModelImpact", () => {
     ]);
     const cll = makeCll(["a"], ["a", "b", "c", "d"]);
     const result = computeWholeModelImpact(graph as any, cll as any);
-    expect(result.nodeIds.size).toBe(4);
-    expect(result.causeMap.get("d")).toBe("a");
+    expect(result.wholeModelImpactedNodeIds.size).toBe(4);
+    expect(result.causeMap.get("d")).toEqual(new Set(["a"]));
+  });
+
+  it("handles a diamond with mixed breaking and non-breaking branch midpoints", () => {
+    // a (breaking)         -> mid1            -> tip
+    // a                    -> mid2 (breaking) -> tip
+    // mid2 is breaking and downstream of a — it classifies as a source
+    // (Q11 source wins). tip sees mid2 at distance 1 (the closer breaking
+    // ancestor, replacing a at distance 2).
+    const graph = makeGraph([
+      ["a", "mid1"],
+      ["a", "mid2"],
+      ["mid1", "tip"],
+      ["mid2", "tip"],
+    ]);
+    const cll = makeCll(["a", "mid2"], ["a", "mid1", "mid2", "tip"]);
+    const result = computeWholeModelImpact(graph as any, cll as any);
+    expect(result.breakingSourceNodeIds).toEqual(new Set(["a", "mid2"]));
+    // tip's only closest cause is mid2 (distance 1), not a (distance 2).
+    expect(result.causeMap.get("tip")).toEqual(new Set(["mid2"]));
+    // mid1 — non-breaking, distance 1 from a — has cause `a`.
+    expect(result.causeMap.get("mid1")).toEqual(new Set(["a"]));
+    // mid2 is its own cause (Q11 — source wins absorbs the upstream).
+    expect(result.causeMap.get("mid2")).toEqual(new Set(["mid2"]));
   });
 });

--- a/js/packages/ui/src/components/lineage/__tests__/computeWholeModelImpact.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/computeWholeModelImpact.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { computeWholeModelImpact } from "../computeWholeModelImpact";
+
+/**
+ * Build a minimal LineageGraph with the given parent→child edges.
+ * Each node carries a display name = the node id (so cause-map lookups have
+ * something to match on).
+ */
+function makeGraph(edges: [string, string][]) {
+  const nodes: Record<string, any> = {};
+  function ensure(id: string) {
+    nodes[id] ??= {
+      id,
+      data: {
+        id,
+        name: id,
+        parents: {} as Record<string, unknown>,
+        children: {} as Record<string, unknown>,
+      },
+    };
+    return nodes[id];
+  }
+  for (const [src, dst] of edges) {
+    const s = ensure(src);
+    const d = ensure(dst);
+    s.data.children[dst] = {};
+    d.data.parents[src] = {};
+  }
+  return {
+    nodes,
+    edges: {},
+    modifiedSet: [],
+    manifestMetadata: {},
+    catalogMetadata: {},
+  };
+}
+
+function makeCll(breakingNodes: string[], allNodeIds: string[]) {
+  const nodes: Record<string, any> = {};
+  for (const id of allNodeIds) {
+    nodes[id] = {
+      id,
+      name: id,
+      source_name: id,
+      resource_type: "model",
+      change_category: breakingNodes.includes(id) ? "breaking" : "non_breaking",
+    };
+  }
+  return {
+    current: {
+      nodes,
+      columns: {},
+      parent_map: {},
+      child_map: {},
+    },
+  };
+}
+
+describe("computeWholeModelImpact", () => {
+  it("returns empty sets when no node is breaking", () => {
+    const graph = makeGraph([
+      ["a", "b"],
+      ["b", "c"],
+    ]);
+    const cll = makeCll([], ["a", "b", "c"]);
+    const result = computeWholeModelImpact(graph as any, cll as any);
+    expect(result.nodeIds.size).toBe(0);
+    expect(result.causeMap.size).toBe(0);
+  });
+
+  it("includes the breaking node itself as whole-model-impacted", () => {
+    const graph = makeGraph([["a", "b"]]);
+    const cll = makeCll(["a"], ["a", "b"]);
+    const result = computeWholeModelImpact(graph as any, cll as any);
+    expect(result.nodeIds.has("a")).toBe(true);
+    // The breaking node is its own cause — sidebar header reads the cause
+    // and decides whether to phrase as "in this model" vs "downstream of X".
+    expect(result.causeMap.get("a")).toBe("a");
+  });
+
+  it("propagates whole-model impact to every downstream node (transitively)", () => {
+    // a (breaking) -> b -> c -> d
+    const graph = makeGraph([
+      ["a", "b"],
+      ["b", "c"],
+      ["c", "d"],
+    ]);
+    const cll = makeCll(["a"], ["a", "b", "c", "d"]);
+    const result = computeWholeModelImpact(graph as any, cll as any);
+    expect(result.nodeIds.has("a")).toBe(true);
+    expect(result.nodeIds.has("b")).toBe(true);
+    expect(result.nodeIds.has("c")).toBe(true);
+    expect(result.nodeIds.has("d")).toBe(true);
+    // All downstream nodes share the same cause (the only breaking ancestor).
+    expect(result.causeMap.get("b")).toBe("a");
+    expect(result.causeMap.get("c")).toBe("a");
+    expect(result.causeMap.get("d")).toBe("a");
+  });
+
+  it("does not propagate whole-model impact to upstream of a breaking node", () => {
+    // up -> a (breaking) -> down
+    const graph = makeGraph([
+      ["up", "a"],
+      ["a", "down"],
+    ]);
+    const cll = makeCll(["a"], ["up", "a", "down"]);
+    const result = computeWholeModelImpact(graph as any, cll as any);
+    expect(result.nodeIds.has("up")).toBe(false);
+    expect(result.nodeIds.has("a")).toBe(true);
+    expect(result.nodeIds.has("down")).toBe(true);
+  });
+
+  it("picks the closest breaking ancestor when a node has multiple breaking upstreams", () => {
+    // a (breaking) -> b (breaking) -> c
+    // BFS visits b at distance 1 from b *before* it would visit c at
+    // distance 2 from a, so c's cause should be b.
+    const graph = makeGraph([
+      ["a", "b"],
+      ["b", "c"],
+    ]);
+    const cll = makeCll(["a", "b"], ["a", "b", "c"]);
+    const result = computeWholeModelImpact(graph as any, cll as any);
+    expect(result.causeMap.get("c")).toBe("b");
+  });
+
+  it("handles a diamond — both branches reach the join node", () => {
+    // a (breaking) -> b -> d
+    // a            -> c -> d
+    const graph = makeGraph([
+      ["a", "b"],
+      ["a", "c"],
+      ["b", "d"],
+      ["c", "d"],
+    ]);
+    const cll = makeCll(["a"], ["a", "b", "c", "d"]);
+    const result = computeWholeModelImpact(graph as any, cll as any);
+    expect(result.nodeIds.size).toBe(4);
+    expect(result.causeMap.get("d")).toBe("a");
+  });
+});

--- a/js/packages/ui/src/components/lineage/computeWholeModelImpact.ts
+++ b/js/packages/ui/src/components/lineage/computeWholeModelImpact.ts
@@ -1,0 +1,86 @@
+import type { ColumnLineageData } from "../../api/cll";
+import type { LineageGraph } from "../../contexts/lineage/types";
+
+/**
+ * Result of whole-model-impact propagation.
+ *
+ * - `nodeIds`: every model that is downstream of (or is) a node whose CLL
+ *   `change_category` is `"breaking"`. The breaking node itself is included
+ *   so the visual treatment lights up the originating model too.
+ * - `causeMap`: for each whole-model-impacted node, the *closest* upstream
+ *   breaking model name. Used to caption the sidebar header
+ *   ("Whole-model impact — downstream of <name>"). When a node has multiple
+ *   breaking ancestors, BFS picks the nearest; the breaking node itself maps
+ *   to its own name.
+ */
+export interface WholeModelImpactSets {
+  nodeIds: Set<string>;
+  causeMap: Map<string, string>;
+}
+
+const EMPTY_RESULT: WholeModelImpactSets = {
+  nodeIds: new Set<string>(),
+  causeMap: new Map<string, string>(),
+};
+
+/**
+ * Walk the lineage graph downstream from every node whose CLL
+ * `change_category` is `"breaking"` and mark every visited node as
+ * whole-model-impacted.
+ *
+ * This is the v1 propagation rule for the `--downstream-of-breaking` feature:
+ * when an upstream model has a breaking change (WHERE / GROUP BY / row-shape
+ * edit), every downstream model has whole-model impact (every column is
+ * affected). Cross-level cases (column-level partial-breaking that becomes
+ * model-level breaking via a downstream JOIN/WHERE/GROUP BY) are deferred —
+ * the classifier in `recce/util/breaking.py` is the source of truth.
+ *
+ * Cheap BFS — runs only when the `downstream_of_breaking` server flag is on.
+ */
+export function computeWholeModelImpact(
+  lineageGraph: LineageGraph,
+  cll: ColumnLineageData,
+): WholeModelImpactSets {
+  const breakingNodes: string[] = [];
+  for (const [nodeId, cllNode] of Object.entries(cll.current.nodes)) {
+    if (cllNode.change_category === "breaking") {
+      breakingNodes.push(nodeId);
+    }
+  }
+  if (breakingNodes.length === 0) return EMPTY_RESULT;
+
+  const nodeIds = new Set<string>();
+  const causeMap = new Map<string, string>();
+
+  // Seed the BFS frontier with every breaking node. The breaking node itself
+  // counts as whole-model-impacted (its own model is affected) and is its own
+  // cause for the sidebar header. We expand outward one level at a time so the
+  // first time a node is reached, it's reached from the *closest* breaking
+  // ancestor — that wins the cause-map slot.
+  let frontier: { id: string; cause: string }[] = breakingNodes.map((id) => ({
+    id,
+    cause: lineageGraph.nodes[id]?.data.name ?? id,
+  }));
+  for (const seed of frontier) {
+    nodeIds.add(seed.id);
+    causeMap.set(seed.id, seed.cause);
+  }
+
+  while (frontier.length > 0) {
+    const next: { id: string; cause: string }[] = [];
+    for (const { id, cause } of frontier) {
+      const node = lineageGraph.nodes[id];
+      if (!node) continue;
+      const childIds = Object.keys(node.data.children);
+      for (const childId of childIds) {
+        if (nodeIds.has(childId)) continue;
+        nodeIds.add(childId);
+        causeMap.set(childId, cause);
+        next.push({ id: childId, cause });
+      }
+    }
+    frontier = next;
+  }
+
+  return { nodeIds, causeMap };
+}

--- a/js/packages/ui/src/components/lineage/computeWholeModelImpact.ts
+++ b/js/packages/ui/src/components/lineage/computeWholeModelImpact.ts
@@ -4,23 +4,34 @@ import type { LineageGraph } from "../../contexts/lineage/types";
 /**
  * Result of whole-model-impact propagation.
  *
- * - `nodeIds`: every model that is downstream of (or is) a node whose CLL
- *   `change_category` is `"breaking"`. The breaking node itself is included
- *   so the visual treatment lights up the originating model too.
- * - `causeMap`: for each whole-model-impacted node, the *closest* upstream
- *   breaking model name. Used to caption the sidebar header
- *   ("Whole-model impact — downstream of <name>"). When a node has multiple
- *   breaking ancestors, BFS picks the nearest; the breaking node itself maps
- *   to its own name.
+ * - `wholeModelImpactedNodeIds`: every model that is downstream of (or is) a
+ *   node whose CLL `change_category` is `"breaking"` (i.e. has a *whole-model
+ *   change* in the new vocabulary). The whole-model-changed node itself is
+ *   included so the visual treatment lights up the originating model too.
+ * - `breakingSourceNodeIds`: the subset of `wholeModelImpactedNodeIds` whose
+ *   own `change_category === "breaking"`. These are the "sources" of the
+ *   impact wave. Per Q11 ("source wins"), a node that is both a source AND
+ *   downstream of another source is still classified as a source — so the
+ *   visual layer can simply check `breakingSourceNodeIds.has(id)` and render
+ *   the brown (changed) treatment without re-walking the CLL.
+ * - `causeMap`: for each whole-model-impacted node, the set of *closest*
+ *   upstream whole-model-changed (breaking) model names. BFS guarantees
+ *   "closest" — when multiple breaking ancestors reach the node at the same
+ *   minimum distance, all of them are recorded. Used to caption the sidebar
+ *   header ("Whole-model impact — downstream of <ancestor list>"). A
+ *   breaking-source node maps to a single-element set containing its own
+ *   name.
  */
 export interface WholeModelImpactSets {
-  nodeIds: Set<string>;
-  causeMap: Map<string, string>;
+  wholeModelImpactedNodeIds: Set<string>;
+  breakingSourceNodeIds: Set<string>;
+  causeMap: Map<string, Set<string>>;
 }
 
 const EMPTY_RESULT: WholeModelImpactSets = {
-  nodeIds: new Set<string>(),
-  causeMap: new Map<string, string>(),
+  wholeModelImpactedNodeIds: new Set<string>(),
+  breakingSourceNodeIds: new Set<string>(),
+  causeMap: new Map<string, Set<string>>(),
 };
 
 /**
@@ -29,11 +40,17 @@ const EMPTY_RESULT: WholeModelImpactSets = {
  * whole-model-impacted.
  *
  * This is the v1 propagation rule for the `--downstream-of-breaking` feature:
- * when an upstream model has a breaking change (WHERE / GROUP BY / row-shape
- * edit), every downstream model has whole-model impact (every column is
- * affected). Cross-level cases (column-level partial-breaking that becomes
- * model-level breaking via a downstream JOIN/WHERE/GROUP BY) are deferred —
- * the classifier in `recce/util/breaking.py` is the source of truth.
+ * when an upstream model has a whole-model (breaking) change — `WHERE` /
+ * `GROUP BY` / row-shape edit — every downstream model has whole-model
+ * impact (every column is affected). Cross-level cases (column-only upstream
+ * that becomes whole-model downstream via a JOIN/WHERE/GROUP BY) are
+ * deferred — the classifier in `recce/util/breaking.py` is the source of
+ * truth.
+ *
+ * Multi-ancestor handling (Q7): when a node has multiple breaking ancestors
+ * at the same minimum BFS distance, the cause map records all of them.
+ * Source-wins handling (Q11): the visual layer separately consults
+ * `breakingSourceNodeIds` to decide brown-vs-amber treatment.
  *
  * Cheap BFS — runs only when the `downstream_of_breaking` server flag is on.
  */
@@ -49,38 +66,72 @@ export function computeWholeModelImpact(
   }
   if (breakingNodes.length === 0) return EMPTY_RESULT;
 
-  const nodeIds = new Set<string>();
-  const causeMap = new Map<string, string>();
+  const wholeModelImpactedNodeIds = new Set<string>();
+  const breakingSourceNodeIds = new Set<string>(breakingNodes);
+  const causeMap = new Map<string, Set<string>>();
+  // Track BFS distance per node so we keep collecting ancestors that arrive
+  // at the same minimum distance and stop merging once a deeper layer is
+  // reached.
+  const distance = new Map<string, number>();
 
-  // Seed the BFS frontier with every breaking node. The breaking node itself
-  // counts as whole-model-impacted (its own model is affected) and is its own
-  // cause for the sidebar header. We expand outward one level at a time so the
-  // first time a node is reached, it's reached from the *closest* breaking
-  // ancestor — that wins the cause-map slot.
-  let frontier: { id: string; cause: string }[] = breakingNodes.map((id) => ({
-    id,
-    cause: lineageGraph.nodes[id]?.data.name ?? id,
-  }));
-  for (const seed of frontier) {
-    nodeIds.add(seed.id);
-    causeMap.set(seed.id, seed.cause);
+  // Seed every breaking node at distance 0. Each is its own cause — a
+  // breaking-source node's sidebar header reads "Whole-model change in this
+  // model" (handled in the visual layer; the cause map just records the
+  // node's display name).
+  let frontier: string[] = [];
+  for (const id of breakingNodes) {
+    wholeModelImpactedNodeIds.add(id);
+    distance.set(id, 0);
+    const name = lineageGraph.nodes[id]?.data.name ?? id;
+    causeMap.set(id, new Set([name]));
+    frontier.push(id);
   }
 
+  // Walk one level at a time. At each step, we propagate the *full* cause
+  // set of the parent to its children — so when two breaking ancestors
+  // converge at a downstream node, the cause sets union naturally rather
+  // than depending on which BFS edge was traversed first.
+  let depth = 0;
   while (frontier.length > 0) {
-    const next: { id: string; cause: string }[] = [];
-    for (const { id, cause } of frontier) {
+    depth += 1;
+    const next: string[] = [];
+    const nextSeen = new Set<string>();
+    for (const id of frontier) {
       const node = lineageGraph.nodes[id];
       if (!node) continue;
+      const parentCauses = causeMap.get(id);
+      if (!parentCauses) continue;
       const childIds = Object.keys(node.data.children);
       for (const childId of childIds) {
-        if (nodeIds.has(childId)) continue;
-        nodeIds.add(childId);
-        causeMap.set(childId, cause);
-        next.push({ id: childId, cause });
+        const seenAt = distance.get(childId);
+        if (seenAt !== undefined && seenAt < depth) {
+          // Already locked in at a closer distance — its cause set is
+          // already final. (Source-wins: a breaking source node is locked
+          // at distance 0, so upstream breaking causes never override it.)
+          continue;
+        }
+        if (seenAt === undefined) {
+          // First visit at this depth.
+          wholeModelImpactedNodeIds.add(childId);
+          distance.set(childId, depth);
+          causeMap.set(childId, new Set(parentCauses));
+        } else {
+          // seenAt === depth — co-equal arrival from another parent.
+          const existing = causeMap.get(childId);
+          if (existing) {
+            for (const c of parentCauses) existing.add(c);
+          } else {
+            causeMap.set(childId, new Set(parentCauses));
+          }
+        }
+        if (!nextSeen.has(childId)) {
+          nextSeen.add(childId);
+          next.push(childId);
+        }
       }
     }
     frontier = next;
   }
 
-  return { nodeIds, causeMap };
+  return { wholeModelImpactedNodeIds, breakingSourceNodeIds, causeMap };
 }

--- a/js/packages/ui/src/components/lineage/hooks/usePublishedImpactSets.ts
+++ b/js/packages/ui/src/components/lineage/hooks/usePublishedImpactSets.ts
@@ -10,17 +10,28 @@ export interface ImpactSets {
    */
   wholeModelImpactedNodeIds?: Set<string>;
   /**
-   * Optional cause map: whole-model-impacted nodeId → name of the closest
-   * upstream breaking model. Drives the sidebar header text.
+   * Optional set of node IDs whose own `change_category === "breaking"` —
+   * the *sources* of whole-model impact waves. Subset of
+   * `wholeModelImpactedNodeIds`. Drives the brown-vs-amber treatment
+   * (Q9/Q10/Q11 of the `downstream-of-breaking` design): a node in this
+   * set renders with the brown "changed" color family even if it is also
+   * downstream of another source ("source wins").
    */
-  wholeModelImpactCauseMap?: Map<string, string>;
+  breakingSourceNodeIds?: Set<string>;
+  /**
+   * Optional cause map: whole-model-impacted nodeId → set of names of the
+   * closest upstream breaking models. A breaking-source node maps to its
+   * own name. Drives the sidebar header text.
+   */
+  wholeModelImpactCauseMap?: Map<string, Set<string>>;
 }
 
 export interface UsePublishedImpactSetsResult {
   impactedNodeIds: Set<string>;
   impactedColumnIds: Set<string>;
   wholeModelImpactedNodeIds: Set<string>;
-  wholeModelImpactCauseMap: Map<string, string>;
+  breakingSourceNodeIds: Set<string>;
+  wholeModelImpactCauseMap: Map<string, Set<string>>;
   publish: (sets: ImpactSets) => void;
 }
 
@@ -37,14 +48,18 @@ export function usePublishedImpactSets(): UsePublishedImpactSetsResult {
   const [wholeModelImpactedNodeIds, setWholeModelImpactedNodeIds] = useState<
     Set<string>
   >(() => new Set());
+  const [breakingSourceNodeIds, setBreakingSourceNodeIds] = useState<
+    Set<string>
+  >(() => new Set());
   const [wholeModelImpactCauseMap, setWholeModelImpactCauseMap] = useState<
-    Map<string, string>
+    Map<string, Set<string>>
   >(() => new Map());
 
   const publish = useCallback((sets: ImpactSets) => {
     setImpactedNodeIds(sets.nodeIds);
     setImpactedColumnIds(sets.columnIds);
     setWholeModelImpactedNodeIds(sets.wholeModelImpactedNodeIds ?? new Set());
+    setBreakingSourceNodeIds(sets.breakingSourceNodeIds ?? new Set());
     setWholeModelImpactCauseMap(sets.wholeModelImpactCauseMap ?? new Map());
   }, []);
 
@@ -52,6 +67,7 @@ export function usePublishedImpactSets(): UsePublishedImpactSetsResult {
     impactedNodeIds,
     impactedColumnIds,
     wholeModelImpactedNodeIds,
+    breakingSourceNodeIds,
     wholeModelImpactCauseMap,
     publish,
   };

--- a/js/packages/ui/src/components/lineage/hooks/usePublishedImpactSets.ts
+++ b/js/packages/ui/src/components/lineage/hooks/usePublishedImpactSets.ts
@@ -3,11 +3,24 @@ import { useCallback, useState } from "react";
 export interface ImpactSets {
   nodeIds: Set<string>;
   columnIds: Set<string>;
+  /**
+   * Optional whole-model-impacted node IDs from the
+   * `--downstream-of-breaking` propagation. Populated only when the
+   * `downstream_of_breaking` server flag is on; left undefined otherwise.
+   */
+  wholeModelImpactedNodeIds?: Set<string>;
+  /**
+   * Optional cause map: whole-model-impacted nodeId → name of the closest
+   * upstream breaking model. Drives the sidebar header text.
+   */
+  wholeModelImpactCauseMap?: Map<string, string>;
 }
 
 export interface UsePublishedImpactSetsResult {
   impactedNodeIds: Set<string>;
   impactedColumnIds: Set<string>;
+  wholeModelImpactedNodeIds: Set<string>;
+  wholeModelImpactCauseMap: Map<string, string>;
   publish: (sets: ImpactSets) => void;
 }
 
@@ -21,11 +34,25 @@ export function usePublishedImpactSets(): UsePublishedImpactSetsResult {
   const [impactedColumnIds, setImpactedColumnIds] = useState<Set<string>>(
     () => new Set(),
   );
+  const [wholeModelImpactedNodeIds, setWholeModelImpactedNodeIds] = useState<
+    Set<string>
+  >(() => new Set());
+  const [wholeModelImpactCauseMap, setWholeModelImpactCauseMap] = useState<
+    Map<string, string>
+  >(() => new Map());
 
   const publish = useCallback((sets: ImpactSets) => {
     setImpactedNodeIds(sets.nodeIds);
     setImpactedColumnIds(sets.columnIds);
+    setWholeModelImpactedNodeIds(sets.wholeModelImpactedNodeIds ?? new Set());
+    setWholeModelImpactCauseMap(sets.wholeModelImpactCauseMap ?? new Map());
   }, []);
 
-  return { impactedNodeIds, impactedColumnIds, publish };
+  return {
+    impactedNodeIds,
+    impactedColumnIds,
+    wholeModelImpactedNodeIds,
+    wholeModelImpactCauseMap,
+    publish,
+  };
 }

--- a/js/packages/ui/src/components/lineage/index.ts
+++ b/js/packages/ui/src/components/lineage/index.ts
@@ -96,3 +96,10 @@ export * from "./styles";
 export * from "./tags";
 // Top bar component for lineage view
 export * from "./topbar";
+// Whole-model treatment palette (DRC-3341)
+export {
+  type WholeModelTreatmentKind,
+  type WholeModelTreatmentTokens,
+  wholeModelTreatmentKind,
+  wholeModelTreatmentTokens,
+} from "./wholeModelTreatment";

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -181,12 +181,14 @@ export interface LineageNodeProps {
 // the per-row `~` / `!` glyphs already carry the column-level
 // "changed" / "impacted" signal. Keeping the bottom-row labels for
 // these two categories duplicates the message and clutters the graph.
-// "Non Breaking" (additive) and "Unknown" (classifier failed) still
-// render — both have no other graph-level visual treatment.
-// See DRC-3341 captain visual review notes.
+// "Additive" (the spec's UI term for `non_breaking` — a change that only
+// adds a column or otherwise leaves existing rows/values untouched) and
+// "Unknown" (classifier failed) still render — both have no other
+// graph-level visual treatment.
+// See DRC-3341 spec §Vocabulary and captain visual review notes.
 const CHANGE_CATEGORY_LABELS: Record<ChangeCategory, string | null> = {
   breaking: null,
-  non_breaking: "Non Breaking",
+  non_breaking: "Additive",
   partial_breaking: null,
   unknown: "Unknown",
 };

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -177,18 +177,16 @@ export interface LineageNodeProps {
 // =============================================================================
 
 // "Breaking" / "Partial Breaking" labels are intentionally null. The
-// brown "ALL" badge already carries the whole-model-change signal, and
-// the per-row `~` / `!` glyphs already carry the column-level
-// "changed" / "impacted" signal. Keeping the bottom-row labels for
-// these two categories duplicates the message and clutters the graph.
-// "Additive" (the spec's UI term for `non_breaking` — a change that only
-// adds a column or otherwise leaves existing rows/values untouched) and
-// "Unknown" (classifier failed) still render — both have no other
-// graph-level visual treatment.
+// brown "ALL" badge carries the whole-model-change signal, the per-row
+// `~` / `!` glyphs carry the column-level "changed" / "impacted" signal,
+// and the green "ADD" badge carries the additive-change signal — so the
+// bottom-row labels for those three categories would be redundant. Only
+// "Unknown" (classifier failed) still renders as a label, because there's
+// no other graph-level visual for it.
 // See DRC-3341 spec §Vocabulary and captain visual review notes.
 const CHANGE_CATEGORY_LABELS: Record<ChangeCategory, string | null> = {
   breaking: null,
-  non_breaking: "Additive",
+  non_breaking: null,
   partial_breaking: null,
   unknown: "Unknown",
 };
@@ -579,40 +577,50 @@ function LineageNodeComponent({
               resourceType={resourceType}
             />
 
-            {/* Whole-model badge — same primitive for both source and
-                impacted nodes (Q9: "if you see a badge, look at the color:
-                brown is the cause, amber is the effect"). Persists
-                regardless of hover state so it's readable at zoomed-out
-                lineage view. Source wins (Q11): when both flags are true
-                the brown source treatment dominates, enforced upstream by
-                GraphNodeOss. */}
+            {/* Node badge — one primitive, three colors (Q9 + additive
+                follow-up). Color carries the meaning:
+                  brown ALL = whole-model-changed source (cause)
+                  amber ALL = whole-model impact (effect)
+                  green ADD = additive-only local change (safe)
+                Precedence (strongest wins): source > downstream > additive.
+                Persists regardless of hover so it's readable at zoomed-out
+                lineage view. */}
             {(() => {
+              const isAdditive =
+                changeCategory === "non_breaking" &&
+                !isBreakingSource &&
+                !isWholeModelImpacted;
               const badgeKind = wholeModelTreatmentKind({
                 isBreakingSource,
                 isWholeModelImpactedDownstream: isWholeModelImpacted,
+                isAdditive,
               });
               if (!badgeKind) return null;
               const tokens = wholeModelTreatmentTokens(badgeKind, isDark);
+              const badgeText = badgeKind === "additive" ? "ADD" : "ALL";
+              const tooltipText = {
+                source:
+                  "Whole-model change — every row of this model is potentially affected",
+                downstream:
+                  "Whole-model impact — every column affected by an upstream whole-model change",
+                additive:
+                  "Additive change — adds a column or otherwise leaves existing rows untouched",
+              }[badgeKind];
+              const ariaLabel = {
+                source: "whole-model change",
+                downstream: "whole-model impact",
+                additive: "additive change",
+              }[badgeKind];
+              const testId = {
+                source: "whole-model-source-badge",
+                downstream: "whole-model-impact-badge",
+                additive: "additive-change-badge",
+              }[badgeKind];
               return (
-                <Tooltip
-                  title={
-                    badgeKind === "source"
-                      ? "Whole-model change — every row of this model is potentially affected"
-                      : "Whole-model impact — every column affected by an upstream whole-model change"
-                  }
-                  placement="top"
-                >
+                <Tooltip title={tooltipText} placement="top">
                   <Box
-                    aria-label={
-                      badgeKind === "source"
-                        ? "whole-model change"
-                        : "whole-model impact"
-                    }
-                    data-testid={
-                      badgeKind === "source"
-                        ? "whole-model-source-badge"
-                        : "whole-model-impact-badge"
-                    }
+                    aria-label={ariaLabel}
+                    data-testid={testId}
                     sx={{
                       display: "inline-flex",
                       alignItems: "center",
@@ -629,7 +637,7 @@ function LineageNodeComponent({
                       border: `1px solid ${tokens.badgeBorder}`,
                     }}
                   >
-                    ALL
+                    {badgeText}
                   </Box>
                 </Tooltip>
               );

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -144,10 +144,16 @@ export interface LineageNodeProps {
   /** Whether this node is impacted by CLL analysis */
   isImpacted?: boolean;
   /** Whether this node has *whole-model impact* — every column is affected
-   *  because it sits downstream of a breaking change. Renders a node-level
-   *  badge on top of the impacted treatment so the state is readable at
-   *  zoomed-out lineage view (Q4 #2 of `downstream-of-breaking`). */
+   *  because it sits downstream of a breaking change. Renders an amber
+   *  "ALL" badge so the state is readable at zoomed-out lineage view
+   *  (Q4 #2 / Q8 of `downstream-of-breaking`). Mutually exclusive with
+   *  `isBreakingSource` (Q11 — source wins). */
   isWholeModelImpacted?: boolean;
+  /** Whether this node is itself the *source* of a whole-model change —
+   *  its own `change_category === "breaking"`. Renders a brown "ALL" badge
+   *  (Q9: same primitive, "changed" color). Takes precedence over
+   *  `isWholeModelImpacted` per Q11 ("source wins"). */
+  isBreakingSource?: boolean;
 
   // === Callbacks ===
   /** Callback when node is clicked */
@@ -323,6 +329,7 @@ function LineageNodeComponent({
   newCllExperience: newCllExperienceProp,
   isImpacted: isImpactedProp,
   isWholeModelImpacted = false,
+  isBreakingSource = false,
   // Callbacks
   onNodeClick,
   onNodeDoubleClick,
@@ -558,17 +565,32 @@ function LineageNodeComponent({
               resourceType={resourceType}
             />
 
-            {/* Whole-model impact badge — readable at zoomed-out lineage
-                view, persists regardless of hover state. Reuses the existing
-                CLL impacted accent color (no new color tokens). */}
-            {isWholeModelImpacted && (
+            {/* Whole-model badge — same primitive for both source and
+                impacted nodes (Q9: "if you see a badge, look at the color:
+                brown is the cause, amber is the effect"). Persists
+                regardless of hover state so it's readable at zoomed-out
+                lineage view. Source wins (Q11): when both flags are true
+                the brown source treatment dominates. */}
+            {(isBreakingSource || isWholeModelImpacted) && (
               <Tooltip
-                title="Whole-model impact — every column affected by an upstream breaking change"
+                title={
+                  isBreakingSource
+                    ? "Whole-model change — every row of this model is potentially affected"
+                    : "Whole-model impact — every column affected by an upstream whole-model change"
+                }
                 placement="top"
               >
                 <Box
-                  aria-label="whole-model impact"
-                  data-testid="whole-model-impact-badge"
+                  aria-label={
+                    isBreakingSource
+                      ? "whole-model change"
+                      : "whole-model impact"
+                  }
+                  data-testid={
+                    isBreakingSource
+                      ? "whole-model-source-badge"
+                      : "whole-model-impact-badge"
+                  }
                   sx={{
                     display: "inline-flex",
                     alignItems: "center",
@@ -580,12 +602,32 @@ function LineageNodeComponent({
                     minWidth: 16,
                     px: 0.5,
                     borderRadius: "3px",
-                    color: isDark ? "rgb(252 211 77)" : "rgb(146 64 14)",
-                    backgroundColor: isDark
-                      ? "rgb(180 83 9 / 0.25)"
-                      : "rgb(252 211 77 / 0.35)",
+                    // Brown (changed) for sources, amber (impacted) for
+                    // downstream — Q9/Q10/Q11. Source-wins is enforced by
+                    // GraphNodeOss zeroing out isWholeModelImpacted when
+                    // isBreakingSource is true.
+                    color: isBreakingSource
+                      ? isDark
+                        ? "rgb(255 200 80)"
+                        : "rgb(160 100 0)"
+                      : isDark
+                        ? "rgb(252 211 77)"
+                        : "rgb(146 64 14)",
+                    backgroundColor: isBreakingSource
+                      ? isDark
+                        ? "rgb(255 173 21 / 0.2)"
+                        : "rgb(255 173 21 / 0.25)"
+                      : isDark
+                        ? "rgb(180 83 9 / 0.25)"
+                        : "rgb(252 211 77 / 0.35)",
                     border: `1px solid ${
-                      isDark ? "rgb(180 83 9)" : "rgb(252 211 77)"
+                      isBreakingSource
+                        ? isDark
+                          ? "rgb(212 133 11)"
+                          : "rgb(212 133 11)"
+                        : isDark
+                          ? "rgb(180 83 9)"
+                          : "rgb(252 211 77)"
                     }`,
                   }}
                 >

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -33,6 +33,10 @@ import {
   getIconForResourceType,
   getStyleForImpacted,
 } from "../styles";
+import {
+  wholeModelTreatmentKind,
+  wholeModelTreatmentTokens,
+} from "../wholeModelTreatment";
 
 // =============================================================================
 // TYPES
@@ -578,71 +582,56 @@ function LineageNodeComponent({
                 brown is the cause, amber is the effect"). Persists
                 regardless of hover state so it's readable at zoomed-out
                 lineage view. Source wins (Q11): when both flags are true
-                the brown source treatment dominates. */}
-            {(isBreakingSource || isWholeModelImpacted) && (
-              <Tooltip
-                title={
-                  isBreakingSource
-                    ? "Whole-model change — every row of this model is potentially affected"
-                    : "Whole-model impact — every column affected by an upstream whole-model change"
-                }
-                placement="top"
-              >
-                <Box
-                  aria-label={
-                    isBreakingSource
-                      ? "whole-model change"
-                      : "whole-model impact"
+                the brown source treatment dominates, enforced upstream by
+                GraphNodeOss. */}
+            {(() => {
+              const badgeKind = wholeModelTreatmentKind({
+                isBreakingSource,
+                isWholeModelImpactedDownstream: isWholeModelImpacted,
+              });
+              if (!badgeKind) return null;
+              const tokens = wholeModelTreatmentTokens(badgeKind, isDark);
+              return (
+                <Tooltip
+                  title={
+                    badgeKind === "source"
+                      ? "Whole-model change — every row of this model is potentially affected"
+                      : "Whole-model impact — every column affected by an upstream whole-model change"
                   }
-                  data-testid={
-                    isBreakingSource
-                      ? "whole-model-source-badge"
-                      : "whole-model-impact-badge"
-                  }
-                  sx={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    fontSize: "0.65rem",
-                    fontWeight: 700,
-                    lineHeight: 1,
-                    height: 16,
-                    minWidth: 16,
-                    px: 0.5,
-                    borderRadius: "3px",
-                    // Brown (changed) for sources, amber (impacted) for
-                    // downstream — Q9/Q10/Q11. Source-wins is enforced by
-                    // GraphNodeOss zeroing out isWholeModelImpacted when
-                    // isBreakingSource is true.
-                    color: isBreakingSource
-                      ? isDark
-                        ? "rgb(255 200 80)"
-                        : "rgb(160 100 0)"
-                      : isDark
-                        ? "rgb(252 211 77)"
-                        : "rgb(146 64 14)",
-                    backgroundColor: isBreakingSource
-                      ? isDark
-                        ? "rgb(255 173 21 / 0.2)"
-                        : "rgb(255 173 21 / 0.25)"
-                      : isDark
-                        ? "rgb(180 83 9 / 0.25)"
-                        : "rgb(252 211 77 / 0.35)",
-                    border: `1px solid ${
-                      isBreakingSource
-                        ? isDark
-                          ? "rgb(212 133 11)"
-                          : "rgb(212 133 11)"
-                        : isDark
-                          ? "rgb(180 83 9)"
-                          : "rgb(252 211 77)"
-                    }`,
-                  }}
+                  placement="top"
                 >
-                  ALL
-                </Box>
-              </Tooltip>
-            )}
+                  <Box
+                    aria-label={
+                      badgeKind === "source"
+                        ? "whole-model change"
+                        : "whole-model impact"
+                    }
+                    data-testid={
+                      badgeKind === "source"
+                        ? "whole-model-source-badge"
+                        : "whole-model-impact-badge"
+                    }
+                    sx={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      fontSize: "0.65rem",
+                      fontWeight: 700,
+                      lineHeight: 1,
+                      height: 16,
+                      minWidth: 16,
+                      px: 0.5,
+                      borderRadius: "3px",
+                      color: tokens.fg,
+                      backgroundColor: tokens.badgeBg,
+                      border: `1px solid ${tokens.badgeBorder}`,
+                    }}
+                  >
+                    ALL
+                  </Box>
+                </Tooltip>
+              );
+            })()}
 
             {/* Hover actions vs icons */}
             {isHovered ? (

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -172,10 +172,18 @@ export interface LineageNodeProps {
 // CONSTANTS
 // =============================================================================
 
-const CHANGE_CATEGORY_LABELS: Record<ChangeCategory, string> = {
-  breaking: "Breaking",
+// "Breaking" / "Partial Breaking" labels are intentionally null. The
+// brown "ALL" badge already carries the whole-model-change signal, and
+// the per-row `~` / `!` glyphs already carry the column-level
+// "changed" / "impacted" signal. Keeping the bottom-row labels for
+// these two categories duplicates the message and clutters the graph.
+// "Non Breaking" (additive) and "Unknown" (classifier failed) still
+// render — both have no other graph-level visual treatment.
+// See DRC-3341 captain visual review notes.
+const CHANGE_CATEGORY_LABELS: Record<ChangeCategory, string | null> = {
+  breaking: null,
   non_breaking: "Non Breaking",
-  partial_breaking: "Partial Breaking",
+  partial_breaking: null,
   unknown: "Unknown",
 };
 
@@ -702,7 +710,9 @@ function LineageNodeComponent({
                   <Box sx={{ flexGrow: 1 }} />
                   {actionTag}
                 </>
-              ) : showChangeAnalysis && changeCategory ? (
+              ) : showChangeAnalysis &&
+                changeCategory &&
+                CHANGE_CATEGORY_LABELS[changeCategory] ? (
                 <Typography
                   sx={{
                     height: 20,

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -143,6 +143,11 @@ export interface LineageNodeProps {
   newCllExperience?: boolean;
   /** Whether this node is impacted by CLL analysis */
   isImpacted?: boolean;
+  /** Whether this node has *whole-model impact* — every column is affected
+   *  because it sits downstream of a breaking change. Renders a node-level
+   *  badge on top of the impacted treatment so the state is readable at
+   *  zoomed-out lineage view (Q4 #2 of `downstream-of-breaking`). */
+  isWholeModelImpacted?: boolean;
 
   // === Callbacks ===
   /** Callback when node is clicked */
@@ -317,6 +322,7 @@ function LineageNodeComponent({
   // New CLL experience props (fall back to data for ReactFlow passthrough)
   newCllExperience: newCllExperienceProp,
   isImpacted: isImpactedProp,
+  isWholeModelImpacted = false,
   // Callbacks
   onNodeClick,
   onNodeDoubleClick,
@@ -551,6 +557,42 @@ function LineageNodeComponent({
               color={titleColor}
               resourceType={resourceType}
             />
+
+            {/* Whole-model impact badge — readable at zoomed-out lineage
+                view, persists regardless of hover state. Reuses the existing
+                CLL impacted accent color (no new color tokens). */}
+            {isWholeModelImpacted && (
+              <Tooltip
+                title="Whole-model impact — every column affected by an upstream breaking change"
+                placement="top"
+              >
+                <Box
+                  aria-label="whole-model impact"
+                  data-testid="whole-model-impact-badge"
+                  sx={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: "0.65rem",
+                    fontWeight: 700,
+                    lineHeight: 1,
+                    height: 16,
+                    minWidth: 16,
+                    px: 0.5,
+                    borderRadius: "3px",
+                    color: isDark ? "rgb(252 211 77)" : "rgb(146 64 14)",
+                    backgroundColor: isDark
+                      ? "rgb(180 83 9 / 0.25)"
+                      : "rgb(252 211 77 / 0.35)",
+                    border: `1px solid ${
+                      isDark ? "rgb(180 83 9)" : "rgb(252 211 77)"
+                    }`,
+                  }}
+                >
+                  ALL
+                </Box>
+              </Tooltip>
+            )}
 
             {/* Hover actions vs icons */}
             {isHovered ? (

--- a/js/packages/ui/src/components/lineage/wholeModelTreatment.ts
+++ b/js/packages/ui/src/components/lineage/wholeModelTreatment.ts
@@ -1,16 +1,24 @@
 /**
- * Visual tokens for the DRC-3341 whole-model treatment.
+ * Visual tokens for the DRC-3341 whole-model treatment and the adjacent
+ * additive-change badge.
  *
- * Brown family = the model is itself a whole-model-changed source.
- * Amber family = the model is downstream of a whole-model change.
+ * - Brown family (`"source"`) — model is itself a whole-model-changed
+ *   source. Renders the panel wash, "ALL" badge, and header line.
+ * - Amber family (`"downstream"`) — model is downstream of a whole-model
+ *   change. Same surfaces as source, amber-colored.
+ * - Green family (`"additive"`) — model has an additive-only change
+ *   (per spec §Vocabulary: `non_breaking`). Only renders a small green
+ *   "ADD" badge on the lineage graph node; no sidebar wash or header
+ *   (the per-column green `+` glyph already calls out the added column
+ *   in the schema view).
  *
  * Per Q9 of the spec: "if you see a badge, look at color — brown is the
- * cause, amber is the effect." All sites that render the wash, "ALL" badge,
- * or header line should source their colors from this helper so the brown
- * vs amber split is defined exactly once.
+ * cause, amber is the effect." Green extends that: a safe local addition
+ * that doesn't propagate. Every site that paints these badges sources
+ * its colors from this helper.
  */
 
-export type WholeModelTreatmentKind = "source" | "downstream";
+export type WholeModelTreatmentKind = "source" | "downstream" | "additive";
 
 export interface WholeModelTreatmentTokens {
   /** Sidebar / panel wash background. */
@@ -38,6 +46,20 @@ export function wholeModelTreatmentTokens(
       badgeBorder: "rgb(212 133 11)",
     };
   }
+  if (kind === "additive") {
+    // Reuses the existing `--schema-color-added*` tokens that the per-row
+    // green `+` glyph already uses for added columns in the schema view.
+    // wash* fields are not painted today (additive renders badge-only),
+    // but they're populated for parity with source/downstream so a future
+    // panel-level signal can opt in without changing this contract.
+    return {
+      washBg: "var(--schema-color-added)",
+      washAccent: "var(--schema-color-added-accent)",
+      fg: isDark ? "rgb(80 200 100)" : "rgb(22 110 40)",
+      badgeBg: "rgb(46 160 67 / 0.2)",
+      badgeBorder: isDark ? "rgb(80 200 100)" : "rgb(46 160 67)",
+    };
+  }
   return {
     washBg: "var(--schema-color-impacted)",
     washAccent: "var(--schema-color-impacted-accent)",
@@ -48,19 +70,29 @@ export function wholeModelTreatmentTokens(
 }
 
 /**
- * Resolve the treatment kind from the two mutually-exclusive flags exposed
- * by `LineageViewContext`. Returns `null` when neither applies.
+ * Resolve the badge kind from the mutually-exclusive flags exposed by
+ * `LineageViewContext` + the node's classifier category. Returns `null`
+ * when no badge applies.
  *
- * Q11 source-wins is enforced upstream: a node that is both a source and
- * downstream of another source must arrive with `isBreakingSource=true` and
- * `isWholeModelImpactedDownstream=false`. This helper does NOT re-derive
- * that — it trusts the inputs.
+ * Precedence (strongest signal wins):
+ * 1. `source` — model is itself a whole-model-changed source.
+ * 2. `downstream` — model is downstream of a whole-model change.
+ * 3. `additive` — model's own change is purely additive AND the model is
+ *    not under any whole-model treatment. The brown/amber badges win over
+ *    green: an additive change consumed by a row-tainted upstream is
+ *    still tainted at the row level.
+ *
+ * Q11 source-wins is enforced upstream by the consumer (e.g.
+ * `GraphNodeOss` zeroes `isWholeModelImpactedDownstream` when
+ * `isBreakingSource` is true). This helper trusts the inputs.
  */
 export function wholeModelTreatmentKind(flags: {
   isBreakingSource?: boolean;
   isWholeModelImpactedDownstream?: boolean;
+  isAdditive?: boolean;
 }): WholeModelTreatmentKind | null {
   if (flags.isBreakingSource) return "source";
   if (flags.isWholeModelImpactedDownstream) return "downstream";
+  if (flags.isAdditive) return "additive";
   return null;
 }

--- a/js/packages/ui/src/components/lineage/wholeModelTreatment.ts
+++ b/js/packages/ui/src/components/lineage/wholeModelTreatment.ts
@@ -1,0 +1,66 @@
+/**
+ * Visual tokens for the DRC-3341 whole-model treatment.
+ *
+ * Brown family = the model is itself a whole-model-changed source.
+ * Amber family = the model is downstream of a whole-model change.
+ *
+ * Per Q9 of the spec: "if you see a badge, look at color — brown is the
+ * cause, amber is the effect." All sites that render the wash, "ALL" badge,
+ * or header line should source their colors from this helper so the brown
+ * vs amber split is defined exactly once.
+ */
+
+export type WholeModelTreatmentKind = "source" | "downstream";
+
+export interface WholeModelTreatmentTokens {
+  /** Sidebar / panel wash background. */
+  washBg: string;
+  /** Sidebar / panel wash left-edge accent stripe. */
+  washAccent: string;
+  /** "ALL" badge text + header line text + header line border. */
+  fg: string;
+  /** "ALL" badge background. */
+  badgeBg: string;
+  /** "ALL" badge border. */
+  badgeBorder: string;
+}
+
+export function wholeModelTreatmentTokens(
+  kind: WholeModelTreatmentKind,
+  isDark = false,
+): WholeModelTreatmentTokens {
+  if (kind === "source") {
+    return {
+      washBg: "var(--schema-color-changed)",
+      washAccent: "var(--schema-color-changed-accent)",
+      fg: isDark ? "rgb(255 200 80)" : "rgb(160 100 0)",
+      badgeBg: isDark ? "rgb(255 173 21 / 0.2)" : "rgb(255 173 21 / 0.25)",
+      badgeBorder: "rgb(212 133 11)",
+    };
+  }
+  return {
+    washBg: "var(--schema-color-impacted)",
+    washAccent: "var(--schema-color-impacted-accent)",
+    fg: isDark ? "rgb(252 211 77)" : "rgb(146 64 14)",
+    badgeBg: isDark ? "rgb(180 83 9 / 0.25)" : "rgb(252 211 77 / 0.35)",
+    badgeBorder: isDark ? "rgb(180 83 9)" : "rgb(252 211 77)",
+  };
+}
+
+/**
+ * Resolve the treatment kind from the two mutually-exclusive flags exposed
+ * by `LineageViewContext`. Returns `null` when neither applies.
+ *
+ * Q11 source-wins is enforced upstream: a node that is both a source and
+ * downstream of another source must arrive with `isBreakingSource=true` and
+ * `isWholeModelImpactedDownstream=false`. This helper does NOT re-derive
+ * that — it trusts the inputs.
+ */
+export function wholeModelTreatmentKind(flags: {
+  isBreakingSource?: boolean;
+  isWholeModelImpactedDownstream?: boolean;
+}): WholeModelTreatmentKind | null {
+  if (flags.isBreakingSource) return "source";
+  if (flags.isWholeModelImpactedDownstream) return "downstream";
+  return null;
+}

--- a/js/packages/ui/src/components/schema/SchemaView.tsx
+++ b/js/packages/ui/src/components/schema/SchemaView.tsx
@@ -235,48 +235,16 @@ export function PrivateSchemaView(
     return frozen?.size ? frozen : undefined;
   }, [newCllExperience, lineageViewContext?.impactedColumnIds]);
 
-  // Whole-model treatment (Q4 / Q9-Q11 of the `downstream-of-breaking`
-  // design). Empty Sets when the flag is off — the wash + header simply
-  // do not render in that case.
-  const nodeId = current?.id ?? base?.id;
-  const isBreakingSource = !!(
-    nodeId && lineageViewContext?.breakingSourceNodeIds.has(nodeId)
-  );
-  const isWholeModelImpactedDownstream =
-    !!(nodeId && lineageViewContext?.wholeModelImpactedNodeIds.has(nodeId)) &&
-    !isBreakingSource;
-  // Either treatment requires the wash + header. Source wins (Q11): a node
-  // that is both a source and downstream of another source is rendered as a
-  // source — brown wash + source-flavored header.
-  const showWholeModelTreatment =
-    isBreakingSource || isWholeModelImpactedDownstream;
-  const wholeModelImpactCauses =
-    nodeId && lineageViewContext?.wholeModelImpactCauseMap.get(nodeId);
-  // Multi-ancestor header text (Q7). Sort for stable rendering.
-  const ancestorList: string[] = wholeModelImpactCauses
-    ? [...wholeModelImpactCauses].sort()
-    : [];
-  // Filter out self for the downstream-only narrative (a downstream node
-  // would never be its own cause; this only matters for safety).
-  const downstreamCauses = ancestorList.filter((n) => n !== current?.name);
-  const joinedCauses = downstreamCauses.join(", ");
-  // Per Q7: list all causes by default; fall back to a generic
-  // pluralization when there are >3 ancestors OR the joined name list
-  // exceeds 60 chars (would otherwise break the header layout).
-  const useGenericFallback =
-    downstreamCauses.length > 3 || joinedCauses.length > 60;
-  const downstreamHeaderText = useGenericFallback
-    ? "Whole-model impact — downstream of multiple changes"
-    : `Whole-model impact — downstream of ${joinedCauses}`;
-  const headerText = isBreakingSource
-    ? "Whole-model change in this model"
-    : downstreamHeaderText;
-  // When falling back to generic phrasing, expose the full ancestor list
-  // via the `title` attribute so a hover tooltip is still informative
-  // (Q7 — "names available via hover/expand").
-  const headerTitle = useGenericFallback
-    ? `Closest upstream whole-model changes: ${joinedCauses}`
-    : undefined;
+  // Whole-model treatment (DRC-3341 — `--downstream-of-breaking`). The
+  // wash + header + "ALL" badge moved up to NodeView so they span every
+  // sidebar tab (Lineage / Columns / Code). SchemaView no longer renders
+  // them itself.
+  //
+  // Multi-ancestor list intentionally omitted in v1 — adds visual noise
+  // without clear value. The closest upstream causes are still computed
+  // and exposed via `LineageViewContext.wholeModelImpactCauseMap` for
+  // future use (e.g., a hover tooltip or expandable detail). See Q7 in
+  // the DRC-3341 spec.
 
   const { columns, rows } = useMemo(() => {
     const resourceType = current?.resource_type ?? base?.resource_type;
@@ -431,28 +399,7 @@ export function PrivateSchemaView(
         display: "flex",
         flexDirection: "column",
         height: "100%",
-        // Whole-model wash — covers the entire sidebar so the reviewer
-        // reads "every column here is affected" at a glance, without the
-        // visual noise of N per-row amber rows. Brown for breaking
-        // sources (Q10), amber for downstream-only impacted (Q4 #1).
-        // Reuses existing CLL background tokens (no new color tokens).
-        ...(isBreakingSource && {
-          backgroundColor: "var(--schema-color-changed)",
-          boxShadow: "inset 4px 0 0 var(--schema-color-changed-accent)",
-        }),
-        ...(isWholeModelImpactedDownstream && {
-          backgroundColor: "var(--schema-color-impacted)",
-          boxShadow: "inset 4px 0 0 var(--schema-color-impacted-accent)",
-        }),
       }}
-      className={showWholeModelTreatment ? "cll-experience" : undefined}
-      data-testid={
-        isBreakingSource
-          ? "whole-model-source-wash"
-          : isWholeModelImpactedDownstream
-            ? "whole-model-impact-wash"
-            : undefined
-      }
     >
       {catalogMissingMessage ? (
         <MuiAlert severity="warning" sx={{ fontSize: "12px", p: 1 }}>
@@ -464,31 +411,6 @@ export function PrivateSchemaView(
         </MuiAlert>
       ) : (
         <></>
-      )}
-
-      {showWholeModelTreatment && (
-        <Box
-          data-testid={
-            isBreakingSource
-              ? "whole-model-source-header"
-              : "whole-model-impact-header"
-          }
-          title={headerTitle}
-          sx={{
-            px: 1,
-            py: 0.75,
-            fontSize: "0.75rem",
-            fontWeight: 600,
-            color: isBreakingSource
-              ? "var(--schema-badge-changed-fg, rgb(160 100 0))"
-              : "var(--schema-badge-impacted-fg, rgb(146 64 14))",
-            borderBottom: isBreakingSource
-              ? "1px solid var(--schema-color-changed-accent)"
-              : "1px solid var(--schema-color-impacted-accent)",
-          }}
-        >
-          {headerText}
-        </Box>
       )}
 
       <SchemaLegend />

--- a/js/packages/ui/src/components/schema/SchemaView.tsx
+++ b/js/packages/ui/src/components/schema/SchemaView.tsx
@@ -235,20 +235,48 @@ export function PrivateSchemaView(
     return frozen?.size ? frozen : undefined;
   }, [newCllExperience, lineageViewContext?.impactedColumnIds]);
 
-  // Whole-model impact (downstream of a breaking change). Drives the sidebar
-  // wash + grouping header (Q4 #1 & #3 of the `downstream-of-breaking`
-  // design). Empty Set when the flag is off — the wash + header simply do not
-  // render in that case.
+  // Whole-model treatment (Q4 / Q9-Q11 of the `downstream-of-breaking`
+  // design). Empty Sets when the flag is off — the wash + header simply
+  // do not render in that case.
   const nodeId = current?.id ?? base?.id;
-  const isWholeModelImpacted = !!(
-    nodeId && lineageViewContext?.wholeModelImpactedNodeIds.has(nodeId)
+  const isBreakingSource = !!(
+    nodeId && lineageViewContext?.breakingSourceNodeIds.has(nodeId)
   );
-  const wholeModelImpactCause =
+  const isWholeModelImpactedDownstream =
+    !!(nodeId && lineageViewContext?.wholeModelImpactedNodeIds.has(nodeId)) &&
+    !isBreakingSource;
+  // Either treatment requires the wash + header. Source wins (Q11): a node
+  // that is both a source and downstream of another source is rendered as a
+  // source — brown wash + source-flavored header.
+  const showWholeModelTreatment =
+    isBreakingSource || isWholeModelImpactedDownstream;
+  const wholeModelImpactCauses =
     nodeId && lineageViewContext?.wholeModelImpactCauseMap.get(nodeId);
-  const isOwnBreakingCause =
-    !!wholeModelImpactCause &&
-    !!current?.name &&
-    wholeModelImpactCause === current.name;
+  // Multi-ancestor header text (Q7). Sort for stable rendering.
+  const ancestorList: string[] = wholeModelImpactCauses
+    ? [...wholeModelImpactCauses].sort()
+    : [];
+  // Filter out self for the downstream-only narrative (a downstream node
+  // would never be its own cause; this only matters for safety).
+  const downstreamCauses = ancestorList.filter((n) => n !== current?.name);
+  const joinedCauses = downstreamCauses.join(", ");
+  // Per Q7: list all causes by default; fall back to a generic
+  // pluralization when there are >3 ancestors OR the joined name list
+  // exceeds 60 chars (would otherwise break the header layout).
+  const useGenericFallback =
+    downstreamCauses.length > 3 || joinedCauses.length > 60;
+  const downstreamHeaderText = useGenericFallback
+    ? "Whole-model impact — downstream of multiple changes"
+    : `Whole-model impact — downstream of ${joinedCauses}`;
+  const headerText = isBreakingSource
+    ? "Whole-model change in this model"
+    : downstreamHeaderText;
+  // When falling back to generic phrasing, expose the full ancestor list
+  // via the `title` attribute so a hover tooltip is still informative
+  // (Q7 — "names available via hover/expand").
+  const headerTitle = useGenericFallback
+    ? `Closest upstream whole-model changes: ${joinedCauses}`
+    : undefined;
 
   const { columns, rows } = useMemo(() => {
     const resourceType = current?.resource_type ?? base?.resource_type;
@@ -403,17 +431,28 @@ export function PrivateSchemaView(
         display: "flex",
         flexDirection: "column",
         height: "100%",
-        // Whole-model impact wash — covers the entire sidebar so the reviewer
+        // Whole-model wash — covers the entire sidebar so the reviewer
         // reads "every column here is affected" at a glance, without the
-        // visual noise of N per-row amber rows. Reuses the existing CLL
-        // impacted background tokens (no new colors).
-        ...(isWholeModelImpacted && {
+        // visual noise of N per-row amber rows. Brown for breaking
+        // sources (Q10), amber for downstream-only impacted (Q4 #1).
+        // Reuses existing CLL background tokens (no new color tokens).
+        ...(isBreakingSource && {
+          backgroundColor: "var(--schema-color-changed)",
+          boxShadow: "inset 4px 0 0 var(--schema-color-changed-accent)",
+        }),
+        ...(isWholeModelImpactedDownstream && {
           backgroundColor: "var(--schema-color-impacted)",
           boxShadow: "inset 4px 0 0 var(--schema-color-impacted-accent)",
         }),
       }}
-      className={isWholeModelImpacted ? "cll-experience" : undefined}
-      data-testid={isWholeModelImpacted ? "whole-model-impact-wash" : undefined}
+      className={showWholeModelTreatment ? "cll-experience" : undefined}
+      data-testid={
+        isBreakingSource
+          ? "whole-model-source-wash"
+          : isWholeModelImpactedDownstream
+            ? "whole-model-impact-wash"
+            : undefined
+      }
     >
       {catalogMissingMessage ? (
         <MuiAlert severity="warning" sx={{ fontSize: "12px", p: 1 }}>
@@ -427,21 +466,28 @@ export function PrivateSchemaView(
         <></>
       )}
 
-      {isWholeModelImpacted && (
+      {showWholeModelTreatment && (
         <Box
-          data-testid="whole-model-impact-header"
+          data-testid={
+            isBreakingSource
+              ? "whole-model-source-header"
+              : "whole-model-impact-header"
+          }
+          title={headerTitle}
           sx={{
             px: 1,
             py: 0.75,
             fontSize: "0.75rem",
             fontWeight: 600,
-            color: "var(--schema-badge-impacted-fg, rgb(146 64 14))",
-            borderBottom: "1px solid var(--schema-color-impacted-accent)",
+            color: isBreakingSource
+              ? "var(--schema-badge-changed-fg, rgb(160 100 0))"
+              : "var(--schema-badge-impacted-fg, rgb(146 64 14))",
+            borderBottom: isBreakingSource
+              ? "1px solid var(--schema-color-changed-accent)"
+              : "1px solid var(--schema-color-impacted-accent)",
           }}
         >
-          {isOwnBreakingCause
-            ? "Whole-model impact — breaking change in this model"
-            : `Whole-model impact — downstream of ${wholeModelImpactCause}`}
+          {headerText}
         </Box>
       )}
 

--- a/js/packages/ui/src/components/schema/SchemaView.tsx
+++ b/js/packages/ui/src/components/schema/SchemaView.tsx
@@ -235,6 +235,21 @@ export function PrivateSchemaView(
     return frozen?.size ? frozen : undefined;
   }, [newCllExperience, lineageViewContext?.impactedColumnIds]);
 
+  // Whole-model impact (downstream of a breaking change). Drives the sidebar
+  // wash + grouping header (Q4 #1 & #3 of the `downstream-of-breaking`
+  // design). Empty Set when the flag is off — the wash + header simply do not
+  // render in that case.
+  const nodeId = current?.id ?? base?.id;
+  const isWholeModelImpacted = !!(
+    nodeId && lineageViewContext?.wholeModelImpactedNodeIds.has(nodeId)
+  );
+  const wholeModelImpactCause =
+    nodeId && lineageViewContext?.wholeModelImpactCauseMap.get(nodeId);
+  const isOwnBreakingCause =
+    !!wholeModelImpactCause &&
+    !!current?.name &&
+    wholeModelImpactCause === current.name;
+
   const { columns, rows } = useMemo(() => {
     const resourceType = current?.resource_type ?? base?.resource_type;
     const node =
@@ -383,7 +398,23 @@ export function PrivateSchemaView(
   };
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        // Whole-model impact wash — covers the entire sidebar so the reviewer
+        // reads "every column here is affected" at a glance, without the
+        // visual noise of N per-row amber rows. Reuses the existing CLL
+        // impacted background tokens (no new colors).
+        ...(isWholeModelImpacted && {
+          backgroundColor: "var(--schema-color-impacted)",
+          boxShadow: "inset 4px 0 0 var(--schema-color-impacted-accent)",
+        }),
+      }}
+      className={isWholeModelImpacted ? "cll-experience" : undefined}
+      data-testid={isWholeModelImpacted ? "whole-model-impact-wash" : undefined}
+    >
       {catalogMissingMessage ? (
         <MuiAlert severity="warning" sx={{ fontSize: "12px", p: 1 }}>
           {catalogMissingMessage}
@@ -394,6 +425,24 @@ export function PrivateSchemaView(
         </MuiAlert>
       ) : (
         <></>
+      )}
+
+      {isWholeModelImpacted && (
+        <Box
+          data-testid="whole-model-impact-header"
+          sx={{
+            px: 1,
+            py: 0.75,
+            fontSize: "0.75rem",
+            fontWeight: 600,
+            color: "var(--schema-badge-impacted-fg, rgb(146 64 14))",
+            borderBottom: "1px solid var(--schema-color-impacted-accent)",
+          }}
+        >
+          {isOwnBreakingCause
+            ? "Whole-model impact — breaking change in this model"
+            : `Whole-model impact — downstream of ${wholeModelImpactCause}`}
+        </Box>
       )}
 
       <SchemaLegend />

--- a/js/packages/ui/src/contexts/lineage/types.ts
+++ b/js/packages/ui/src/contexts/lineage/types.ts
@@ -261,16 +261,25 @@ export interface LineageViewContextType {
   /** Frozen set of column IDs that are impacted, same lifecycle as impactedNodeIds. */
   impactedColumnIds: Set<string>;
   /** Frozen set of node IDs that have *whole-model impact* — every column is
-   *  affected because they sit downstream of a breaking change. Populated only
-   *  when the `downstream_of_breaking` server flag is on; otherwise an empty
-   *  Set. Used to drive the node-level mark on the lineage graph and the
-   *  sidebar wash + header.
+   *  affected because they sit downstream of a breaking change (or are
+   *  themselves a breaking source). Populated only when the
+   *  `downstream_of_breaking` server flag is on; otherwise an empty Set.
+   *  Used to drive the amber sidebar wash + node mark on
+   *  downstream-only impacted nodes.
    *  @see computeWholeModelImpact */
   wholeModelImpactedNodeIds: Set<string>;
-  /** For each whole-model-impacted node, the closest upstream breaking
-   *  model's display name. Drives the sidebar header text. Empty Map when
-   *  the flag is off. */
-  wholeModelImpactCauseMap: Map<string, string>;
+  /** Frozen set of node IDs whose own `change_category === "breaking"` — the
+   *  *sources* of whole-model impact waves. Subset of
+   *  `wholeModelImpactedNodeIds`. Drives the brown (changed) treatment per
+   *  Q9/Q10/Q11: a node in this set renders with the brown badge + brown
+   *  wash + source-flavored header even if it is also downstream of another
+   *  breaking source ("source wins"). */
+  breakingSourceNodeIds: Set<string>;
+  /** For each whole-model-impacted node, the set of closest upstream breaking
+   *  model display names (Q7 — multi-ancestor). A breaking-source node maps
+   *  to its own name. Drives the sidebar header text. Empty Map when the
+   *  flag is off. */
+  wholeModelImpactCauseMap: Map<string, Set<string>>;
   /** Set change analysis mode on/off */
   setChangeAnalysisMode: (active: boolean) => void;
 

--- a/js/packages/ui/src/contexts/lineage/types.ts
+++ b/js/packages/ui/src/contexts/lineage/types.ts
@@ -260,6 +260,17 @@ export interface LineageViewContextType {
   impactedNodeIds: Set<string>;
   /** Frozen set of column IDs that are impacted, same lifecycle as impactedNodeIds. */
   impactedColumnIds: Set<string>;
+  /** Frozen set of node IDs that have *whole-model impact* — every column is
+   *  affected because they sit downstream of a breaking change. Populated only
+   *  when the `downstream_of_breaking` server flag is on; otherwise an empty
+   *  Set. Used to drive the node-level mark on the lineage graph and the
+   *  sidebar wash + header.
+   *  @see computeWholeModelImpact */
+  wholeModelImpactedNodeIds: Set<string>;
+  /** For each whole-model-impacted node, the closest upstream breaking
+   *  model's display name. Drives the sidebar header text. Empty Map when
+   *  the flag is off. */
+  wholeModelImpactCauseMap: Map<string, string>;
   /** Set change analysis mode on/off */
   setChangeAnalysisMode: (active: boolean) => void;
 

--- a/js/src/components/lineage/__tests__/GraphNode.test.tsx
+++ b/js/src/components/lineage/__tests__/GraphNode.test.tsx
@@ -250,6 +250,11 @@ const createMockContext = (
   viewOptions: {},
   cll: undefined,
   showColumnLevelLineage: vi.fn(),
+  // CLL impact sets — empty by default. GraphNodeOss reads `.has()` on each
+  // of these to decide whether to render the impacted/whole-model badges.
+  impactedNodeIds: new Set<string>(),
+  wholeModelImpactedNodeIds: new Set<string>(),
+  breakingSourceNodeIds: new Set<string>(),
   ...overrides,
 });
 

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -1212,6 +1212,13 @@ def diff(
     help="Enable the new column-level lineage visual experience.",
     envvar="RECCE_NEW_CLL_EXPERIENCE",
 )
+@click.option(
+    "--downstream-of-breaking",
+    is_flag=True,
+    help="Highlight downstream models impacted by a *breaking* change (red) "
+    "differently from non-breaking impacts (amber). Requires --new-cll-experience.",
+    envvar="RECCE_DOWNSTREAM_OF_BREAKING",
+)
 @add_options(dbt_related_options)
 @add_options(sqlmesh_related_options)
 @add_options(recce_options)
@@ -1281,6 +1288,7 @@ def server(host, port, lifetime, idle_timeout=0, state_file=None, **kwargs):
         "disable_cll_cache": True,
         "impact_at_startup": False,
         "new_cll_experience": False,
+        "downstream_of_breaking": False,
     }
     console = Console()
 
@@ -1332,6 +1340,11 @@ def server(host, port, lifetime, idle_timeout=0, state_file=None, **kwargs):
         flag["impact_at_startup"] = True
 
     if kwargs.get("new_cll_experience", False):
+        flag["new_cll_experience"] = True
+
+    if kwargs.get("downstream_of_breaking", False):
+        # Implies new_cll_experience — the surface lives inside the new CLL UI.
+        flag["downstream_of_breaking"] = True
         flag["new_cll_experience"] = True
 
     # Create state loader using shared function


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`feat` — new CLI flag + new visual treatment in column-level lineage.

**What this PR does / why we need it**

When an upstream model has a change that affects every row (a `WHERE` clause, a `GROUP BY` key, a `JOIN` type change), every column of every downstream model is potentially affected. Today CLL marks all such downstream models with the same generic amber "impacted" treatment as a model touched by a single column-only change — reviewers can't tell which models are *fully* impacted at a glance.

This PR introduces:

- **CLI flag** `--downstream-of-breaking` (env `RECCE_DOWNSTREAM_OF_BREAKING`) that implies `--new-cll-experience`.
- **Two visual treatments** in the new-CLL experience:
  - **Brown** — model is itself a whole-model-changed source. Brown panel wash + brown ALL badge in the sidebar + brown ALL badge on the graph node + `"Whole-model change in this model"` header.
  - **Amber** — model is downstream of a whole-model change. Amber panel wash + amber ALL badge in the sidebar + amber ALL badge on the graph node + `"Whole-model impact"` header.
- **Source-wins** (Q11): a node that is both a whole-model source AND downstream of another whole-model change renders as a source (brown). Enforced in the visual layer.
- **One-place palette** (`wholeModelTreatment.ts`): every site that paints brown or amber pulls from a single helper, so adding a new render site is a one-line lookup.
- **Storybook coverage**: stories for AC-1 (downstream-only), AC-2 (column-only / whole-model / both stacked), AC-4 (pure source + source-also-downstream).

**Which issue(s) this PR fixes**

DRC-3341. Spec: `docs/plans/2026-05-08-DRC-3341-downstream-of-whole-model-change.md`.

**Special notes for your reviewer**

The flag is off by default. With the flag off, CLL behavior is unchanged.

What's deliberately out of scope for v1:
- **Cross-level (Type 2) propagation** — a column-only upstream change consumed by a downstream model in a row-determining clause should also produce whole-model impact, but is deferred. Tracked in DRC-3388. v1 under-reports on these cases.
- **Multi-ancestor list in the header** — when a downstream node has multiple closest whole-model-changed ancestors, the cause map is still computed and exposed via `LineageViewContext.wholeModelImpactCauseMap`, but the sidebar header simply reads `"Whole-model impact"` without listing names. Captain feedback during review: the list added more visual noise than value.
- **Secondary "also downstream of [...]" annotation** on source-also-downstream nodes — spec-optional, not implemented.

Files touched cluster around: `recce/cli.py` (flag scaffolding), `js/packages/ui/src/components/lineage/*` (compute layer + visuals), `js/packages/ui/src/components/schema/SchemaView.tsx` (per-column impacted highlighting), `js/packages/storybook/stories/lineage/WholeModelImpact.stories.tsx` (visual coverage).

**Does this PR introduce a user-facing change?**

Yes.

## release-note
`recce server --downstream-of-breaking\` (also via `RECCE_DOWNSTREAM_OF_BREAKING=1`) opts into a new column-level lineage visual that distinguishes whole-model changes (row-shape edits: WHERE/GROUP BY/JOIN type) from column-only changes. Whole-model-changed source models get a brown wash + ALL badge; their downstream models get an amber wash + ALL badge. Off by default; implies `--new-cll-experience`.

<img width="375" height="253" alt="image" src="https://github.com/user-attachments/assets/4a28ed15-0969-420e-8cfb-04d77b006878" />
<img width="378" height="219" alt="image" src="https://github.com/user-attachments/assets/5b1b86a0-8d26-47c4-85fd-7ce770e99de9" />
<img width="348" height="130" alt="image" src="https://github.com/user-attachments/assets/1750c411-212b-40e6-bd30-bab61190ed9c" />
<img width="561" height="618" alt="image" src="https://github.com/user-attachments/assets/594b4ec9-4073-4e93-8da7-631919ed8e33" />
<img width="561" height="618" alt="image" src="https://github.com/user-attachments/assets/9117b278-d532-473f-97cd-67b5becf3c1a" />



