### PR TITLE
docs(cli): add cloud-mode examples to recce mcp-server --help

### DIFF
--- a/recce/cli.py
+++ b/recce/cli.py
@@ -2717,6 +2717,14 @@ def mcp_server(state_file, sse, host, port, **kwargs):
     # Start in HTTP/SSE mode with custom host and port
     recce mcp-server --sse --host 0.0.0.0 --port 9000
 
+    \b
+    # Cloud mode: connect to a Recce Cloud session
+    recce mcp-server --cloud --session <SID> --api-token <token>
+
+    \b
+    # Cloud mode using profile.yml token (after login)
+    recce mcp-server --cloud --session <SID>
+
     SSE Connection URL (when using --sse): http://<host>:<port>/sse
     """
     import asyncio


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

docs

**What this PR does / why we need it**:

Adds cloud-mode examples to `recce mcp-server --help`. Previously the Examples block only showed local and SSE modes; users had no way to discover the cloud-session flag combination from `--help`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

- Docstring-only change. Uses the public `--session` flag (not the hidden `--session-id`).

**Does this PR introduce a user-facing change?**:

NONE