### PR TITLE
feat(profile-distribution): polyglot SQL foundation (DRC-3390 PR 1)

### DIFF
--- a/js/packages/ui/src/api/flag.ts
+++ b/js/packages/ui/src/api/flag.ts
@@ -9,6 +9,7 @@ export interface RecceServerFlags {
   disable_cll_cache: boolean;
   impact_at_startup: boolean;
   new_cll_experience: boolean;
+  inline_profile: boolean;
 }
 
 /**

--- a/js/packages/ui/src/api/types/run.ts
+++ b/js/packages/ui/src/api/types/run.ts
@@ -431,8 +431,12 @@ export function isValidRunType(value: string): value is RunType {
 /**
  * Run types that support screenshot/ref functionality.
  * These are run types that render a visual result view with forwardRef support.
+ *
+ * Declared with ``as const satisfies readonly RunType[]`` so the literal-tuple
+ * type survives — that lets {@link runTypeHasRef} act as a true type guard
+ * narrowing to ``RunTypeWithRef`` instead of bare ``boolean``.
  */
-const RUN_TYPES_WITH_REF: readonly RunType[] = [
+const RUN_TYPES_WITH_REF = [
   "query",
   "query_base",
   "query_diff",
@@ -444,12 +448,19 @@ const RUN_TYPES_WITH_REF: readonly RunType[] = [
   "value_diff_detail",
   "top_k_diff",
   "histogram_diff",
-] as const;
+] as const satisfies readonly RunType[];
+
+/**
+ * Subset of {@link RunType} whose result view supports forwardRef. A narrower
+ * type than ``RunType`` so a positive {@link runTypeHasRef} check transitively
+ * narrows to a registered run type (every entry here also has a registry entry).
+ */
+export type RunTypeWithRef = (typeof RUN_TYPES_WITH_REF)[number];
 
 /**
  * Check if a run type supports ref forwarding (for screenshots).
  * Run types with refs can capture screenshots of their result views.
  */
-export function runTypeHasRef(runType: RunType): boolean {
-  return RUN_TYPES_WITH_REF.includes(runType);
+export function runTypeHasRef(runType: RunType): runType is RunTypeWithRef {
+  return (RUN_TYPES_WITH_REF as readonly RunType[]).includes(runType);
 }

--- a/js/packages/ui/src/api/types/run.ts
+++ b/js/packages/ui/src/api/types/run.ts
@@ -53,7 +53,8 @@ export type RunType =
   | "row_count_diff"
   | "lineage_diff"
   | "top_k_diff"
-  | "histogram_diff";
+  | "histogram_diff"
+  | "profile_distribution";
 
 // ============================================================================
 // Run Status Types
@@ -157,6 +158,7 @@ export type RunParamTypes =
   | LineageDiffParams
   | TopKDiffParams
   | HistogramDiffParams
+  | ProfileDistributionParams
   | undefined;
 
 // ============================================================================
@@ -245,7 +247,31 @@ export type Run =
       type: "histogram_diff";
       params?: HistogramDiffParams;
       result?: HistogramDiffResult;
+    })
+  | (BaseRun & {
+      type: "profile_distribution";
+      params?: ProfileDistributionParams;
+      result?: ProfileDistributionResult;
     });
+
+/**
+ * Profile distribution params - used by profile_distribution runs.
+ * PR 1 stub; PR 2 populates the shape (model name + optional column list).
+ */
+export interface ProfileDistributionParams {
+  model?: string;
+  columns?: string[];
+}
+
+/**
+ * Profile distribution result - per-column paired distributions.
+ * PR 1 stub; PR 2 populates columns with quantile-binned histogram + top-K payloads.
+ */
+export interface ProfileDistributionResult {
+  columns?: Record<string, unknown>;
+  status?: "ok" | "unsupported";
+  reason?: string;
+}
 
 // ============================================================================
 // Type Guards
@@ -361,6 +387,15 @@ export function isHistogramDiffRun(
   return run.type === "histogram_diff";
 }
 
+/**
+ * Type guard for profile_distribution runs
+ */
+export function isProfileDistributionRun(
+  run: Run,
+): run is Run & { type: "profile_distribution" } {
+  return run.type === "profile_distribution";
+}
+
 // ============================================================================
 // Utility Types
 // ============================================================================
@@ -383,6 +418,7 @@ export const RUN_TYPES: readonly RunType[] = [
   "lineage_diff",
   "top_k_diff",
   "histogram_diff",
+  "profile_distribution",
 ] as const;
 
 /**

--- a/js/packages/ui/src/components/check/CheckDetailOss.tsx
+++ b/js/packages/ui/src/components/check/CheckDetailOss.tsx
@@ -85,6 +85,7 @@ import { DualSqlEditor, SqlEditor } from "../query";
 import {
   findByRunType,
   type IconComponent,
+  isRegisteredRunType,
   RefTypes,
   RegistryEntry,
   RunViewOss,
@@ -143,7 +144,10 @@ export function CheckDetailOss({
     ? !run || run.status === "Running"
     : run?.status === "Running";
 
-  const runTypeEntry = check?.type ? findByRunType(check.type) : undefined;
+  const runTypeEntry =
+    check?.type && isRegisteredRunType(check.type)
+      ? findByRunType(check.type)
+      : undefined;
 
   let RunResultView: RegistryEntry["RunResultView"] | undefined;
   if (runTypeEntry) {

--- a/js/packages/ui/src/components/run/__tests__/registry.test.ts
+++ b/js/packages/ui/src/components/run/__tests__/registry.test.ts
@@ -10,14 +10,13 @@
  * - Registry extension patterns work correctly
  */
 
-import type { RunType } from "../../../api";
-import { RUN_TYPES } from "../../../api";
 import {
   createBoundFindByRunType,
   createRunTypeRegistry,
   defaultRunTypeConfig,
   findByRunType,
   type IconComponent,
+  REGISTERED_RUN_TYPES,
   type RunTypeConfig,
   type RunTypeRegistry,
 } from "../registry";
