### PR TITLE
feat(storybook): improve NodeView stories with real SchemaView

### DIFF
--- a/js/packages/storybook/.storybook/main.ts
+++ b/js/packages/storybook/.storybook/main.ts
@@ -41,6 +41,7 @@ const config: StorybookConfig = {
       ),
       "@datarecce/ui/advanced": resolve(__dirname, "../../ui/src/advanced.ts"),
       "@datarecce/ui/api": resolve(__dirname, "../../ui/src/api.ts"),
+      "@datarecce/ui/theme": resolve(__dirname, "../../ui/src/theme/index.ts"),
       "@datarecce/ui": resolve(__dirname, "../../ui/src/index.ts"),
     };
 

--- a/js/packages/storybook/.storybook/mocks/handlers.ts
+++ b/js/packages/storybook/.storybook/mocks/handlers.ts
@@ -113,6 +113,20 @@ export const handlers = [
     return HttpResponse.json(response);
   }),
 
+  // Handler for /api/flag endpoint
+  // Used by useRecceServerFlag (e.g. via SchemaView)
+  http.get("/api/flag", () => {
+    return HttpResponse.json({
+      data: {
+        single_env_onboarding: false,
+        show_relaunch_hint: false,
+        disable_cll_cache: false,
+        impact_at_startup: false,
+        new_cll_experience: false,
+      },
+    });
+  }),
+
   // Handler for /api/info endpoint
   // Used by various components to get server info
   http.get("/api/info", () => {

--- a/js/packages/storybook/.storybook/preview.tsx
+++ b/js/packages/storybook/.storybook/preview.tsx
@@ -1,8 +1,6 @@
+import { theme } from "@datarecce/ui/theme";
 import CssBaseline from "@mui/material/CssBaseline";
-import {
-  createTheme,
-  ThemeProvider as MuiThemeProvider,
-} from "@mui/material/styles";
+import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
 import type { Preview } from "@storybook/react-vite";
 import "chartjs-adapter-date-fns";
 import { useEffect } from "react";
@@ -20,17 +18,9 @@ if (typeof window !== "undefined") {
   });
 }
 
