### PR TITLE
feat(lineage): make Columns the default tab in NodeView

### DIFF
--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -162,7 +162,8 @@ export interface NodeViewProps<
   };
   /**
    * Optional slot rendered as a "Lineage" tab body. When provided, a tab
-   * labeled "Lineage" appears as the FIRST tab (alongside Columns/Code).
+   * labeled "Lineage" appears as the LAST tab (after Columns/Code).
+   * Columns remains the default landing tab.
    * Consumers inject this to expose the focused node's upstream/downstream
    * without coupling NodeView to the lineage graph context.
    */

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -766,11 +766,11 @@ export function NodeView<TNode extends NodeViewNodeData>({
             </Box>
           )}
 
-          {/* Tabs — when lineageTabContent is provided, "Lineage" is index 0 */}
+          {/* Tabs — "Columns" is always index 0 (default landing tab) */}
           {(() => {
-            const lineageTabIndex = lineageTabContent ? 0 : -1;
-            const columnsTabIndex = lineageTabContent ? 1 : 0;
-            const codeTabIndex = lineageTabContent ? 2 : 1;
+            const columnsTabIndex = 0;
+            const codeTabIndex = 1;
+            const lineageTabIndex = lineageTabContent ? 2 : -1;
             return (
               <>
                 <Tabs
@@ -778,7 +778,6 @@ export function NodeView<TNode extends NodeViewNodeData>({
                   onChange={(_, newValue) => setTabValue(newValue)}
                   sx={{ borderBottom: 1, borderColor: "divider" }}
                 >
-                  {lineageTabContent && <Tab label="Lineage" />}
                   <Tab
                     label={
                       <Box
@@ -831,15 +830,11 @@ export function NodeView<TNode extends NodeViewNodeData>({
                       </Box>
                     }
                   />
+                  {lineageTabContent && <Tab label="Lineage" />}
                 </Tabs>
 
                 {/* Tab panels */}
                 <Box sx={{ overflow: "auto", height: "calc(100% - 48px)" }}>
-                  {lineageTabContent && (
-                    <TabPanel value={tabValue} index={lineageTabIndex}>
-                      <Box sx={{ height: "100%" }}>{lineageTabContent}</Box>
-                    </TabPanel>
-                  )}
                   <TabPanel value={tabValue} index={columnsTabIndex}>
                     <Box sx={{ overflowY: "auto", height: "100%" }}>
                       {isSingleEnv
@@ -861,6 +856,11 @@ export function NodeView<TNode extends NodeViewNodeData>({
                       {NodeSqlView && <NodeSqlView node={node} />}
                     </Box>
                   </TabPanel>
+                  {lineageTabContent && (
+                    <TabPanel value={tabValue} index={lineageTabIndex}>
+                      <Box sx={{ height: "100%" }}>{lineageTabContent}</Box>
+                    </TabPanel>
+                  )}
                 </Box>
               </>
             );

--- a/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
@@ -131,4 +131,25 @@ describe("NodeView", () => {
       expect(screen.queryByTestId("schema-view")).not.toBeInTheDocument();
     });
   });
+
+  describe("default landing tab", () => {
+    // DRC-3468: Columns must be the default tab even when lineageTabContent
+    // is provided. Without this assertion, a regression that re-inverts the
+    // tab indices would pass — existing tests only exercise the 2-tab branch.
+    test("lands on Columns (not Lineage) when lineageTabContent is provided", () => {
+      render(
+        <NodeView
+          node={createNode("model", testColumns)}
+          modelDetail={createModelDetail(testColumns)}
+          onCloseNode={vi.fn()}
+          isSingleEnv={false}
+          SchemaView={MockSchemaView}
+          lineageTabContent={<div data-testid="lineage-content">lineage</div>}
+        />,
+      );
+
+      expect(screen.getByTestId("schema-view")).toBeInTheDocument();
+      expect(screen.queryByTestId("lineage-content")).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

UI tweak / small refactor.

**What this PR does / why we need it**:

Reorders the tabs in `NodeView` from **Lineage → Columns → Code** to **Columns → Code → Lineage**, and makes **Columns** the default landing tab.

Rationale (from DRC-3468): users most commonly open a node panel to understand *what changed* (the Columns view). Defaulting to Lineage adds a click for the most common task.

Implementation: `columnsTabIndex` is now always `0`, so the existing `useState(0)` initializer naturally lands on Columns. `lineageTabIndex` shifts to `2` when `lineageTabContent` is provided, otherwise the Lineage tab is not rendered.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

- No test changes: existing `NodeView.test.tsx` cases don't pass `lineageTabContent`, so they exercise the `Columns=0` branch — identical behavior before and after.
- Verified with `pnpm lint:fix`, `pnpm type:check`, and the full `pnpm test` suite (3708 passed).

**Does this PR introduce a user-facing change?**:

\`\`\`release-note
Columns is now the default tab in the node detail panel. New tab order: Columns → Code → Lineage.
\`\`\`