### PR TITLE
test(smoke): cover auto-snapshot session lifecycle staleness + refresh

### DIFF
--- a/integration_tests/dbt/smoke_test_recce_cloud.sh
+++ b/integration_tests/dbt/smoke_test_recce_cloud.sh
@@ -28,6 +28,8 @@ fi
 
 SESSION_NAME="smoke-rc-${ENV_NAME}-py${PY:-unknown}-dbt${DBT:-unknown}-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
 SESSION_ID=""
+DETAIL_BODY=""
+REFRESH_BODY=""
 
 NEW_WORKSPACE=$(dirname "${GITHUB_WORKSPACE:-$PWD}")
 cd "$NEW_WORKSPACE"
@@ -43,6 +45,12 @@ cleanup() {
     if [[ -n "$SESSION_ID" ]]; then
         echo "Teardown: deleting session $SESSION_ID"
         recce-cloud delete --session-id "$SESSION_ID" --force || true
+    fi
+    if [[ -n "$DETAIL_BODY" ]]; then
+        rm -f "$DETAIL_BODY"
+    fi
+    if [[ -n "$REFRESH_BODY" ]]; then
+        rm -f "$REFRESH_BODY"
     fi
     exit $exit_code
 }
@@ -142,11 +150,18 @@ AUTH_HEADER="Authorization: Bearer $RECCE_API_TOKEN"
 # 7a-i. GET /sessions/{id} returns the four staleness fields (all four
 # present in the response, but each may be null for a brand-new session
 # that has not seen a shared-base change yet).
-SESSION_DETAIL=$(curl -sf -H "$AUTH_HEADER" "$API_HOST/api/v2/sessions/$SESSION_ID")
-echo "$SESSION_DETAIL" | jq -e '.session | has("source_session_id")' > /dev/null
-echo "$SESSION_DETAIL" | jq -e '.session | has("source_session_updated_at")' > /dev/null
-echo "$SESSION_DETAIL" | jq -e '.session | has("current_base_session_id")' > /dev/null
-echo "$SESSION_DETAIL" | jq -e '.session | has("current_base_updated_at")' > /dev/null
+DETAIL_BODY=$(mktemp)
+DETAIL_STATUS=$(curl -s -o "$DETAIL_BODY" -w "%{http_code}" \
+    -H "$AUTH_HEADER" "$API_HOST/api/v2/sessions/$SESSION_ID")
+if [[ "$DETAIL_STATUS" != "200" ]]; then
+    echo "ERROR: GET /sessions/{id} expected 200, got $DETAIL_STATUS"
+    cat "$DETAIL_BODY"
+    exit 1
+fi
+jq -e '.session | has("source_session_id")' "$DETAIL_BODY" > /dev/null
+jq -e '.session | has("source_session_updated_at")' "$DETAIL_BODY" > /dev/null
+jq -e '.session | has("current_base_session_id")' "$DETAIL_BODY" > /dev/null
+jq -e '.session | has("current_base_updated_at")' "$DETAIL_BODY" > /dev/null
 echo "GET /sessions/{id} returns all four staleness fields"
 
 # 7a-ii. POST /sessions/{id}/refresh-base must return 202 with either a