@@ -39,13 +38,13 @@ CustomIcon.displayName = "CustomIcon";
 describe("registry", () => {
   describe("defaultRunTypeConfig", () => {
     it("contains entries for all run types", () => {
-      for (const runType of RUN_TYPES) {
+      for (const runType of REGISTERED_RUN_TYPES) {
         expect(defaultRunTypeConfig[runType]).toBeDefined();
       }
     });
 
     it("all entries have title and icon", () => {
-      for (const runType of RUN_TYPES) {
+      for (const runType of REGISTERED_RUN_TYPES) {
         const entry = defaultRunTypeConfig[runType];
         expect(entry.title).toBeTruthy();
         expect(typeof entry.title).toBe("string");
@@ -78,7 +77,7 @@ describe("registry", () => {
     it("returns a complete registry with defaults", () => {
       const registry = createRunTypeRegistry({});
 
-      for (const runType of RUN_TYPES) {
+      for (const runType of REGISTERED_RUN_TYPES) {
         expect(registry[runType]).toBeDefined();
         expect(registry[runType].title).toBe(
           defaultRunTypeConfig[runType].title,
@@ -134,7 +133,7 @@ describe("registry", () => {
       } as Record<string, Partial<RunTypeConfig>>);
 
       // Should still have all valid types
-      for (const runType of RUN_TYPES) {
+      for (const runType of REGISTERED_RUN_TYPES) {
         expect(registry[runType]).toBeDefined();
       }
     });
@@ -142,7 +141,7 @@ describe("registry", () => {
 
   describe("findByRunType", () => {
     it("returns correct entry for each run type", () => {
-      for (const runType of RUN_TYPES) {
+      for (const runType of REGISTERED_RUN_TYPES) {
         const entry = findByRunType(runType);
         expect(entry).toBe(defaultRunTypeConfig[runType]);
       }

--- a/js/packages/ui/src/components/run/index.ts
+++ b/js/packages/ui/src/components/run/index.ts
@@ -78,6 +78,9 @@ export {
   createRunTypeRegistry,
   defaultRunTypeConfig,
   findByRunType,
+  isRegisteredRunType,
+  REGISTERED_RUN_TYPES,
+  type RegisteredRunType,
   type RunRegistry,
   registry,
 } from "./registry";

--- a/js/packages/ui/src/components/run/registry.ts
+++ b/js/packages/ui/src/components/run/registry.ts
@@ -93,10 +93,47 @@ export interface RunRegistry {
   lineage_diff: RegistryEntry<never>;
   schema_diff: RegistryEntry<never>;
   simple: RegistryEntry<never>;
-  // PR 1 stub (DRC-3390). Backend-only run type — feeds into schema-view
-  // cells rather than a stand-alone result view. PR 3 may add a focused
-  // result view if the design calls for one.
-  profile_distribution: RegistryEntry<never>;
+}
+
+/**
+ * Subset of {@link RunType} that has a registry entry — i.e., the user-facing
+ * run types that surface as checklist items with a title, icon, and (for
+ * most) a result view. Backend-only run types like ``profile_distribution``
+ * are deliberately *not* in this set: their results feed into other views
+ * (the schema cells) rather than rendering as stand-alone checklist runs.
+ */
+export type RegisteredRunType = keyof RunRegistry;
+
+/**
+ * Enumeration of registered run types. Iterate this (not ``RUN_TYPES``) when
+ * you need to walk every type that has a checklist-displayable entry.
+ */
+export const REGISTERED_RUN_TYPES: readonly RegisteredRunType[] = [
+  "query",
+  "query_base",
+  "query_diff",
+  "row_count",
+  "row_count_diff",
+  "profile",
+  "profile_diff",
+  "value_diff",
+  "value_diff_detail",
+  "top_k_diff",
+  "histogram_diff",
+  "lineage_diff",
+  "schema_diff",
+  "simple",
+] as const;
+
+/**
+ * Runtime guard narrowing an arbitrary {@link RunType} to a registered one.
+ * Use this when a value typed as ``RunType`` (e.g., ``check.type``) needs to
+ * be passed to {@link findByRunType}.
+ */
+export function isRegisteredRunType(
+  runType: RunType,
+): runType is RegisteredRunType {
+  return (REGISTERED_RUN_TYPES as readonly RunType[]).includes(runType);
 }
 
 // ============================================================================
@@ -202,10 +239,6 @@ export const registry: RunRegistry = {
     title: "Simple",
     icon: TbEyeEdit,
   },
-  profile_distribution: {
-    title: "Profile Distribution",
-    icon: TbChartHistogram,
-  },
 };
 
 // ============================================================================
@@ -225,7 +258,9 @@ export const registry: RunRegistry = {
  * console.log(entry.icon); // TbSql
  * ```
  */
-export function findByRunType<T extends RunType>(runType: T): RunRegistry[T] {
+export function findByRunType<T extends RegisteredRunType>(
+  runType: T,
+): RunRegistry[T] {
   return registry[runType];
 }
 
@@ -287,6 +322,6 @@ export function createRunTypeRegistry(
  */
 export function createBoundFindByRunType(
   reg: RunRegistry,
-): <T extends RunType>(runType: T) => RunRegistry[T] {
-  return <T extends RunType>(runType: T) => reg[runType];
+): <T extends RegisteredRunType>(runType: T) => RunRegistry[T] {
+  return <T extends RegisteredRunType>(runType: T) => reg[runType];
 }

--- a/js/packages/ui/src/components/run/registry.ts
+++ b/js/packages/ui/src/components/run/registry.ts
@@ -93,6 +93,10 @@ export interface RunRegistry {
   lineage_diff: RegistryEntry<never>;
   schema_diff: RegistryEntry<never>;
   simple: RegistryEntry<never>;
+  // PR 1 stub (DRC-3390). Backend-only run type — feeds into schema-view
+  // cells rather than a stand-alone result view. PR 3 may add a focused
+  // result view if the design calls for one.
+  profile_distribution: RegistryEntry<never>;
 }
 
 // ============================================================================
@@ -197,6 +201,10 @@ export const registry: RunRegistry = {
   simple: {
     title: "Simple",
     icon: TbEyeEdit,
+  },
+  profile_distribution: {
+    title: "Profile Distribution",
+    icon: TbChartHistogram,
   },
 };
 

--- a/js/packages/ui/src/components/run/types.ts
+++ b/js/packages/ui/src/components/run/types.ts
@@ -130,8 +130,12 @@ export interface RunTypeConfig<
  *   custom: { title: "Custom", icon: MyIcon }
  * };
  */
+// Keyed on the registered subset, not all of RunType, so backend-only run
+// types like ``profile_distribution`` (which never surface as checklist
+// runs with their own title / icon / result view) don't require a placeholder
+// entry. See ``RegisteredRunType`` in registry.ts.
 export type RunTypeRegistry = {
-  [K in RunType]: RunTypeConfig;
+  [K in keyof import("./registry").RunRegistry]: RunTypeConfig;
 };
 
 /**

--- a/js/packages/ui/src/hooks/RecceActionAdapter.tsx
+++ b/js/packages/ui/src/hooks/RecceActionAdapter.tsx
@@ -18,6 +18,7 @@ import {
 } from "../api";
 import {
   findByRunType,
+  isRegisteredRunType,
   type RegistryEntry,
   type RunFormParamTypes,
   type RunFormProps,
@@ -153,7 +154,11 @@ export function RecceActionAdapter({ children }: RecceActionAdapterProps) {
           }
         }
 
-        const run = findByRunType(type as RunType);
+        const runType = type as RunType;
+        if (!isRegisteredRunType(runType)) {
+          throw new Error(`Run type ${type} does not have a result view`);
+        }
+        const run = findByRunType(runType);
         const RunResultView = run.RunResultView as
           | RegistryEntry["RunResultView"]
           | undefined;

--- a/js/src/components/run/__tests__/registry.test.ts
+++ b/js/src/components/run/__tests__/registry.test.ts
@@ -15,8 +15,10 @@
 // Imports
 // ============================================================================
 
-import type { RunType } from "@datarecce/ui/api";
-import { findByRunType } from "@datarecce/ui/components/run";
+import {
+  findByRunType,
+  type RegisteredRunType,
+} from "@datarecce/ui/components/run";
 
 // ============================================================================
 // Test Suites
@@ -166,7 +168,7 @@ describe("registry", () => {
 
     describe("icon consistency", () => {
       it("all run types have icons that are functions", () => {
-        const runTypes: RunType[] = [
+        const runTypes: RegisteredRunType[] = [
           "lineage_diff",
           "schema_diff",
           "query",
@@ -196,7 +198,7 @@ describe("registry", () => {
 
     describe("title consistency", () => {
       it("all run types have non-empty string titles", () => {
-        const runTypes: RunType[] = [
+        const runTypes: RegisteredRunType[] = [
           "lineage_diff",
           "schema_diff",
           "query",
@@ -348,7 +350,7 @@ describe("registry", () => {
 
     describe("edge cases", () => {
       it("handles all valid run types without errors", () => {
-        const runTypes: RunType[] = [
+        const runTypes: RegisteredRunType[] = [
           "lineage_diff",
           "schema_diff",
           "query",

--- a/js/src/lib/hooks/__tests__/RecceActionAdapter.test.tsx
+++ b/js/src/lib/hooks/__tests__/RecceActionAdapter.test.tsx
@@ -49,6 +49,11 @@ vi.mock("@datarecce/ui/components/run", () => ({
     RunResultView: () => <div>Result View</div>,
     RunForm: undefined,
   })),
+  // PR 1 (DRC-3390) gated `findByRunType` calls behind `isRegisteredRunType`
+  // inside RecceActionAdapter. The mock replaces the whole module, so we
+  // need to stub the guard too — return true for the run types the tests
+  // exercise so the adapter doesn't bail out before calling submitRun.
+  isRegisteredRunType: vi.fn(() => true),
   RunModalOss: vi.fn(({ isOpen, onClose, title }) =>
     isOpen ? (
       <div data-testid="run-modal">

--- a/recce/adapter/approx_aggregates.py
+++ b/recce/adapter/approx_aggregates.py
@@ -1,0 +1,179 @@
+"""Per-dialect SQL rendering for approximate-aggregate primitives (DRC-3390).
+
+Pairs with :mod:`recce.adapter.capabilities`. ``capabilities.py`` answers
+"can this adapter do X?"; this module answers "what's the SQL for X on this
+adapter?". The :class:`ProfileDistributionTask` orchestration layer (PR 2)
+calls these to compose the six-query ``approx_all`` pipeline:
+
+  1. ``APPROX_COUNT_DISTINCT`` probe (one batched query)
+  2. ``APPROX_PERCENTILE``      x base + current  (continuous columns)
+  3. ``APPROX_TOP_K``           x base + current  (categorical columns)
+
+Each renderer returns a SQL fragment suitable for inclusion in a ``SELECT``
+list. Callers are responsible for column-identifier quoting (typically via
+``adapter.quote(column_name)``) and for handling the per-adapter result-shape
+variation in post-processing — e.g., DuckDB's ``approx_top_k`` returns a
+list of values only, while Snowflake's ``APPROX_TOP_K`` returns an array of
+``(value, count)`` pairs.
+
+Raises :class:`UnsupportedAggregateError` when called for an adapter that
+doesn't expose the aggregate natively. Strategy router in
+:class:`ProfileDistributionTask` should consult
+:func:`recce.adapter.capabilities.detect_capabilities` before dispatch and
+should never call into a renderer for an unsupported adapter — the raise is
+a defense-in-depth backstop.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+class UnsupportedAggregateError(ValueError):
+    """Raised when the requested approximate aggregate has no native rendering for the adapter."""
+
+
+def _normalize(adapter_type: str | None) -> str:
+    return (adapter_type or "").lower()
+
+
+def render_approx_count_distinct(adapter_type: str | None, column_expr: str) -> str:
+    """Return a SQL fragment computing approximate distinct count via HLL.
+
+    ``column_expr`` is the (already-quoted) identifier or expression for the
+    target column. The fragment is suitable for use directly in a
+    ``SELECT`` list.
+    """
+    db = _normalize(adapter_type)
+
+    if db in {
+        "snowflake",
+        "bigquery",
+        "duckdb",
+        "databricks",
+        "spark",
+    }:
+        return f"approx_count_distinct({column_expr})"
+
+    if db in {"athena", "trino", "presto"}:
+        return f"approx_distinct({column_expr})"
+
+    if db == "clickhouse":
+        # ClickHouse's default ``uniq`` uses an adaptive sampling + HLL hybrid.
+        return f"uniq({column_expr})"
+
+    if db == "redshift":
+        # Redshift exposes APPROX inside a regular ``count(distinct …)``.
+        return f"approximate count(distinct {column_expr})"
+
+    raise UnsupportedAggregateError(f"approx_count_distinct is not supported on adapter type {adapter_type!r}")
+
+
+def render_approx_top_k(adapter_type: str | None, column_expr: str, k: int) -> str:
+    """Return a SQL fragment computing the approximate top-K values + counts.
+
+    The shape of the returned value is **not** uniform across adapters:
+
+    - Snowflake: ``ARRAY`` of ``[value, count]`` two-element arrays.
+    - BigQuery: ``ARRAY<STRUCT<value …, count INT64>>``.
+    - DuckDB: ``LIST`` of values only — **no counts**; callers must derive
+      counts via a follow-up query if they need them.
+    - Databricks / Spark 3.5+: ``ARRAY<STRUCT<item …, count BIGINT>>``.
+    - ClickHouse: ``Array`` of values via ``topK(k)(col)`` — no counts.
+
+    The strategy router (PR 2) is responsible for handling these shapes in
+    post-processing. PR 1 only renders the SQL.
+    """
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+    db = _normalize(adapter_type)
+
+    if db in {"snowflake", "duckdb", "databricks", "spark"}:
+        return f"approx_top_k({column_expr}, {k})"
+
+    if db == "bigquery":
+        return f"approx_top_count({column_expr}, {k})"
+
+    if db in {"athena", "trino", "presto"}:
+        # ``approx_most_frequent(buckets, value, capacity)`` — Presto/Trino-style
+        # space-saving sketch. Capacity is the sketch's working-set size; the
+        # docs recommend roughly k * 10 for good error bounds. We use a fixed
+        # 10x ratio at the lower bound of common k (k=12 → capacity=120).
+        capacity = max(k * 10, 100)
+        return f"approx_most_frequent({k}, {column_expr}, {capacity})"
+
+    if db == "clickhouse":
+        # ClickHouse parametrized aggregate: ``topK(k)(col)``.
+        return f"topK({k})({column_expr})"
+
+    raise UnsupportedAggregateError(f"approx_top_k is not supported on adapter type {adapter_type!r}")
+
+
+def render_approx_percentile(
+    adapter_type: str | None,
+    column_expr: str,
+    quantiles: Sequence[float],
+) -> str:
+    """Return a SQL fragment computing approximate percentiles at ``quantiles``.
+
+    ``quantiles`` is a sequence of values in [0, 1]. The returned fragment
+    produces an array (or array-like) of percentile values in the same order.
+
+    As with :func:`render_approx_top_k`, the result *shape* varies across
+    adapters; orchestration handles that in post-processing.
+    """
+    if not quantiles:
+        raise ValueError("quantiles must be a non-empty sequence")
+    if any(q < 0.0 or q > 1.0 for q in quantiles):
+        raise ValueError(f"quantiles must each lie in [0, 1], got {list(quantiles)}")
+
+    db = _normalize(adapter_type)
+    quantile_csv = ", ".join(f"{q}" for q in quantiles)
+
+    if db == "snowflake":
+        # Snowflake's single-quantile ``APPROX_PERCENTILE(col, q)`` does not
+        # accept an array. The orchestration layer (PR 2) is expected to use
+        # the state-based ``APPROX_PERCENTILE_ACCUMULATE`` /
+        # ``APPROX_PERCENTILE_ESTIMATE`` pair for multi-quantile efficiency.
+        # PR 1's fragment renders ``ARRAY_CONSTRUCT(APPROX_PERCENTILE(col, q1), …)``
+        # so a SELECT can produce all quantiles in one column.
+        calls = ", ".join(f"approx_percentile({column_expr}, {q})" for q in quantiles)
+        return f"array_construct({calls})"
+
+    if db == "bigquery":
+        # ``APPROX_QUANTILES`` divides the column into N+1 buckets and returns
+        # all N+1 boundaries. We render the full call and let the orchestration
+        # layer slice out the percentiles it cares about; that's simpler than
+        # rendering N separate single-quantile fragments and stitching them.
+        # ``IGNORE NULLS`` matches recce's existing precedent.
+        # NOTE: For a fixed quantile set like [0.05, 0.10, …], the canonical
+        # divisor is 100 (returning an array of 101 percentile boundaries).
+        return f"approx_quantiles({column_expr}, 100 IGNORE NULLS)"
+
+    if db == "duckdb":
+        # DuckDB's ``approx_quantile`` accepts a list and returns a list.
+        return f"approx_quantile({column_expr}, [{quantile_csv}])"
+
+    if db in {"databricks", "spark"}:
+        return f"approx_percentile({column_expr}, array({quantile_csv}))"
+
+    if db in {"athena", "trino", "presto"}:
+        return f"approx_percentile({column_expr}, ARRAY[{quantile_csv}])"
+
+    if db == "clickhouse":
+        # ``quantilesTDigest(p1, p2, …)(col)`` returns an array of length len(quantiles).
+        return f"quantilesTDigest({quantile_csv})({column_expr})"
+
+    if db == "redshift":
+        # Redshift only supports a single percentile per call via
+        # ``APPROXIMATE PERCENTILE_DISC(q) WITHIN GROUP (ORDER BY col)``. The
+        # multi-quantile form is composed by the orchestration layer as
+        # separate aggregates in a single SELECT. PR 1 renders the single-
+        # quantile form per ``quantiles[i]`` and joins via comma; the caller
+        # gets a comma-separated set of SQL fragments rather than one array
+        # expression. Document the divergence so the strategy router handles
+        # it explicitly.
+        calls = [f"approximate percentile_disc({q}) within group (order by {column_expr})" for q in quantiles]
+        return ", ".join(calls)
+
+    raise UnsupportedAggregateError(f"approx_percentile is not supported on adapter type {adapter_type!r}")

--- a/recce/adapter/capabilities.py
+++ b/recce/adapter/capabilities.py
@@ -1,0 +1,133 @@
+"""Adapter capability detection for the paired-distribution feature (DRC-3390).
+
+Decides which approximate-aggregate strategy is available for a given dbt
+adapter. The data-pull strategy locked in DRC-3389 uses:
+
+- ``APPROX_COUNT_DISTINCT`` / HLL — cardinality probe across all columns
+- ``APPROX_PERCENTILE`` — quantile-binned histograms (continuous columns)
+- ``APPROX_TOP_K``    — categorical top-K (discrete columns)
+
+Not every adapter ships all three. This module is the single source of truth
+for "what can this engine do." The :class:`ProfileDistributionTask` strategy
+router (PR 2) reads these flags to pick between ``approx_all``,
+``percentile_only`` (histograms render, top-K cells blank), and
+``unsupported`` (feature disabled, one-time banner).
+
+See DRC-3390 ("Adapter coverage at GA") and DRC-3389 ("Adapter compatibility")
+for the full matrix and rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class AdapterCapabilities:
+    """Per-adapter approximate-aggregate support.
+
+    All three fields default to ``False`` so unknown adapters fall back to the
+    disabled tier — the safe choice. Add adapters to :data:`_CAPABILITY_TABLE`
+    below to opt them into a higher tier.
+    """
+
+    # ``APPROX_COUNT_DISTINCT`` (HLL) for the cardinality probe phase.
+    has_approx_count_distinct: bool = False
+    # ``APPROX_PERCENTILE`` / equivalent quantile sketch for continuous columns.
+    has_approx_percentile: bool = False
+    # ``APPROX_TOP_K`` / equivalent space-saving sketch for categorical columns.
+    has_approx_top_k: bool = False
+
+
+# Capability matrix keyed by ``dbt_adapter.adapter.type()`` (lowercase).
+#
+# The dbt-side string varies across adapters; values observed in the recce
+# codebase include 'snowflake', 'bigquery', 'duckdb', 'postgres', 'redshift',
+# 'athena', 'sqlserver'. Databricks and Spark expose 'databricks' and 'spark'
+# respectively; Trino and Presto each have their own.
+#
+# Caveats baked into the GA matrix that this table cannot enforce by adapter
+# type alone — runtime version detection is out of scope for PR 1:
+#   * 'sqlserver' covers Azure SQL + SQL Server. Versions 2022+ added
+#     ``APPROX_PERCENTILE_CONT/_DISC``; pre-2022 has neither. Defaulting to
+#     False here (disabled tier). Refine via runtime version detection if
+#     SQL Server becomes a target adapter.
+#   * 'databricks' / 'spark' added ``approx_top_k`` in 3.5. Older Databricks
+#     would land in percentile-only tier in practice. Defaulting to full here
+#     since the typical customer is on a recent runtime.
+_CAPABILITY_TABLE: Dict[str, AdapterCapabilities] = {
+    # Full tier — both percentile and top-K available natively.
+    "snowflake": AdapterCapabilities(
+        has_approx_count_distinct=True,
+        has_approx_percentile=True,
+        has_approx_top_k=True,
+    ),
+    "bigquery": AdapterCapabilities(
+        has_approx_count_distinct=True,
+        has_approx_percentile=True,
+        has_approx_top_k=True,
+    ),
+    "duckdb": AdapterCapabilities(
+        has_approx_count_distinct=True,
+        has_approx_percentile=True,
+        has_approx_top_k=True,
+    ),
+    "databricks": AdapterCapabilities(
+        has_approx_count_distinct=True,
+        has_approx_percentile=True,
+        has_approx_top_k=True,
+    ),
+    "spark": AdapterCapabilities(
+        has_approx_count_distinct=True,
+        has_approx_percentile=True,
+        has_approx_top_k=True,
+    ),
+    "athena": AdapterCapabilities(
+        has_approx_count_distinct=True,
+        has_approx_percentile=True,
+        has_approx_top_k=True,
+    ),
+    "trino": AdapterCapabilities(
+        has_approx_count_distinct=True,
+        has_approx_percentile=True,
+        has_approx_top_k=True,
+    ),
+    "presto": AdapterCapabilities(
+        has_approx_count_distinct=True,
+        has_approx_percentile=True,
+        has_approx_top_k=True,
+    ),
+    "clickhouse": AdapterCapabilities(
+        has_approx_count_distinct=True,
+        has_approx_percentile=True,
+        has_approx_top_k=True,
+    ),
+    # Percentile-only tier — histograms render; top-K cells blank.
+    "redshift": AdapterCapabilities(
+        has_approx_count_distinct=True,
+        has_approx_percentile=True,
+        has_approx_top_k=False,
+    ),
+    # Disabled tier — feature unavailable; UI shows one-time banner.
+    # Postgres: no built-in approx; ``tdigest`` extension unreliable on
+    # managed Postgres (RDS, Cloud SQL).
+    "postgres": AdapterCapabilities(),
+    "mysql": AdapterCapabilities(),
+    "sqlite": AdapterCapabilities(),
+    # See caveat above re: SQL Server 2022+ vs pre-2022.
+    "sqlserver": AdapterCapabilities(),
+}
+
+
+def detect_capabilities(adapter_type: str | None) -> AdapterCapabilities:
+    """Return :class:`AdapterCapabilities` for a dbt adapter type string.
+
+    The input is :py:meth:`dbt_adapter.adapter.type` (e.g. ``'snowflake'``,
+    ``'bigquery'``). Unknown or ``None`` adapter types fall back to the
+    disabled tier — feature unavailable rather than risk emitting SQL the
+    engine can't parse.
+    """
+    if not adapter_type:
+        return AdapterCapabilities()
+    return _CAPABILITY_TABLE.get(adapter_type.lower(), AdapterCapabilities())

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -65,6 +65,7 @@ from ...models.types import (
 from ...tasks import (
     HistogramDiffTask,
     ProfileDiffTask,
+    ProfileDistributionTask,
     QueryBaseTask,
     QueryDiffTask,
     QueryTask,
@@ -89,6 +90,10 @@ dbt_supported_registry: Dict[RunType, Type[Task]] = {
     RunType.ROW_COUNT_DIFF: RowCountDiffTask,
     RunType.TOP_K_DIFF: TopKDiffTask,
     RunType.HISTOGRAM_DIFF: HistogramDiffTask,
+    # PR 1 stub. PR 2 wires the full approx_all pipeline. Always registered;
+    # the frontend uses the ``inline_profile`` server flag to decide whether
+    # to fire the task.
+    RunType.PROFILE_DISTRIBUTION: ProfileDistributionTask,
 }
 
 # Reference: https://github.com/AltimateAI/vscode-dbt-power-user/blob/master/dbt_core_integration.py

--- a/recce/cli.py
+++ b/recce/cli.py
@@ -1212,6 +1212,12 @@ def diff(
     help="Enable the new column-level lineage visual experience.",
     envvar="RECCE_NEW_CLL_EXPERIENCE",
 )
+@click.option(
+    "--inline-profile",
+    is_flag=True,
+    help="Enable inline paired-distribution profiles in the schema view (DRC-3390).",
+    envvar="RECCE_INLINE_PROFILE",
+)
 @add_options(dbt_related_options)
 @add_options(sqlmesh_related_options)
 @add_options(recce_options)
@@ -1281,6 +1287,7 @@ def server(host, port, lifetime, idle_timeout=0, state_file=None, **kwargs):
         "disable_cll_cache": True,
         "impact_at_startup": False,
         "new_cll_experience": False,
+        "inline_profile": False,
     }
     console = Console()
 
@@ -1333,6 +1340,9 @@ def server(host, port, lifetime, idle_timeout=0, state_file=None, **kwargs):
 
     if kwargs.get("new_cll_experience", False):
         flag["new_cll_experience"] = True
+
+    if kwargs.get("inline_profile", False):
+        flag["inline_profile"] = True
 
     # Create state loader using shared function
     from recce.util.startup_perf import get_startup_tracker

--- a/recce/models/types.py
+++ b/recce/models/types.py
@@ -23,6 +23,7 @@ class RunType(Enum):
     LINEAGE_DIFF = "lineage_diff"
     TOP_K_DIFF = "top_k_diff"
     HISTOGRAM_DIFF = "histogram_diff"
+    PROFILE_DISTRIBUTION = "profile_distribution"
 
     def __str__(self):
         return self.value

--- a/recce/tasks/__init__.py
+++ b/recce/tasks/__init__.py
@@ -1,6 +1,7 @@
 from .core import Task
 from .histogram import HistogramDiffTask
 from .profile import ProfileDiffTask, ProfileTask
+from .profile_distribution import ProfileDistributionTask
 from .query import QueryBaseTask, QueryDiffTask, QueryTask
 from .rowcount import RowCountDiffTask, RowCountTask
 from .top_k import TopKDiffTask
@@ -11,6 +12,7 @@ __all__ = [
     "Task",
     "HistogramDiffTask",
     "ProfileDiffTask",
+    "ProfileDistributionTask",
     "ProfileTask",
     "QueryBaseTask",
     "QueryDiffTask",

--- a/recce/tasks/profile_distribution.py
+++ b/recce/tasks/profile_distribution.py
@@ -1,0 +1,43 @@
+"""Paired column-distribution task — PR 1 stub (DRC-3390).
+
+This file is the registration anchor for ``RunType.PROFILE_DISTRIBUTION``.
+PR 1 (the polyglot foundation) ships only the wire: the run type, the CLI
+flag, the per-dialect SQL renderers, and the capability table. PR 2 wires
+the ``approx_all`` pipeline that fills in this task's :meth:`execute`.
+
+The stub returns an empty payload tagged ``status: "ok"`` so end-to-end flag
+plumbing can be validated before PR 2 lands.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from recce.tasks import Task
+
+
+class ProfileDistributionParams(BaseModel):
+    """Input parameters for the profile-distribution task."""
+
+    model: str
+    columns: Optional[List[str]] = None
+
+
+class ProfileDistributionTask(Task):
+    """Stub for the paired-distribution backend task.
+
+    PR 2 replaces the body of :meth:`execute` with the ``approx_all`` pipeline
+    (HLL probe + ``APPROX_PERCENTILE`` per env + ``APPROX_TOP_K`` per env)
+    composed from :mod:`recce.adapter.approx_aggregates` and gated on
+    :func:`recce.adapter.capabilities.detect_capabilities`.
+    """
+
+    def __init__(self, params):
+        super().__init__()
+        self.params = ProfileDistributionParams(**params)
+
+    def execute(self):
+        return {
+            "columns": {},
+            "status": "ok",
+        }

--- a/tests/adapter/test_approx_aggregates.py
+++ b/tests/adapter/test_approx_aggregates.py
@@ -1,0 +1,152 @@
+"""Per-dialect SQL snapshot tests for :mod:`recce.adapter.approx_aggregates`.
+
+These exist because dialect mistakes in the renderers are silent at unit-test
+time — they only surface when a real warehouse rejects the query. Asserting
+the exact rendered string per adapter catches dialect bugs in CI without
+requiring real Snowflake/BigQuery credentials.
+
+The strings here are the contract — if a renderer changes, the test should
+change in the same commit and the diff should be reviewable.
+"""
+
+import pytest
+
+from recce.adapter.approx_aggregates import (
+    UnsupportedAggregateError,
+    render_approx_count_distinct,
+    render_approx_percentile,
+    render_approx_top_k,
+)
+
+# -----------------------------------------------------------------------------
+# approx_count_distinct
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "adapter_type,expected",
+    [
+        ("snowflake", 'approx_count_distinct("col")'),
+        ("bigquery", 'approx_count_distinct("col")'),
+        ("duckdb", 'approx_count_distinct("col")'),
+        ("databricks", 'approx_count_distinct("col")'),
+        ("spark", 'approx_count_distinct("col")'),
+        ("athena", 'approx_distinct("col")'),
+        ("trino", 'approx_distinct("col")'),
+        ("presto", 'approx_distinct("col")'),
+        ("clickhouse", 'uniq("col")'),
+        ("redshift", 'approximate count(distinct "col")'),
+    ],
+)
+def test_render_approx_count_distinct(adapter_type, expected):
+    assert render_approx_count_distinct(adapter_type, '"col"') == expected
+
+
+@pytest.mark.parametrize("adapter_type", ["postgres", "mysql", "sqlite", "sqlserver"])
+def test_render_approx_count_distinct_raises_on_disabled_tier(adapter_type):
+    with pytest.raises(UnsupportedAggregateError):
+        render_approx_count_distinct(adapter_type, '"col"')
+
+
+def test_render_approx_count_distinct_case_insensitive():
+    assert render_approx_count_distinct("SNOWFLAKE", '"col"') == render_approx_count_distinct("snowflake", '"col"')
+
+
+# -----------------------------------------------------------------------------
+# approx_top_k
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "adapter_type,expected",
+    [
+        ("snowflake", 'approx_top_k("col", 12)'),
+        ("duckdb", 'approx_top_k("col", 12)'),
+        ("databricks", 'approx_top_k("col", 12)'),
+        ("spark", 'approx_top_k("col", 12)'),
+        ("bigquery", 'approx_top_count("col", 12)'),
+        ("athena", 'approx_most_frequent(12, "col", 120)'),
+        ("trino", 'approx_most_frequent(12, "col", 120)'),
+        ("presto", 'approx_most_frequent(12, "col", 120)'),
+        ("clickhouse", 'topK(12)("col")'),
+    ],
+)
+def test_render_approx_top_k(adapter_type, expected):
+    assert render_approx_top_k(adapter_type, '"col"', 12) == expected
+
+
+def test_approx_top_k_athena_capacity_floors_at_100():
+    """Tiny k still gets a sensible sketch-capacity floor."""
+    assert render_approx_top_k("trino", '"col"', 3) == 'approx_most_frequent(3, "col", 100)'
+
+
+@pytest.mark.parametrize("adapter_type", ["postgres", "mysql", "sqlite", "sqlserver", "redshift"])
+def test_render_approx_top_k_raises_on_unsupported(adapter_type):
+    with pytest.raises(UnsupportedAggregateError):
+        render_approx_top_k(adapter_type, '"col"', 12)
+
+
+def test_render_approx_top_k_rejects_non_positive_k():
+    with pytest.raises(ValueError):
+        render_approx_top_k("snowflake", '"col"', 0)
+    with pytest.raises(ValueError):
+        render_approx_top_k("snowflake", '"col"', -5)
+
+
+# -----------------------------------------------------------------------------
+# approx_percentile
+# -----------------------------------------------------------------------------
+
+
+QUANTILES_3 = [0.1, 0.5, 0.9]
+
+
+@pytest.mark.parametrize(
+    "adapter_type,expected",
+    [
+        (
+            "snowflake",
+            'array_construct(approx_percentile("col", 0.1), '
+            'approx_percentile("col", 0.5), approx_percentile("col", 0.9))',
+        ),
+        ("bigquery", 'approx_quantiles("col", 100 IGNORE NULLS)'),
+        ("duckdb", 'approx_quantile("col", [0.1, 0.5, 0.9])'),
+        ("databricks", 'approx_percentile("col", array(0.1, 0.5, 0.9))'),
+        ("spark", 'approx_percentile("col", array(0.1, 0.5, 0.9))'),
+        ("athena", 'approx_percentile("col", ARRAY[0.1, 0.5, 0.9])'),
+        ("trino", 'approx_percentile("col", ARRAY[0.1, 0.5, 0.9])'),
+        ("presto", 'approx_percentile("col", ARRAY[0.1, 0.5, 0.9])'),
+        ("clickhouse", 'quantilesTDigest(0.1, 0.5, 0.9)("col")'),
+        (
+            "redshift",
+            'approximate percentile_disc(0.1) within group (order by "col"), '
+            'approximate percentile_disc(0.5) within group (order by "col"), '
+            'approximate percentile_disc(0.9) within group (order by "col")',
+        ),
+    ],
+)
+def test_render_approx_percentile(adapter_type, expected):
+    assert render_approx_percentile(adapter_type, '"col"', QUANTILES_3) == expected
+
+
+@pytest.mark.parametrize("adapter_type", ["postgres", "mysql", "sqlite", "sqlserver"])
+def test_render_approx_percentile_raises_on_disabled_tier(adapter_type):
+    with pytest.raises(UnsupportedAggregateError):
+        render_approx_percentile(adapter_type, '"col"', QUANTILES_3)
+
+
+def test_render_approx_percentile_rejects_empty_quantiles():
+    with pytest.raises(ValueError):
+        render_approx_percentile("snowflake", '"col"', [])
+
+
+@pytest.mark.parametrize("bad_q", [-0.1, 1.5, 2.0])
+def test_render_approx_percentile_rejects_out_of_range(bad_q):
+    with pytest.raises(ValueError):
+        render_approx_percentile("snowflake", '"col"', [0.5, bad_q])
+
+
+def test_render_approx_percentile_case_insensitive():
+    a = render_approx_percentile("SNOWFLAKE", '"col"', [0.5])
+    b = render_approx_percentile("snowflake", '"col"', [0.5])
+    assert a == b

--- a/tests/adapter/test_capabilities.py
+++ b/tests/adapter/test_capabilities.py
@@ -1,0 +1,78 @@
+"""Tests for :mod:`recce.adapter.capabilities` (DRC-3390 PR 1)."""
+
+import pytest
+
+from recce.adapter.capabilities import AdapterCapabilities, detect_capabilities
+
+# Adapter tier matrix, asserted directly so the test fails loudly if the
+# table in ``capabilities.py`` is reshaped without intent. The tiers mirror
+# the matrix in the DRC-3390 issue description.
+FULL_TIER = [
+    "snowflake",
+    "bigquery",
+    "duckdb",
+    "databricks",
+    "spark",
+    "athena",
+    "trino",
+    "presto",
+    "clickhouse",
+]
+PERCENTILE_ONLY_TIER = ["redshift"]
+DISABLED_TIER = ["postgres", "mysql", "sqlite", "sqlserver"]
+
+
+@pytest.mark.parametrize("adapter_type", FULL_TIER)
+def test_full_tier_has_both_aggregates(adapter_type):
+    caps = detect_capabilities(adapter_type)
+    assert caps.has_approx_percentile is True, adapter_type
+    assert caps.has_approx_top_k is True, adapter_type
+    assert caps.has_approx_count_distinct is True, adapter_type
+
+
+@pytest.mark.parametrize("adapter_type", PERCENTILE_ONLY_TIER)
+def test_percentile_only_tier(adapter_type):
+    caps = detect_capabilities(adapter_type)
+    assert caps.has_approx_percentile is True, adapter_type
+    assert caps.has_approx_top_k is False, adapter_type
+    # Probe phase still needs HLL; percentile-only adapters all happen to
+    # have it natively.
+    assert caps.has_approx_count_distinct is True, adapter_type
+
+
+@pytest.mark.parametrize("adapter_type", DISABLED_TIER)
+def test_disabled_tier_has_nothing(adapter_type):
+    caps = detect_capabilities(adapter_type)
+    assert caps.has_approx_percentile is False, adapter_type
+    assert caps.has_approx_top_k is False, adapter_type
+    assert caps.has_approx_count_distinct is False, adapter_type
+
+
+def test_unknown_adapter_falls_back_to_disabled():
+    """Unknown adapter types must not opt into any feature path."""
+    caps = detect_capabilities("some-future-engine")
+    assert caps == AdapterCapabilities()
+    assert caps.has_approx_percentile is False
+    assert caps.has_approx_top_k is False
+
+
+def test_none_adapter_falls_back_to_disabled():
+    assert detect_capabilities(None) == AdapterCapabilities()
+
+
+def test_empty_string_adapter_falls_back_to_disabled():
+    assert detect_capabilities("") == AdapterCapabilities()
+
+
+def test_adapter_type_is_case_insensitive():
+    """``adapter.type()`` upstream sometimes returns title-cased values."""
+    upper = detect_capabilities("SNOWFLAKE")
+    lower = detect_capabilities("snowflake")
+    assert upper == lower
+
+
+def test_capabilities_frozen():
+    """Capabilities are dataclass(frozen=True) — defensive against mutation."""
+    caps = detect_capabilities("snowflake")
+    with pytest.raises((AttributeError, Exception)):
+        caps.has_approx_percentile = False  # type: ignore[misc]


### PR DESCRIPTION
First of four PRs landing the paired-histogram feature on `main`. Scope is intentionally narrow: this PR adds the wire — RunType, CLI flag, capability detection, per-dialect SQL renderers — and **nothing user-visible**. PR 2 wires the orchestration; PRs 3–4 ship the frontend cells, schema view integration, in-session cache, and lineage pre-warm.

Full 4-PR plan + locked decisions are in [DRC-3390](https://linear.app/recce/issue/DRC-3390/paired-histograms-live-prototype-in-schemaview-multiphase). Data-pull strategy decision (`approx_all`) is in [DRC-3389](https://linear.app/recce/issue/DRC-3389/paired-histograms-scope-data-pull-strategy-sampling-pre-caching-lazy).

## What's in this PR

**Backend**
- `RunType.PROFILE_DISTRIBUTION` enum + registration in `dbt_supported_registry`
- `--inline-profile` CLI flag (default off), plumbed to the server `flag` dict
- `recce/adapter/capabilities.py`: per-adapter `AdapterCapabilities` lookup
- `recce/adapter/approx_aggregates.py`: per-dialect SQL fragment renderers for `approx_count_distinct` / `approx_top_k` / `approx_percentile`. Raises `UnsupportedAggregateError` on adapters without native support
- `ProfileDistributionTask` stub returning empty payload so PR 1 flag plumbing is end-to-end verifiable before PR 2 lands

**Frontend** (minimal — just keeping types coherent)
- `RecceServerFlags.inline_profile`
- `RunType` union + discriminated union + `RUN_TYPES` list + type guard for `"profile_distribution"`
- Placeholder `ProfileDistributionParams` / `ProfileDistributionResult` (PR 2 will populate)
- Stub entry in `RunRegistry` so existing components type-check

## Adapter coverage matrix (locked in DRC-3389/DRC-3390)

| Tier | Engines | Behavior |
| --- | --- | --- |
| **Full** | Snowflake, BigQuery, DuckDB, Databricks/Spark 3.5+, Athena/Trino/Presto, ClickHouse | Histograms + top-K |
| **Histograms only** | Redshift | Continuous columns render; categorical cells blank |
| **Disabled** | Postgres, MySQL, SQLite, SQL Server (incl. Azure SQL pre/post-2022) | Feature unavailable; banner if flag is on |

Caveats baked into the matrix that capability detection by adapter type can't enforce (deferred to runtime version detection):
- `sqlserver` defaults to disabled. SQL Server 2022+ / Azure SQL added `APPROX_PERCENTILE_CONT/_DISC`; pre-2022 has neither. A version-aware refinement can move 2022+ users into percentile-only tier.
- `databricks` / `spark` default to full. Databricks/Spark added `approx_top_k` in 3.5; older clusters would land in percentile-only.

## Test plan

- [x] `pytest tests/adapter/test_capabilities.py tests/adapter/test_approx_aggregates.py` — **69/69 pass** (capability mapping + per-dialect SQL snapshots)
- [x] `pytest tests/tasks/test_{histogram,profile,top_k}.py tests/test_cli.py` — **35/35 pass** (no regression)
- [x] `recce server --help` — `--inline-profile` flag present and described
- [x] Smoke: `RunType.PROFILE_DISTRIBUTION` in registry, stub task instantiates and returns `{columns: {}, status: "ok"}`
- [x] `pnpm run --filter @datarecce/ui type:check` — pre-existing baseline errors only; no new type errors introduced

## Why this split

Reviewers can audit each dialect's SQL in isolation. Lots of small dialect mistakes possible here — snapshot tests are load-bearing. Landing the SQL foundation alone makes them easy to catch before PR 2 wires the orchestration around them.

## Out of scope (lands in subsequent PRs)

- Full `ProfileDistributionTask` (HLL probe + APPROX_PERCENTILE + APPROX_TOP_K) — PR 2
- Frontend cells, hook, schema view integration, in-session memoization — PR 3
- Lineage-click pre-warm + GA flip — PR 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)