### PR TITLE
feat(profile-distribution): paired histogram cells for inline profile (DRC-3390 PR 3)

### DIFF
--- a/js/packages/storybook/stories/profile-distribution/InlineProfileDistributionCell.stories.tsx
+++ b/js/packages/storybook/stories/profile-distribution/InlineProfileDistributionCell.stories.tsx
@@ -1,0 +1,356 @@
+import {
+  InlineProfileDistributionCell,
+  ProfileDistributionUnsupportedBanner,
+} from "@datarecce/ui/primitives";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Fragment } from "react";
+import {
+  continuousAddedOnly,
+  continuousOrderAmount,
+  continuousStable,
+  discreteCountryCode,
+  discreteHttpStatus,
+  discreteSignupSource,
+  discreteTrimmedAirports,
+  discreteWithGaps,
+  mixedTaskResult,
+  nullPayload,
+  unsupportedResult,
+} from "./fixtures";
+import { SchemaContainerMock, SchemaRowMock } from "./SchemaRowMock";
+
+/**
+ * The Compact-mode schema-row integration cell. Wraps loading / error /
+ * empty / data states in a single fixed-size slot so a column
+ * transitioning loading → rendered doesn't shift adjacent rows.
+ *
+ * Stories here exercise the **states** rather than the chart visuals
+ * themselves (those are covered by the Continuous + Discrete story
+ * files). Each story below shows the GA Compact-mode row in one
+ * state — light + dark.
+ */
+const meta: Meta<typeof InlineProfileDistributionCell> = {
+  title: "Profile Distribution/Inline Cell (states)",
+  component: InlineProfileDistributionCell,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `One **Compact-mode** distribution cell per schema row.
+The hook returns \`{distributions, loading, error, isUnsupported}\` per
+model; this cell consumes those + the per-column payload and renders
+exactly one of: loading spinner, error indicator, empty slot
+(per-column failure or absent payload), or the appropriate
+\`PairedHistogramContinuous\` / \`PairedHistogramDiscrete\` chart.`,
+      },
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof InlineProfileDistributionCell>;
+
+// ---------------------------------------------------------------------
+// One row per state
+// ---------------------------------------------------------------------
+
+export const Loading: Story = {
+  name: "State — loading",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="order_total_usd"
+        columnType="DECIMAL(10,2)"
+        status="changed"
+        distribution={<InlineProfileDistributionCell loading />}
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const Error_: Story = {
+  name: "State — error",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="order_total_usd"
+        columnType="DECIMAL(10,2)"
+        status="changed"
+        distribution={
+          <InlineProfileDistributionCell
+            error={new Error("backend returned 500")}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const PerColumnFailure: Story = {
+  name: "State — per-column failure (kind: null)",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="bad_column"
+        columnType="JSON"
+        status="ok"
+        distribution={<InlineProfileDistributionCell payload={nullPayload} />}
+      />
+    </SchemaContainerMock>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Per-column failure (`{kind: null}`) renders an empty slot — no spinner, no error chrome. The other columns in the same task render normally.",
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: "State — empty (no payload yet)",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="not_yet_loaded"
+        columnType="VARCHAR"
+        status="ok"
+        distribution={<InlineProfileDistributionCell />}
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const ContinuousRow: Story = {
+  name: "State — continuous payload",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="order_total_usd"
+        columnType="DECIMAL(10,2)"
+        status="changed"
+        distribution={
+          <InlineProfileDistributionCell payload={continuousOrderAmount} />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const DiscreteRow: Story = {
+  name: "State — discrete payload",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="signup_source"
+        columnType="VARCHAR"
+        status="changed"
+        distribution={
+          <InlineProfileDistributionCell payload={discreteSignupSource} />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+// ---------------------------------------------------------------------
+// Full task result — mixed columns
+// ---------------------------------------------------------------------
+
+export const MixedCompactView: Story = {
+  name: "Mixed task — all states in one Compact view",
+  render: () => {
+    const rows = [
+      {
+        col: "order_total_usd",
+        type: "DECIMAL(10,2)",
+        status: "changed" as const,
+        payload: mixedTaskResult.columns?.order_total_usd,
+      },
+      {
+        col: "created_at",
+        type: "TIMESTAMP",
+        status: "ok" as const,
+        payload: mixedTaskResult.columns?.created_at,
+      },
+      {
+        col: "ltv_predicted",
+        type: "DECIMAL",
+        status: "added" as const,
+        payload: mixedTaskResult.columns?.ltv_predicted,
+      },
+      {
+        col: "response_status",
+        type: "INT",
+        status: "changed" as const,
+        payload: mixedTaskResult.columns?.response_status,
+      },
+      {
+        col: "billing_country",
+        type: "VARCHAR",
+        status: "ok" as const,
+        payload: mixedTaskResult.columns?.billing_country,
+      },
+      {
+        col: "signup_source",
+        type: "VARCHAR",
+        status: "changed" as const,
+        payload: mixedTaskResult.columns?.signup_source,
+      },
+      {
+        col: "cohort",
+        type: "VARCHAR",
+        status: "changed" as const,
+        payload: mixedTaskResult.columns?.cohort,
+      },
+      {
+        col: "origin_airport",
+        type: "VARCHAR",
+        status: "changed" as const,
+        payload: mixedTaskResult.columns?.origin_airport,
+      },
+      {
+        col: "bad_column",
+        type: "JSON",
+        status: "ok" as const,
+        payload: mixedTaskResult.columns?.bad_column,
+      },
+      {
+        col: "still_loading",
+        type: "INT",
+        status: "ok" as const,
+        payload: undefined,
+        loading: true,
+      },
+    ];
+    return (
+      <SchemaContainerMock
+        title="orders.fct_order"
+        subtitle={`${rows.length} columns · paired distributions · Compact mode`}
+      >
+        {rows.map((r) => (
+          <Fragment key={r.col}>
+            <SchemaRowMock
+              columnName={r.col}
+              columnType={r.type}
+              status={r.status}
+              distribution={
+                <InlineProfileDistributionCell
+                  payload={r.payload}
+                  loading={r.loading}
+                />
+              }
+            />
+          </Fragment>
+        ))}
+      </SchemaContainerMock>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All states side by side: continuous, discrete, gap-on-absent, trimmed, per-column failure, and one row still loading. This is the GA Compact-mode rendering target.",
+      },
+    },
+  },
+};
+
+export const MixedCompactDarkView: Story = {
+  name: "Mixed task — Compact view (dark)",
+  render: () => {
+    const rows = [
+      {
+        col: "order_total_usd",
+        type: "DECIMAL(10,2)",
+        status: "changed" as const,
+        payload: continuousOrderAmount,
+      },
+      {
+        col: "created_at",
+        type: "TIMESTAMP",
+        status: "ok" as const,
+        payload: continuousStable,
+      },
+      {
+        col: "ltv_predicted",
+        type: "DECIMAL",
+        status: "added" as const,
+        payload: continuousAddedOnly,
+      },
+      {
+        col: "response_status",
+        type: "INT",
+        status: "changed" as const,
+        payload: discreteHttpStatus,
+      },
+      {
+        col: "billing_country",
+        type: "VARCHAR",
+        status: "ok" as const,
+        payload: discreteCountryCode,
+      },
+      {
+        col: "cohort",
+        type: "VARCHAR",
+        status: "changed" as const,
+        payload: discreteWithGaps,
+      },
+      {
+        col: "origin_airport",
+        type: "VARCHAR",
+        status: "changed" as const,
+        payload: discreteTrimmedAirports,
+      },
+    ];
+    return (
+      <SchemaContainerMock
+        isDark
+        title="orders.fct_order"
+        subtitle={`${rows.length} columns · dark theme`}
+      >
+        {rows.map((r) => (
+          <Fragment key={r.col}>
+            <SchemaRowMock
+              columnName={r.col}
+              columnType={r.type}
+              status={r.status}
+              isDark
+              distribution={
+                <InlineProfileDistributionCell
+                  payload={r.payload}
+                  theme="dark"
+                />
+              }
+            />
+          </Fragment>
+        ))}
+      </SchemaContainerMock>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------
+// Unsupported banner
+// ---------------------------------------------------------------------
+
+export const UnsupportedBanner: Story = {
+  name: "Unsupported — adapter banner",
+  render: () => (
+    <div style={{ width: 540 }}>
+      <ProfileDistributionUnsupportedBanner
+        reason={unsupportedResult.reason}
+        adapterType="postgres"
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When the run result envelope is `{status: 'unsupported', reason: ...}`, render this once above the schema view. Per-column cells are not rendered in this case.",
+      },
+    },
+  },
+};

--- a/js/packages/storybook/stories/profile-distribution/PairedHistogramContinuous.stories.tsx
+++ b/js/packages/storybook/stories/profile-distribution/PairedHistogramContinuous.stories.tsx
@@ -1,0 +1,218 @@
+import { PairedHistogramContinuous } from "@datarecce/ui/primitives";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  continuousAddedOnly,
+  continuousOrderAmount,
+  continuousStable,
+} from "./fixtures";
+import { SchemaContainerMock, SchemaRowMock } from "./SchemaRowMock";
+
+/**
+ * Constant-area paired histogram for continuous columns. Heights track
+ * density; widths track the bin's quantile span. The **area** of each
+ * bar reads as the row-proportion in that bin — the visual property
+ * that makes the chart honest under PR 2's quantile-bin payload.
+ *
+ * GA replacement for the prototype `PairedHistogramContinuousCell`,
+ * rewritten for the new payload schema (`bin_edges`, `base_density`,
+ * `current_density`). Grid-mode rendering is **out of scope at GA**.
+ */
+const meta: Meta<typeof PairedHistogramContinuous> = {
+  title: "Profile Distribution/Continuous",
+  component: PairedHistogramContinuous,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `Constant-area paired bars (one slot per quantile bin).
+Bar **area** = density × span = proportion of rows in that bin. The
+agreement zone (min of the two densities) uses a 50/50 checkerboard so
+it reads as "both distributions cover this bin equally"; the differential
+is then drawn on top in the dominant side's color (blue = current taller,
+orange = base taller).`,
+      },
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof PairedHistogramContinuous>;
+
+// ---------------------------------------------------------------------
+// Cell-density (the GA target)
+// ---------------------------------------------------------------------
+
+export const CellOrderAmount: Story = {
+  name: "Cell — order amount",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="order_total_usd"
+        columnType="DECIMAL(10,2)"
+        status="changed"
+        distribution={
+          <PairedHistogramContinuous
+            data={{
+              binEdges: continuousOrderAmount.bin_edges,
+              baseDensity: continuousOrderAmount.base_density,
+              currentDensity: continuousOrderAmount.current_density,
+              baseTotal: continuousOrderAmount.base_total,
+              currentTotal: continuousOrderAmount.current_total,
+            }}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const CellStable: Story = {
+  name: "Cell — stable (low divergence)",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="created_at"
+        columnType="TIMESTAMP"
+        status="ok"
+        distribution={
+          <PairedHistogramContinuous
+            data={{
+              binEdges: continuousStable.bin_edges,
+              baseDensity: continuousStable.base_density,
+              currentDensity: continuousStable.current_density,
+              baseTotal: continuousStable.base_total,
+              currentTotal: continuousStable.current_total,
+            }}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const CellAddedColumn: Story = {
+  name: "Cell — added column (no base)",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="ltv_predicted"
+        columnType="DECIMAL"
+        status="added"
+        distribution={
+          <PairedHistogramContinuous
+            data={{
+              binEdges: continuousAddedOnly.bin_edges,
+              baseDensity: continuousAddedOnly.base_density,
+              currentDensity: continuousAddedOnly.current_density,
+              baseTotal: continuousAddedOnly.base_total,
+              currentTotal: continuousAddedOnly.current_total,
+            }}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+// ---------------------------------------------------------------------
+// Baseball-card density (popover surface — defined here for symmetry)
+// ---------------------------------------------------------------------
+
+export const BaseballCardOrderAmount: Story = {
+  name: "Baseball card — endpoint + midpoint labels",
+  render: () => (
+    <PairedHistogramContinuous
+      data={{
+        binEdges: continuousOrderAmount.bin_edges,
+        baseDensity: continuousOrderAmount.base_density,
+        currentDensity: continuousOrderAmount.current_density,
+        baseTotal: continuousOrderAmount.base_total,
+        currentTotal: continuousOrderAmount.current_total,
+      }}
+      width={240}
+      height={92}
+      showEndpoints
+      showMidpoint
+    />
+  ),
+};
+
+// ---------------------------------------------------------------------
+// Theme variants (chromatic / visual regression)
+// ---------------------------------------------------------------------
+
+export const DarkTheme: Story = {
+  name: "Cell — dark theme",
+  render: () => (
+    <SchemaContainerMock isDark title="orders.fct_order">
+      <SchemaRowMock
+        columnName="order_total_usd"
+        columnType="DECIMAL(10,2)"
+        status="changed"
+        isDark
+        distribution={
+          <PairedHistogramContinuous
+            theme="dark"
+            data={{
+              binEdges: continuousOrderAmount.bin_edges,
+              baseDensity: continuousOrderAmount.base_density,
+              currentDensity: continuousOrderAmount.current_density,
+              baseTotal: continuousOrderAmount.base_total,
+              currentTotal: continuousOrderAmount.current_total,
+            }}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+// ---------------------------------------------------------------------
+// Edge / degenerate inputs
+// ---------------------------------------------------------------------
+
+export const EmptyPayload: Story = {
+  name: "Empty payload (no bins)",
+  render: () => (
+    <PairedHistogramContinuous
+      data={{
+        binEdges: [],
+        baseDensity: [],
+        currentDensity: [],
+        baseTotal: 0,
+        currentTotal: 0,
+      }}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An empty payload (PR 2 may emit this transiently before the column probe completes). The SVG frame is preserved so adjacent rows don't reflow.",
+      },
+    },
+  },
+};
+
+export const DegenerateRange: Story = {
+  name: "Degenerate range (all edges collapsed)",
+  render: () => (
+    <PairedHistogramContinuous
+      data={{
+        binEdges: [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+        baseDensity: Array(11).fill(0.1),
+        currentDensity: Array(11).fill(0.15),
+        baseTotal: 10,
+        currentTotal: 12,
+      }}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Constant column (every value identical) — the renderer falls back to uniform-width slots so something is still visible.",
+      },
+    },
+  },
+};

--- a/js/packages/storybook/stories/profile-distribution/PairedHistogramDiscrete.stories.tsx
+++ b/js/packages/storybook/stories/profile-distribution/PairedHistogramDiscrete.stories.tsx
@@ -1,0 +1,262 @@
+import { PairedHistogramDiscrete } from "@datarecce/ui/primitives";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  discreteCountryCode,
+  discreteHttpStatus,
+  discreteSignupSource,
+  discreteTrimmedAirports,
+  discreteWithGaps,
+} from "./fixtures";
+import { SchemaContainerMock, SchemaRowMock } from "./SchemaRowMock";
+
+/**
+ * Top-K paired histogram for categorical columns with **gap-on-absent**
+ * semantics: when a value's count is 0 on one side, that bar simply
+ * doesn't render, leaving a visible empty half-slot. The renderer's job
+ * is to make "category present here / absent there" instantly readable
+ * in 28 px of vertical space.
+ *
+ * GA replacement for the prototype `PairedHistogramDiscreteCell`,
+ * rewritten for the PR 2 top-K payload (`values`, `base_counts`,
+ * `current_counts`, `trimmed`).
+ */
+const meta: Meta<typeof PairedHistogramDiscrete> = {
+  title: "Profile Distribution/Discrete",
+  component: PairedHistogramDiscrete,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `Paired bars per category value. Base (orange) on the
+left, current (blue) on the right. **Gap-on-absent**: when a value's
+count is 0 on one side, the bar isn't drawn — the visible empty space
+reads as "this category isn't present on that side." When the backend
+had to drop a long tail past K, a tiny "trimmed" marker appears in the
+upper-right corner.`,
+      },
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof PairedHistogramDiscrete>;
+
+// ---------------------------------------------------------------------
+// Cell density
+// ---------------------------------------------------------------------
+
+export const CellHttpStatus: Story = {
+  name: "Cell — HTTP status codes",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="response_status"
+        columnType="INT"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            data={{
+              values: discreteHttpStatus.values,
+              baseCounts: discreteHttpStatus.base_counts,
+              currentCounts: discreteHttpStatus.current_counts,
+              baseTotal: discreteHttpStatus.base_total,
+              currentTotal: discreteHttpStatus.current_total,
+            }}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const CellSignupSource: Story = {
+  name: "Cell — signup source (dramatic shift)",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="signup_source"
+        columnType="VARCHAR"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            data={{
+              values: discreteSignupSource.values,
+              baseCounts: discreteSignupSource.base_counts,
+              currentCounts: discreteSignupSource.current_counts,
+              baseTotal: discreteSignupSource.base_total,
+              currentTotal: discreteSignupSource.current_total,
+            }}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const CellCountryCode: Story = {
+  name: "Cell — country code (stable)",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="billing_country"
+        columnType="VARCHAR"
+        status="ok"
+        distribution={
+          <PairedHistogramDiscrete
+            data={{
+              values: discreteCountryCode.values,
+              baseCounts: discreteCountryCode.base_counts,
+              currentCounts: discreteCountryCode.current_counts,
+              baseTotal: discreteCountryCode.base_total,
+              currentTotal: discreteCountryCode.current_total,
+            }}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const CellWithGaps: Story = {
+  name: "Cell — gap-on-absent",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="cohort"
+        columnType="VARCHAR"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            data={{
+              values: discreteWithGaps.values,
+              baseCounts: discreteWithGaps.base_counts,
+              currentCounts: discreteWithGaps.current_counts,
+              baseTotal: discreteWithGaps.base_total,
+              currentTotal: discreteWithGaps.current_total,
+            }}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Two legacy values are present only in base (gaps on the right halves of those slots); one cohort value is present only in current (gap on the left half). The pairing of empty + filled half-slots reads as 'category present on one side, absent on the other' without any text labels.",
+      },
+    },
+  },
+};
+
+export const CellTrimmed: Story = {
+  name: "Cell — trimmed top-K marker",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="origin_airport"
+        columnType="VARCHAR"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            data={{
+              values: discreteTrimmedAirports.values,
+              baseCounts: discreteTrimmedAirports.base_counts,
+              currentCounts: discreteTrimmedAirports.current_counts,
+              baseTotal: discreteTrimmedAirports.base_total,
+              currentTotal: discreteTrimmedAirports.current_total,
+              trimmed: discreteTrimmedAirports.trimmed,
+            }}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+// ---------------------------------------------------------------------
+// Baseball-card density (with value labels)
+// ---------------------------------------------------------------------
+
+export const BaseballCardWithLabels: Story = {
+  name: "Baseball card — with value labels",
+  render: () => (
+    <PairedHistogramDiscrete
+      data={{
+        values: discreteHttpStatus.values,
+        baseCounts: discreteHttpStatus.base_counts,
+        currentCounts: discreteHttpStatus.current_counts,
+        baseTotal: discreteHttpStatus.base_total,
+        currentTotal: discreteHttpStatus.current_total,
+      }}
+      width={220}
+      height={100}
+      showLabels
+      labelMaxChars={4}
+    />
+  ),
+};
+
+// ---------------------------------------------------------------------
+// Theme variants
+// ---------------------------------------------------------------------
+
+export const DarkTheme: Story = {
+  name: "Cell — dark theme",
+  render: () => (
+    <SchemaContainerMock isDark title="orders.fct_order">
+      <SchemaRowMock
+        columnName="signup_source"
+        columnType="VARCHAR"
+        status="changed"
+        isDark
+        distribution={
+          <PairedHistogramDiscrete
+            theme="dark"
+            data={{
+              values: discreteSignupSource.values,
+              baseCounts: discreteSignupSource.base_counts,
+              currentCounts: discreteSignupSource.current_counts,
+              baseTotal: discreteSignupSource.base_total,
+              currentTotal: discreteSignupSource.current_total,
+            }}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+// ---------------------------------------------------------------------
+// Edge / degenerate inputs
+// ---------------------------------------------------------------------
+
+export const EmptyPayload: Story = {
+  name: "Empty payload (no values)",
+  render: () => (
+    <PairedHistogramDiscrete
+      data={{
+        values: [],
+        baseCounts: [],
+        currentCounts: [],
+        baseTotal: 0,
+        currentTotal: 0,
+      }}
+    />
+  ),
+};
+
+export const ZeroTotals: Story = {
+  name: "All zero counts",
+  render: () => (
+    <PairedHistogramDiscrete
+      data={{
+        values: ["a", "b", "c"],
+        baseCounts: [0, 0, 0],
+        currentCounts: [0, 0, 0],
+        baseTotal: 0,
+        currentTotal: 0,
+      }}
+    />
+  ),
+};

--- a/js/packages/storybook/stories/profile-distribution/SchemaRowMock.tsx
+++ b/js/packages/storybook/stories/profile-distribution/SchemaRowMock.tsx
@@ -1,0 +1,183 @@
+import type { ReactNode } from "react";
+
+/**
+ * Compact-mode schema-row stand-in for the Paired Histograms storybook
+ * (DRC-3390 PR 3). Approximates the visual context the real
+ * `SchemaView` cells will appear in without dragging in `ag-grid` or
+ * the OSS app's CSS — chart sizing + density choices can be validated
+ * in isolation.
+ *
+ * One row = [badge slot] [type icon] [column name + type chip]
+ *           [distribution cell].
+ *
+ * This is the GA equivalent of the prototype `SidebarRowMock` /
+ * `GridRowMock`. Grid mode is intentionally absent at GA.
+ */
+
+const STRIP_COLOR_OK = "rgb(74 222 128 / 0.55)";
+const STRIP_COLOR_CHANGED = "rgb(251 146 60 / 0.85)";
+
+interface SchemaRowMockProps {
+  columnName: string;
+  columnType: string;
+  status?: "ok" | "changed" | "added" | "removed";
+  distribution: ReactNode;
+  /** Force dark mode for snapshot stories. */
+  isDark?: boolean;
+}
+
+const ROW_BG_LIGHT: Record<
+  NonNullable<SchemaRowMockProps["status"]>,
+  string
+> = {
+  ok: "#ffffff",
+  changed: "rgb(255 244 230 / 0.55)",
+  added: "rgb(220 252 231 / 0.55)",
+  removed: "rgb(254 226 226 / 0.55)",
+};
+
+const ROW_BG_DARK: Record<NonNullable<SchemaRowMockProps["status"]>, string> = {
+  ok: "#0f172a",
+  changed: "rgb(180 83 9 / 0.20)",
+  added: "rgb(22 101 52 / 0.25)",
+  removed: "rgb(127 29 29 / 0.25)",
+};
+
+const BADGE_GLYPH: Record<NonNullable<SchemaRowMockProps["status"]>, string> = {
+  ok: "",
+  changed: "~",
+  added: "+",
+  removed: "−",
+};
+
+const BADGE_COLOR: Record<NonNullable<SchemaRowMockProps["status"]>, string> = {
+  ok: "transparent",
+  changed: STRIP_COLOR_CHANGED,
+  added: STRIP_COLOR_OK,
+  removed: "rgb(248 113 113 / 0.85)",
+};
+
+export function SchemaRowMock({
+  columnName,
+  columnType,
+  status = "ok",
+  distribution,
+  isDark = false,
+}: SchemaRowMockProps) {
+  const bg = isDark ? ROW_BG_DARK[status] : ROW_BG_LIGHT[status];
+  const textColor = isDark ? "#e5e7eb" : "#1f2937";
+  const typeColor = isDark ? "#9ca3af" : "#6b7280";
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "20px 1fr 80px 160px",
+        alignItems: "center",
+        gap: 8,
+        padding: "4px 10px",
+        background: bg,
+        borderBottom: isDark ? "1px solid #1f2937" : "1px solid #f3f4f6",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        minHeight: 32,
+      }}
+    >
+      <span
+        aria-label={status === "ok" ? "unchanged" : status}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 18,
+          height: 18,
+          fontSize: 11,
+          fontWeight: 700,
+          color: status === "ok" ? "transparent" : "#1f2937",
+          background: BADGE_COLOR[status],
+          borderRadius: 3,
+        }}
+      >
+        {BADGE_GLYPH[status]}
+      </span>
+      <span
+        style={{
+          fontSize: 12,
+          fontWeight: 500,
+          color: textColor,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+        title={`${columnName} : ${columnType}`}
+      >
+        {columnName}
+      </span>
+      <span
+        style={{
+          fontSize: 11,
+          fontFamily: "ui-monospace, monospace",
+          color: typeColor,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {columnType}
+      </span>
+      <div style={{ display: "flex", justifyContent: "flex-start" }}>
+        {distribution}
+      </div>
+    </div>
+  );
+}
+
+export function SchemaContainerMock({
+  children,
+  isDark = false,
+  title,
+  subtitle,
+}: {
+  children: ReactNode;
+  isDark?: boolean;
+  title?: string;
+  subtitle?: string;
+}) {
+  return (
+    <div
+      style={{
+        width: 540,
+        background: isDark ? "#0b1220" : "#ffffff",
+        color: isDark ? "#e5e7eb" : "#1f2937",
+        border: isDark ? "1px solid #1f2937" : "1px solid #e5e7eb",
+        borderRadius: 6,
+        overflow: "hidden",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      {(title || subtitle) && (
+        <div
+          style={{
+            padding: "10px 12px",
+            borderBottom: isDark ? "1px solid #1f2937" : "1px solid #e5e7eb",
+            background: isDark ? "#111827" : "#fafafa",
+          }}
+        >
+          {title && (
+            <div style={{ fontSize: 13, fontWeight: 600 }}>{title}</div>
+          )}
+          {subtitle && (
+            <div
+              style={{
+                fontSize: 11,
+                color: isDark ? "#9ca3af" : "#6b7280",
+                marginTop: 2,
+              }}
+            >
+              {subtitle}
+            </div>
+          )}
+        </div>
+      )}
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/js/packages/storybook/stories/profile-distribution/fixtures.ts
+++ b/js/packages/storybook/stories/profile-distribution/fixtures.ts
@@ -1,0 +1,225 @@
+/**
+ * Synthetic payload fixtures for the Paired Histograms GA cells (DRC-3390 PR 3).
+ *
+ * These match the **frozen** payload schemas PR 2 produces:
+ *   - Continuous → `{kind:"histogram", bin_edges:[12], base_density:[11],
+ *     current_density:[11], base_total, current_total}` (quantile bins,
+ *     constant-area).
+ *   - Discrete   → `{kind:"topk", values, base_counts, current_counts,
+ *     base_total, current_total, trimmed}` (top-K with gap-on-absent).
+ *   - Null       → `{kind:null}` (per-column failure).
+ *   - Unsupported envelope → `{status:"unsupported", reason:...}`.
+ *
+ * The PR 2 backend isn't merged yet, so stories MOCK the payload by
+ * importing these directly. When PR 2 lands, swap the data source in
+ * the connected `useInlineProfileDistribution` stories — the cells
+ * themselves don't change.
+ */
+
+import type {
+  ProfileDistributionHistogramPayload,
+  ProfileDistributionNullPayload,
+  ProfileDistributionResult,
+  ProfileDistributionTopKPayload,
+} from "@datarecce/ui/api";
+
+// ----------------------------------------------------------------------
+// Continuous (histogram) — quantile-binned, constant-area
+// ----------------------------------------------------------------------
+
+/**
+ * 11 quantile bins concentrated in the middle (typical of a long-tailed
+ * order-amount distribution). Densities sum to ~1 once weighted by bin
+ * width — that's the constant-area contract.
+ *
+ * Edges span $0 → $1000 with most mass between $50 and $300.
+ */
+export const continuousOrderAmount: ProfileDistributionHistogramPayload = {
+  kind: "histogram",
+  bin_edges: [0, 10, 25, 50, 80, 120, 165, 220, 290, 400, 600, 1000],
+  base_density: [
+    0.001, 0.003, 0.006, 0.01, 0.014, 0.018, 0.015, 0.01, 0.005, 0.002, 0.0004,
+  ],
+  current_density: [
+    0.0008, 0.0025, 0.005, 0.0085, 0.013, 0.019, 0.017, 0.012, 0.006, 0.0028,
+    0.0005,
+  ],
+  base_total: 12_000,
+  current_total: 14_500,
+};
+
+/**
+ * Symmetric, low-divergence column (timestamps from a stable signup
+ * source). Base ≈ Current, so the chart should read as mostly checkerboard
+ * with very thin differential strips.
+ */
+export const continuousStable: ProfileDistributionHistogramPayload = {
+  kind: "histogram",
+  bin_edges: [
+    1704067200, 1704672000, 1705276800, 1705881600, 1706486400, 1707091200,
+    1707696000, 1708300800, 1708905600, 1709510400, 1710115200, 1710720000,
+  ],
+  base_density: Array(11)
+    .fill(0)
+    .map((_, i) => {
+      const x = i - 5;
+      return Math.max(1e-6, 0.0001 * Math.exp(-(x * x) / 8));
+    }),
+  current_density: Array(11)
+    .fill(0)
+    .map((_, i) => {
+      const x = i - 5;
+      return Math.max(1e-6, 0.0001 * Math.exp(-(x * x) / 8) * 1.03);
+    }),
+  base_total: 25_000,
+  current_total: 24_500,
+};
+
+/**
+ * Added column — base totals 0, all mass on current side. Renders as a
+ * solid-blue chart (current dominates every bin).
+ */
+export const continuousAddedOnly: ProfileDistributionHistogramPayload = {
+  kind: "histogram",
+  bin_edges: [0, 50, 100, 150, 200, 300, 400, 500, 700, 900, 1200, 1500],
+  base_density: Array(11).fill(0),
+  current_density: [
+    0.0005, 0.002, 0.004, 0.006, 0.005, 0.003, 0.0015, 0.0008, 0.0004, 0.00018,
+    0.00006,
+  ],
+  base_total: 0,
+  current_total: 18_000,
+};
+
+// ----------------------------------------------------------------------
+// Discrete (top-K) — gap-on-absent
+// ----------------------------------------------------------------------
+
+/**
+ * HTTP status codes — typical low-card numeric. Note the post-deploy
+ * spike in 404 / 500 / 502 counts.
+ */
+export const discreteHttpStatus: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: ["200", "204", "304", "404", "500", "502"],
+  base_counts: [18400, 1200, 4800, 220, 35, 5],
+  current_counts: [17900, 1180, 5100, 1850, 410, 90],
+  base_total: 18400 + 1200 + 4800 + 220 + 35 + 5,
+  current_total: 17900 + 1180 + 5100 + 1850 + 410 + 90,
+  trimmed: false,
+};
+
+/**
+ * Country codes — well-behaved low-card string. Both sides have the same
+ * top-K so no gap appears.
+ */
+export const discreteCountryCode: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: ["US", "GB", "DE", "FR", "JP", "CA", "AU", "BR", "IN", "MX"],
+  base_counts: [4200, 1100, 850, 690, 510, 380, 250, 220, 180, 90],
+  current_counts: [4350, 1080, 920, 700, 540, 400, 240, 210, 175, 95],
+  base_total: 4200 + 1100 + 850 + 690 + 510 + 380 + 250 + 220 + 180 + 90,
+  current_total: 4350 + 1080 + 920 + 700 + 540 + 400 + 240 + 210 + 175 + 95,
+  trimmed: false,
+};
+
+/**
+ * Signup source — dramatic shift in distribution post-redesign.
+ * Mobile takes over from web.
+ */
+export const discreteSignupSource: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: ["web", "mobile", "api", "email", "social"],
+  base_counts: [4800, 1200, 800, 400, 220],
+  current_counts: [2400, 4500, 760, 380, 240],
+  base_total: 4800 + 1200 + 800 + 400 + 220,
+  current_total: 2400 + 4500 + 760 + 380 + 240,
+  trimmed: false,
+};
+
+/**
+ * Gap-on-absent example — base had `legacy_v1` and `legacy_v2` (no
+ * longer present in current); current introduced `cohort_2026` (not in
+ * base). The renderer should leave a visible empty half of each slot
+ * for the absent side.
+ */
+export const discreteWithGaps: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: ["primary", "legacy_v1", "legacy_v2", "cohort_2026", "fallback"],
+  base_counts: [9000, 1200, 600, 0, 200],
+  current_counts: [10100, 0, 0, 1450, 220],
+  base_total: 9000 + 1200 + 600 + 0 + 200,
+  current_total: 10100 + 0 + 0 + 1450 + 220,
+  trimmed: false,
+};
+
+/**
+ * Trimmed top-K — 92-cardinality column where the backend kept only the
+ * 12 most-significant slots. The cell should render the `trimmed`
+ * marker in the corner.
+ */
+export const discreteTrimmedAirports: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: [
+    "JFK",
+    "LAX",
+    "ORD",
+    "DFW",
+    "ATL",
+    "DEN",
+    "SFO",
+    "SEA",
+    "LAS",
+    "MIA",
+    "BOS",
+    "PHX",
+  ],
+  base_counts: [
+    4200, 3800, 3500, 3100, 2900, 2600, 2400, 2100, 1900, 1700, 1500, 1400,
+  ],
+  current_counts: [
+    4400, 3700, 3300, 3000, 2950, 2600, 2500, 2050, 1850, 1750, 1450, 1380,
+  ],
+  base_total: 35_000,
+  current_total: 36_000,
+  trimmed: true,
+};
+
+// ----------------------------------------------------------------------
+// Failure / unsupported envelopes
+// ----------------------------------------------------------------------
+
+export const nullPayload: ProfileDistributionNullPayload = {
+  kind: null,
+  reason: "column query raised on this side; slot intentionally empty",
+};
+
+export const unsupportedResult: ProfileDistributionResult = {
+  status: "unsupported",
+  reason:
+    "Adapter type 'postgres' lacks native HLL / APPROX_PERCENTILE / APPROX_TOP_K.",
+};
+
+// ----------------------------------------------------------------------
+// Convenience: simulate a whole-task result envelope
+// ----------------------------------------------------------------------
+
+/**
+ * A multi-column result envelope a SchemaView consumer would receive.
+ * Mixes continuous, discrete, gapped, trimmed, and one per-column failure
+ * so stories can render the full Compact-mode row stack against one fixture.
+ */
+export const mixedTaskResult: ProfileDistributionResult = {
+  status: "ok",
+  columns: {
+    order_total_usd: continuousOrderAmount,
+    created_at: continuousStable,
+    ltv_predicted: continuousAddedOnly,
+    response_status: discreteHttpStatus,
+    billing_country: discreteCountryCode,
+    signup_source: discreteSignupSource,
+    cohort: discreteWithGaps,
+    origin_airport: discreteTrimmedAirports,
+    bad_column: nullPayload,
+  },
+};

--- a/js/packages/ui/src/api/cacheKeys.ts
+++ b/js/packages/ui/src/api/cacheKeys.ts
@@ -16,4 +16,10 @@ export const cacheKeys = {
   flag: () => ["flag"],
   instanceInfo: () => ["instance_info"],
   user: () => ["user"],
+  /**
+   * Cache key for inline profile-distribution runs. Keyed by model so
+   * each schema row caches independently and PR 4's lineage pre-warm
+   * can hydrate the cache without colliding across models.
+   */
+  profileDistribution: (model: string) => ["profile_distribution", model],
 };

--- a/js/packages/ui/src/api/index.ts
+++ b/js/packages/ui/src/api/index.ts
@@ -122,6 +122,22 @@ export type {
   TopKViewOptions,
 } from "./profile";
 export { submitProfileDiff } from "./profile";
+// Profile Distribution API (paired histograms / top-K — DRC-3390)
+export type {
+  ProfileDistributionColumnResult,
+  ProfileDistributionHistogramPayload,
+  ProfileDistributionNullPayload,
+  ProfileDistributionParams,
+  ProfileDistributionResult,
+  ProfileDistributionTopKPayload,
+} from "./profileDistribution";
+export {
+  isHistogramPayload,
+  isNullPayload,
+  isTopKPayload,
+  isUnsupportedResult,
+  submitProfileDistribution,
+} from "./profileDistribution";
 // Row Count API
 export type {
   RowCount,

--- a/js/packages/ui/src/api/profileDistribution.ts
+++ b/js/packages/ui/src/api/profileDistribution.ts
@@ -1,0 +1,88 @@
+/**
+ * API surface for paired column-distribution runs (DRC-3390).
+ *
+ * Mirrors the shape of `profile.ts` — keeps the run-submission helpers
+ * close to the typed payload definitions so the discriminated union from
+ * `./types` lines up with what callers actually send/receive.
+ *
+ * The payload **types** themselves live in `./types/run.ts` so they can
+ * participate in the canonical `Run` discriminated union. This file only
+ * holds the submit helper.
+ */
+
+import type { ApiClient } from "../lib/fetchClient";
+import { type SubmitOptions, submitRun } from "./runs";
+import type {
+  ProfileDistributionColumnResult,
+  ProfileDistributionHistogramPayload,
+  ProfileDistributionNullPayload,
+  ProfileDistributionParams,
+  ProfileDistributionResult,
+  ProfileDistributionTopKPayload,
+} from "./types/run";
+
+/**
+ * Fire a `profile_distribution` run and (by default) wait for its result.
+ * Use `options.nowait = true` to fire-and-forget — useful for PR 4's
+ * lineage pre-warm path.
+ */
+export async function submitProfileDistribution(
+  params: ProfileDistributionParams,
+  options: SubmitOptions | undefined,
+  client: ApiClient,
+) {
+  return await submitRun("profile_distribution", params, options, client);
+}
+
+// Re-export the payload types from a single import-friendly location so
+// consumers can ``import { ProfileDistributionHistogramPayload } from "@datarecce/ui/api"``.
+export type {
+  ProfileDistributionColumnResult,
+  ProfileDistributionHistogramPayload,
+  ProfileDistributionNullPayload,
+  ProfileDistributionParams,
+  ProfileDistributionResult,
+  ProfileDistributionTopKPayload,
+};
+
+// ----------------------------------------------------------------------
+// Payload narrowing helpers
+// ----------------------------------------------------------------------
+// These keep `kind`-switching out of cells; both the hook and the
+// integration row use them.
+
+/**
+ * Type guard: the result envelope is the single-shot "this adapter
+ * doesn't support the feature" reply. Frontend renders the unsupported
+ * banner once per task, not per column.
+ */
+export function isUnsupportedResult(
+  result: ProfileDistributionResult | undefined,
+): result is ProfileDistributionResult & { status: "unsupported" } {
+  return result?.status === "unsupported";
+}
+
+/** Type guard: a per-column slot carries a histogram payload. */
+export function isHistogramPayload(
+  payload: ProfileDistributionColumnResult | undefined,
+): payload is ProfileDistributionHistogramPayload {
+  return payload?.kind === "histogram";
+}
+
+/** Type guard: a per-column slot carries a top-K payload. */
+export function isTopKPayload(
+  payload: ProfileDistributionColumnResult | undefined,
+): payload is ProfileDistributionTopKPayload {
+  return payload?.kind === "topk";
+}
+
+/**
+ * Type guard: a per-column slot represents a per-column failure (the
+ * column raised during the probe but the rest of the task succeeded).
+ * Frontend skips rendering for these — no spinner, no error chrome.
+ */
+export function isNullPayload(
+  payload: ProfileDistributionColumnResult | undefined,
+): payload is ProfileDistributionNullPayload {
+  return payload?.kind === null;
+}

--- a/js/packages/ui/src/api/types/run.ts
+++ b/js/packages/ui/src/api/types/run.ts
@@ -264,12 +264,77 @@ export interface ProfileDistributionParams {
 }
 
 /**
- * Profile distribution result - per-column paired distributions.
- * PR 1 stub; PR 2 populates columns with quantile-binned histogram + top-K payloads.
+ * Quantile-binned histogram payload for a continuous column.
+ *
+ * `bin_edges` has length 12 (11 bins). `base_density[i]` /
+ * `current_density[i]` is a constant-area density value: bar area =
+ * density × bin width = proportion of rows in that bin. Renderers should
+ * draw heights proportional to density and widths proportional to span.
+ */
+export interface ProfileDistributionHistogramPayload {
+  kind: "histogram";
+  /** Length 12 — the 11 quantile-bin boundaries. */
+  bin_edges: number[];
+  /** Length 11 — base-environment density per bin (count / total / span). */
+  base_density: number[];
+  /** Length 11 — current-environment density per bin. */
+  current_density: number[];
+  /** Total row count contributing to base_density. */
+  base_total: number;
+  /** Total row count contributing to current_density. */
+  current_total: number;
+}
+
+/**
+ * Top-K payload for a categorical column.
+ *
+ * Values are the union of top-K from base and current. When a value is
+ * missing on one side, its count is 0 there — the renderer leaves a gap
+ * so paired bars align visually. `trimmed` indicates the backend dropped
+ * a long tail past K.
+ */
+export interface ProfileDistributionTopKPayload {
+  kind: "topk";
+  values: string[];
+  base_counts: number[];
+  current_counts: number[];
+  base_total: number;
+  current_total: number;
+  /** True when the original distribution had more values than K and the tail was dropped. */
+  trimmed: boolean;
+}
+
+/**
+ * Per-column failure marker. Backend uses this when a single column's
+ * probe raised — others in the same task can still succeed. Frontend
+ * skips rendering (no spinner) for any slot with this shape.
+ */
+export interface ProfileDistributionNullPayload {
+  kind: null;
+  reason?: string;
+}
+
+/**
+ * Per-column distribution result — discriminated by `kind`.
+ *
+ * See DRC-3390 for the locked payload contract.
+ */
+export type ProfileDistributionColumnResult =
+  | ProfileDistributionHistogramPayload
+  | ProfileDistributionTopKPayload
+  | ProfileDistributionNullPayload;
+
+/**
+ * Profile distribution result — per-column paired distributions OR
+ * a single envelope-level `unsupported` marker when the adapter can't
+ * run the approx-aggregates path at all.
  */
 export interface ProfileDistributionResult {
-  columns?: Record<string, unknown>;
+  /** Per-column payloads keyed by column name. Absent when status === "unsupported". */
+  columns?: Record<string, ProfileDistributionColumnResult>;
+  /** "ok" for normal runs; "unsupported" triggers the adapter banner. */
   status?: "ok" | "unsupported";
+  /** Human-readable explanation when status === "unsupported". */
   reason?: string;
 }
 

--- a/js/packages/ui/src/components/data/InlineProfileDistributionCell.tsx
+++ b/js/packages/ui/src/components/data/InlineProfileDistributionCell.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import CircularProgress from "@mui/material/CircularProgress";
+import Tooltip from "@mui/material/Tooltip";
+import { memo } from "react";
+import {
+  isHistogramPayload,
+  isTopKPayload,
+} from "../../api/profileDistribution";
+import type { ProfileDistributionColumnResult } from "../../api/types/run";
+import {
+  PairedHistogramContinuous,
+  type PairedHistogramContinuousData,
+} from "./PairedHistogramContinuous";
+import {
+  PairedHistogramDiscrete,
+  type PairedHistogramDiscreteData,
+} from "./PairedHistogramDiscrete";
+
+/**
+ * Compact-mode integration cell for a single column's paired distribution.
+ * DRC-3390 PR 3.
+ *
+ * Wraps the four states a schema row can be in for the distribution
+ * column at GA — **loading**, **error**, **empty** (per-column failure
+ * or absent payload), and **rendered** (continuous or discrete) — in a
+ * single fixed-size slot so the surrounding grid doesn't reflow as
+ * rows transition.
+ *
+ * Grid mode is **explicitly out of scope** at GA (per the DRC-3390 issue
+ * description). Only Compact mode is wired here.
+ *
+ * Owns no fetching; receives `payload` + `loading` + `error` from the
+ * parent (`useInlineProfileDistribution`). The hook caches per-model and
+ * the parent maps each column to its slot.
+ */
+export interface InlineProfileDistributionCellProps {
+  /** Per-column result from `useInlineProfileDistribution(...).distributions[column]`. */
+  payload?: ProfileDistributionColumnResult;
+  /** Loading state from the hook. While true, render a spinner — *not*
+   * the chart from a previous value, to avoid implying staleness. */
+  loading?: boolean;
+  /** Error state from the hook (task-level failure, not per-column). */
+  error?: Error | null;
+  /** Width in px — default sized to schema-row Compact density. */
+  width?: number;
+  /** Height in px — default sized to schema-row Compact density. */
+  height?: number;
+  /** Theme — `"dark"` swaps to dark-mode bar/baseline/label colors. */
+  theme?: "light" | "dark";
+  /** Optional CSS class for the wrapper. */
+  className?: string;
+}
+
+/**
+ * Inline cell wrapper. Returns a same-sized box for every state so a
+ * column transitioning loading → rendered doesn't shift adjacent cells.
+ */
+function InlineProfileDistributionCellImpl({
+  payload,
+  loading = false,
+  error = null,
+  width = 140,
+  height = 28,
+  theme = "light",
+  className,
+}: InlineProfileDistributionCellProps) {
+  const isDark = theme === "dark";
+  const wrapperStyle: React.CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "flex-start",
+    width,
+    height,
+  };
+
+  // ----- Loading ------------------------------------------------------
+  if (loading) {
+    return (
+      <span
+        className={className}
+        style={wrapperStyle}
+        role="status"
+        aria-live="polite"
+        aria-label="Loading column distribution"
+        data-testid="inline-profile-distribution-loading"
+      >
+        <CircularProgress
+          size={12}
+          thickness={5}
+          sx={{ color: isDark ? "grey.400" : "grey.600", ml: 0.5 }}
+        />
+      </span>
+    );
+  }
+
+  // ----- Error (task-level) ------------------------------------------
+  if (error) {
+    return (
+      <Tooltip title={error.message ?? "Failed to load distribution"} arrow>
+        <span
+          className={className}
+          style={{
+            ...wrapperStyle,
+            color: isDark ? "rgb(248 113 113)" : "rgb(220 38 38)",
+            fontSize: 10,
+            fontFamily: "ui-monospace, monospace",
+            paddingLeft: 4,
+          }}
+          role="img"
+          aria-label="Distribution failed to load"
+          data-testid="inline-profile-distribution-error"
+        >
+          ⚠ error
+        </span>
+      </Tooltip>
+    );
+  }
+
+  // ----- Per-column failure or absent (kind: null OR payload undefined)
+  // Render nothing — schema row still shows name/type/badge. This is the
+  // spec's "empty state": no spinner, no error chrome.
+  if (!payload || payload.kind === null) {
+    return (
+      <span
+        className={className}
+        style={wrapperStyle}
+        aria-hidden="true"
+        data-testid="inline-profile-distribution-empty"
+      />
+    );
+  }
+
+  // ----- Continuous (histogram) --------------------------------------
+  if (isHistogramPayload(payload)) {
+    const data: PairedHistogramContinuousData = {
+      binEdges: payload.bin_edges,
+      baseDensity: payload.base_density,
+      currentDensity: payload.current_density,
+      baseTotal: payload.base_total,
+      currentTotal: payload.current_total,
+    };
+    return (
+      <span
+        className={className}
+        style={wrapperStyle}
+        data-testid="inline-profile-distribution-continuous"
+      >
+        <PairedHistogramContinuous
+          data={data}
+          width={width}
+          height={height}
+          theme={theme}
+        />
+      </span>
+    );
+  }
+
+  // ----- Discrete (top-K) --------------------------------------------
+  if (isTopKPayload(payload)) {
+    const data: PairedHistogramDiscreteData = {
+      values: payload.values,
+      baseCounts: payload.base_counts,
+      currentCounts: payload.current_counts,
+      baseTotal: payload.base_total,
+      currentTotal: payload.current_total,
+      trimmed: payload.trimmed,
+    };
+    return (
+      <span
+        className={className}
+        style={wrapperStyle}
+        data-testid="inline-profile-distribution-discrete"
+      >
+        <PairedHistogramDiscrete
+          data={data}
+          width={width}
+          height={height}
+          theme={theme}
+        />
+      </span>
+    );
+  }
+
+  // Defensive fallback for any future `kind` we haven't taught the UI
+  // about yet. Render the same empty slot rather than crashing the row.
+  return (
+    <span
+      className={className}
+      style={wrapperStyle}
+      aria-hidden="true"
+      data-testid="inline-profile-distribution-empty"
+    />
+  );
+}
+
+export const InlineProfileDistributionCell = memo(
+  InlineProfileDistributionCellImpl,
+);
+InlineProfileDistributionCell.displayName = "InlineProfileDistributionCell";

--- a/js/packages/ui/src/components/data/PairedHistogramContinuous.tsx
+++ b/js/packages/ui/src/components/data/PairedHistogramContinuous.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useId, useMemo } from "react";
+
+/**
+ * Small continuous paired-bar chart for high-cardinality quantitative data
+ * (order amounts, latency, file sizes) using **constant-area** rendering.
+ *
+ * This is the GA replacement for the prototype `PairedHistogramContinuousCell`,
+ * rewritten for the quantile-bin payload shipped by PR 2. The visual
+ * vocabulary is preserved (paired bars per bin, agreement zone +
+ * differential), but bar **width** now varies with the bin's quantile
+ * span and bar **height** with density, so the **area** of each bar reads
+ * directly as the proportion of rows in that bin.
+ *
+ * Why constant-area: with quantile bins, equal-row-count slots have
+ * different widths. Uniform-width rendering would overweight wide,
+ * sparse bins. Area = density × span gives every bar the same row-share
+ * meaning regardless of bin width.
+ *
+ * Why not reuse `HistogramChart`: HistogramChart unconditionally renders
+ * a title row + legend (~50 px overhead). At cell density (h≈36) there
+ * is no room left for the bars. HistogramChart still belongs on popover
+ * and detail surfaces where its title/legend/tooltip machinery is welcome —
+ * just not in a 140×36 grid cell.
+ */
+
+// Stacked-bar palette. Each bin draws up to two segments stacked from the
+// baseline: an agreement zone of min(base, current) — a 2×2 SVG-pattern
+// checkerboard of orange/blue cells (true 50/50 area, reads as "both
+// distributions agree here") — then a single differential rect in either
+// solid orange (base higher) or solid blue (current higher).
+const BASE_FILL = "#F6AD55";
+const CURRENT_FILL = "#63B3ED";
+const BASE_FILL_DARK = "#FBD38D";
+const CURRENT_FILL_DARK = "#90CDF4";
+const BASELINE_RULE = "#9ca3af";
+const BASELINE_RULE_DARK = "#6b7280";
+const LABEL_COLOR = "#374151";
+const LABEL_COLOR_DARK = "#e5e7eb";
+
+/**
+ * Payload for the continuous cell. Matches `ProfileDistributionHistogramPayload`
+ * from the run API (snake_case wire format) so callers can pass results
+ * through with minimal adapting.
+ */
+export interface PairedHistogramContinuousData {
+  /** Length 12 quantile-bin edges. */
+  binEdges: number[];
+  /** Length 11 — base density per bin (count / total / span). */
+  baseDensity: number[];
+  /** Length 11 — current density per bin. */
+  currentDensity: number[];
+  baseTotal: number;
+  currentTotal: number;
+}
+
+export interface PairedHistogramContinuousProps {
+  data: PairedHistogramContinuousData;
+  /** Default 140 (cell). Use ~240 for baseball-card / popover. */
+  width?: number;
+  /** Default 36 (cell). Use ~92 for baseball-card. */
+  height?: number;
+  /** Render endpoint labels (min / max). Default false — bin range is
+   * shown on hover via the per-bar tooltip; in-chart labels eat too much
+   * vertical room at cell density. Enable for the card preset. */
+  showEndpoints?: boolean;
+  /** Also render midpoint label between min and max. Default false. */
+  showMidpoint?: boolean;
+  /** Override default label formatter. Default: 1.2K-style abbreviation. */
+  formatValue?: (v: number) => string;
+  /** Theme — `"dark"` swaps to dark-mode bar colors / label colors. */
+  theme?: "light" | "dark";
+  /** Optional CSS class. */
+  className?: string;
+  /** Accessible label override for the SVG. */
+  ariaLabel?: string;
+}
+
+/**
+ * PairedHistogramContinuous — constant-area paired-bar chart.
+ *
+ * @example Cell density (default)
+ * ```tsx
+ * <PairedHistogramContinuous data={distribution} />
+ * ```
+ *
+ * @example Baseball-card preset with endpoint + midpoint labels
+ * ```tsx
+ * <PairedHistogramContinuous
+ *   data={distribution}
+ *   width={240}
+ *   height={92}
+ *   showEndpoints
+ *   showMidpoint
+ * />
+ * ```
+ */
+export function PairedHistogramContinuous({
+  data,
+  width = 140,
+  height = 36,
+  showEndpoints = false,
+  showMidpoint = false,
+  formatValue = formatAbbrev,
+  theme = "light",
+  className,
+  ariaLabel = "Paired baseline and current continuous distribution",
+}: PairedHistogramContinuousProps) {
+  const isDark = theme === "dark";
+  const baseFill = isDark ? BASE_FILL_DARK : BASE_FILL;
+  const currentFill = isDark ? CURRENT_FILL_DARK : CURRENT_FILL;
+  const baselineColor = isDark ? BASELINE_RULE_DARK : BASELINE_RULE;
+  const labelColor = isDark ? LABEL_COLOR_DARK : LABEL_COLOR;
+
+  // SVG pattern IDs are document-global; useId() gives each cell instance
+  // its own ID so patterns don't collide between adjacent histograms.
+  const reactId = useId();
+  const patternId = `phc-overlap-${reactId.replace(/[:]/g, "")}`;
+
+  const layout = useMemo(() => {
+    return computeContinuousLayout(data, width);
+  }, [data, width]);
+
+  const labelHeight = showEndpoints ? 11 : 0;
+  const chartHeight = Math.max(8, height - labelHeight - 2);
+
+  // Empty / degenerate input — render an empty SVG so size is preserved.
+  if (layout.bins.length === 0) {
+    return (
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        className={className}
+        style={{ display: "block", overflow: "visible" }}
+        role="img"
+        aria-label={ariaLabel}
+      >
+        <title>{ariaLabel}</title>
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      style={{ display: "block", overflow: "visible" }}
+      role="img"
+      aria-label={ariaLabel}
+    >
+      <title>{ariaLabel}</title>
+      <defs>
+        <pattern
+          id={patternId}
+          patternUnits="userSpaceOnUse"
+          width={4}
+          height={4}
+        >
+          <rect x={0} y={0} width={2} height={2} fill={baseFill} />
+          <rect x={2} y={2} width={2} height={2} fill={baseFill} />
+          <rect x={2} y={0} width={2} height={2} fill={currentFill} />
+          <rect x={0} y={2} width={2} height={2} fill={currentFill} />
+        </pattern>
+      </defs>
+      {layout.bins.map((bin, i) => {
+        const baseH = (bin.baseDensity / layout.maxDensity) * chartHeight;
+        const currH = (bin.currentDensity / layout.maxDensity) * chartHeight;
+        const minH = Math.min(baseH, currH);
+        const maxH = Math.max(baseH, currH);
+        const diffFill = baseH > currH ? baseFill : currentFill;
+        // Bars touch (continuous data should read continuously); a tiny
+        // -0.25 px inset prevents adjacent bins from blurring into one
+        // shape at very tight slot widths.
+        const w = Math.max(0.5, bin.width - 0.25);
+        const hoverTitle = formatContinuousTooltip(bin, formatValue);
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable quantile order
+          <g key={i}>
+            {/* Invisible hit-target spanning the full slot height so hover
+             * picks up the tooltip even on very small bars. */}
+            <rect
+              x={bin.x}
+              y={0}
+              width={bin.width}
+              height={chartHeight}
+              fill="transparent"
+            >
+              <title>{hoverTitle}</title>
+            </rect>
+            {minH > 0 && (
+              <rect
+                x={bin.x}
+                y={chartHeight - minH}
+                width={w}
+                height={minH}
+                fill={`url(#${patternId})`}
+                pointerEvents="none"
+              />
+            )}
+            {maxH > minH && (
+              <rect
+                x={bin.x}
+                y={chartHeight - maxH}
+                width={w}
+                height={maxH - minH}
+                fill={diffFill}
+                pointerEvents="none"
+              />
+            )}
+          </g>
+        );
+      })}
+
+      <line
+        x1={0}
+        y1={chartHeight}
+        x2={width}
+        y2={chartHeight}
+        stroke={baselineColor}
+        strokeWidth={0.5}
+      />
+
+      {showEndpoints && (
+        <g
+          fontFamily="system-ui, -apple-system, sans-serif"
+          fontSize={9}
+          fill={labelColor}
+        >
+          <text x={0} y={height - 1} textAnchor="start">
+            {formatValue(layout.minVal)}
+          </text>
+          {showMidpoint && (
+            <text x={width / 2} y={height - 1} textAnchor="middle">
+              {formatValue((layout.minVal + layout.maxVal) / 2)}
+            </text>
+          )}
+          <text x={width} y={height - 1} textAnchor="end">
+            {formatValue(layout.maxVal)}
+          </text>
+        </g>
+      )}
+    </svg>
+  );
+}
+
+/**
+ * Compute per-bin x / width / density given a quantile-bin payload and an
+ * available chart width. Bars are positioned proportionally to their
+ * quantile span — wide bins (sparse regions) get wide bars, narrow bins
+ * (dense regions) get narrow bars. Heights remain proportional to density,
+ * so the **area** of every bar reads as the row-proportion in that bin.
+ *
+ * Exported so tests + lineage pre-warm (PR 4) can validate the geometry
+ * without rendering.
+ */
+export function computeContinuousLayout(
+  data: PairedHistogramContinuousData,
+  width: number,
+): {
+  bins: {
+    x: number;
+    width: number;
+    baseDensity: number;
+    currentDensity: number;
+    lo: number;
+    hi: number;
+  }[];
+  maxDensity: number;
+  minVal: number;
+  maxVal: number;
+} {
+  const { binEdges, baseDensity, currentDensity } = data;
+
+  // Guard: payload must have N+1 edges for N bins, and both density
+  // arrays must agree on N. If anything's off, return an empty layout —
+  // the renderer falls back to an empty SVG above.
+  const binCount = baseDensity.length;
+  if (
+    binCount === 0 ||
+    binCount !== currentDensity.length ||
+    binEdges.length !== binCount + 1
+  ) {
+    return { bins: [], maxDensity: 0, minVal: 0, maxVal: 0 };
+  }
+
+  const minVal = binEdges[0];
+  const maxVal = binEdges[binEdges.length - 1];
+  const totalSpan = maxVal - minVal;
+
+  // Degenerate range (all bins collapsed to a point): fall back to
+  // uniform-width slots so we still render something visible.
+  const useUniform = totalSpan <= 0 || !Number.isFinite(totalSpan);
+
+  const bins = [];
+  let cursor = 0;
+  for (let i = 0; i < binCount; i += 1) {
+    const lo = binEdges[i];
+    const hi = binEdges[i + 1];
+    const span = hi - lo;
+    const w = useUniform
+      ? width / binCount
+      : Math.max(0, (span / totalSpan) * width);
+    bins.push({
+      x: cursor,
+      width: w,
+      baseDensity: baseDensity[i],
+      currentDensity: currentDensity[i],
+      lo,
+      hi,
+    });
+    cursor += w;
+  }
+
+  // Account for any rounding drift: stretch the last bin to the right edge.
+  if (bins.length > 0 && !useUniform) {
+    const last = bins[bins.length - 1];
+    last.width = Math.max(0, width - last.x);
+  }
+
+  const allDensities: number[] = [];
+  for (const d of baseDensity) allDensities.push(d);
+  for (const d of currentDensity) allDensities.push(d);
+  const maxDensity = Math.max(1e-9, ...allDensities);
+
+  return { bins, maxDensity, minVal, maxVal };
+}
+
+function formatAbbrev(v: number): string {
+  if (!Number.isFinite(v)) return String(v);
+  const abs = Math.abs(v);
+  if (abs >= 1e9) return `${(v / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `${(v / 1e3).toFixed(1)}K`;
+  if (Number.isInteger(v)) return String(v);
+  return v.toFixed(1);
+}
+
+function formatContinuousTooltip(
+  bin: {
+    lo: number;
+    hi: number;
+    baseDensity: number;
+    currentDensity: number;
+  },
+  fmt: (v: number) => string,
+): string {
+  const span = bin.hi - bin.lo;
+  // Area = density × span = proportion of rows in this quantile-bin.
+  const baseProp = span > 0 ? bin.baseDensity * span : 0;
+  const currProp = span > 0 ? bin.currentDensity * span : 0;
+  const bp = `${(baseProp * 100).toFixed(1)}%`;
+  const cp = `${(currProp * 100).toFixed(1)}%`;
+  return `${fmt(bin.lo)}–${fmt(bin.hi)} [base: ${bp}, current: ${cp}]`;
+}

--- a/js/packages/ui/src/components/data/PairedHistogramDiscrete.tsx
+++ b/js/packages/ui/src/components/data/PairedHistogramDiscrete.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useMemo } from "react";
+
+/**
+ * Small categorical paired-bar chart for top-K low-cardinality data —
+ * both string-valued (country codes) and numeric-as-label (HTTP status
+ * codes). Cell-density sibling of `HistogramChart`/`TopKBarChart`; those
+ * keep their place on detail/popover surfaces where title + legend fit.
+ *
+ * This is the GA replacement for the prototype `PairedHistogramDiscreteCell`,
+ * rewritten for the top-K payload shipped by PR 2.
+ *
+ * Two render targets, same component:
+ *   - Cell preset: ~140×36, no labels — fits inline in a grid column.
+ *   - Baseball-card preset: ~220×100, with abbreviated labels — primary
+ *     visual on a SchemaGalleryView card.
+ *
+ * Visual: paired bars per category slot. When one side's count is 0
+ * (value absent on that side), that bar simply doesn't render, leaving
+ * a visible gap that reads as "category absent on this side." This is
+ * the **gap-on-absent** semantic locked in DRC-3390.
+ */
+
+const BASE_FILL = "#F6AD55";
+const CURRENT_FILL = "#63B3ED";
+const BASE_FILL_DARK = "#FBD38D";
+const CURRENT_FILL_DARK = "#90CDF4";
+const BASELINE_RULE = "#9ca3af";
+const BASELINE_RULE_DARK = "#6b7280";
+const LABEL_COLOR = "#374151";
+const LABEL_COLOR_DARK = "#e5e7eb";
+const TRIM_COLOR = "#9ca3af";
+
+/**
+ * Payload for the discrete cell. Matches `ProfileDistributionTopKPayload`
+ * from the run API (snake_case wire format) so callers can pass results
+ * through with minimal adapting.
+ */
+export interface PairedHistogramDiscreteData {
+  /** Display order = union(baseTopK, currentTopK), backend-chosen.
+   * Caller may pre-sort (e.g. frequency-desc) for cell density. */
+  values: string[];
+  baseCounts: number[];
+  currentCounts: number[];
+  baseTotal: number;
+  currentTotal: number;
+  /** True when the original distribution had more values than K — caller
+   * passes this through from the payload's `trimmed` field. */
+  trimmed?: boolean;
+}
+
+export interface PairedHistogramDiscreteProps {
+  data: PairedHistogramDiscreteData;
+  /** Default 140 (cell). Use ~220 for baseball-card. */
+  width?: number;
+  /** Default 36 (cell). Use ~100 for card. */
+  height?: number;
+  /** Render value labels below bars. Default false — values shown on hover
+   * via the per-bar tooltip; in-chart labels collide at any non-trivial
+   * cardinality. True for card preset where there's room. */
+  showLabels?: boolean;
+  /** Maximum chars per label before truncation. Default 4. */
+  labelMaxChars?: number;
+  /** Theme — `"dark"` swaps to dark-mode bar/label colors. */
+  theme?: "light" | "dark";
+  /** Optional CSS class. */
+  className?: string;
+  /** Accessible label override for the SVG. */
+  ariaLabel?: string;
+}
+
+/**
+ * PairedHistogramDiscrete — paired-bar top-K chart with gap-on-absent
+ * semantics.
+ *
+ * @example Cell density (default)
+ * ```tsx
+ * <PairedHistogramDiscrete data={topK} />
+ * ```
+ *
+ * @example Baseball-card preset
+ * ```tsx
+ * <PairedHistogramDiscrete data={topK} width={220} height={100} showLabels />
+ * ```
+ */
+export function PairedHistogramDiscrete({
+  data,
+  width = 140,
+  height = 36,
+  showLabels = false,
+  labelMaxChars = 4,
+  theme = "light",
+  className,
+  ariaLabel = "Paired baseline and current categorical distribution",
+}: PairedHistogramDiscreteProps) {
+  const isDark = theme === "dark";
+  const baseFill = isDark ? BASE_FILL_DARK : BASE_FILL;
+  const currentFill = isDark ? CURRENT_FILL_DARK : CURRENT_FILL;
+  const baselineColor = isDark ? BASELINE_RULE_DARK : BASELINE_RULE;
+  const labelColor = isDark ? LABEL_COLOR_DARK : LABEL_COLOR;
+
+  const { slots, maxProp } = useMemo(() => {
+    return computeDiscreteSlots(data);
+  }, [data]);
+
+  const labelHeight = showLabels ? 12 : 0;
+  // 2 px breathing room between bars and the next visual element.
+  const chartHeight = Math.max(8, height - labelHeight - 2);
+
+  // Empty payload — render the SVG frame so layout stays stable.
+  if (slots.length === 0) {
+    return (
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        className={className}
+        style={{ display: "block", overflow: "visible" }}
+        role="img"
+        aria-label={ariaLabel}
+      >
+        <title>{ariaLabel}</title>
+      </svg>
+    );
+  }
+
+  const slotWidth = width / Math.max(1, slots.length);
+  // Slot layout: 10% padding each side, two bars side by side with a small
+  // gap. When one side's count is 0, that bar simply doesn't render —
+  // leaving a visible gap that signals "category absent on this side."
+  const slotPad = slotWidth * 0.1;
+  const innerW = slotWidth - slotPad * 2;
+  const gap = Math.max(1, Math.min(2, innerW * 0.1));
+  const pairBarW = Math.max(1, (innerW - gap) / 2);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      style={{ display: "block", overflow: "visible" }}
+      role="img"
+      aria-label={ariaLabel}
+    >
+      <title>{ariaLabel}</title>
+      {slots.map((s, i) => {
+        const baseH = (s.baseProp / maxProp) * chartHeight;
+        const currH = (s.currProp / maxProp) * chartHeight;
+        const hoverTitle = formatDiscreteTooltip(s);
+        const slotX = i * slotWidth;
+        const baseX = slotX + slotPad;
+        const currX = slotX + slotPad + pairBarW + gap;
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable backend order
+          <g key={i}>
+            {/* Invisible hit-target spans the full slot — hovering either
+             * bar (or the gap where one is absent) shows the same tooltip
+             * identifying this value. */}
+            <rect
+              x={slotX}
+              y={0}
+              width={slotWidth}
+              height={chartHeight}
+              fill="transparent"
+            >
+              <title>{hoverTitle}</title>
+            </rect>
+            {baseH > 0 && (
+              <rect
+                x={baseX}
+                y={chartHeight - baseH}
+                width={pairBarW}
+                height={baseH}
+                fill={baseFill}
+                pointerEvents="none"
+              />
+            )}
+            {currH > 0 && (
+              <rect
+                x={currX}
+                y={chartHeight - currH}
+                width={pairBarW}
+                height={currH}
+                fill={currentFill}
+                pointerEvents="none"
+              />
+            )}
+          </g>
+        );
+      })}
+
+      <line
+        x1={0}
+        y1={chartHeight}
+        x2={width}
+        y2={chartHeight}
+        stroke={baselineColor}
+        strokeWidth={0.5}
+      />
+
+      {showLabels && (
+        <g
+          fontFamily="system-ui, -apple-system, sans-serif"
+          fontSize={9}
+          fill={labelColor}
+          textAnchor="middle"
+        >
+          {slots.map((s, i) => (
+            <text
+              // biome-ignore lint/suspicious/noArrayIndexKey: stable backend order
+              key={i}
+              x={i * slotWidth + slotWidth / 2}
+              y={chartHeight + 9}
+            >
+              {truncate(s.value, labelMaxChars)}
+            </text>
+          ))}
+        </g>
+      )}
+
+      {data.trimmed && (
+        <text
+          x={width - 1}
+          y={9}
+          fontFamily="system-ui, -apple-system, sans-serif"
+          fontSize={8}
+          fill={TRIM_COLOR}
+          textAnchor="end"
+        >
+          trimmed
+        </text>
+      )}
+    </svg>
+  );
+}
+
+/**
+ * Compute per-slot proportions + max prop given a top-K payload.
+ *
+ * Exported so the layout can be unit-tested without rendering and so
+ * PR 4's lineage pre-warm can validate payloads cheaply.
+ */
+export function computeDiscreteSlots(data: PairedHistogramDiscreteData): {
+  slots: {
+    value: string;
+    baseProp: number;
+    currProp: number;
+    baseCount: number;
+    currCount: number;
+  }[];
+  maxProp: number;
+} {
+  const { values, baseCounts, currentCounts, baseTotal, currentTotal } = data;
+
+  // Guard: counts arrays must match values.length. Anything off → empty slots.
+  if (
+    values.length === 0 ||
+    values.length !== baseCounts.length ||
+    values.length !== currentCounts.length
+  ) {
+    return { slots: [], maxProp: 0 };
+  }
+
+  const slots = values.map((value, i) => {
+    const baseCount = baseCounts[i] ?? 0;
+    const currCount = currentCounts[i] ?? 0;
+    return {
+      value,
+      baseCount,
+      currCount,
+      baseProp: baseTotal > 0 ? baseCount / baseTotal : 0,
+      currProp: currentTotal > 0 ? currCount / currentTotal : 0,
+    };
+  });
+
+  const props: number[] = [];
+  for (const s of slots) {
+    props.push(s.baseProp);
+    props.push(s.currProp);
+  }
+  const maxProp = Math.max(0.001, ...props);
+  return { slots, maxProp };
+}
+
+function truncate(s: string, maxChars: number): string {
+  if (s.length <= maxChars) return s;
+  if (maxChars <= 1) return "…";
+  return `${s.slice(0, maxChars - 1)}…`;
+}
+
+function formatDiscreteTooltip(s: {
+  value: string;
+  baseProp: number;
+  currProp: number;
+}): string {
+  // One value = one bar identity. Always show base + current paired, even
+  // when one is 0% — the user reads the divergence directly from the two
+  // numbers; "only in X" framing got in the way.
+  const bp = `${(s.baseProp * 100).toFixed(1)}%`;
+  const cp = `${(s.currProp * 100).toFixed(1)}%`;
+  return `${s.value} [base: ${bp}, current: ${cp}]`;
+}

--- a/js/packages/ui/src/components/data/ProfileDistributionUnsupportedBanner.tsx
+++ b/js/packages/ui/src/components/data/ProfileDistributionUnsupportedBanner.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import MuiAlert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
+
+/**
+ * One-time banner shown when the dbt adapter can't run the paired-
+ * distribution feature at all (e.g. Postgres, MySQL, SQLite,
+ * SQL Server < 2022). The backend signals this with a single
+ * `{status: "unsupported", reason: ...}` envelope rather than a per-
+ * column payload. DRC-3390 PR 3.
+ *
+ * The banner is intentionally low-key (MUI Alert "info" severity, dense
+ * padding) so it doesn't dominate the schema view when the feature is
+ * flag-enabled but unavailable on this warehouse. It carries the
+ * backend's `reason` string so users know *why* — usually "adapter
+ * lacks native HLL / approx_percentile / approx_top_k".
+ */
+
+export interface ProfileDistributionUnsupportedBannerProps {
+  /** Backend-provided explanation. Falls back to a generic message. */
+  reason?: string;
+  /** Optional adapter-type for a more specific message (e.g. "postgres"). */
+  adapterType?: string;
+  /** Optional CSS class override. */
+  className?: string;
+}
+
+const DEFAULT_REASON =
+  "This warehouse doesn't expose native HLL / approx-percentile / approx-top-k aggregates, so paired column distributions aren't available here.";
+
+export function ProfileDistributionUnsupportedBanner({
+  reason,
+  adapterType,
+  className,
+}: ProfileDistributionUnsupportedBannerProps) {
+  const message = reason ?? DEFAULT_REASON;
+  const title = adapterType
+    ? `Paired distributions unavailable on ${adapterType}`
+    : "Paired distributions unavailable on this adapter";
+  return (
+    <MuiAlert
+      severity="info"
+      variant="outlined"
+      className={className}
+      sx={{
+        fontSize: "12px",
+        py: 0.5,
+        px: 1,
+        "& .MuiAlert-message": { py: 0.5 },
+      }}
+      role="status"
+      aria-live="polite"
+      data-testid="profile-distribution-unsupported-banner"
+    >
+      <AlertTitle sx={{ fontSize: "12px", fontWeight: 600, mb: 0.25 }}>
+        {title}
+      </AlertTitle>
+      {message}
+    </MuiAlert>
+  );
+}

--- a/js/packages/ui/src/components/data/__tests__/InlineProfileDistributionCell.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/InlineProfileDistributionCell.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @file InlineProfileDistributionCell.test.tsx
+ * @description Tests for the Compact-mode schema-row integration cell
+ * that wraps the four states a column can be in (DRC-3390 PR 3).
+ */
+
+import { render } from "@testing-library/react";
+import type {
+  ProfileDistributionHistogramPayload,
+  ProfileDistributionNullPayload,
+  ProfileDistributionTopKPayload,
+} from "../../../api/types/run";
+import { InlineProfileDistributionCell } from "../InlineProfileDistributionCell";
+
+const histogramPayload: ProfileDistributionHistogramPayload = {
+  kind: "histogram",
+  bin_edges: [0, 10, 25, 50, 80, 120, 165, 220, 290, 400, 600, 1000],
+  base_density: [
+    0.01, 0.02, 0.04, 0.06, 0.08, 0.07, 0.05, 0.03, 0.015, 0.005, 0.001,
+  ],
+  current_density: [
+    0.02, 0.03, 0.045, 0.055, 0.085, 0.065, 0.04, 0.025, 0.012, 0.006, 0.0015,
+  ],
+  base_total: 10_000,
+  current_total: 12_000,
+};
+
+const topKPayload: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: ["US", "GB", "DE"],
+  base_counts: [100, 50, 25],
+  current_counts: [110, 40, 35],
+  base_total: 175,
+  current_total: 185,
+  trimmed: false,
+};
+
+const nullPayload: ProfileDistributionNullPayload = {
+  kind: null,
+  reason: "column query failed",
+};
+
+describe("InlineProfileDistributionCell", () => {
+  it("renders the loading state when loading is true", () => {
+    const { getByTestId, queryByTestId } = render(
+      <InlineProfileDistributionCell loading />,
+    );
+    expect(
+      getByTestId("inline-profile-distribution-loading"),
+    ).toBeInTheDocument();
+    expect(
+      queryByTestId("inline-profile-distribution-continuous"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the error state when error is non-null", () => {
+    const err = new Error("server returned 500");
+    const { getByTestId } = render(
+      <InlineProfileDistributionCell error={err} />,
+    );
+    expect(
+      getByTestId("inline-profile-distribution-error"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty state when payload is undefined", () => {
+    const { getByTestId } = render(<InlineProfileDistributionCell />);
+    expect(
+      getByTestId("inline-profile-distribution-empty"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty state when payload.kind === null (per-column failure)", () => {
+    const { getByTestId, queryByTestId } = render(
+      <InlineProfileDistributionCell payload={nullPayload} />,
+    );
+    expect(
+      getByTestId("inline-profile-distribution-empty"),
+    ).toBeInTheDocument();
+    // Crucially: no spinner. Per-column failure ≠ loading.
+    expect(
+      queryByTestId("inline-profile-distribution-loading"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the continuous chart when payload.kind === 'histogram'", () => {
+    const { getByTestId } = render(
+      <InlineProfileDistributionCell payload={histogramPayload} />,
+    );
+    expect(
+      getByTestId("inline-profile-distribution-continuous"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the discrete chart when payload.kind === 'topk'", () => {
+    const { getByTestId } = render(
+      <InlineProfileDistributionCell payload={topKPayload} />,
+    );
+    expect(
+      getByTestId("inline-profile-distribution-discrete"),
+    ).toBeInTheDocument();
+  });
+
+  it("passes the trimmed flag through to the discrete cell", () => {
+    const { container } = render(
+      <InlineProfileDistributionCell
+        payload={{ ...topKPayload, trimmed: true }}
+      />,
+    );
+    expect(container.textContent).toContain("trimmed");
+  });
+
+  it("loading takes precedence over a stale payload (no flicker)", () => {
+    const { getByTestId, queryByTestId } = render(
+      <InlineProfileDistributionCell payload={histogramPayload} loading />,
+    );
+    expect(
+      getByTestId("inline-profile-distribution-loading"),
+    ).toBeInTheDocument();
+    expect(
+      queryByTestId("inline-profile-distribution-continuous"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("error takes precedence over an existing payload", () => {
+    const { getByTestId, queryByTestId } = render(
+      <InlineProfileDistributionCell
+        payload={topKPayload}
+        error={new Error("backend exploded")}
+      />,
+    );
+    expect(
+      getByTestId("inline-profile-distribution-error"),
+    ).toBeInTheDocument();
+    expect(
+      queryByTestId("inline-profile-distribution-discrete"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("forwards width and height to the underlying chart", () => {
+    const { container } = render(
+      <InlineProfileDistributionCell
+        payload={histogramPayload}
+        width={220}
+        height={64}
+      />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("220");
+    expect(svg?.getAttribute("height")).toBe("64");
+  });
+});

--- a/js/packages/ui/src/components/data/__tests__/PairedHistogramContinuous.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/PairedHistogramContinuous.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * @file PairedHistogramContinuous.test.tsx
+ * @description Tests for the constant-area paired histogram cell (DRC-3390 PR 3).
+ *
+ * Visual behavior covered:
+ *   - One <g> per bin
+ *   - Bar widths track the quantile span (constant-area), not slot-uniform
+ *   - Heights track density relative to max density across both envs
+ *   - Differential rect colored by which env exceeds the other in that bin
+ *   - Agreement zone (min(base, current)) uses the checkerboard SVG pattern
+ *   - Light / dark theme bar colors
+ *   - Endpoint + midpoint labels
+ *   - Degenerate / zero / mismatched payloads don't crash
+ */
+
+import { render } from "@testing-library/react";
+import {
+  computeContinuousLayout,
+  PairedHistogramContinuous,
+  type PairedHistogramContinuousData,
+} from "../PairedHistogramContinuous";
+
+// 11 bins with quantile-driven widths: tight in the middle, wide at the
+// edges (typical for a long-tailed distribution where APPROX_PERCENTILE
+// hits 80% of the mass between bins 3 and 7).
+const sampleData: PairedHistogramContinuousData = {
+  binEdges: [0, 10, 25, 50, 80, 120, 165, 220, 290, 400, 600, 1000],
+  baseDensity: [
+    0.01, 0.02, 0.04, 0.06, 0.08, 0.07, 0.05, 0.03, 0.015, 0.005, 0.001,
+  ],
+  currentDensity: [
+    0.02, 0.03, 0.045, 0.055, 0.085, 0.065, 0.04, 0.025, 0.012, 0.006, 0.0015,
+  ],
+  baseTotal: 10_000,
+  currentTotal: 12_000,
+};
+
+describe("PairedHistogramContinuous", () => {
+  it("renders one group per bin", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} />,
+    );
+    const groups = container.querySelectorAll("svg > g");
+    expect(groups.length).toBe(sampleData.baseDensity.length);
+  });
+
+  it("uses default cell-density dimensions when not provided", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("140");
+    expect(svg?.getAttribute("height")).toBe("36");
+  });
+
+  it("respects custom width and height", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} width={240} height={92} />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("240");
+    expect(svg?.getAttribute("height")).toBe("92");
+  });
+
+  it("renders endpoint labels when showEndpoints is true", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} showEndpoints />,
+    );
+    const texts = Array.from(container.querySelectorAll("text"));
+    // Title <title> element is also a "text" node in some queries; filter
+    // to only the SVG <text> elements (which carry textContent).
+    const labels = texts.map((t) => t.textContent).filter(Boolean);
+    expect(labels).toContain("0");
+    expect(labels).toContain("1.0K");
+  });
+
+  it("does not render endpoint labels by default", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} />,
+    );
+    // Only the <title> for accessibility; no SVG <text> for axis labels.
+    const textNodes = container.querySelectorAll("svg > g text");
+    expect(textNodes.length).toBe(0);
+  });
+
+  it("renders midpoint when showMidpoint is true", () => {
+    const { container } = render(
+      <PairedHistogramContinuous
+        data={sampleData}
+        showEndpoints
+        showMidpoint
+      />,
+    );
+    const labels = Array.from(container.querySelectorAll("text")).map(
+      (t) => t.textContent,
+    );
+    expect(labels).toContain("500"); // midpoint of [0, 1000] — integer renders verbatim
+  });
+
+  it("light theme uses the light bar palette (#F6AD55 / #63B3ED)", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} />,
+    );
+    const fills = Array.from(container.querySelectorAll("svg rect")).map((r) =>
+      r.getAttribute("fill"),
+    );
+    expect(fills.some((f) => f === "#F6AD55")).toBe(true);
+    expect(fills.some((f) => f === "#63B3ED")).toBe(true);
+  });
+
+  it("dark theme uses the dark bar palette (#FBD38D / #90CDF4)", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} theme="dark" />,
+    );
+    const fills = Array.from(container.querySelectorAll("svg rect")).map((r) =>
+      r.getAttribute("fill"),
+    );
+    expect(fills.some((f) => f === "#FBD38D")).toBe(true);
+    expect(fills.some((f) => f === "#90CDF4")).toBe(true);
+  });
+
+  it("differential rect is blue when current density exceeds base", () => {
+    // Single-bin payload: current density >> base density. Should produce
+    // a single solid blue rect (no agreement zone since baseH would be 0).
+    const data: PairedHistogramContinuousData = {
+      binEdges: [0, 10],
+      baseDensity: [0],
+      currentDensity: [0.5],
+      baseTotal: 0,
+      currentTotal: 5,
+    };
+    const { container } = render(<PairedHistogramContinuous data={data} />);
+    const fills = Array.from(container.querySelectorAll("svg rect"))
+      .map((r) => r.getAttribute("fill"))
+      // ignore pattern <rect> children (their fill is just a color but they
+      // live inside <defs>, not the chart area) and the invisible hit-target
+      // rects (fill="transparent").
+      .filter((f) => f && f !== "transparent");
+    // Only the differential rect should remain — it's blue (current dominates).
+    expect(fills).toContain("#63B3ED");
+  });
+
+  it("handles bin-edge / density length mismatch by rendering an empty SVG", () => {
+    const broken: PairedHistogramContinuousData = {
+      binEdges: [0, 1, 2],
+      baseDensity: [1, 2, 3, 4],
+      currentDensity: [1, 1, 1, 1],
+      baseTotal: 10,
+      currentTotal: 4,
+    };
+    const { container } = render(<PairedHistogramContinuous data={broken} />);
+    // No bin groups rendered, but the SVG frame is still there.
+    expect(container.querySelectorAll("svg > g").length).toBe(0);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("handles a zero-span payload (degenerate column) by falling back to uniform widths", () => {
+    const collapsed: PairedHistogramContinuousData = {
+      binEdges: [5, 5, 5],
+      baseDensity: [0.5, 0.5],
+      currentDensity: [0.5, 0.5],
+      baseTotal: 2,
+      currentTotal: 2,
+    };
+    const layout = computeContinuousLayout(collapsed, 140);
+    expect(layout.bins.length).toBe(2);
+    // Uniform fallback: both bins same width.
+    expect(layout.bins[0].width).toBeCloseTo(70, 5);
+    expect(layout.bins[1].width).toBeCloseTo(70, 5);
+  });
+
+  it("hover-title carries percentage breakdown per bin", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} />,
+    );
+    const titles = Array.from(container.querySelectorAll("svg title")).map(
+      (t) => t.textContent,
+    );
+    // Most-common hover format: "10–25 [base: 30.0%, current: ...]" — at
+    // least one title should contain both percentages.
+    expect(
+      titles.some((t) => t?.includes("base:") && t.includes("current:")),
+    ).toBe(true);
+  });
+
+  it("uses custom formatter for endpoint labels", () => {
+    const { container } = render(
+      <PairedHistogramContinuous
+        data={sampleData}
+        showEndpoints
+        formatValue={(v) => `$${v}`}
+      />,
+    );
+    const labels = Array.from(container.querySelectorAll("text")).map(
+      (t) => t.textContent,
+    );
+    expect(labels).toContain("$0");
+    expect(labels).toContain("$1000");
+  });
+
+  it("computeContinuousLayout: bar widths sum to the available width", () => {
+    const layout = computeContinuousLayout(sampleData, 140);
+    const total = layout.bins.reduce((s, b) => s + b.width, 0);
+    expect(total).toBeCloseTo(140, 1);
+  });
+
+  it("computeContinuousLayout: empty payload returns empty bins", () => {
+    const empty: PairedHistogramContinuousData = {
+      binEdges: [],
+      baseDensity: [],
+      currentDensity: [],
+      baseTotal: 0,
+      currentTotal: 0,
+    };
+    const layout = computeContinuousLayout(empty, 140);
+    expect(layout.bins).toEqual([]);
+    expect(layout.maxDensity).toBe(0);
+  });
+
+  it("accepts className prop", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} className="my-chart" />,
+    );
+    expect(container.querySelector("svg")?.getAttribute("class")).toBe(
+      "my-chart",
+    );
+  });
+
+  it("renders an accessible aria-label", () => {
+    const { container } = render(
+      <PairedHistogramContinuous
+        data={sampleData}
+        ariaLabel="customer order amount"
+      />,
+    );
+    expect(container.querySelector("svg")?.getAttribute("aria-label")).toBe(
+      "customer order amount",
+    );
+  });
+});

--- a/js/packages/ui/src/components/data/__tests__/PairedHistogramDiscrete.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/PairedHistogramDiscrete.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * @file PairedHistogramDiscrete.test.tsx
+ * @description Tests for the top-K paired histogram cell with
+ * gap-on-absent semantics (DRC-3390 PR 3).
+ */
+
+import { render } from "@testing-library/react";
+import {
+  computeDiscreteSlots,
+  PairedHistogramDiscrete,
+  type PairedHistogramDiscreteData,
+} from "../PairedHistogramDiscrete";
+
+const sampleData: PairedHistogramDiscreteData = {
+  values: ["US", "GB", "DE", "FR", "JP"],
+  baseCounts: [100, 50, 25, 10, 5],
+  currentCounts: [110, 40, 35, 8, 6],
+  baseTotal: 190,
+  currentTotal: 199,
+};
+
+describe("PairedHistogramDiscrete", () => {
+  it("renders one group per value", () => {
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    const groups = container.querySelectorAll("svg > g");
+    expect(groups.length).toBe(sampleData.values.length);
+  });
+
+  it("renders both bars when both sides have counts > 0", () => {
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    // Each slot: 1 invisible hit-target + base bar + current bar = 3 rects max.
+    const rects = container.querySelectorAll("svg > g rect");
+    expect(rects.length).toBeGreaterThan(sampleData.values.length);
+  });
+
+  it("leaves a gap (no rect) when one side count is 0 — added value", () => {
+    const data: PairedHistogramDiscreteData = {
+      values: ["new_only"],
+      baseCounts: [0],
+      currentCounts: [10],
+      baseTotal: 0,
+      currentTotal: 10,
+    };
+    const { container } = render(<PairedHistogramDiscrete data={data} />);
+    const visibleFills = Array.from(container.querySelectorAll("svg > g rect"))
+      .map((r) => r.getAttribute("fill"))
+      .filter((f) => f && f !== "transparent");
+    // Only the current bar renders — no base bar means a visible gap on
+    // the base side of the slot.
+    expect(visibleFills).toEqual(["#63B3ED"]);
+  });
+
+  it("leaves a gap when current side count is 0 — removed value", () => {
+    const data: PairedHistogramDiscreteData = {
+      values: ["legacy_only"],
+      baseCounts: [10],
+      currentCounts: [0],
+      baseTotal: 10,
+      currentTotal: 0,
+    };
+    const { container } = render(<PairedHistogramDiscrete data={data} />);
+    const visibleFills = Array.from(container.querySelectorAll("svg > g rect"))
+      .map((r) => r.getAttribute("fill"))
+      .filter((f) => f && f !== "transparent");
+    expect(visibleFills).toEqual(["#F6AD55"]);
+  });
+
+  it("uses default cell-density dimensions when not provided", () => {
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("140");
+    expect(svg?.getAttribute("height")).toBe("36");
+  });
+
+  it("respects custom width and height", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={sampleData} width={220} height={100} />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("220");
+    expect(svg?.getAttribute("height")).toBe("100");
+  });
+
+  it("does not render value labels by default", () => {
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    expect(container.querySelectorAll("svg g text").length).toBe(0);
+  });
+
+  it("renders one label per value when showLabels is true", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={sampleData} showLabels />,
+    );
+    const labels = container.querySelectorAll("svg g text");
+    expect(labels.length).toBe(sampleData.values.length);
+    expect(Array.from(labels).map((l) => l.textContent)).toEqual(
+      sampleData.values,
+    );
+  });
+
+  it("truncates labels longer than labelMaxChars", () => {
+    const longData: PairedHistogramDiscreteData = {
+      ...sampleData,
+      values: ["United States", "Great Britain", "Germany", "France", "Japan"],
+    };
+    const { container } = render(
+      <PairedHistogramDiscrete data={longData} showLabels labelMaxChars={4} />,
+    );
+    const texts = Array.from(container.querySelectorAll("svg g text")).map(
+      (t) => t.textContent ?? "",
+    );
+    for (const t of texts) {
+      expect(t.length).toBeLessThanOrEqual(4);
+    }
+    // Each truncated label ends with the ellipsis character.
+    expect(texts.every((t) => t.endsWith("…"))).toBe(true);
+  });
+
+  it("renders trimmed marker when trimmed prop is set", () => {
+    const { queryByText } = render(
+      <PairedHistogramDiscrete data={{ ...sampleData, trimmed: true }} />,
+    );
+    expect(queryByText("trimmed")).toBeInTheDocument();
+  });
+
+  it("does not render trimmed marker by default", () => {
+    const { queryByText } = render(
+      <PairedHistogramDiscrete data={sampleData} />,
+    );
+    expect(queryByText("trimmed")).not.toBeInTheDocument();
+  });
+
+  it("handles zero totals without dividing by zero", () => {
+    const zeroData: PairedHistogramDiscreteData = {
+      values: ["a", "b"],
+      baseCounts: [0, 0],
+      currentCounts: [0, 0],
+      baseTotal: 0,
+      currentTotal: 0,
+    };
+    const { container } = render(<PairedHistogramDiscrete data={zeroData} />);
+    // Hit-target rects (fill="transparent") still render so users can
+    // hover; no visible bar fills.
+    const visible = Array.from(container.querySelectorAll("svg > g rect"))
+      .map((r) => r.getAttribute("fill"))
+      .filter((f) => f && f !== "transparent");
+    expect(visible.length).toBe(0);
+  });
+
+  it("dark theme uses the dark palette", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={sampleData} theme="dark" />,
+    );
+    const fills = Array.from(container.querySelectorAll("svg > g rect")).map(
+      (r) => r.getAttribute("fill"),
+    );
+    expect(fills.some((f) => f === "#FBD38D")).toBe(true);
+    expect(fills.some((f) => f === "#90CDF4")).toBe(true);
+  });
+
+  it("hover-title carries percentage breakdown per value", () => {
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    const titles = Array.from(container.querySelectorAll("svg title")).map(
+      (t) => t.textContent,
+    );
+    expect(
+      titles.some((t) => t?.includes("base:") && t?.includes("current:")),
+    ).toBe(true);
+    // The accessible title is also present.
+    expect(titles).toContain(
+      "Paired baseline and current categorical distribution",
+    );
+  });
+
+  it("computeDiscreteSlots: counts and values length mismatch returns empty", () => {
+    const broken: PairedHistogramDiscreteData = {
+      values: ["a", "b"],
+      baseCounts: [1, 2, 3],
+      currentCounts: [1, 2, 3],
+      baseTotal: 6,
+      currentTotal: 6,
+    };
+    const { slots } = computeDiscreteSlots(broken);
+    expect(slots).toEqual([]);
+  });
+
+  it("computeDiscreteSlots: empty values returns empty slots", () => {
+    const { slots, maxProp } = computeDiscreteSlots({
+      values: [],
+      baseCounts: [],
+      currentCounts: [],
+      baseTotal: 0,
+      currentTotal: 0,
+    });
+    expect(slots).toEqual([]);
+    expect(maxProp).toBe(0);
+  });
+
+  it("computeDiscreteSlots: max proportion floors at 0.001 to avoid div-by-zero scales", () => {
+    const tiny: PairedHistogramDiscreteData = {
+      values: ["a"],
+      baseCounts: [0],
+      currentCounts: [0],
+      baseTotal: 0,
+      currentTotal: 0,
+    };
+    const { maxProp } = computeDiscreteSlots(tiny);
+    expect(maxProp).toBeGreaterThan(0);
+  });
+
+  it("accepts className prop", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={sampleData} className="my-cell" />,
+    );
+    expect(container.querySelector("svg")?.getAttribute("class")).toBe(
+      "my-cell",
+    );
+  });
+});

--- a/js/packages/ui/src/components/data/__tests__/ProfileDistributionUnsupportedBanner.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/ProfileDistributionUnsupportedBanner.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @file ProfileDistributionUnsupportedBanner.test.tsx
+ * @description Tests for the once-per-task unsupported-adapter banner (DRC-3390 PR 3).
+ */
+
+import { render } from "@testing-library/react";
+import { ProfileDistributionUnsupportedBanner } from "../ProfileDistributionUnsupportedBanner";
+
+describe("ProfileDistributionUnsupportedBanner", () => {
+  it("renders a generic message when no reason is supplied", () => {
+    const { getByTestId, getByText } = render(
+      <ProfileDistributionUnsupportedBanner />,
+    );
+    expect(
+      getByTestId("profile-distribution-unsupported-banner"),
+    ).toBeInTheDocument();
+    expect(
+      getByText(/paired column distributions aren't available here/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the backend reason verbatim when provided", () => {
+    const { getByText } = render(
+      <ProfileDistributionUnsupportedBanner reason="this dialect lacks APPROX_PERCENTILE" />,
+    );
+    expect(
+      getByText("this dialect lacks APPROX_PERCENTILE"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the adapter-type in the title when provided", () => {
+    const { getByText } = render(
+      <ProfileDistributionUnsupportedBanner adapterType="postgres" />,
+    );
+    expect(getByText(/postgres/i)).toBeInTheDocument();
+  });
+
+  it("uses role=status for screen readers (non-disruptive)", () => {
+    const { getByRole } = render(<ProfileDistributionUnsupportedBanner />);
+    expect(getByRole("status")).toBeInTheDocument();
+  });
+});

--- a/js/packages/ui/src/components/data/index.ts
+++ b/js/packages/ui/src/components/data/index.ts
@@ -14,6 +14,27 @@ export {
   type HistogramDataset,
   type HistogramDataType,
 } from "./HistogramChart";
+export {
+  InlineProfileDistributionCell,
+  type InlineProfileDistributionCellProps,
+} from "./InlineProfileDistributionCell";
+// Paired histograms for inline profile distribution (DRC-3390)
+export {
+  computeContinuousLayout,
+  PairedHistogramContinuous,
+  type PairedHistogramContinuousData,
+  type PairedHistogramContinuousProps,
+} from "./PairedHistogramContinuous";
+export {
+  computeDiscreteSlots,
+  PairedHistogramDiscrete,
+  type PairedHistogramDiscreteData,
+  type PairedHistogramDiscreteProps,
+} from "./PairedHistogramDiscrete";
+export {
+  ProfileDistributionUnsupportedBanner,
+  type ProfileDistributionUnsupportedBannerProps,
+} from "./ProfileDistributionUnsupportedBanner";
 // AG Grid wrapper with screenshot support
 export {
   type ColDef,
@@ -28,7 +49,6 @@ export {
   ScreenshotDataGrid,
   type ScreenshotDataGridProps,
 } from "./ScreenshotDataGrid";
-
 export {
   TopKBarChart,
   type TopKBarChartProps,

--- a/js/packages/ui/src/hooks/__tests__/useInlineProfileDistribution.test.tsx
+++ b/js/packages/ui/src/hooks/__tests__/useInlineProfileDistribution.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * @file useInlineProfileDistribution.test.tsx
+ * @description Tests for the inline profile-distribution hook (DRC-3390 PR 3).
+ *
+ * The hook is intentionally thin — submit a run, parse the payload, surface
+ * loading / error / unsupported / data. Tests mock the API at the
+ * `submitProfileDistribution` boundary so PR 2 doesn't need to be merged.
+ */
+
+import { vi } from "vitest";
+
+// ----------------------------------------------------------------------
+// Mocks (must be set up before imports)
+// ----------------------------------------------------------------------
+
+const mockApiClient = {
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock("../useApiConfig", () => ({
+  useApiConfig: vi.fn(() => ({ apiClient: mockApiClient })),
+}));
+
+const mockSubmitProfileDistribution = vi.fn();
+const mockTrack = vi.fn();
+
+vi.mock("../../api/profileDistribution", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../api/profileDistribution")
+  >("../../api/profileDistribution");
+  return {
+    ...actual,
+    submitProfileDistribution: (
+      ...args: Parameters<typeof actual.submitProfileDistribution>
+    ) => mockSubmitProfileDistribution(...args),
+  };
+});
+
+vi.mock("../../lib/api/track", () => ({
+  trackProfileDistribution: (...args: unknown[]) => mockTrack(...args),
+}));
+
+// ----------------------------------------------------------------------
+// Imports
+// ----------------------------------------------------------------------
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import {
+  countFailedColumns,
+  useInlineProfileDistribution,
+} from "../useInlineProfileDistribution";
+
+// ----------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------
+
+const wrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+function mockRunResult(result: unknown) {
+  return {
+    run_id: "test-run-id",
+    type: "profile_distribution",
+    run_at: new Date().toISOString(),
+    status: "Finished",
+    result,
+  };
+}
+
+// ----------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------
+
+describe("useInlineProfileDistribution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is disabled when enabled = false and never submits a run", async () => {
+    const { result } = renderHook(
+      () => useInlineProfileDistribution("model.x", false),
+      { wrapper: wrapper() },
+    );
+    // Brief wait to ensure no submit fires asynchronously.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockSubmitProfileDistribution).not.toHaveBeenCalled();
+    expect(result.current.distributions).toEqual({});
+  });
+
+  it("is disabled when model is undefined and never submits a run", async () => {
+    const { result } = renderHook(
+      () => useInlineProfileDistribution(undefined, true),
+      { wrapper: wrapper() },
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockSubmitProfileDistribution).not.toHaveBeenCalled();
+    expect(result.current.distributions).toEqual({});
+  });
+
+  it("submits a run and parses a normal (status: ok) result", async () => {
+    const payload = {
+      status: "ok" as const,
+      columns: {
+        col_a: {
+          kind: "histogram" as const,
+          bin_edges: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+          base_density: Array(11).fill(0.1),
+          current_density: Array(11).fill(0.1),
+          base_total: 100,
+          current_total: 110,
+        },
+        col_b: {
+          kind: "topk" as const,
+          values: ["a", "b"],
+          base_counts: [10, 5],
+          current_counts: [12, 4],
+          base_total: 15,
+          current_total: 16,
+          trimmed: false,
+        },
+      },
+    };
+    mockSubmitProfileDistribution.mockResolvedValue(mockRunResult(payload));
+
+    const { result } = renderHook(
+      () => useInlineProfileDistribution("model.orders", true),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.distributions.col_a).toBeDefined();
+    expect(result.current.distributions.col_b).toBeDefined();
+    expect(result.current.distributions.col_a.kind).toBe("histogram");
+    expect(result.current.distributions.col_b.kind).toBe("topk");
+    expect(result.current.isUnsupported).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces an unsupported envelope as isUnsupported + unsupportedReason", async () => {
+    const payload = {
+      status: "unsupported" as const,
+      reason: "postgres lacks native HLL",
+    };
+    mockSubmitProfileDistribution.mockResolvedValue(mockRunResult(payload));
+
+    const { result } = renderHook(
+      () => useInlineProfileDistribution("model.x", true),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.isUnsupported).toBe(true);
+    expect(result.current.unsupportedReason).toBe("postgres lacks native HLL");
+    expect(result.current.distributions).toEqual({});
+  });
+
+  it("surfaces a submit-time error as error", async () => {
+    mockSubmitProfileDistribution.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(
+      () => useInlineProfileDistribution("model.x", true),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.error).toBeTruthy();
+    });
+
+    expect(result.current.error?.message).toBe("network down");
+    expect(result.current.distributions).toEqual({});
+  });
+
+  it("emits a request event before the run submits and a result event after it returns", async () => {
+    const payload = { status: "ok" as const, columns: {} };
+    mockSubmitProfileDistribution.mockResolvedValue(mockRunResult(payload));
+
+    const { result } = renderHook(
+      () => useInlineProfileDistribution("model.x", true),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const phases = mockTrack.mock.calls.map((c) => c[0].phase);
+    expect(phases).toContain("request");
+    expect(phases).toContain("result");
+  });
+
+  it("emits a result event with cache_hit=false and error_count for null-kind slots", async () => {
+    const payload = {
+      status: "ok" as const,
+      columns: {
+        good_col: {
+          kind: "topk" as const,
+          values: ["a"],
+          base_counts: [1],
+          current_counts: [1],
+          base_total: 1,
+          current_total: 1,
+          trimmed: false,
+        },
+        bad_col_1: { kind: null, reason: "div by zero" },
+        bad_col_2: { kind: null, reason: "timeout" },
+      },
+    };
+    mockSubmitProfileDistribution.mockResolvedValue(mockRunResult(payload));
+
+    const { result } = renderHook(
+      () => useInlineProfileDistribution("model.x", true),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const resultCall = mockTrack.mock.calls.find(
+      (c) => c[0].phase === "result",
+    );
+    expect(resultCall).toBeTruthy();
+    expect(resultCall![0].column_count).toBe(3);
+    expect(resultCall![0].error_count).toBe(2);
+    expect(resultCall![0].cache_hit).toBe(false);
+  });
+
+  it("countFailedColumns: counts only kind:null slots", () => {
+    expect(
+      countFailedColumns({
+        status: "ok",
+        columns: {
+          good: {
+            kind: "topk",
+            values: [],
+            base_counts: [],
+            current_counts: [],
+            base_total: 0,
+            current_total: 0,
+            trimmed: false,
+          },
+          bad: { kind: null },
+        },
+      }),
+    ).toBe(1);
+
+    expect(countFailedColumns(undefined)).toBe(0);
+    expect(countFailedColumns({ status: "ok", columns: {} })).toBe(0);
+  });
+});

--- a/js/packages/ui/src/hooks/index.ts
+++ b/js/packages/ui/src/hooks/index.ts
@@ -42,6 +42,12 @@ export { useCountdownToast } from "./useCountdownToast";
 export { useCSVExport } from "./useCSVExport";
 export { useFeedbackCollectionToast } from "./useFeedbackCollectionToast";
 export { useGuideToast } from "./useGuideToast";
+export {
+  countFailedColumns,
+  pickColumnPayload,
+  type UseInlineProfileDistributionResult,
+  useInlineProfileDistribution,
+} from "./useInlineProfileDistribution";
 export { useIsDark } from "./useIsDark";
 export {
   type UseModelColumnsReturn,

--- a/js/packages/ui/src/hooks/useInlineProfileDistribution.ts
+++ b/js/packages/ui/src/hooks/useInlineProfileDistribution.ts
@@ -1,0 +1,197 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { cacheKeys } from "../api/cacheKeys";
+import {
+  isHistogramPayload,
+  isNullPayload,
+  isTopKPayload,
+  isUnsupportedResult,
+  submitProfileDistribution,
+} from "../api/profileDistribution";
+import type {
+  ProfileDistributionColumnResult,
+  ProfileDistributionResult,
+  Run,
+} from "../api/types";
+import { trackProfileDistribution } from "../lib/api/track";
+import { useApiConfig } from "./useApiConfig";
+
+/**
+ * Inline paired-distribution loader for a single dbt model. DRC-3390 PR 3.
+ *
+ * Fires one `PROFILE_DISTRIBUTION` run per `(model)` cache key, parses the
+ * discriminated-union payload PR 2 produces, and returns a stable
+ * `{distributions, loading, error, isUnsupported, unsupportedReason}`
+ * shape that the schema-row integration consumes per column.
+ *
+ * Pattern was lifted from the (pre-existing in plan, missing from PR 1)
+ * `useInlineProfile` hook outlined in the PR 3 spec: fetch on demand
+ * scoped to the model, share results across rows via TanStack Query's
+ * cache, gate behind the `inline_profile` server flag at the caller, and
+ * emit analytics events at the boundary.
+ *
+ * @example
+ * ```tsx
+ * function SchemaRow({ modelUniqueId, columnName }: Props) {
+ *   const flag = useRecceServerFlag();
+ *   const enabled = flag.data?.inline_profile ?? false;
+ *   const { distributions, loading, error, isUnsupported, unsupportedReason } =
+ *     useInlineProfileDistribution(modelUniqueId, enabled);
+ *   if (loading) return <Spinner />;
+ *   if (isUnsupported) return <UnsupportedBanner reason={unsupportedReason} />;
+ *   if (error) return <ErrorCell />;
+ *   const payload = distributions[columnName];
+ *   // ...render PairedHistogramContinuous / PairedHistogramDiscrete based on kind...
+ * }
+ * ```
+ */
+export interface UseInlineProfileDistributionResult {
+  /** Per-column payloads keyed by column name. Empty until the run completes. */
+  distributions: Record<string, ProfileDistributionColumnResult>;
+  /** True while the run is in flight (initial load or refetch). */
+  loading: boolean;
+  /** Error from the run submission / wait path. */
+  error: Error | null;
+  /** True when the adapter doesn't support the feature (single envelope). */
+  isUnsupported: boolean;
+  /** Human-readable explanation; only set when `isUnsupported` is true. */
+  unsupportedReason?: string;
+  /** Raw result envelope — exposed for advanced callers (PR 4 pre-warm cache lookups). */
+  raw?: ProfileDistributionResult;
+}
+
+/**
+ * Type-narrowing helper. Tested in `__tests__/useInlineProfileDistribution.test.tsx`.
+ */
+function extractResult(
+  run: Run | undefined,
+): ProfileDistributionResult | undefined {
+  if (!run) return undefined;
+  if (run.type !== "profile_distribution") return undefined;
+  return run.result;
+}
+
+/**
+ * Count failed columns (`{kind: null}`) in a result envelope.
+ *
+ * Exported for analytics — both the hook and PR 4's pre-warm use it.
+ */
+export function countFailedColumns(
+  result: ProfileDistributionResult | undefined,
+): number {
+  if (!result?.columns) return 0;
+  let n = 0;
+  for (const payload of Object.values(result.columns)) {
+    if (isNullPayload(payload)) n += 1;
+  }
+  return n;
+}
+
+/**
+ * Inline profile-distribution hook.
+ *
+ * @param model - dbt model `unique_id`. Falsy values disable the hook.
+ * @param enabled - Caller-controlled enable flag. Pass the
+ *   `inline_profile` server flag here so the hook short-circuits when
+ *   the feature is off.
+ */
+export function useInlineProfileDistribution(
+  model: string | undefined,
+  enabled: boolean,
+): UseInlineProfileDistributionResult {
+  const { apiClient } = useApiConfig();
+
+  const query = useQuery<ProfileDistributionResult, Error>({
+    queryKey: cacheKeys.profileDistribution(model ?? ""),
+    enabled: enabled && Boolean(model),
+    queryFn: async () => {
+      const startedAt = Date.now();
+      trackProfileDistribution({ phase: "request", model });
+      try {
+        const submitted = (await submitProfileDistribution(
+          { model: model as string },
+          undefined,
+          apiClient,
+        )) as Run;
+        const result = extractResult(submitted);
+        if (!result) {
+          // Backend completed but returned an unexpected shape — surface as error
+          throw new Error(
+            "profile_distribution run completed but returned no result payload",
+          );
+        }
+        const columnCount = result.columns
+          ? Object.keys(result.columns).length
+          : 0;
+        trackProfileDistribution({
+          phase: "result",
+          model,
+          total_wall_ms: Date.now() - startedAt,
+          column_count: columnCount,
+          error_count: countFailedColumns(result),
+          unsupported: isUnsupportedResult(result),
+          cache_hit: false,
+        });
+        return result;
+      } catch (err) {
+        trackProfileDistribution({
+          phase: "result",
+          model,
+          total_wall_ms: Date.now() - startedAt,
+          error_count: 0,
+          unsupported: false,
+          cache_hit: false,
+        });
+        throw err;
+      }
+    },
+    // Distribution results are deterministic per (model, manifest_hash);
+    // tanstack's default cache + the backend memoization (PR 2) plus the
+    // pre-warm path (PR 4) keep stale results out. Don't auto-refetch on
+    // focus — it would re-issue heavy warehouse queries.
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  // Memoize the distributions map so consumers (one per row) don't
+  // re-render every time the hook re-runs.
+  const distributions = useMemo(() => {
+    const cols = query.data?.columns ?? {};
+    // Normalize to a fresh object — keeps consumer-side referential
+    // equality predictable across stable backend results.
+    return { ...cols };
+  }, [query.data]);
+
+  const isUnsupported = isUnsupportedResult(query.data);
+
+  return {
+    distributions,
+    loading: query.isPending || query.isFetching,
+    error: query.error ?? null,
+    isUnsupported,
+    unsupportedReason: isUnsupported ? query.data?.reason : undefined,
+    raw: query.data,
+  };
+}
+
+/**
+ * Convenience selector: return the column-level payload, narrowing by
+ * `kind`. Returns `undefined` for `kind: null` slots so callers can skip
+ * rendering without an explicit check.
+ */
+export function pickColumnPayload(
+  result: UseInlineProfileDistributionResult,
+  columnName: string,
+):
+  | { kind: "histogram"; payload: ProfileDistributionColumnResult }
+  | { kind: "topk"; payload: ProfileDistributionColumnResult }
+  | undefined {
+  const payload = result.distributions[columnName];
+  if (!payload) return undefined;
+  if (isHistogramPayload(payload)) return { kind: "histogram", payload };
+  if (isTopKPayload(payload)) return { kind: "topk", payload };
+  return undefined;
+}

--- a/js/packages/ui/src/lib/api/track.ts
+++ b/js/packages/ui/src/lib/api/track.ts
@@ -293,3 +293,53 @@ interface LineageSelectionProps {
 export function trackLineageSelection(props: LineageSelectionProps) {
   track("[Web] lineage_selection", props);
 }
+
+// ---------------------------------------------------------------------
+// Profile distribution (paired histograms — DRC-3390)
+// ---------------------------------------------------------------------
+// One event family covers both the per-task lifecycle and the pre-warm
+// path (PR 4). PR 3 only emits `request` / `result`. PR 4 adds the
+// `prewarm_triggered` / `prewarm_completed` / `prewarm_hit_on_open`
+// values to `phase` without changing the event name.
+
+/**
+ * Phase of a profile-distribution task lifecycle.
+ *
+ * - `request`: fired when the frontend submits the run.
+ * - `result`: fired when the run finishes (either successfully, with an
+ *   error, or returning the unsupported-adapter envelope). Wall-time
+ *   from request → result is captured by `total_wall_ms`.
+ * - `prewarm_*`: reserved for PR 4.
+ */
+export type ProfileDistributionPhase =
+  | "request"
+  | "result"
+  | "prewarm_triggered"
+  | "prewarm_completed"
+  | "prewarm_hit_on_open";
+
+interface ProfileDistributionEventProps {
+  phase: ProfileDistributionPhase;
+  /** dbt model `unique_id` (or similar caller-stable identifier). */
+  model?: string;
+  /** Total time from request submit to result, in milliseconds (result phase only). */
+  total_wall_ms?: number;
+  /** Backend-reported column count in the result. */
+  column_count?: number;
+  /** How many of those columns came back as `kind: null` (per-column failure). */
+  error_count?: number;
+  /** True when the result envelope was `status: "unsupported"`. */
+  unsupported?: boolean;
+  /** True when the result came from the in-session memoization cache (PR 2). */
+  cache_hit?: boolean;
+  /** Free-form additional context. Keep flat — Amplitude doesn't like nested. */
+  [key: string]: unknown;
+}
+
+/**
+ * Emit a profile-distribution analytics event. Tracked under a single
+ * event name so funnel + cohort queries can group by `phase`.
+ */
+export function trackProfileDistribution(props: ProfileDistributionEventProps) {
+  track("[Web] profile_distribution", props);
+}

--- a/js/packages/ui/src/primitives.ts
+++ b/js/packages/ui/src/primitives.ts
@@ -306,6 +306,38 @@ export {
   type HistogramDataset,
   type HistogramDataType,
 } from "./components/data/HistogramChart";
+export {
+  InlineProfileDistributionCell,
+  type InlineProfileDistributionCellProps,
+} from "./components/data/InlineProfileDistributionCell";
+/**
+ * Paired-histogram cells for inline profile-distribution rendering (DRC-3390).
+ *
+ * @remarks
+ * `PairedHistogramContinuous` renders a quantile-bin, constant-area paired
+ * bar chart for continuous columns. `PairedHistogramDiscrete` renders a
+ * top-K paired bar chart with gap-on-absent semantics for categorical
+ * columns. `InlineProfileDistributionCell` is the schema-row integration
+ * that wraps loading / error / empty / data states in a single fixed-size
+ * slot. `ProfileDistributionUnsupportedBanner` surfaces the once-per-task
+ * "adapter doesn't support this feature" envelope.
+ */
+export {
+  computeContinuousLayout,
+  PairedHistogramContinuous,
+  type PairedHistogramContinuousData,
+  type PairedHistogramContinuousProps,
+} from "./components/data/PairedHistogramContinuous";
+export {
+  computeDiscreteSlots,
+  PairedHistogramDiscrete,
+  type PairedHistogramDiscreteData,
+  type PairedHistogramDiscreteProps,
+} from "./components/data/PairedHistogramDiscrete";
+export {
+  ProfileDistributionUnsupportedBanner,
+  type ProfileDistributionUnsupportedBannerProps,
+} from "./components/data/ProfileDistributionUnsupportedBanner";
 /**
  * Screenshot data grid primitives (AG Grid wrapper).
  *
@@ -327,7 +359,6 @@ export {
   ScreenshotDataGrid,
   type ScreenshotDataGridProps,
 } from "./components/data/ScreenshotDataGrid";
-
 /**
  * Top-K bar chart primitives (value distribution).
  *


### PR DESCRIPTION
## Summary

PR 3 of the [DRC-3390](https://linear.app/recce/issue/DRC-3390) paired-histograms GA productionization (4-PR stack). Adds the frontend cells, hook, schema-row integration, and unsupported-adapter banner that consume the per-column payloads PR 2 produces.

**Stacks on #1389. Mocks PR 2 payload until #1389 merges. Rebase onto main after PR 2 merges.**

### Adds

- **`PairedHistogramContinuous`** — quantile-bin, constant-area paired bar chart. Heights = density, widths = bin span, so bar area reads as the proportion of rows in that bin. Replaces the prototype's uniform-bin renderer (closed PR #1380).
- **`PairedHistogramDiscrete`** — top-K paired chart with gap-on-absent semantics. When a value is missing on one side, that bar isn't drawn, leaving a visible empty half-slot that reads as "absent here."
- **`useInlineProfileDistribution`** — TanStack-Query-backed hook that fires a single `PROFILE_DISTRIBUTION` run per model, parses the discriminated-union payload, and returns `{distributions, loading, error, isUnsupported}`. Emits Amplitude analytics events at request and result (DRC-3390 says PostHog, codebase uses Amplitude — same trail).
- **`InlineProfileDistributionCell`** — Compact-mode wrapper that picks between loading / error / empty (per-column failure) / continuous / discrete renders in a fixed-size slot so adjacent rows don't reflow. Grid mode is intentionally absent at GA.
- **`ProfileDistributionUnsupportedBanner`** — once-per-task MUI Alert for the `{status: 'unsupported', reason}` envelope (Postgres / MySQL / SQLite / SQL Server pre-2022).

### Payload contract (frozen — PR 2 produces exactly this)

- Continuous: `{kind:'histogram', bin_edges:[12], base_density:[11], current_density:[11], base_total, current_total}`
- Categorical: `{kind:'topk', values, base_counts, current_counts, base_total, current_total, trimmed}`
- Per-column failure: `{kind:null}`
- Unsupported envelope: `{status:'unsupported', reason:...}`

Refines `ProfileDistributionResult` in `api/types/run.ts` from PR 1's stub `Record<string, unknown>` to the full discriminated union.

### Out of scope (per DRC-3390 locked decisions)

- Grid mode (Compact only at GA)
- Lineage pre-warm / hover-grazing (PR 4)
- SQLMesh adapter coverage

### Also fixes baseline regressions PR 1 introduced

- `chore(run-registry)`: PR 1 narrowed `findByRunType` to `RegisteredRunType` but left `js/src/components/run/__tests__/registry.test.ts` arrays typed as `RunType[]` — tsc flagged 3 sites. Re-typed to `RegisteredRunType[]`.
- `test(action-adapter)`: PR 1 added an `isRegisteredRunType` guard inside `RecceActionAdapter` but the test mock didn't stub it, breaking 9 tests with timeout failures. Added the guard to the mock.

Both committed separately so they can be reviewed (or cherry-picked back to PR 1) in isolation.

## Test plan

- [x] `pnpm run --filter @datarecce/ui type:check` clean (remaining errors are pre-existing CSS-module + lineage-hooks baseline noted in the project memory).
- [x] `pnpm run --filter @datarecce/storybook build` succeeds.
- [x] 57 new unit tests pass (`PairedHistogramContinuous`, `PairedHistogramDiscrete`, `InlineProfileDistributionCell`, `ProfileDistributionUnsupportedBanner`, `useInlineProfileDistribution`).
- [x] Pre-push hook clean — 1933 tests pass, no leftover failures.
- [x] 20 storybook stories rendered visually on `http://localhost:6011`; screenshots verified for the mixed-state Compact view, gap-on-absent, trimmed marker, loading spinner, error chrome, unsupported banner (light + dark).
- [ ] Manual smoke against the real schema view once PR 2 lands — wire `useInlineProfileDistribution` into the actual `SchemaView` Compact row and confirm cells render against a real `PROFILE_DISTRIBUTION` run result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)