-const lightTheme = createTheme({
-  palette: {
-    mode: "light",
-  },
-});
-
-const darkTheme = createTheme({
-  palette: {
-    mode: "dark",
-  },
-});
+// The @datarecce/ui theme uses CSS-variables mode with `colorSchemeSelector:
+// "class"`, so a single theme drives both light and dark modes — the global
+// decorator below toggles the `.dark` class on <html>.
 
 const preview: Preview = {
   parameters: {
@@ -63,15 +53,15 @@ const preview: Preview = {
   decorators: [
     (Story, context) => {
       const isDark = context.globals.theme === "dark";
-      const muiTheme = isDark ? darkTheme : lightTheme;
 
       // Manually manage .dark class on document element for useIsDark() hook
+      // and for the CSS-variables theme's class-based color scheme selector.
       useEffect(() => {
         document.documentElement.classList.toggle("dark", isDark);
       }, [isDark]);
 
       return (
-        <MuiThemeProvider theme={muiTheme}>
+        <MuiThemeProvider theme={theme}>
           <CssBaseline />
           <Story />
         </MuiThemeProvider>

--- a/js/packages/storybook/package.json
+++ b/js/packages/storybook/package.json
@@ -12,7 +12,8 @@
     "test:visual:update": "playwright test --update-snapshots"
   },
   "dependencies": {
-    "@datarecce/ui": "workspace:*"
+    "@datarecce/ui": "workspace:*",
+    "@tanstack/react-query": "^5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",

--- a/js/packages/storybook/stories/lineage/NodeView.stories.tsx
+++ b/js/packages/storybook/stories/lineage/NodeView.stories.tsx
@@ -3,12 +3,13 @@
  * @description Stories for the NodeView component — the node detail sidebar
  * rendered when a user focuses a lineage graph node.
  *
- * Renders the real NodeView and the real SchemaView (ag-grid). SchemaView is
- * wrapped in QueryClientProvider + MockLineageProvider so its server-flag
- * query and lineage context lookups resolve against MSW fixtures. The
- * RowCountDiffTag / RowCountTag / SandboxDialog injection slots take light
- * inline stubs (chips and an empty dialog) so the layout demonstrates the
- * sidebar at parity with production without depending on app-level contexts.
+ * Renders the real NodeView and the real SchemaView (ag-grid), wrapped in
+ * QueryClientProvider + MockLineageProvider so the server-flag query and
+ * lineage context lookups resolve against MSW fixtures. Each story supplies
+ * row-count fixture data via `parameters.mockRunsAggregated`, which the
+ * meta-level decorator threads into `MockLineageProvider` so the production
+ * `RowCountDiffTag` / `RowCountTag` render with realistic values (no
+ * story-side reimplementation of tag visuals).
  */
 
 import type {
@@ -17,8 +18,8 @@ import type {
   NodeViewProps,
   RunTypeIconMap,
 } from "@datarecce/ui/advanced";
-import { NodeView } from "@datarecce/ui/advanced";
-import type { RowCount, RowCountDiff } from "@datarecce/ui/api";
+import { NodeView, RowCountDiffTag, RowCountTag } from "@datarecce/ui/advanced";
+import type { RowCount, RowCountDiff, RunsAggregated } from "@datarecce/ui/api";
 import {
   findByRunType,
   SchemaView,
@@ -26,15 +27,11 @@ import {
 } from "@datarecce/ui/components";
 import { NodeTag } from "@datarecce/ui/primitives";
 import Box from "@mui/material/Box";
-import Chip from "@mui/material/Chip";
 import Paper from "@mui/material/Paper";
-import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ComponentType } from "react";
-import { FiArrowRight } from "react-icons/fi";
-import { RiArrowDownSFill, RiArrowUpSFill, RiSwapLine } from "react-icons/ri";
 import { fn } from "storybook/test";
 import { MockLineageProvider } from "../mocks/MockProviders";
 
@@ -97,122 +94,42 @@ function StubSandboxDialog() {
   return null;
 }
 
-// =============================================================================
-// ROW-COUNT TAG STUB FACTORIES
-// =============================================================================
-// Production RowCountDiffTag / RowCountTag read from runsAggregated context.
-// In stories we close over fixture data so the chip renders without wiring up
-// a real run-results context.
-
-function makeRowCountDiffTag(
-  rowCount?: RowCountDiff,
-): ComponentType<{ node: NodeViewNodeData; onRefresh?: () => void }> {
-  return function StubRowCountDiffTag() {
-    if (!rowCount) {
-      return <Chip size="small" variant="outlined" label="row count" />;
-    }
-    const { base, curr } = rowCount;
-    const baseLabel = base === null ? "N/A" : `${base} rows`;
-    const currLabel = curr === null ? "N/A" : `${curr} rows`;
-
-    let content: React.ReactNode;
-    if (base === null && curr === null) {
-      content = <span>Failed to load</span>;
-    } else if (base === null || curr === null) {
-      content = (
-        <Stack
-          component="span"
-          direction="row"
-          spacing={0.5}
-          sx={{ alignItems: "center" }}
-        >
-          <span>{baseLabel}</span>
-          <FiArrowRight />
-          <span>{currLabel}</span>
-        </Stack>
-      );
-    } else if (base === curr) {
-      content = (
-        <Stack
-          component="span"
-          direction="row"
-          spacing={0.5}
-          sx={{ alignItems: "center" }}
-        >
-          <span>{currLabel}</span>
-          <Box component="span" sx={{ color: "grey.500", display: "flex" }}>
-            <RiSwapLine />
-          </Box>
-        </Stack>
-      );
-    } else {
-      const Arrow = base < curr ? RiArrowUpSFill : RiArrowDownSFill;
-      const tone = base < curr ? "success.main" : "error.main";
-      const pct = Math.round(((curr - base) / base) * 100);
-      content = (
-        <Stack
-          component="span"
-          direction="row"
-          spacing={0.5}
-          sx={{ alignItems: "center" }}
-        >
-          <span>{currLabel}</span>
-          <Box component="span" sx={{ color: tone, display: "flex" }}>
-            <Arrow />
-          </Box>
-          <Box component="span" sx={{ color: tone }}>
-            {pct > 0 ? "+" : ""}
-            {pct}%
-          </Box>
-        </Stack>
-      );
-    }
-    return <Chip size="small" variant="outlined" label={content} />;
-  };
-}
-
-function makeRowCountTag(
-  rowCount?: RowCount,
-): ComponentType<{ node: NodeViewNodeData; onRefresh?: () => void }> {
-  return function StubRowCountTag() {
-    if (!rowCount) {
-      return <Chip size="small" variant="outlined" label="row count" />;
-    }
-    const label = rowCount.curr === null ? "N/A" : `${rowCount.curr} rows`;
-    return <Chip size="small" variant="outlined" label={label} />;
-  };
-}
+// Real `RowCountDiffTag` / `RowCountTag` are typed against `LineageGraphNode`
+// (full lineage shape). The story uses the lighter `NodeViewNodeData` for its
+// fixture nodes. The real components only read `node.id`, so this cast is
+// sound — the runtime contract is satisfied by the story fixtures.
+type NodeTagComponent = ComponentType<{
+  node: NodeViewNodeData;
+  onRefresh?: () => void;
+}>;
+const RealRowCountDiffTag = RowCountDiffTag as unknown as NodeTagComponent;
+const RealRowCountTag = RowCountTag as unknown as NodeTagComponent;
 
 // =============================================================================
 // FIXTURE FACTORY
 // =============================================================================
 
-function createStoryArgs(
-  overrides: {
-    baseColumns?: Record<string, { name: string; type: string }>;
-    currentColumns?: Record<string, { name: string; type: string }>;
-    baseCode?: string;
-    currentCode?: string;
-    name?: string;
-    resourceType?: string;
-    changeStatus?: string;
-    materialized?: string;
-    baseMaterialized?: string;
-    rowCountDiff?: RowCountDiff;
-    rowCount?: RowCount;
-  } = {},
-): {
+interface FixtureOverrides {
+  baseColumns?: Record<string, { name: string; type: string }>;
+  currentColumns?: Record<string, { name: string; type: string }>;
+  baseCode?: string;
+  currentCode?: string;
+  name?: string;
+  resourceType?: string;
+  changeStatus?: string;
+  materialized?: string;
+  baseMaterialized?: string;
+  rowCountDiff?: RowCountDiff;
+  rowCount?: RowCount;
+}
+
+interface Fixture {
   node: NodeViewNodeData;
   modelDetail: NodeViewProps["modelDetail"];
-  RowCountDiffTag: ComponentType<{
-    node: NodeViewNodeData;
-    onRefresh?: () => void;
-  }>;
-  RowCountTag: ComponentType<{
-    node: NodeViewNodeData;
-    onRefresh?: () => void;
-  }>;
-} {
+  runsAggregated?: RunsAggregated;
+}
+
+function buildFixture(overrides: FixtureOverrides = {}): Fixture {
   const baseMat = overrides.baseMaterialized ?? overrides.materialized;
   const baseConfig = baseMat ? { materialized: baseMat } : undefined;
   const currentConfig = overrides.materialized
@@ -259,11 +176,47 @@ function createStoryArgs(
     },
   };
 
+  // Build the runsAggregated entry keyed by node.id only if the story
+  // supplied row-count fixture data. The real RowCountDiffTag / RowCountTag
+  // read these slots directly from LineageGraphProvider's `runsAggregated`.
+  // `value_diff` is required by the RunsAggregated type but the row-count tags
+  // never read it — pass an empty result.
+  let runsAggregated: RunsAggregated | undefined;
+  if (overrides.rowCountDiff || overrides.rowCount) {
+    runsAggregated = {
+      [node.id]: {
+        row_count_diff: {
+          run_id: "story-row-count-diff",
+          result: overrides.rowCountDiff,
+        },
+        row_count: {
+          run_id: "story-row-count",
+          result: overrides.rowCount,
+        },
+        value_diff: {
+          run_id: "story-value-diff",
+          result: undefined,
+        },
+      },
+    };
+  }
+
+  return { node, modelDetail, runsAggregated };
+}
+
+/**
+ * Build a complete Story from fixture overrides and optional NodeView arg
+ * overrides. Splits row-count data into `parameters.mockRunsAggregated` so
+ * the meta-level decorator can plumb it into `MockLineageProvider`.
+ */
+function makeStory(
+  overrides: FixtureOverrides,
+  argOverrides: Partial<NodeViewProps> = {},
+): Story {
+  const { node, modelDetail, runsAggregated } = buildFixture(overrides);
   return {
-    node,
-    modelDetail,
-    RowCountDiffTag: makeRowCountDiffTag(overrides.rowCountDiff),
-    RowCountTag: makeRowCountTag(overrides.rowCount),
+    args: { node, modelDetail, ...argOverrides },
+    parameters: { mockRunsAggregated: runsAggregated },
   };
 }
 
@@ -299,28 +252,33 @@ const meta: Meta<typeof NodeView> = {
     docs: {
       description: {
         component:
-          "Node detail sidebar — header row (name, action buttons, close), tags row (resource type, row count), action buttons for diffs/queries, and tabbed Columns/Code content. Renders the real NodeView and real SchemaView. Story is wrapped in QueryClientProvider + MockLineageProvider so SchemaView's server-flag query and lineage lookups resolve against MSW fixtures.",
+          "Node detail sidebar — header row (name, action buttons, close), tags row (resource type, row count), action buttons for diffs/queries, and tabbed Columns/Code content. Renders the real NodeView, SchemaView, RowCountDiffTag, and RowCountTag. Story is wrapped in QueryClientProvider + MockLineageProvider so SchemaView's server-flag query and the row-count tags' lineage lookups resolve against MSW fixtures.",
       },
     },
   },
   decorators: [
-    (Story) => (
-      <QueryClientProvider client={queryClient}>
-        <MockLineageProvider>
-          <Paper
-            elevation={2}
-            sx={{
-              width: 560,
-              height: 640,
-              overflow: "hidden",
-              borderRadius: 1,
-            }}
-          >
-            <Story />
-          </Paper>
-        </MockLineageProvider>
-      </QueryClientProvider>
-    ),
+    (Story, context) => {
+      const runsAggregated = context.parameters.mockRunsAggregated as
+        | RunsAggregated
+        | undefined;
+      return (
+        <QueryClientProvider client={queryClient}>
+          <MockLineageProvider runsAggregated={runsAggregated}>
+            <Paper
+              elevation={2}
+              sx={{
+                width: 560,
+                height: 640,
+                overflow: "hidden",
+                borderRadius: 1,
+              }}
+            >
+              <Story />
+            </Paper>
+          </MockLineageProvider>
+        </QueryClientProvider>
+      );
+    },
   ],
   args: {
     onCloseNode: fn(),
@@ -329,6 +287,8 @@ const meta: Meta<typeof NodeView> = {
     SingleEnvSchemaView,
     NodeSqlView: StubNodeSqlView,
     ResourceTypeTag,
+    RowCountDiffTag: RealRowCountDiffTag,
+    RowCountTag: RealRowCountTag,
     SandboxDialog: StubSandboxDialog,
     runTypeIcons,
     actionCallbacks: noopCallbacks,
@@ -346,100 +306,77 @@ type Story = StoryObj<typeof NodeView>;
  * Default: matches the production sidebar for a table-materialized model in
  * multi-env mode with row-count data available.
  */
-export const Default: Story = {
-  args: {
-    ...createStoryArgs({
-      name: "finance_revenue",
-      materialized: "table",
-      rowCountDiff: { base: null, curr: 280844 },
-      baseColumns: {
-        order_id: { name: "order_id", type: "integer" },
-        customer_id: { name: "customer_id", type: "integer" },
-        revenue: { name: "revenue", type: "numeric" },
-      },
-      currentColumns: {
-        order_id: { name: "order_id", type: "integer" },
-        customer_id: { name: "customer_id", type: "integer" },
-        revenue: { name: "revenue", type: "numeric" },
-        status: { name: "status", type: "varchar" },
-      },
-    }),
+export const Default: Story = makeStory({
+  name: "finance_revenue",
+  materialized: "table",
+  rowCountDiff: { base: null, curr: 280844 },
+  baseColumns: {
+    order_id: { name: "order_id", type: "integer" },
+    customer_id: { name: "customer_id", type: "integer" },
+    revenue: { name: "revenue", type: "numeric" },
   },
-};
+  currentColumns: {
+    order_id: { name: "order_id", type: "integer" },
+    customer_id: { name: "customer_id", type: "integer" },
+    revenue: { name: "revenue", type: "numeric" },
+    status: { name: "status", type: "varchar" },
+  },
+});
 
 /** No row count data yet — Row Count tag shows just "row count". */
-export const NoRowCountData: Story = {
-  args: {
-    ...createStoryArgs({ name: "finance_revenue", materialized: "table" }),
-  },
-};
+export const NoRowCountData: Story = makeStory({
+  name: "finance_revenue",
+  materialized: "table",
+});
 
 /** View materialization (instead of table). */
-export const ViewMaterialization: Story = {
-  args: {
-    ...createStoryArgs({
-      name: "stg_customers",
-      materialized: "view",
-      rowCountDiff: { base: 1000, curr: 1200 },
-    }),
-  },
-};
+export const ViewMaterialization: Story = makeStory({
+  name: "stg_customers",
+  materialized: "view",
+  rowCountDiff: { base: 1000, curr: 1200 },
+});
 
 /** Single env mode — fewer buttons, no "Diff" section. */
-export const SingleEnvMode: Story = {
-  args: {
-    isSingleEnv: true,
-    ...createStoryArgs({
-      name: "stg_orders",
-      materialized: "table",
-      rowCount: { curr: 99231 },
-      baseCode: "SELECT 1",
-      currentCode: "SELECT 2",
-    }),
+export const SingleEnvMode: Story = makeStory(
+  {
+    name: "stg_orders",
+    materialized: "table",
+    rowCount: { curr: 99231 },
+    baseCode: "SELECT 1",
+    currentCode: "SELECT 2",
   },
-};
+  { isSingleEnv: true },
+);
 
 /** Schema changed — dot indicator on Columns tab, added/removed rows highlighted. */
-export const SchemaChanged: Story = {
-  args: {
-    ...createStoryArgs({
-      name: "stg_orders",
-      materialized: "table",
-      rowCountDiff: { base: 99000, curr: 99231 },
-      baseColumns: {
-        order_id: { name: "order_id", type: "integer" },
-      },
-      currentColumns: {
-        order_id: { name: "order_id", type: "integer" },
-        status: { name: "status", type: "varchar" },
-      },
-    }),
+export const SchemaChanged: Story = makeStory({
+  name: "stg_orders",
+  materialized: "table",
+  rowCountDiff: { base: 99000, curr: 99231 },
+  baseColumns: {
+    order_id: { name: "order_id", type: "integer" },
   },
-};
+  currentColumns: {
+    order_id: { name: "order_id", type: "integer" },
+    status: { name: "status", type: "varchar" },
+  },
+});
 
 /** Code changed — dot indicator on Code tab. */
-export const CodeChanged: Story = {
-  args: {
-    ...createStoryArgs({
-      name: "stg_orders",
-      materialized: "table",
-      changeStatus: "modified",
-      rowCountDiff: { base: 99000, curr: 99231 },
-      baseCode: "SELECT * FROM raw.orders",
-      currentCode: "SELECT * FROM raw.orders WHERE status != 'deleted'",
-    }),
-  },
-};
+export const CodeChanged: Story = makeStory({
+  name: "stg_orders",
+  materialized: "table",
+  changeStatus: "modified",
+  rowCountDiff: { base: 99000, curr: 99231 },
+  baseCode: "SELECT * FROM raw.orders",
+  currentCode: "SELECT * FROM raw.orders WHERE status != 'deleted'",
+});
 
 /** Materialization changed (view → table). */
-export const MaterializationChanged: Story = {
-  args: {
-    ...createStoryArgs({
-      name: "stg_orders",
-      baseMaterialized: "view",
-      materialized: "table",
-      changeStatus: "modified",
-      rowCountDiff: { base: 1000, curr: 1200 },
-    }),
-  },
-};
+export const MaterializationChanged: Story = makeStory({
+  name: "stg_orders",
+  baseMaterialized: "view",
+  materialized: "table",
+  changeStatus: "modified",
+  rowCountDiff: { base: 1000, curr: 1200 },
+});

--- a/js/packages/storybook/stories/lineage/NodeView.stories.tsx
+++ b/js/packages/storybook/stories/lineage/NodeView.stories.tsx
@@ -1,41 +1,64 @@
-import type {
-  NodeViewNodeData,
-  NodeViewProps,
-  SchemaViewProps,
-} from "@datarecce/ui/advanced";
-import { NodeView } from "@datarecce/ui/advanced";
-import { NodeTag } from "@datarecce/ui/primitives";
-import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
-import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
-
 /**
  * @file NodeView.stories.tsx
- * @description Stories for the NodeView component, focusing on the
- * tab change indicators (blue dot on Columns/Code tabs when diffs exist).
+ * @description Stories for the NodeView component — the node detail sidebar
+ * rendered when a user focuses a lineage graph node.
+ *
+ * Renders the real NodeView and the real SchemaView (ag-grid). SchemaView is
+ * wrapped in QueryClientProvider + MockLineageProvider so its server-flag
+ * query and lineage context lookups resolve against MSW fixtures. The
+ * RowCountDiffTag / RowCountTag / SandboxDialog injection slots take light
+ * inline stubs (chips and an empty dialog) so the layout demonstrates the
+ * sidebar at parity with production without depending on app-level contexts.
  */
+
+import type {
+  NodeViewActionCallbacks,
+  NodeViewNodeData,
+  NodeViewProps,
+  RunTypeIconMap,
+} from "@datarecce/ui/advanced";
+import { NodeView } from "@datarecce/ui/advanced";
+import type { RowCount, RowCountDiff } from "@datarecce/ui/api";
+import {
+  findByRunType,
+  SchemaView,
+  SingleEnvSchemaView,
+} from "@datarecce/ui/components";
+import { NodeTag } from "@datarecce/ui/primitives";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ComponentType } from "react";
+import { FiArrowRight } from "react-icons/fi";
+import { RiArrowDownSFill, RiArrowUpSFill, RiSwapLine } from "react-icons/ri";
+import { fn } from "storybook/test";
+import { MockLineageProvider } from "../mocks/MockProviders";
+
+// =============================================================================
+// REAL REGISTRY ICONS (no stubbing)
+// =============================================================================
+
+const runTypeIcons: RunTypeIconMap = {
+  query: findByRunType("query").icon,
+  row_count: findByRunType("row_count").icon,
+  row_count_diff: findByRunType("row_count_diff").icon,
+  profile: findByRunType("profile").icon,
+  profile_diff: findByRunType("profile_diff").icon,
+  query_diff: findByRunType("query_diff").icon,
+  value_diff: findByRunType("value_diff").icon,
+  top_k_diff: findByRunType("top_k_diff").icon,
+  histogram_diff: findByRunType("histogram_diff").icon,
+  schema_diff: findByRunType("schema_diff").icon,
+  sandbox: findByRunType("sandbox").icon,
+};
 
 // =============================================================================
 // STUB COMPONENTS
 // =============================================================================
-
-function StubSchemaView({ base, current }: SchemaViewProps) {
-  return (
-    <Box sx={{ p: 2 }}>
-      <Typography
-        variant="body2"
-        sx={{
-          color: "text.secondary",
-        }}
-      >
-        Schema diff view — base has{" "}
-        {base?.columns ? Object.keys(base.columns).length : 0} columns, current
-        has {current?.columns ? Object.keys(current.columns).length : 0} columns
-      </Typography>
-    </Box>
-  );
-}
 
 function StubNodeSqlView({
   modelDetail,
@@ -59,6 +82,7 @@ function StubNodeSqlView({
   );
 }
 
+/** Real `NodeTag` from primitives — no stubbing. */
 function ResourceTypeTag({ node }: { node: NodeViewNodeData }) {
   return (
     <NodeTag
@@ -68,8 +92,99 @@ function ResourceTypeTag({ node }: { node: NodeViewNodeData }) {
   );
 }
 
+/** Empty Sandbox dialog stub. Story never opens the sandbox. */
+function StubSandboxDialog() {
+  return null;
+}
+
 // =============================================================================
-// FIXTURE FACTORIES
+// ROW-COUNT TAG STUB FACTORIES
+// =============================================================================
+// Production RowCountDiffTag / RowCountTag read from runsAggregated context.
+// In stories we close over fixture data so the chip renders without wiring up
+// a real run-results context.
+
+function makeRowCountDiffTag(
+  rowCount?: RowCountDiff,
+): ComponentType<{ node: NodeViewNodeData; onRefresh?: () => void }> {
+  return function StubRowCountDiffTag() {
+    if (!rowCount) {
+      return <Chip size="small" variant="outlined" label="row count" />;
+    }
+    const { base, curr } = rowCount;
+    const baseLabel = base === null ? "N/A" : `${base} rows`;
+    const currLabel = curr === null ? "N/A" : `${curr} rows`;
+
+    let content: React.ReactNode;
+    if (base === null && curr === null) {
+      content = <span>Failed to load</span>;
+    } else if (base === null || curr === null) {
+      content = (
+        <Stack
+          component="span"
+          direction="row"
+          spacing={0.5}
+          sx={{ alignItems: "center" }}
+        >
+          <span>{baseLabel}</span>
+          <FiArrowRight />
+          <span>{currLabel}</span>
+        </Stack>
+      );
+    } else if (base === curr) {
+      content = (
+        <Stack
+          component="span"
+          direction="row"
+          spacing={0.5}
+          sx={{ alignItems: "center" }}
+        >
+          <span>{currLabel}</span>
+          <Box component="span" sx={{ color: "grey.500", display: "flex" }}>
+            <RiSwapLine />
+          </Box>
+        </Stack>
+      );
+    } else {
+      const Arrow = base < curr ? RiArrowUpSFill : RiArrowDownSFill;
+      const tone = base < curr ? "success.main" : "error.main";
+      const pct = Math.round(((curr - base) / base) * 100);
+      content = (
+        <Stack
+          component="span"
+          direction="row"
+          spacing={0.5}
+          sx={{ alignItems: "center" }}
+        >
+          <span>{currLabel}</span>
+          <Box component="span" sx={{ color: tone, display: "flex" }}>
+            <Arrow />
+          </Box>
+          <Box component="span" sx={{ color: tone }}>
+            {pct > 0 ? "+" : ""}
+            {pct}%
+          </Box>
+        </Stack>
+      );
+    }
+    return <Chip size="small" variant="outlined" label={content} />;
+  };
+}
+
+function makeRowCountTag(
+  rowCount?: RowCount,
+): ComponentType<{ node: NodeViewNodeData; onRefresh?: () => void }> {
+  return function StubRowCountTag() {
+    if (!rowCount) {
+      return <Chip size="small" variant="outlined" label="row count" />;
+    }
+    const label = rowCount.curr === null ? "N/A" : `${rowCount.curr} rows`;
+    return <Chip size="small" variant="outlined" label={label} />;
+  };
+}
+
+// =============================================================================
+// FIXTURE FACTORY
 // =============================================================================
 
 function createStoryArgs(
@@ -83,19 +198,33 @@ function createStoryArgs(
     changeStatus?: string;
     materialized?: string;
     baseMaterialized?: string;
+    rowCountDiff?: RowCountDiff;
+    rowCount?: RowCount;
   } = {},
-): { node: NodeViewNodeData; modelDetail: NodeViewProps["modelDetail"] } {
+): {
+  node: NodeViewNodeData;
+  modelDetail: NodeViewProps["modelDetail"];
+  RowCountDiffTag: ComponentType<{
+    node: NodeViewNodeData;
+    onRefresh?: () => void;
+  }>;
+  RowCountTag: ComponentType<{
+    node: NodeViewNodeData;
+    onRefresh?: () => void;
+  }>;
+} {
   const baseMat = overrides.baseMaterialized ?? overrides.materialized;
   const baseConfig = baseMat ? { materialized: baseMat } : undefined;
   const currentConfig = overrides.materialized
     ? { materialized: overrides.materialized }
     : undefined;
+  const resourceType = overrides.resourceType ?? "model";
 
   const node: NodeViewNodeData = {
-    id: "model.jaffle_shop.stg_orders",
+    id: `model.jaffle_shop.${overrides.name ?? "stg_orders"}`,
     data: {
       name: overrides.name ?? "stg_orders",
-      resourceType: overrides.resourceType ?? "model",
+      resourceType,
       changeStatus: overrides.changeStatus,
       materialized: overrides.materialized,
     },
@@ -103,9 +232,10 @@ function createStoryArgs(
 
   const modelDetail: NodeViewProps["modelDetail"] = {
     base: {
-      id: "stg_orders",
-      unique_id: "model.jaffle_shop.stg_orders",
-      name: "stg_orders",
+      id: node.id,
+      unique_id: node.id,
+      name: node.data.name,
+      resource_type: resourceType,
       raw_code: overrides.baseCode ?? "SELECT * FROM raw.orders",
       columns: overrides.baseColumns ?? {
         order_id: { name: "order_id", type: "integer" },
@@ -115,9 +245,10 @@ function createStoryArgs(
       config: baseConfig,
     },
     current: {
-      id: "stg_orders",
-      unique_id: "model.jaffle_shop.stg_orders",
-      name: "stg_orders",
+      id: node.id,
+      unique_id: node.id,
+      name: node.data.name,
+      resource_type: resourceType,
       raw_code: overrides.currentCode ?? "SELECT * FROM raw.orders",
       columns: overrides.currentColumns ?? {
         order_id: { name: "order_id", type: "integer" },
@@ -128,12 +259,37 @@ function createStoryArgs(
     },
   };
 
-  return { node, modelDetail };
+  return {
+    node,
+    modelDetail,
+    RowCountDiffTag: makeRowCountDiffTag(overrides.rowCountDiff),
+    RowCountTag: makeRowCountTag(overrides.rowCount),
+  };
 }
+
+const noopCallbacks: NodeViewActionCallbacks = {
+  onQueryClick: fn(),
+  onRowCountClick: fn(),
+  onRowCountDiffClick: fn(),
+  onProfileClick: fn(),
+  onProfileDiffClick: fn(),
+  onQueryDiffClick: fn(),
+  onValueDiffClick: fn(),
+  onTopKDiffClick: fn(),
+  onHistogramDiffClick: fn(),
+  onAddSchemaDiffClick: fn(),
+  onSandboxClick: fn(),
+};
 
 // =============================================================================
 // META
 // =============================================================================
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, staleTime: Infinity },
+  },
+});
 
 const meta: Meta<typeof NodeView> = {
   title: "Lineage/NodeView",
@@ -143,23 +299,39 @@ const meta: Meta<typeof NodeView> = {
     docs: {
       description: {
         component:
-          "Node detail panel showing Columns and Code tabs. A blue dot indicator appears on each tab when that view has differences between base and current environments.",
+          "Node detail sidebar — header row (name, action buttons, close), tags row (resource type, row count), action buttons for diffs/queries, and tabbed Columns/Code content. Renders the real NodeView and real SchemaView. Story is wrapped in QueryClientProvider + MockLineageProvider so SchemaView's server-flag query and lineage lookups resolve against MSW fixtures.",
       },
     },
   },
   decorators: [
     (Story) => (
-      <Box sx={{ width: 400, height: 500, border: 1, borderColor: "divider" }}>
-        <Story />
-      </Box>
+      <QueryClientProvider client={queryClient}>
+        <MockLineageProvider>
+          <Paper
+            elevation={2}
+            sx={{
+              width: 560,
+              height: 640,
+              overflow: "hidden",
+              borderRadius: 1,
+            }}
+          >
+            <Story />
+          </Paper>
+        </MockLineageProvider>
+      </QueryClientProvider>
     ),
   ],
   args: {
     onCloseNode: fn(),
     isSingleEnv: false,
-    SchemaView: StubSchemaView,
+    SchemaView,
+    SingleEnvSchemaView,
     NodeSqlView: StubNodeSqlView,
     ResourceTypeTag,
+    SandboxDialog: StubSandboxDialog,
+    runTypeIcons,
+    actionCallbacks: noopCallbacks,
   },
 };
 
@@ -170,103 +342,104 @@ type Story = StoryObj<typeof NodeView>;
 // STORIES
 // =============================================================================
 
-/** No differences in schema or code — no dots shown on either tab. */
-export const NoDifferences: Story = {
-  args: {
-    ...createStoryArgs({ materialized: "view" }),
-  },
-};
-
-/** Both schema and code have changed — dots on both tabs. */
-export const BothChanged: Story = {
+/**
+ * Default: matches the production sidebar for a table-materialized model in
+ * multi-env mode with row-count data available.
+ */
+export const Default: Story = {
   args: {
     ...createStoryArgs({
+      name: "finance_revenue",
+      materialized: "table",
+      rowCountDiff: { base: null, curr: 280844 },
       baseColumns: {
         order_id: { name: "order_id", type: "integer" },
         customer_id: { name: "customer_id", type: "integer" },
+        revenue: { name: "revenue", type: "numeric" },
       },
       currentColumns: {
         order_id: { name: "order_id", type: "integer" },
         customer_id: { name: "customer_id", type: "integer" },
-        status: { name: "status", type: "varchar" },
-      },
-      baseCode: "SELECT id, customer_id FROM raw.orders",
-      currentCode: "SELECT id, customer_id, status FROM raw.orders",
-    }),
-  },
-};
-
-/** Only schema changed (column added) — dot on Columns tab only. */
-export const SchemaChangedOnly: Story = {
-  args: {
-    ...createStoryArgs({
-      baseColumns: {
-        order_id: { name: "order_id", type: "integer" },
-      },
-      currentColumns: {
-        order_id: { name: "order_id", type: "integer" },
+        revenue: { name: "revenue", type: "numeric" },
         status: { name: "status", type: "varchar" },
       },
     }),
   },
 };
 
-/** Only code changed — dot on Code tab only. */
-export const CodeChangedOnly: Story = {
+/** No row count data yet — Row Count tag shows just "row count". */
+export const NoRowCountData: Story = {
+  args: {
+    ...createStoryArgs({ name: "finance_revenue", materialized: "table" }),
+  },
+};
+
+/** View materialization (instead of table). */
+export const ViewMaterialization: Story = {
   args: {
     ...createStoryArgs({
+      name: "stg_customers",
+      materialized: "view",
+      rowCountDiff: { base: 1000, curr: 1200 },
+    }),
+  },
+};
+
+/** Single env mode — fewer buttons, no "Diff" section. */
+export const SingleEnvMode: Story = {
+  args: {
+    isSingleEnv: true,
+    ...createStoryArgs({
+      name: "stg_orders",
+      materialized: "table",
+      rowCount: { curr: 99231 },
+      baseCode: "SELECT 1",
+      currentCode: "SELECT 2",
+    }),
+  },
+};
+
+/** Schema changed — dot indicator on Columns tab, added/removed rows highlighted. */
+export const SchemaChanged: Story = {
+  args: {
+    ...createStoryArgs({
+      name: "stg_orders",
+      materialized: "table",
+      rowCountDiff: { base: 99000, curr: 99231 },
+      baseColumns: {
+        order_id: { name: "order_id", type: "integer" },
+      },
+      currentColumns: {
+        order_id: { name: "order_id", type: "integer" },
+        status: { name: "status", type: "varchar" },
+      },
+    }),
+  },
+};
+
+/** Code changed — dot indicator on Code tab. */
+export const CodeChanged: Story = {
+  args: {
+    ...createStoryArgs({
+      name: "stg_orders",
+      materialized: "table",
+      changeStatus: "modified",
+      rowCountDiff: { base: 99000, curr: 99231 },
       baseCode: "SELECT * FROM raw.orders",
       currentCode: "SELECT * FROM raw.orders WHERE status != 'deleted'",
     }),
   },
 };
 
-/** Column type modification — dot on Columns tab. */
-export const ColumnTypeModified: Story = {
-  args: {
-    ...createStoryArgs({
-      baseColumns: {
-        order_id: { name: "order_id", type: "integer" },
-        amount: { name: "amount", type: "integer" },
-      },
-      currentColumns: {
-        order_id: { name: "order_id", type: "integer" },
-        amount: { name: "amount", type: "numeric" },
-      },
-    }),
-  },
-};
-
-/** Single env mode — no dots shown regardless of data. */
-export const SingleEnvMode: Story = {
-  args: {
-    isSingleEnv: true,
-    ...createStoryArgs({
-      materialized: "table",
-      baseCode: "SELECT 1",
-      currentCode: "SELECT 2",
-      baseColumns: {
-        a: { name: "a", type: "integer" },
-      },
-      currentColumns: {
-        a: { name: "a", type: "varchar" },
-        b: { name: "b", type: "integer" },
-      },
-    }),
-  },
-};
-
-// =============================================================================
-// MATERIALIZATION CHANGE STORY
-// =============================================================================
-
-/** Materialization changed from view to table between base and current. */
+/** Materialization changed (view → table). */
 export const MaterializationChanged: Story = {
   args: {
     ...createStoryArgs({
+      name: "stg_orders",
       baseMaterialized: "view",
       materialized: "table",
       changeStatus: "modified",
+      rowCountDiff: { base: 1000, curr: 1200 },
     }),
   },
 };

--- a/js/packages/storybook/stories/mocks/MockProviders.tsx
+++ b/js/packages/storybook/stories/mocks/MockProviders.tsx
@@ -139,9 +139,25 @@ const mockLineageGraph = {
     base: undefined,
     current: undefined,
   },
+  // Non-null catalogs so SchemaView doesn't render its "catalog.json not
+  // found" warning in stories. Truthiness is all SchemaView checks.
   catalogMetadata: {
-    base: undefined,
-    current: undefined,
+    base: {
+      dbt_version: "1.8.0",
+      dbt_schema_version: "https://schemas.getdbt.com/dbt/catalog/v1.json",
+      generated_at: "2026-05-19T00:00:00Z",
+      adapter_type: "duckdb",
+      env: {},
+      invocation_id: "mock-base",
+    },
+    current: {
+      dbt_version: "1.8.0",
+      dbt_schema_version: "https://schemas.getdbt.com/dbt/catalog/v1.json",
+      generated_at: "2026-05-19T00:00:00Z",
+      adapter_type: "duckdb",
+      env: {},
+      invocation_id: "mock-current",
+    },
   },
 };
 

--- a/js/packages/storybook/stories/mocks/MockProviders.tsx
+++ b/js/packages/storybook/stories/mocks/MockProviders.tsx
@@ -1,3 +1,4 @@
+import type { RunsAggregated } from "@datarecce/ui/api";
 import { LineageGraphProvider } from "@datarecce/ui/contexts";
 import type { ReactNode } from "react";
 
@@ -161,10 +162,27 @@ const mockLineageGraph = {
   },
 };
 
-export function MockLineageProvider({ children }: { children: ReactNode }) {
+export interface MockLineageProviderProps {
+  children: ReactNode;
+  /**
+   * Pre-aggregated run results keyed by `node.id`. Components like
+   * `RowCountDiffTag` / `RowCountTag` read row-count data from here. Stories
+   * pass fixture data so the real production components render with realistic
+   * values instead of being stubbed.
+   */
+  runsAggregated?: RunsAggregated;
+}
+
+export function MockLineageProvider({
+  children,
+  runsAggregated,
+}: MockLineageProviderProps) {
   return (
-    // biome-ignore lint/suspicious/noExplicitAny: Mock data doesn't need full type compliance
-    <LineageGraphProvider lineageGraph={mockLineageGraph as any}>
+    <LineageGraphProvider
+      // biome-ignore lint/suspicious/noExplicitAny: Mock data doesn't need full type compliance
+      lineageGraph={mockLineageGraph as any}
+      runsAggregated={runsAggregated}
+    >
       {children}
     </LineageGraphProvider>
   );

--- a/js/packages/ui/src/advanced.ts
+++ b/js/packages/ui/src/advanced.ts
@@ -117,8 +117,10 @@ export { layout, toReactFlow } from "./components/lineage/lineage";
  */
 export {
   NodeView,
+  type NodeViewActionCallbacks,
   type NodeViewNodeData,
   type NodeViewProps,
+  type RunTypeIconMap,
   type SchemaViewProps,
 } from "./components/lineage/NodeView";
 

--- a/js/packages/ui/src/advanced.ts
+++ b/js/packages/ui/src/advanced.ts
@@ -113,6 +113,11 @@ export {
  */
 export { layout, toReactFlow } from "./components/lineage/lineage";
 /**
+ * Row-count tags rendered inside `NodeView`. They read row-count data from
+ * `LineageGraphProvider`'s `runsAggregated` prop, keyed by `node.id`.
+ */
+export { RowCountDiffTag, RowCountTag } from "./components/lineage/NodeTag";
+/**
  * Node detail panel with Columns and Code tabs.
  */
 export {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       '@datarecce/ui':
         specifier: workspace:*
         version: link:../ui
+      '@tanstack/react-query':
+        specifier: 5.100.10
+        version: 5.100.10(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6


### PR DESCRIPTION
**Storybook only change.**  The Storybook story for Schema View was really bad -- it was hard to see what it did, since the formatting was dramatically off. 

See, for example, this sample image:
<img width="445" height="540" alt="image" src="https://github.com/user-attachments/assets/912518f4-845a-4980-a0ea-aceb9e696d7e" />

The goal of this PR is to make the NodeView story accurate enough that we can actually do design against it. I had hoped this would just pull in some CSS (and it did!), but it also needs a smarter stub/mock machinery.

After this PR, and the stacked next one that makes actual changes to the layout, the storybook version now looks like this:
<img width="601" height="678" alt="image" src="https://github.com/user-attachments/assets/8b5d4fe3-e54a-4473-9a92-698e4a9e0869" />

## Summary

Improve the Storybook stories for `NodeView` so they render the real `SchemaView` (ag-grid) and the real run-registry icons, with light inline stubs for the dependency-injection slots that need app-level context. No changes to ship-to-app `NodeView` behavior — this only touches `js/packages/storybook/**`, an additive type re-export in `js/packages/ui/src/advanced.ts`, and the catalog-metadata stubs in `MockProviders`.

- Real `SchemaView` / `SingleEnvSchemaView` wired through `QueryClientProvider` + `MockLineageProvider` so column rendering, the schema legend, and added/removed row highlights all demo accurately.
- Real registry icons via `findByRunType` so the action buttons match production.
- Light inline stubs (\`Chip\` + closures over fixture data) for `RowCountDiffTag`, `RowCountTag`, and an empty `SandboxDialog`, so the layout works without wiring up `runsAggregated`.
- Story variants: `Default`, `NoRowCountData`, `ViewMaterialization`, `SingleEnvMode`, `SchemaChanged`, `CodeChanged`, `MaterializationChanged`.

Storybook infra updates that come along:
- Alias `@datarecce/ui/theme` so the preview uses the real CSS-variables theme (single theme drives both modes via the `.dark` class) instead of the ad-hoc `createTheme` calls.
- New MSW handler for `/api/flag` so `useRecceServerFlag` resolves under MSW (`SchemaView` reads server flags during render).
- Add `@tanstack/react-query` to the storybook package so the story can wrap children in `QueryClientProvider`.
- Mock `catalogMetadata.base/current` with realistic `ArtifactMetadata` stubs in `MockProviders` so `SchemaView` doesn't render the \"catalog.json not found\" warning in stories.
- Additive type exports (`NodeViewActionCallbacks`, `RunTypeIconMap`) from `@datarecce/ui/advanced` so consumers can type injected icons / callbacks without reaching into internal paths.

This PR is intentionally independent of any `NodeView` redesign — it demonstrates the component as it exists on \`main\` today.

## Type of change
- [x] Documentation / Storybook (story improvements + infra)

## Test plan
- [x] \`pnpm type:check\` clean
- [x] \`pnpm lint:fix\` clean
- [x] \`pnpm run build\` clean
- [ ] Reviewer: open Storybook → Lineage → NodeView and click through each variant; confirm the \"catalog.json not found\" warning no longer fires and the columns table renders with the index/name/type cells.

## User-facing changes
None — Storybook-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)