@@ -159,11 +174,9 @@ REFRESH_STATUS=$(curl -s -o "$REFRESH_BODY" -w "%{http_code}" \
 if [[ "$REFRESH_STATUS" != "202" ]]; then
     echo "ERROR: refresh-base expected 202, got $REFRESH_STATUS"
     cat "$REFRESH_BODY"
-    rm -f "$REFRESH_BODY"
     exit 1
 fi
 jq -e '(.task_id != null) or (.in_progress == true)' "$REFRESH_BODY" > /dev/null
-rm -f "$REFRESH_BODY"
 echo "POST /sessions/{id}/refresh-base returned 202 with valid body"
 
 # --------------------------------------------------------------------

--- a/integration_tests/dbt/smoke_test_recce_cloud.sh
+++ b/integration_tests/dbt/smoke_test_recce_cloud.sh
@@ -125,6 +125,48 @@ recce-cloud list --json | jq -e --arg i "$SESSION_ID" \
 echo "Auto-snapshot post-condition passed (has_isolated_base == true)"
 
 # --------------------------------------------------------------------
+# 7a. Auto-snapshot session-lifecycle staleness + refresh (DRC-3311 / DRC-3548)
+#
+# Cover the drift→refresh contract the frontend StalenessBanner depends on:
+#   GET /sessions/{id} must surface the four staleness fields, and
+#   POST /sessions/{id}/refresh-base must accept the refresh and either
+#   return a task_id (202, fresh refresh) or in_progress=true (202, in-flight).
+#
+# Both endpoints are auth'd by the same RECCE_API_TOKEN used by the CLI.
+# Called via curl until a dedicated `recce-cloud refresh-base` subcommand
+# exists (tracked separately under DRC-3548).
+# --------------------------------------------------------------------
+API_HOST="${RECCE_CLOUD_API_HOST:-https://cloud.reccehq.com}"
+AUTH_HEADER="Authorization: Bearer $RECCE_API_TOKEN"
+
+# 7a-i. GET /sessions/{id} returns the four staleness fields (all four
+# present in the response, but each may be null for a brand-new session
+# that has not seen a shared-base change yet).
+SESSION_DETAIL=$(curl -sf -H "$AUTH_HEADER" "$API_HOST/api/v2/sessions/$SESSION_ID")
+echo "$SESSION_DETAIL" | jq -e '.session | has("source_session_id")' > /dev/null
+echo "$SESSION_DETAIL" | jq -e '.session | has("source_session_updated_at")' > /dev/null
+echo "$SESSION_DETAIL" | jq -e '.session | has("current_base_session_id")' > /dev/null
+echo "$SESSION_DETAIL" | jq -e '.session | has("current_base_updated_at")' > /dev/null
+echo "GET /sessions/{id} returns all four staleness fields"
+
+# 7a-ii. POST /sessions/{id}/refresh-base must return 202 with either a
+# task_id or in_progress=true. We just verify the contract; the actual
+# drift→banner→clear UI loop is covered by the DRC-3293 acid-test E2E.
+REFRESH_BODY=$(mktemp)
+REFRESH_STATUS=$(curl -s -o "$REFRESH_BODY" -w "%{http_code}" \
+    -X POST -H "$AUTH_HEADER" \
+    "$API_HOST/api/v2/sessions/$SESSION_ID/refresh-base")
+if [[ "$REFRESH_STATUS" != "202" ]]; then
+    echo "ERROR: refresh-base expected 202, got $REFRESH_STATUS"
+    cat "$REFRESH_BODY"
+    rm -f "$REFRESH_BODY"
+    exit 1
+fi
+jq -e '(.task_id != null) or (.in_progress == true)' "$REFRESH_BODY" > /dev/null
+rm -f "$REFRESH_BODY"
+echo "POST /sessions/{id}/refresh-base returned 202 with valid body"
+
+# --------------------------------------------------------------------
 # 8. Upload SESSION BASE artifacts explicitly (idempotent overwrite of
 # the auto-snapshot from step 7).
 # --------------------------------------------------------------------

--- a/integration_tests/dbt/smoke_test_recce_cloud.sh
+++ b/integration_tests/dbt/smoke_test_recce_cloud.sh
@@ -28,6 +28,7 @@ fi
 
 SESSION_NAME="smoke-rc-${ENV_NAME}-py${PY:-unknown}-dbt${DBT:-unknown}-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
 SESSION_ID=""
+INFO_BODY=""
 DETAIL_BODY=""
 REFRESH_BODY=""
 
@@ -45,6 +46,9 @@ cleanup() {
     if [[ -n "$SESSION_ID" ]]; then
         echo "Teardown: deleting session $SESSION_ID"
         recce-cloud delete --session-id "$SESSION_ID" --force || true
+    fi
+    if [[ -n "$INFO_BODY" ]]; then
+        rm -f "$INFO_BODY"
     fi
     if [[ -n "$DETAIL_BODY" ]]; then
         rm -f "$DETAIL_BODY"
@@ -136,20 +140,49 @@ echo "Auto-snapshot post-condition passed (has_isolated_base == true)"
 # 7a. Auto-snapshot session-lifecycle staleness + refresh (DRC-3311 / DRC-3548)
 #
 # Cover the drift→refresh contract the frontend StalenessBanner depends on:
-#   GET /sessions/{id} must surface the four staleness fields, and
-#   POST /sessions/{id}/refresh-base must accept the refresh and either
-#   return a task_id (202, fresh refresh) or in_progress=true (202, in-flight).
+#   GET /sessions/{id}/info must surface session_staleness (the field the
+#     frontend's useServerInfo selector reads),
+#   GET /sessions/{id} must surface the four staleness fields populated on
+#     the session-detail handler (CLI / API-token consumers), and
+#   POST /sessions/{id}/refresh-base must accept the refresh and return a
+#     task_id (202). The in_progress=true branch is reserved for concurrent
+#     refresh races and cannot fire on a session's first call.
 #
-# Both endpoints are auth'd by the same RECCE_API_TOKEN used by the CLI.
-# Called via curl until a dedicated `recce-cloud refresh-base` subcommand
-# exists (tracked separately under DRC-3548).
+# All three endpoints are auth'd by the same RECCE_API_TOKEN used by the
+# CLI. The staging API token must have MANAGER+ role on the org —
+# refresh-base requires MANAGER+ for user-actor tokens (sessions_api.py
+# refresh_session_base_endpoint). Called via curl until a dedicated
+# `recce-cloud refresh-base` subcommand exists (tracked under DRC-3548).
 # --------------------------------------------------------------------
 API_HOST="${RECCE_CLOUD_API_HOST:-https://cloud.reccehq.com}"
 AUTH_HEADER="Authorization: Bearer $RECCE_API_TOKEN"
 
-# 7a-i. GET /sessions/{id} returns the four staleness fields (all four
-# present in the response, but each may be null for a brand-new session
-# that has not seen a shared-base change yet).
+# 7a-i. GET /sessions/{id}/info — the frontend StalenessBanner reads
+# session_staleness from /info via useServerInfo (StalenessBanner.tsx).
+# /info is a separate code path from /sessions/{id}; the two can regress
+# independently, so cover the frontend's actual consumer endpoint here.
+INFO_BODY=$(mktemp)
+INFO_STATUS=$(curl -s -o "$INFO_BODY" -w "%{http_code}" \
+    -H "$AUTH_HEADER" "$API_HOST/api/v2/sessions/$SESSION_ID/info")
+if [[ "$INFO_STATUS" != "200" ]]; then
+    echo "ERROR: GET /sessions/{id}/info expected 200, got $INFO_STATUS"
+    cat "$INFO_BODY"
+    exit 1
+fi
+jq -e '.session_staleness | has("source_session_id")' "$INFO_BODY" > /dev/null
+jq -e '.session_staleness | has("source_session_updated_at")' "$INFO_BODY" > /dev/null
+jq -e '.session_staleness | has("current_base_session_id")' "$INFO_BODY" > /dev/null
+jq -e '.session_staleness | has("current_base_updated_at")' "$INFO_BODY" > /dev/null
+echo "GET /sessions/{id}/info surfaces session_staleness with four keys"
+
+# 7a-ii. GET /sessions/{id} — session-detail handler populates the four
+# staleness fields inline (sessions_api.py get_session_by_id_only). All
+# four RecceSessionResponse fields default to None at the model level
+# (Pydantic emits the keys regardless of whether the handler wrote them),
+# so a key-presence check is tautological and a typo in the handler
+# would pass. Assert non-null on the two fields guaranteed populated by
+# the preceding auto-snapshot (source_session_id from the session row,
+# current_base_session_id from the project's base session).
 DETAIL_BODY=$(mktemp)
 DETAIL_STATUS=$(curl -s -o "$DETAIL_BODY" -w "%{http_code}" \
     -H "$AUTH_HEADER" "$API_HOST/api/v2/sessions/$SESSION_ID")
@@ -158,15 +191,15 @@ if [[ "$DETAIL_STATUS" != "200" ]]; then
     cat "$DETAIL_BODY"
     exit 1
 fi
-jq -e '.session | has("source_session_id")' "$DETAIL_BODY" > /dev/null
-jq -e '.session | has("source_session_updated_at")' "$DETAIL_BODY" > /dev/null
-jq -e '.session | has("current_base_session_id")' "$DETAIL_BODY" > /dev/null
-jq -e '.session | has("current_base_updated_at")' "$DETAIL_BODY" > /dev/null
-echo "GET /sessions/{id} returns all four staleness fields"
+jq -e '.session.source_session_id != null' "$DETAIL_BODY" > /dev/null
+jq -e '.session.current_base_session_id != null' "$DETAIL_BODY" > /dev/null
+echo "GET /sessions/{id} populated source_session_id + current_base_session_id"
 
-# 7a-ii. POST /sessions/{id}/refresh-base must return 202 with either a
-# task_id or in_progress=true. We just verify the contract; the actual
-# drift→banner→clear UI loop is covered by the DRC-3293 acid-test E2E.
+# 7a-iii. POST /sessions/{id}/refresh-base must return 202 with task_id
+# non-null. The in_progress=true branch is reserved for concurrent
+# refresh races (sessions_func.py refresh_session_base) and cannot fire
+# on a session's first call — asserting task_id != null directly catches
+# stuck-lock regressions.
 REFRESH_BODY=$(mktemp)
 REFRESH_STATUS=$(curl -s -o "$REFRESH_BODY" -w "%{http_code}" \
     -X POST -H "$AUTH_HEADER" \
@@ -176,8 +209,8 @@ if [[ "$REFRESH_STATUS" != "202" ]]; then
     cat "$REFRESH_BODY"
     exit 1
 fi
-jq -e '(.task_id != null) or (.in_progress == true)' "$REFRESH_BODY" > /dev/null
-echo "POST /sessions/{id}/refresh-base returned 202 with valid body"
+jq -e '.task_id != null' "$REFRESH_BODY" > /dev/null
+echo "POST /sessions/{id}/refresh-base returned 202 with task_id"
 
 # --------------------------------------------------------------------
 # 8. Upload SESSION BASE artifacts explicitly (idempotent overwrite of


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`test` — extend the staging `recce-cloud` CLI smoke test to cover the auto-snapshot session-lifecycle contract.

**What this PR does / why we need it**:

Closes the smoke-test gap noted on DRC-3293 (2026-04-23) and originally scoped under DRC-3312: the existing smoke covers the upload + `has_isolated_base` post-condition, but never exercised the *drift detection* endpoints that DRC-3311 (slice 2) shipped and that the StalenessBanner depends on.

This PR adds a new step 7a that:

- `GET /api/v2/sessions/{id}` — asserts the four staleness fields are present on the response shape (`source_session_id`, `source_session_updated_at`, `current_base_session_id`, `current_base_updated_at`). All four may be null on a freshly-uploaded session; presence is the contract.
- `POST /api/v2/sessions/{id}/refresh-base` — asserts 202 with a body where either `task_id != null` (fresh refresh) or `in_progress == true` (in-flight, idempotent).

Both endpoints accept the same `RECCE_API_TOKEN` the CLI already uses, so the new coverage is purely additive — no new CLI subcommand needed.

The full *drift → banner → Refresh → clear* UI loop is the DRC-3293 acid-test E2E surface (a separate teammate dispatch); this smoke only nails down the API contract the frontend depends on, so future regressions are caught daily on staging instead of waiting for an acid test.

**Which issue(s) this PR fixes**:

Resolves DRC-3312
Contributes to DRC-3548

**Special notes for your reviewer**:

- `curl` is used instead of a `recce-cloud refresh-base` subcommand because no such CLI command exists yet — adding one would expand scope past the smoke gap and is tracked separately on DRC-3548.
- Cleanup: `mktemp` body file is `rm -f`'d on both branches; the `set -euo pipefail` invariant is preserved.
- The auth header reads `RECCE_API_TOKEN` directly because that env var is already required by the script header (lines 19-21).

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
