### PR TITLE
feat: paired histogram cells in Storybook (DRC-3390 Stage A)

### DIFF
--- a/js/packages/storybook/stories/profile-distribution/PairedHistogramContinuous.stories.tsx
+++ b/js/packages/storybook/stories/profile-distribution/PairedHistogramContinuous.stories.tsx
@@ -1,0 +1,147 @@
+import { PairedHistogramContinuous } from "@datarecce/ui/primitives";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  continuousAddedOnly,
+  continuousOrderAmount,
+  continuousStable,
+  toContinuousProps,
+} from "./fixtures";
+import { SchemaContainerMock, SchemaRowMock } from "./SchemaRowMock";
+
+/**
+ * Constant-area paired histogram for continuous columns. Heights track
+ * density; widths track the bin's quantile span. The **area** of each
+ * bar reads as the row-proportion in that bin — the visual property
+ * that makes the chart honest under PR 2's quantile-bin payload.
+ *
+ * GA replacement for the prototype `PairedHistogramContinuousCell`,
+ * rewritten for the new payload schema (`bin_edges`, `base_density`,
+ * `current_density`). Grid-mode rendering is **out of scope at GA**.
+ *
+ * Theme follows the storybook toolbar (light / dark) via `useIsDark()`.
+ */
+const meta: Meta<typeof PairedHistogramContinuous> = {
+  title: "Visualizations/Profile Distribution/Continuous",
+  component: PairedHistogramContinuous,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `Constant-area paired bars (one slot per quantile bin).
+Bar **area** = density × span = proportion of rows in that bin. The
+agreement zone (min of the two densities) uses a 50/50 checkerboard so
+it reads as "both distributions cover this bin equally"; the differential
+is then drawn on top in the dominant side's color (blue = current taller,
+orange = base taller).`,
+      },
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof PairedHistogramContinuous>;
+
+// ---------------------------------------------------------------------
+// Cell-density (the GA target)
+// ---------------------------------------------------------------------
+
+export const CellOrderAmount: Story = {
+  name: "Cell — order amount",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="order_total_usd"
+        status="changed"
+        distribution={
+          <PairedHistogramContinuous
+            data={toContinuousProps(continuousOrderAmount)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const CellStable: Story = {
+  name: "Cell — stable (low divergence)",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="created_at"
+        status="ok"
+        distribution={
+          <PairedHistogramContinuous
+            data={toContinuousProps(continuousStable)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const CellAddedColumn: Story = {
+  name: "Cell — added column (no base)",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="ltv_predicted"
+        status="added"
+        distribution={
+          <PairedHistogramContinuous
+            data={toContinuousProps(continuousAddedOnly)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+// ---------------------------------------------------------------------
+// Edge / degenerate inputs
+// ---------------------------------------------------------------------
+
+export const EmptyPayload: Story = {
+  name: "Empty payload (no bins)",
+  render: () => (
+    <PairedHistogramContinuous
+      data={{
+        binEdges: [],
+        baseDensity: [],
+        currentDensity: [],
+        baseTotal: 0,
+        currentTotal: 0,
+      }}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An empty payload (PR 2 may emit this transiently before the column probe completes). The SVG frame is preserved so adjacent rows don't reflow.",
+      },
+    },
+  },
+};
+
+export const DegenerateRange: Story = {
+  name: "Degenerate range (all edges collapsed)",
+  render: () => (
+    <PairedHistogramContinuous
+      data={{
+        binEdges: [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+        baseDensity: Array(11).fill(0.1),
+        currentDensity: Array(11).fill(0.15),
+        baseTotal: 10,
+        currentTotal: 12,
+      }}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Constant column (every value identical) — the renderer falls back to uniform-width slots so something is still visible.",
+      },
+    },
+  },
+};

--- a/js/packages/storybook/stories/profile-distribution/PairedHistogramContinuous.stories.tsx
+++ b/js/packages/storybook/stories/profile-distribution/PairedHistogramContinuous.stories.tsx
@@ -15,8 +15,11 @@ import { SchemaContainerMock, SchemaRowMock } from "./SchemaRowMock";
  * that makes the chart honest under PR 2's quantile-bin payload.
  *
  * GA replacement for the prototype `PairedHistogramContinuousCell`,
- * rewritten for the new payload schema (`bin_edges`, `base_density`,
- * `current_density`). Grid-mode rendering is **out of scope at GA**.
+ * rewritten for the new payload schema (`base_bin_edges`,
+ * `current_bin_edges`, `base_density`, `current_density`). Base and current
+ * carry **independent** quantile edges; the cell overlays both onto a shared
+ * value axis and bars the merged edge grid. Grid-mode rendering is **out of
+ * scope at GA**.
  *
  * Theme follows the storybook toolbar (light / dark) via `useIsDark()`.
  */
@@ -105,7 +108,8 @@ export const EmptyPayload: Story = {
   render: () => (
     <PairedHistogramContinuous
       data={{
-        binEdges: [],
+        baseBinEdges: [],
+        currentBinEdges: [],
         baseDensity: [],
         currentDensity: [],
         baseTotal: 0,
@@ -128,7 +132,8 @@ export const DegenerateRange: Story = {
   render: () => (
     <PairedHistogramContinuous
       data={{
-        binEdges: [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+        baseBinEdges: [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
+        currentBinEdges: [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5],
         baseDensity: Array(11).fill(0.1),
         currentDensity: Array(11).fill(0.15),
         baseTotal: 10,

--- a/js/packages/storybook/stories/profile-distribution/PairedHistogramDiscrete.stories.tsx
+++ b/js/packages/storybook/stories/profile-distribution/PairedHistogramDiscrete.stories.tsx
@@ -1,0 +1,400 @@
+import { PairedHistogramDiscrete } from "@datarecce/ui/primitives";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  discreteCountryCode,
+  discreteHttpStatus,
+  discreteMixedTypes,
+  discreteRankDramatic,
+  discreteRankShuffled,
+  discreteRankStable,
+  discreteRankTrimmedAirports,
+  discreteRankWithNewEntrants,
+  discreteSignupSource,
+  discreteTrimmedAirports,
+  discreteWithGaps,
+  toDiscreteProps,
+  toDiscreteRanksProps,
+} from "./fixtures";
+import { SchemaContainerMock, SchemaRowMock } from "./SchemaRowMock";
+
+/**
+ * Top-K paired histogram for categorical columns with **gap-on-absent**
+ * semantics: when a value's count is 0 on one side, that bar simply
+ * doesn't render, leaving a visible empty half-slot. The renderer's job
+ * is to make "category present here / absent there" instantly readable
+ * in 28 px of vertical space.
+ *
+ * GA replacement for the prototype `PairedHistogramDiscreteCell`,
+ * rewritten for the PR 2 top-K payload (`values`, `base_counts`,
+ * `current_counts`, `trimmed`).
+ *
+ * Theme follows the storybook toolbar (light / dark) via `useIsDark()`.
+ */
+const meta: Meta<typeof PairedHistogramDiscrete> = {
+  title: "Visualizations/Profile Distribution/Discrete",
+  component: PairedHistogramDiscrete,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `Paired bars per category value. Base (orange) on the
+left, current (blue) on the right. **Gap-on-absent**: when a value's
+count is 0 on one side, the bar isn't drawn — the visible empty space
+reads as "this category isn't present on that side." When the backend
+had to drop a long tail past K, a tiny "trimmed" marker appears in the
+upper-right corner.`,
+      },
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof PairedHistogramDiscrete>;
+
+// ---------------------------------------------------------------------
+// Cell density
+// ---------------------------------------------------------------------
+
+export const CellHttpStatus: Story = {
+  name: "Cell — HTTP status codes",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="response_status"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete data={toDiscreteProps(discreteHttpStatus)} />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const CellSignupSource: Story = {
+  name: "Cell — signup source (dramatic shift)",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="signup_source"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            data={toDiscreteProps(discreteSignupSource)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const CellCountryCode: Story = {
+  name: "Cell — country code (stable)",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="billing_country"
+        status="ok"
+        distribution={
+          <PairedHistogramDiscrete
+            data={toDiscreteProps(discreteCountryCode)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+export const CellWithGaps: Story = {
+  name: "Cell — gap-on-absent",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="cohort"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete data={toDiscreteProps(discreteWithGaps)} />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Two legacy values are present only in base (gaps on the right halves of those slots); one cohort value is present only in current (gap on the left half). The pairing of empty + filled half-slots reads as 'category present on one side, absent on the other' without any text labels.",
+      },
+    },
+  },
+};
+
+export const CellTrimmed: Story = {
+  name: "Cell — trimmed top-K marker",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="origin_airport"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            data={toDiscreteProps(discreteTrimmedAirports)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+};
+
+// ---------------------------------------------------------------------
+// Edge / degenerate inputs
+// ---------------------------------------------------------------------
+
+export const EmptyPayload: Story = {
+  name: "Empty payload (no values)",
+  render: () => (
+    <PairedHistogramDiscrete
+      data={{
+        values: [],
+        baseCounts: [],
+        currentCounts: [],
+        baseTotal: 0,
+        currentTotal: 0,
+      }}
+    />
+  ),
+};
+
+export const ZeroTotals: Story = {
+  name: "All zero counts",
+  render: () => (
+    <PairedHistogramDiscrete
+      data={{
+        values: ["a", "b", "c"],
+        baseCounts: [0, 0, 0],
+        currentCounts: [0, 0, 0],
+        baseTotal: 0,
+        currentTotal: 0,
+      }}
+    />
+  ),
+};
+
+// ---------------------------------------------------------------------
+// Rank staircase — rank-only rendering (DuckDB `approx_top_k` path)
+// ---------------------------------------------------------------------
+//
+// When the engine returns top-K values without counts, Stage B emits a
+// ranks-mode payload and the cell sizes bars by rank position only:
+// `height = (k - rank + 1) / k * chartHeight`. Rank 1 is the tallest
+// bar, rank k is the shortest. Slot order is fixed by the wire contract:
+// base's top-K in base-rank order, then values present only in current's
+// top-K appended on the right.
+
+export const RankStable: Story = {
+  name: "Rank — stable (no order change)",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="region_code"
+        status="ok"
+        distribution={
+          <PairedHistogramDiscrete
+            data={toDiscreteRanksProps(discreteRankStable)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Matched staircases = ranks identical between base and current. The two side-by-side descending shapes are the rank-only equivalent of 'no drift.'",
+      },
+    },
+  },
+};
+
+export const RankShuffled: Story = {
+  name: "Rank — adjacent swaps",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="region_code"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            data={toDiscreteRanksProps(discreteRankShuffled)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Swapped ranks show as current bars zig-zagging against base's smooth descent. The eye locks onto the spike where adjacent positions traded places.",
+      },
+    },
+  },
+};
+
+export const RankDramatic: Story = {
+  name: "Rank — full inversion",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="region_code"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            data={toDiscreteRanksProps(discreteRankDramatic)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Dramatic order reversal — current bars are nearly the mirror of base. The whole top-K has flipped: what used to be #1 is now last.",
+      },
+    },
+  },
+};
+
+export const RankWithNewEntrants: Story = {
+  name: "Rank — new entrants and dropouts",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="region_code"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            data={toDiscreteRanksProps(discreteRankWithNewEntrants)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Leftmost slots are base's top-K (some now missing on current — note the gaps on the current side). The rightmost slots are values newly in current's top-K that weren't in base, sorted by current rank — those slots have no base bar.",
+      },
+    },
+  },
+};
+
+export const RankTrimmed: Story = {
+  name: "Rank — trimmed top-K",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="origin_airport"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            data={toDiscreteRanksProps(discreteRankTrimmedAirports)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The trimmed marker behaves the same in rank mode — when the original distribution had more values than K, the corner chip signals that the cell shows only the top K.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------
+// Mixed-type values — `values: unknown[]` contract + `formatValue` seam
+// ---------------------------------------------------------------------
+//
+// Stage B's `ProfileDistributionTopKPayload.values` is typed `unknown[]`:
+// real-world top-K columns return strings, NULL, integers, booleans,
+// big numbers, dates, etc. The cell exposes a `formatValue` prop so
+// Stage C can dispatch on column type and pass a column-appropriate
+// formatter. The cell itself stays type-blind.
+//
+// These two stories use the same heterogeneous fixture to show what
+// happens with the default `String(v)` versus a column-aware override.
+
+/**
+ * Tiny number abbreviator for the "after" story. Stage C will provide
+ * something more substantial; this is just enough to demonstrate that a
+ * caller-supplied formatter reaches the label and tooltip.
+ */
+function abbreviateNumber(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+  if (abs >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function mixedFormatter(v: unknown): string {
+  if (v === null || v === undefined) return "∅";
+  if (typeof v === "number" && Math.abs(v) >= 1000) return abbreviateNumber(v);
+  return String(v);
+}
+
+export const MixedTypesDefault: Story = {
+  name: "Mixed types — default formatter",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="mixed_column"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            showLabels
+            data={toDiscreteProps(discreteMixedTypes)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '**Before** view: no `formatValue` prop supplied, so the cell falls back to `String(v)`. The NULL bucket renders as the literal text `"null"`, the boolean renders as `"true"`, and the big integer `1500000` becomes a wide digit string that crowds the label. The cell still renders — it just looks ugly. This is what Stage C would ship if it forgot to pass a formatter.',
+      },
+    },
+  },
+};
+
+export const MixedTypesCustomFormatter: Story = {
+  name: "Mixed types — custom formatter",
+  render: () => (
+    <SchemaContainerMock>
+      <SchemaRowMock
+        columnName="mixed_column"
+        status="changed"
+        distribution={
+          <PairedHistogramDiscrete
+            showLabels
+            formatValue={mixedFormatter}
+            data={toDiscreteProps(discreteMixedTypes)}
+          />
+        }
+      />
+    </SchemaContainerMock>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**After** view: a caller-supplied `formatValue` collapses NULL to `∅`, abbreviates `1500000` to `1.5M`, and lets strings/booleans pass through. Stage C will dispatch on `column.type` to pick the right formatter (NULL glyph, number abbreviation, date format, etc.); the cell itself stays type-blind — this single prop is the entire seam.",
+      },
+    },
+  },
+};

--- a/js/packages/storybook/stories/profile-distribution/PairedHistogramDiscrete.stories.tsx
+++ b/js/packages/storybook/stories/profile-distribution/PairedHistogramDiscrete.stories.tsx
@@ -354,10 +354,7 @@ export const MixedTypesDefault: Story = {
         columnName="mixed_column"
         status="changed"
         distribution={
-          <PairedHistogramDiscrete
-            showLabels
-            data={toDiscreteProps(discreteMixedTypes)}
-          />
+          <PairedHistogramDiscrete data={toDiscreteProps(discreteMixedTypes)} />
         }
       />
     </SchemaContainerMock>
@@ -366,7 +363,7 @@ export const MixedTypesDefault: Story = {
     docs: {
       description: {
         story:
-          '**Before** view: no `formatValue` prop supplied, so the cell falls back to `String(v)`. The NULL bucket renders as the literal text `"null"`, the boolean renders as `"true"`, and the big integer `1500000` becomes a wide digit string that crowds the label. The cell still renders — it just looks ugly. This is what Stage C would ship if it forgot to pass a formatter.',
+          '**Before** view: no `formatValue` prop supplied, so the cell falls back to `String(v)`. Hover any bar to see the tooltip prefix — the NULL bucket reads as `"null"`, the boolean as `"true"`, and the big integer `1500000` verbatim. The cell still renders correctly — the values are just unprettified. This is what Stage C would ship if it forgot to pass a formatter.',
       },
     },
   },
@@ -381,7 +378,6 @@ export const MixedTypesCustomFormatter: Story = {
         status="changed"
         distribution={
           <PairedHistogramDiscrete
-            showLabels
             formatValue={mixedFormatter}
             data={toDiscreteProps(discreteMixedTypes)}
           />
@@ -393,7 +389,7 @@ export const MixedTypesCustomFormatter: Story = {
     docs: {
       description: {
         story:
-          "**After** view: a caller-supplied `formatValue` collapses NULL to `∅`, abbreviates `1500000` to `1.5M`, and lets strings/booleans pass through. Stage C will dispatch on `column.type` to pick the right formatter (NULL glyph, number abbreviation, date format, etc.); the cell itself stays type-blind — this single prop is the entire seam.",
+          "**After** view: a caller-supplied `formatValue` collapses NULL to `∅`, abbreviates `1500000` to `1.5M`, and lets strings/booleans pass through. Hover any bar to see the formatted tooltip prefix. Stage C will dispatch on `column.type` to pick the right formatter (NULL glyph, number abbreviation, date format, etc.); the cell itself stays type-blind — this single prop is the entire seam.",
       },
     },
   },

--- a/js/packages/storybook/stories/profile-distribution/SchemaRowMock.tsx
+++ b/js/packages/storybook/stories/profile-distribution/SchemaRowMock.tsx
@@ -1,0 +1,164 @@
+import { useIsDark } from "@datarecce/ui";
+import type { ReactNode } from "react";
+
+/**
+ * Compact-mode schema-row stand-in for the Paired Histograms storybook
+ * (DRC-3390 Stage A). Approximates the visual context the real
+ * `SchemaView` cells will appear in without dragging in `ag-grid` or
+ * the OSS app's CSS — chart sizing + density choices can be validated
+ * in isolation.
+ *
+ * One row = [badge slot] [column name] [distribution cell].
+ *
+ * Theme follows the storybook toolbar (light / dark) via `useIsDark()`.
+ */
+
+const STRIP_COLOR_OK = "rgb(74 222 128 / 0.55)";
+const STRIP_COLOR_CHANGED = "rgb(251 146 60 / 0.85)";
+
+interface SchemaRowMockProps {
+  columnName: string;
+  status?: "ok" | "changed" | "added" | "removed";
+  distribution: ReactNode;
+}
+
+const ROW_BG_LIGHT: Record<
+  NonNullable<SchemaRowMockProps["status"]>,
+  string
+> = {
+  ok: "#ffffff",
+  changed: "rgb(255 244 230 / 0.55)",
+  added: "rgb(220 252 231 / 0.55)",
+  removed: "rgb(254 226 226 / 0.55)",
+};
+
+const ROW_BG_DARK: Record<NonNullable<SchemaRowMockProps["status"]>, string> = {
+  ok: "#0f172a",
+  changed: "rgb(180 83 9 / 0.20)",
+  added: "rgb(22 101 52 / 0.25)",
+  removed: "rgb(127 29 29 / 0.25)",
+};
+
+const BADGE_GLYPH: Record<NonNullable<SchemaRowMockProps["status"]>, string> = {
+  ok: "",
+  changed: "~",
+  added: "+",
+  removed: "−",
+};
+
+const BADGE_COLOR: Record<NonNullable<SchemaRowMockProps["status"]>, string> = {
+  ok: "transparent",
+  changed: STRIP_COLOR_CHANGED,
+  added: STRIP_COLOR_OK,
+  removed: "rgb(248 113 113 / 0.85)",
+};
+
+export function SchemaRowMock({
+  columnName,
+  status = "ok",
+  distribution,
+}: SchemaRowMockProps) {
+  const isDark = useIsDark();
+  const bg = isDark ? ROW_BG_DARK[status] : ROW_BG_LIGHT[status];
+  const textColor = isDark ? "#e5e7eb" : "#1f2937";
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "20px 1fr 160px",
+        alignItems: "center",
+        gap: 8,
+        padding: "4px 10px",
+        background: bg,
+        borderBottom: isDark ? "1px solid #1f2937" : "1px solid #f3f4f6",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        minHeight: 32,
+      }}
+    >
+      <span
+        aria-label={status === "ok" ? "unchanged" : status}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 18,
+          height: 18,
+          fontSize: 11,
+          fontWeight: 700,
+          color: status === "ok" ? "transparent" : "#1f2937",
+          background: BADGE_COLOR[status],
+          borderRadius: 3,
+        }}
+      >
+        {BADGE_GLYPH[status]}
+      </span>
+      <span
+        style={{
+          fontSize: 12,
+          fontWeight: 500,
+          color: textColor,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+        title={columnName}
+      >
+        {columnName}
+      </span>
+      <div style={{ display: "flex", justifyContent: "flex-start" }}>
+        {distribution}
+      </div>
+    </div>
+  );
+}
+
+export function SchemaContainerMock({
+  children,
+  title,
+  subtitle,
+}: {
+  children: ReactNode;
+  title?: string;
+  subtitle?: string;
+}) {
+  const isDark = useIsDark();
+  return (
+    <div
+      style={{
+        width: 540,
+        background: isDark ? "#0b1220" : "#ffffff",
+        color: isDark ? "#e5e7eb" : "#1f2937",
+        border: isDark ? "1px solid #1f2937" : "1px solid #e5e7eb",
+        borderRadius: 6,
+        overflow: "hidden",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      {(title || subtitle) && (
+        <div
+          style={{
+            padding: "10px 12px",
+            borderBottom: isDark ? "1px solid #1f2937" : "1px solid #e5e7eb",
+            background: isDark ? "#111827" : "#fafafa",
+          }}
+        >
+          {title && (
+            <div style={{ fontSize: 13, fontWeight: 600 }}>{title}</div>
+          )}
+          {subtitle && (
+            <div
+              style={{
+                fontSize: 11,
+                color: isDark ? "#9ca3af" : "#6b7280",
+                marginTop: 2,
+              }}
+            >
+              {subtitle}
+            </div>
+          )}
+        </div>
+      )}
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/js/packages/storybook/stories/profile-distribution/fixtures.ts
+++ b/js/packages/storybook/stories/profile-distribution/fixtures.ts
@@ -2,9 +2,9 @@
  * Synthetic payload fixtures for the Paired Histograms GA cells (DRC-3390 Stage A).
  *
  * These match the **frozen** payload schemas Stage B produces:
- *   - Continuous → `{kind:"histogram", bin_edges:[12], base_density:[11],
- *     current_density:[11], base_total, current_total}` (quantile bins,
- *     constant-area).
+ *   - Continuous → `{kind:"histogram", base_bin_edges:[12],
+ *     current_bin_edges:[12], base_density:[11], current_density:[11],
+ *     base_total, current_total}` (per-env quantile bins, constant-area).
  *   - Discrete   → `{kind:"topk", values, base_counts, current_counts,
  *     base_total, current_total, trimmed}` (top-K with gap-on-absent).
  *   - Null       → `{kind:null}` (per-column failure).
@@ -23,7 +23,10 @@
 
 interface ProfileDistributionHistogramPayload {
   kind: "histogram";
-  bin_edges: number[];
+  /** Per-env quantile edges — base and current bin on their own edges, so
+   * each side stays constant-area (see PR #1398). They generally differ. */
+  base_bin_edges: number[];
+  current_bin_edges: number[];
   base_density: number[];
   current_density: number[];
   base_total: number;
@@ -84,28 +87,32 @@ type ProfileDistributionResult =
 
 /**
  * Build a histogram payload from per-bin row proportions instead of
- * raw densities. The constant-area contract is `density × span =
- * proportion`, so feeding proportions in (which sum to ~1.0) lets the
- * tooltip percentages read sensibly. Stage B's real payloads always
- * arrive density-normalized; this helper keeps the fixtures honest.
+ * raw densities, with **independent base / current edges** (the post-#1398
+ * contract). The constant-area contract is `density × span = proportion`,
+ * so feeding proportions in (each side summing to ~1.0) lets the tooltip
+ * percentages read sensibly. Stage B's real payloads always arrive
+ * density-normalized on per-env quantile edges; this helper keeps the
+ * fixtures honest.
  */
 function continuousFromProportions(
-  edges: number[],
+  baseEdges: number[],
   baseProps: number[],
+  currentEdges: number[],
   currentProps: number[],
   baseTotal: number,
   currentTotal: number,
 ): ProfileDistributionHistogramPayload {
-  const toDensity = (props: number[]) =>
+  const toDensity = (edges: number[], props: number[]) =>
     props.map((p, i) => {
       const span = edges[i + 1] - edges[i];
       return span > 0 ? p / span : 0;
     });
   return {
     kind: "histogram",
-    bin_edges: edges,
-    base_density: toDensity(baseProps),
-    current_density: toDensity(currentProps),
+    base_bin_edges: baseEdges,
+    current_bin_edges: currentEdges,
+    base_density: toDensity(baseEdges, baseProps),
+    current_density: toDensity(currentEdges, currentProps),
     base_total: baseTotal,
     current_total: currentTotal,
   };
@@ -115,12 +122,15 @@ function continuousFromProportions(
  * 11 quantile bins concentrated in the middle (typical of a long-tailed
  * order-amount distribution).
  *
- * Edges span $0 → $1000 with most mass between $50 and $300. Per-bin
- * proportions sum to 1.0, so tooltip percentages add up to 100%.
+ * Base and current span $0 → $1000 but break at **different** quantile
+ * edges (current's mass shifted slightly right post-deploy), so the merged
+ * x-grid has more than 11 segments. Per-bin proportions sum to 1.0 on each
+ * side, so each side's tooltip percentages add up to 100%.
  */
 export const continuousOrderAmount = continuousFromProportions(
   [0, 10, 25, 50, 80, 120, 165, 220, 290, 400, 600, 1000],
   [0.01, 0.04, 0.08, 0.12, 0.16, 0.2, 0.14, 0.1, 0.08, 0.05, 0.02],
+  [0, 8, 22, 48, 95, 140, 185, 245, 320, 430, 640, 1000],
   [0.008, 0.03, 0.07, 0.11, 0.17, 0.22, 0.15, 0.1, 0.07, 0.05, 0.02],
   12_000,
   14_500,
@@ -128,8 +138,9 @@ export const continuousOrderAmount = continuousFromProportions(
 
 /**
  * Symmetric, low-divergence column (timestamps from a stable signup
- * source). Base ≈ Current, so the chart should read as mostly checkerboard
- * with very thin differential strips.
+ * source). Base ≈ Current — edges nearly coincide and densities barely
+ * move — so the chart reads as mostly checkerboard with very thin
+ * differential strips.
  */
 export const continuousStable = continuousFromProportions(
   [
@@ -137,6 +148,10 @@ export const continuousStable = continuousFromProportions(
     1707696000, 1708300800, 1708905600, 1709510400, 1710115200, 1710720000,
   ],
   [0.02, 0.03, 0.06, 0.1, 0.15, 0.28, 0.15, 0.1, 0.06, 0.03, 0.02],
+  [
+    1704067200, 1704680000, 1705280000, 1705885000, 1706490000, 1707095000,
+    1707700000, 1708305000, 1708910000, 1709515000, 1710118000, 1710720000,
+  ],
   [0.025, 0.035, 0.06, 0.1, 0.14, 0.27, 0.15, 0.1, 0.06, 0.04, 0.02],
   25_000,
   24_500,
@@ -144,11 +159,17 @@ export const continuousStable = continuousFromProportions(
 
 /**
  * Added column — base totals 0, all mass on current side. Renders as a
- * solid-blue chart (current dominates every bin).
+ * solid-blue chart (current dominates every bin). Base still carries valid
+ * edges (the warehouse returns them even for an empty side); we reuse
+ * current's edges so the merged grid stays clean with no base mass.
  */
+const addedCurrentEdges = [
+  0, 50, 100, 150, 200, 300, 400, 500, 700, 900, 1200, 1500,
+];
 export const continuousAddedOnly = continuousFromProportions(
-  [0, 50, 100, 150, 200, 300, 400, 500, 700, 900, 1200, 1500],
+  addedCurrentEdges,
   Array(11).fill(0),
+  addedCurrentEdges,
   [0.02, 0.08, 0.2, 0.3, 0.18, 0.1, 0.06, 0.03, 0.02, 0.008, 0.002],
   0,
   18_000,
@@ -451,7 +472,8 @@ export const mixedTaskResult: ProfileDistributionResult = {
 
 export function toContinuousProps(p: ProfileDistributionHistogramPayload) {
   return {
-    binEdges: p.bin_edges,
+    baseBinEdges: p.base_bin_edges,
+    currentBinEdges: p.current_bin_edges,
     baseDensity: p.base_density,
     currentDensity: p.current_density,
     baseTotal: p.base_total,

--- a/js/packages/storybook/stories/profile-distribution/fixtures.ts
+++ b/js/packages/storybook/stories/profile-distribution/fixtures.ts
@@ -1,0 +1,482 @@
+/**
+ * Synthetic payload fixtures for the Paired Histograms GA cells (DRC-3390 Stage A).
+ *
+ * These match the **frozen** payload schemas Stage B produces:
+ *   - Continuous → `{kind:"histogram", bin_edges:[12], base_density:[11],
+ *     current_density:[11], base_total, current_total}` (quantile bins,
+ *     constant-area).
+ *   - Discrete   → `{kind:"topk", values, base_counts, current_counts,
+ *     base_total, current_total, trimmed}` (top-K with gap-on-absent).
+ *   - Null       → `{kind:null}` (per-column failure).
+ *   - Unsupported envelope → `{status:"unsupported", reason:...}`.
+ *
+ * Stage A is Storybook-only — no API/backend dependency. The payload
+ * types are inlined here as a frozen contract. Stage B introduces the
+ * canonical `ProfileDistribution*Payload` exports from `@datarecce/ui/api`;
+ * when Stage C wires up `useInlineProfileDistribution`, these fixtures
+ * can be replaced with real responses without touching the cells.
+ */
+
+// ----------------------------------------------------------------------
+// Inline payload-shape types (frozen Stage B contract; Storybook-only)
+// ----------------------------------------------------------------------
+
+interface ProfileDistributionHistogramPayload {
+  kind: "histogram";
+  bin_edges: number[];
+  base_density: number[];
+  current_density: number[];
+  base_total: number;
+  current_total: number;
+}
+
+interface ProfileDistributionTopKPayload {
+  kind: "topk";
+  /** Heterogeneous by contract — Stage B may return strings, numbers,
+   * booleans, dates, NULL, etc. Cells format each entry through
+   * `formatValue` to produce a display string. */
+  values: unknown[];
+  base_counts: number[];
+  current_counts: number[];
+  base_total: number;
+  current_total: number;
+  trimmed: boolean;
+}
+
+/**
+ * Rank-only variant — emitted when the underlying engine (e.g. DuckDB
+ * `approx_top_k`) returns the top-K values but no counts. Stage B
+ * guarantees both sides switch to rank-only together: a cell never has
+ * to render counts on one side and ranks on the other.
+ *
+ * Values appearing in only one side's top-K carry `null` for the other
+ * side's rank. Stage B's slot ordering is base-first (base's top-K in
+ * base-rank order), then values present only in current's top-K
+ * appended on the right (sorted by current rank ascending).
+ */
+interface ProfileDistributionTopKRanksPayload {
+  kind: "topk";
+  mode: "ranks";
+  values: string[];
+  base_ranks: (number | null)[];
+  current_ranks: (number | null)[];
+  k: number;
+  trimmed: boolean;
+}
+
+interface ProfileDistributionNullPayload {
+  kind: null;
+  reason?: string;
+}
+
+type ProfileDistributionColumnPayload =
+  | ProfileDistributionHistogramPayload
+  | ProfileDistributionTopKPayload
+  | ProfileDistributionNullPayload;
+
+type ProfileDistributionResult =
+  | { status: "ok"; columns: Record<string, ProfileDistributionColumnPayload> }
+  | { status: "unsupported"; reason: string };
+
+// ----------------------------------------------------------------------
+// Continuous (histogram) — quantile-binned, constant-area
+// ----------------------------------------------------------------------
+
+/**
+ * Build a histogram payload from per-bin row proportions instead of
+ * raw densities. The constant-area contract is `density × span =
+ * proportion`, so feeding proportions in (which sum to ~1.0) lets the
+ * tooltip percentages read sensibly. Stage B's real payloads always
+ * arrive density-normalized; this helper keeps the fixtures honest.
+ */
+function continuousFromProportions(
+  edges: number[],
+  baseProps: number[],
+  currentProps: number[],
+  baseTotal: number,
+  currentTotal: number,
+): ProfileDistributionHistogramPayload {
+  const toDensity = (props: number[]) =>
+    props.map((p, i) => {
+      const span = edges[i + 1] - edges[i];
+      return span > 0 ? p / span : 0;
+    });
+  return {
+    kind: "histogram",
+    bin_edges: edges,
+    base_density: toDensity(baseProps),
+    current_density: toDensity(currentProps),
+    base_total: baseTotal,
+    current_total: currentTotal,
+  };
+}
+
+/**
+ * 11 quantile bins concentrated in the middle (typical of a long-tailed
+ * order-amount distribution).
+ *
+ * Edges span $0 → $1000 with most mass between $50 and $300. Per-bin
+ * proportions sum to 1.0, so tooltip percentages add up to 100%.
+ */
+export const continuousOrderAmount = continuousFromProportions(
+  [0, 10, 25, 50, 80, 120, 165, 220, 290, 400, 600, 1000],
+  [0.01, 0.04, 0.08, 0.12, 0.16, 0.2, 0.14, 0.1, 0.08, 0.05, 0.02],
+  [0.008, 0.03, 0.07, 0.11, 0.17, 0.22, 0.15, 0.1, 0.07, 0.05, 0.02],
+  12_000,
+  14_500,
+);
+
+/**
+ * Symmetric, low-divergence column (timestamps from a stable signup
+ * source). Base ≈ Current, so the chart should read as mostly checkerboard
+ * with very thin differential strips.
+ */
+export const continuousStable = continuousFromProportions(
+  [
+    1704067200, 1704672000, 1705276800, 1705881600, 1706486400, 1707091200,
+    1707696000, 1708300800, 1708905600, 1709510400, 1710115200, 1710720000,
+  ],
+  [0.02, 0.03, 0.06, 0.1, 0.15, 0.28, 0.15, 0.1, 0.06, 0.03, 0.02],
+  [0.025, 0.035, 0.06, 0.1, 0.14, 0.27, 0.15, 0.1, 0.06, 0.04, 0.02],
+  25_000,
+  24_500,
+);
+
+/**
+ * Added column — base totals 0, all mass on current side. Renders as a
+ * solid-blue chart (current dominates every bin).
+ */
+export const continuousAddedOnly = continuousFromProportions(
+  [0, 50, 100, 150, 200, 300, 400, 500, 700, 900, 1200, 1500],
+  Array(11).fill(0),
+  [0.02, 0.08, 0.2, 0.3, 0.18, 0.1, 0.06, 0.03, 0.02, 0.008, 0.002],
+  0,
+  18_000,
+);
+
+// ----------------------------------------------------------------------
+// Discrete (top-K) — gap-on-absent
+// ----------------------------------------------------------------------
+
+/**
+ * HTTP status codes — typical low-card numeric. Note the post-deploy
+ * spike in 404 / 500 / 502 counts.
+ */
+export const discreteHttpStatus: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: ["200", "204", "304", "404", "500", "502"],
+  base_counts: [18400, 1200, 4800, 220, 35, 5],
+  current_counts: [17900, 1180, 5100, 1850, 410, 90],
+  base_total: 18400 + 1200 + 4800 + 220 + 35 + 5,
+  current_total: 17900 + 1180 + 5100 + 1850 + 410 + 90,
+  trimmed: false,
+};
+
+/**
+ * Country codes — well-behaved low-card string. Both sides have the same
+ * top-K so no gap appears.
+ */
+export const discreteCountryCode: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: ["US", "GB", "DE", "FR", "JP", "CA", "AU", "BR", "IN", "MX"],
+  base_counts: [4200, 1100, 850, 690, 510, 380, 250, 220, 180, 90],
+  current_counts: [4350, 1080, 920, 700, 540, 400, 240, 210, 175, 95],
+  base_total: 4200 + 1100 + 850 + 690 + 510 + 380 + 250 + 220 + 180 + 90,
+  current_total: 4350 + 1080 + 920 + 700 + 540 + 400 + 240 + 210 + 175 + 95,
+  trimmed: false,
+};
+
+/**
+ * Signup source — dramatic shift in distribution post-redesign.
+ * Mobile takes over from web.
+ */
+export const discreteSignupSource: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: ["web", "mobile", "api", "email", "social"],
+  base_counts: [4800, 1200, 800, 400, 220],
+  current_counts: [2400, 4500, 760, 380, 240],
+  base_total: 4800 + 1200 + 800 + 400 + 220,
+  current_total: 2400 + 4500 + 760 + 380 + 240,
+  trimmed: false,
+};
+
+/**
+ * Gap-on-absent example — base had `legacy_v1` and `legacy_v2` (no
+ * longer present in current); current introduced `cohort_2026` (not in
+ * base). The renderer should leave a visible empty half of each slot
+ * for the absent side.
+ */
+export const discreteWithGaps: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: ["primary", "legacy_v1", "legacy_v2", "cohort_2026", "fallback"],
+  base_counts: [9000, 1200, 600, 0, 200],
+  current_counts: [10100, 0, 0, 1450, 220],
+  base_total: 9000 + 1200 + 600 + 0 + 200,
+  current_total: 10100 + 0 + 0 + 1450 + 220,
+  trimmed: false,
+};
+
+/**
+ * Trimmed top-K — 92-cardinality column where the backend kept only the
+ * 12 most-significant slots. The cell should render the `trimmed`
+ * marker in the corner.
+ */
+export const discreteTrimmedAirports: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: [
+    "JFK",
+    "LAX",
+    "ORD",
+    "DFW",
+    "ATL",
+    "DEN",
+    "SFO",
+    "SEA",
+    "LAS",
+    "MIA",
+    "BOS",
+    "PHX",
+  ],
+  base_counts: [
+    4200, 3800, 3500, 3100, 2900, 2600, 2400, 2100, 1900, 1700, 1500, 1400,
+  ],
+  current_counts: [
+    4400, 3700, 3300, 3000, 2950, 2600, 2500, 2050, 1850, 1750, 1450, 1380,
+  ],
+  base_total: 35_000,
+  current_total: 36_000,
+  trimmed: true,
+};
+
+/**
+ * Demonstrates the heterogeneous-values reality of Stage B's
+ * `values: unknown[]` contract — strings, NULL, integer, boolean, big
+ * number. Used by stories to validate `formatValue` plumbing.
+ */
+export const discreteMixedTypes: ProfileDistributionTopKPayload = {
+  kind: "topk",
+  values: ["primary", null, 42, "a_pretty_long_display_value", true, 1500000],
+  base_counts: [4200, 850, 600, 420, 180, 95],
+  current_counts: [4000, 920, 580, 380, 220, 80],
+  base_total: 12_000,
+  current_total: 12_000,
+  trimmed: false,
+};
+
+// ----------------------------------------------------------------------
+// Discrete (top-K) — rank-only (DuckDB `approx_top_k` path)
+// ----------------------------------------------------------------------
+
+/**
+ * Stable case — base and current top-K agree, in the same order. Renders
+ * as two side-by-side descending staircases.
+ */
+export const discreteRankStable: ProfileDistributionTopKRanksPayload = {
+  kind: "topk",
+  mode: "ranks",
+  values: [
+    "alpha",
+    "beta",
+    "gamma",
+    "delta",
+    "epsilon",
+    "zeta",
+    "eta",
+    "theta",
+  ],
+  base_ranks: [1, 2, 3, 4, 5, 6, 7, 8],
+  current_ranks: [1, 2, 3, 4, 5, 6, 7, 8],
+  k: 8,
+  trimmed: false,
+};
+
+/**
+ * Adjacent swaps — same values appear in both top-Ks but with some
+ * neighbouring positions transposed. The eye sees base's smooth descent
+ * and current bars zig-zagging against it.
+ */
+export const discreteRankShuffled: ProfileDistributionTopKRanksPayload = {
+  kind: "topk",
+  mode: "ranks",
+  values: [
+    "alpha",
+    "beta",
+    "gamma",
+    "delta",
+    "epsilon",
+    "zeta",
+    "eta",
+    "theta",
+  ],
+  base_ranks: [1, 2, 3, 4, 5, 6, 7, 8],
+  current_ranks: [1, 3, 2, 5, 4, 7, 6, 8],
+  k: 8,
+  trimmed: false,
+};
+
+/**
+ * Full inversion — every rank flips. Current bars read as the mirror of
+ * base's staircase: the leftmost slot has the tallest base bar and the
+ * shortest current bar, and so on.
+ */
+export const discreteRankDramatic: ProfileDistributionTopKRanksPayload = {
+  kind: "topk",
+  mode: "ranks",
+  values: [
+    "alpha",
+    "beta",
+    "gamma",
+    "delta",
+    "epsilon",
+    "zeta",
+    "eta",
+    "theta",
+  ],
+  base_ranks: [1, 2, 3, 4, 5, 6, 7, 8],
+  current_ranks: [8, 7, 6, 5, 4, 3, 2, 1],
+  k: 8,
+  trimmed: false,
+};
+
+/**
+ * New entrants and dropouts. `alpha`/`gamma` fell out of current's
+ * top-K; `omicron`/`sigma` are new to current. Slot order follows
+ * Stage B's contract: base's top-K in base-rank order first (positions
+ * 1–8), then current-only values appended at the right in current-rank
+ * order. Values absent from one side carry a `null` rank.
+ */
+export const discreteRankWithNewEntrants: ProfileDistributionTopKRanksPayload =
+  {
+    kind: "topk",
+    mode: "ranks",
+    values: [
+      // Base's top-K in base-rank order:
+      "alpha",
+      "beta",
+      "gamma",
+      "delta",
+      "epsilon",
+      "zeta",
+      "eta",
+      "theta",
+      // Then values in current's top-K but not base's, by current rank:
+      "omicron",
+      "sigma",
+    ],
+    // alpha=base#1 dropped from current; gamma=base#3 dropped from current.
+    base_ranks: [1, 2, 3, 4, 5, 6, 7, 8, null, null],
+    // omicron is current#3, sigma is current#6. beta/delta/epsilon/zeta/eta/theta
+    // keep similar positions; alpha/gamma absent on current side.
+    current_ranks: [null, 1, null, 2, 4, 5, 7, 8, 3, 6],
+    k: 8,
+    trimmed: false,
+  };
+
+/**
+ * Trimmed rank-only top-K — 92-cardinality airports column where the
+ * engine returned values without counts. Same trimmed-marker behavior
+ * as counts mode.
+ */
+export const discreteRankTrimmedAirports: ProfileDistributionTopKRanksPayload =
+  {
+    kind: "topk",
+    mode: "ranks",
+    values: [
+      "JFK",
+      "LAX",
+      "ORD",
+      "DFW",
+      "ATL",
+      "DEN",
+      "SFO",
+      "SEA",
+      "LAS",
+      "MIA",
+      "BOS",
+      "PHX",
+    ],
+    base_ranks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+    current_ranks: [1, 2, 4, 3, 5, 7, 6, 8, 10, 9, 12, 11],
+    k: 12,
+    trimmed: true,
+  };
+
+// ----------------------------------------------------------------------
+// Failure / unsupported envelopes
+// ----------------------------------------------------------------------
+
+export const nullPayload: ProfileDistributionNullPayload = {
+  kind: null,
+  reason: "column query raised on this side; slot intentionally empty",
+};
+
+export const unsupportedResult: ProfileDistributionResult = {
+  status: "unsupported",
+  reason:
+    "Adapter type 'postgres' lacks native HLL / APPROX_PERCENTILE / APPROX_TOP_K.",
+};
+
+// ----------------------------------------------------------------------
+// Convenience: simulate a whole-task result envelope
+// ----------------------------------------------------------------------
+
+/**
+ * A multi-column result envelope a SchemaView consumer would receive.
+ * Mixes continuous, discrete, gapped, trimmed, and one per-column failure
+ * so stories can render the full Compact-mode row stack against one fixture.
+ */
+export const mixedTaskResult: ProfileDistributionResult = {
+  status: "ok",
+  columns: {
+    order_total_usd: continuousOrderAmount,
+    created_at: continuousStable,
+    ltv_predicted: continuousAddedOnly,
+    response_status: discreteHttpStatus,
+    billing_country: discreteCountryCode,
+    signup_source: discreteSignupSource,
+    cohort: discreteWithGaps,
+    origin_airport: discreteTrimmedAirports,
+    bad_column: nullPayload,
+  },
+};
+
+// ----------------------------------------------------------------------
+// snake_case → camelCase adapters
+// ----------------------------------------------------------------------
+//
+// Stage B emits payloads in snake_case (matches the run API wire format);
+// the React cells take camelCase props. Each story used to inline the
+// shape conversion, so the same five-line copy appeared a dozen times.
+// These adapters centralize it.
+
+export function toContinuousProps(p: ProfileDistributionHistogramPayload) {
+  return {
+    binEdges: p.bin_edges,
+    baseDensity: p.base_density,
+    currentDensity: p.current_density,
+    baseTotal: p.base_total,
+    currentTotal: p.current_total,
+  };
+}
+
+export function toDiscreteProps(p: ProfileDistributionTopKPayload) {
+  return {
+    values: p.values,
+    baseCounts: p.base_counts,
+    currentCounts: p.current_counts,
+    baseTotal: p.base_total,
+    currentTotal: p.current_total,
+    trimmed: p.trimmed,
+  };
+}
+
+export function toDiscreteRanksProps(p: ProfileDistributionTopKRanksPayload) {
+  return {
+    mode: p.mode,
+    values: p.values,
+    baseRanks: p.base_ranks,
+    currentRanks: p.current_ranks,
+    k: p.k,
+    trimmed: p.trimmed,
+  };
+}

--- a/js/packages/ui/src/components/data/HistogramChart.tsx
+++ b/js/packages/ui/src/components/data/HistogramChart.tsx
@@ -14,6 +14,11 @@ import {
 } from "chart.js";
 import { memo, useMemo } from "react";
 import { Chart } from "react-chartjs-2";
+import { getChartBarColors, getChartThemeColors } from "../../theme";
+import {
+  formatAsAbbreviatedNumber,
+  formatIntervalMinMax,
+} from "../../utils/formatters";
 
 // Register Chart.js modules once
 ChartJS.register(
@@ -25,74 +30,6 @@ ChartJS.register(
   Legend,
   Tooltip,
 );
-
-/**
- * Theme-aware colors for charts
- */
-export interface ChartThemeColors {
-  gridColor: string;
-  textColor: string;
-  borderColor: string;
-  tooltipBackgroundColor: string;
-  tooltipTextColor: string;
-  /** Text color for labels drawn inside bars (must contrast with pastel bar fills) */
-  barLabelColor: string;
-  /** Subdued text color for secondary labels like percentages */
-  secondaryTextColor: string;
-}
-
-/**
- * Bar colors for base/current comparison
- */
-export interface ChartBarColors {
-  current: string;
-  base: string;
-  currentWithAlpha: string;
-  baseWithAlpha: string;
-}
-
-// Light mode colors
-const CURRENT_BAR_COLOR = "#63B3ED";
-const BASE_BAR_COLOR = "#F6AD55";
-const CURRENT_BAR_COLOR_WITH_ALPHA = `${CURRENT_BAR_COLOR}A5`;
-const BASE_BAR_COLOR_WITH_ALPHA = `${BASE_BAR_COLOR}A5`;
-
-// Dark mode colors
-const CURRENT_BAR_COLOR_DARK = "#90CDF4";
-const BASE_BAR_COLOR_DARK = "#FBD38D";
-const CURRENT_BAR_COLOR_DARK_WITH_ALPHA = `${CURRENT_BAR_COLOR_DARK}A5`;
-const BASE_BAR_COLOR_DARK_WITH_ALPHA = `${BASE_BAR_COLOR_DARK}A5`;
-
-/**
- * Get theme-aware colors for charts
- */
-export function getChartThemeColors(isDark: boolean): ChartThemeColors {
-  return {
-    gridColor: isDark ? "#4b5563" : "#d1d5db",
-    textColor: isDark ? "#e5e7eb" : "#374151",
-    borderColor: isDark ? "#6b7280" : "#9ca3af",
-    tooltipBackgroundColor: isDark ? "#1f2937" : "#ffffff",
-    tooltipTextColor: isDark ? "#e5e7eb" : "#111827",
-    barLabelColor: isDark ? "#ffffff" : "#1f2937",
-    secondaryTextColor: isDark ? "#e5e7eb" : "#6b7280",
-  };
-}
-
-/**
- * Get theme-aware bar colors
- */
-export function getChartBarColors(isDark: boolean): ChartBarColors {
-  return {
-    current: isDark ? CURRENT_BAR_COLOR_DARK : CURRENT_BAR_COLOR,
-    base: isDark ? BASE_BAR_COLOR_DARK : BASE_BAR_COLOR,
-    currentWithAlpha: isDark
-      ? CURRENT_BAR_COLOR_DARK_WITH_ALPHA
-      : CURRENT_BAR_COLOR_WITH_ALPHA,
-    baseWithAlpha: isDark
-      ? BASE_BAR_COLOR_DARK_WITH_ALPHA
-      : BASE_BAR_COLOR_WITH_ALPHA,
-  };
-}
 
 /**
  * Histogram dataset for a single environment
@@ -142,54 +79,12 @@ export interface HistogramChartProps {
 }
 
 /**
- * Format number as abbreviated (K, M, B, T)
- */
-function formatAbbreviatedNumber(input: number | string): string {
-  if (typeof input !== "number") return String(input);
-
-  const absValue = Math.abs(input);
-  const trillion = 1e12;
-  const billion = 1e9;
-  const million = 1e6;
-  const thousand = 1e3;
-
-  if (absValue >= trillion) {
-    return `${(input / trillion).toFixed(1)}T`;
-  }
-  if (absValue >= billion) {
-    return `${(input / billion).toFixed(1)}B`;
-  }
-  if (absValue >= million) {
-    return `${(input / million).toFixed(1)}M`;
-  }
-  if (absValue >= thousand) {
-    return `${(input / thousand).toFixed(1)}K`;
-  }
-  if (absValue >= 1) {
-    return input.toFixed(2);
-  }
-  if (absValue >= 0.01) {
-    return input.toFixed(3);
-  }
-  return input.toExponential(2);
-}
-
-/**
  * Format bin range display
  */
 function formatBinRange(binEdges: number[], index: number): string {
   const start = binEdges[index];
   const end = binEdges[index + 1];
-  return `${formatAbbreviatedNumber(start)} - ${formatAbbreviatedNumber(end)}`;
-}
-
-/**
- * Format percentage display
- */
-function formatPercentage(value: number): string {
-  if (value > 0 && value <= 0.001) return "<0.1%";
-  if (value < 1 && value >= 0.999) return ">99.9%";
-  return `${(value * 100).toFixed(1)}%`;
+  return `${formatAsAbbreviatedNumber(start)} - ${formatAsAbbreviatedNumber(end)}`;
 }
 
 /**
@@ -343,7 +238,7 @@ function HistogramChartComponent({
                 datasetIndex === 0 ? currentData.counts : baseData.counts;
               const count = counts[dataIndex];
               const percent =
-                samples > 0 ? formatPercentage(count / samples) : "";
+                samples > 0 ? formatIntervalMinMax(count / samples) : "";
               return `${dataset.label}: ${count}${percent ? ` (${percent})` : ""}`;
             },
           },
@@ -388,7 +283,7 @@ function HistogramChartComponent({
             maxTicksLimit: 8,
             color: themeColors.textColor,
             callback(val) {
-              return formatAbbreviatedNumber(val as number);
+              return formatAsAbbreviatedNumber(val as number);
             },
           },
           beginAtZero: true,

--- a/js/packages/ui/src/components/data/PairedHistogramCanvas.tsx
+++ b/js/packages/ui/src/components/data/PairedHistogramCanvas.tsx
@@ -18,37 +18,41 @@ import type { ReactNode } from "react";
  * side-by-side bars, etc.
  */
 
-/** Default schema-row cell width (px). Tuned to the SchemaView column. */
+/** Schema-row cell width (px). Tuned to the SchemaView column. */
 export const CELL_WIDTH = 140;
 
-/** Default schema-row cell height (px). Fits inside the current 35px schema row. */
+/** Schema-row cell height (px). Fits inside the current 35px schema row. */
 export const CELL_HEIGHT = 28;
 
+/** Accessible label for the continuous paired-histogram cell. */
+export const CONTINUOUS_ARIA_LABEL =
+  "Paired baseline and current continuous distribution";
+
+/** Accessible label for the discrete paired-histogram cell. */
+export const DISCRETE_ARIA_LABEL =
+  "Paired baseline and current categorical distribution";
+
 export interface PairedHistogramSvgProps {
-  width: number;
-  height: number;
-  className?: string;
   ariaLabel: string;
+  className?: string;
   children?: ReactNode;
 }
 
 /**
  * Outer SVG frame used by both paired-histogram cells. Renders an
  * accessible title and reserves the chart area; callers draw bins and
- * decorations as children.
+ * decorations as children. Size is fixed at `CELL_WIDTH × CELL_HEIGHT`.
  */
 export function PairedHistogramSvg({
-  width,
-  height,
-  className,
   ariaLabel,
+  className,
   children,
 }: PairedHistogramSvgProps) {
   return (
     <svg
-      width={width}
-      height={height}
-      viewBox={`0 0 ${width} ${height}`}
+      width={CELL_WIDTH}
+      height={CELL_HEIGHT}
+      viewBox={`0 0 ${CELL_WIDTH} ${CELL_HEIGHT}`}
       className={className}
       style={{ display: "block", overflow: "visible" }}
       role="img"
@@ -61,7 +65,6 @@ export function PairedHistogramSvg({
 }
 
 export interface BaselineRuleProps {
-  width: number;
   y: number;
   stroke: string;
 }
@@ -69,10 +72,18 @@ export interface BaselineRuleProps {
 /**
  * Horizontal rule drawn under the bars so empty slots still read as
  * "this slot has zero bars" rather than "this slot doesn't exist".
+ * Spans the full `CELL_WIDTH`.
  */
-export function BaselineRule({ width, y, stroke }: BaselineRuleProps) {
+export function BaselineRule({ y, stroke }: BaselineRuleProps) {
   return (
-    <line x1={0} y1={y} x2={width} y2={y} stroke={stroke} strokeWidth={0.5} />
+    <line
+      x1={0}
+      y1={y}
+      x2={CELL_WIDTH}
+      y2={y}
+      stroke={stroke}
+      strokeWidth={0.5}
+    />
   );
 }
 

--- a/js/packages/ui/src/components/data/PairedHistogramContinuous.tsx
+++ b/js/packages/ui/src/components/data/PairedHistogramContinuous.tsx
@@ -19,10 +19,21 @@ import {
  *
  * This is the GA replacement for the prototype `PairedHistogramContinuousCell`,
  * rewritten for the quantile-bin payload shipped by PR 2. The visual
- * vocabulary is preserved (paired bars per bin, agreement zone +
- * differential), but bar **width** now varies with the bin's quantile
+ * vocabulary is preserved (agreement zone + differential), but bar
+ * **width** now varies with the bin's quantile
  * span and bar **height** with density, so the **area** of each bar reads
  * directly as the proportion of rows in that bin.
+ *
+ * Per-env edges, merged x-grid: base and current are binned on their own
+ * quantile edges (that's the only way each stays constant-area — see the
+ * PR #1398 discussion). They generally don't line up. Rather than force
+ * one env onto the other's edges (which destroys the equal-area property
+ * and, in the backend, collapses the two densities into one), we overlay
+ * both edge sets onto a **shared value axis** and draw a bar at every
+ * segment of the *merged* edge set. Each merged segment falls entirely
+ * within one base bin and one current bin, so both densities are constant
+ * across it — which lets the original agreement-zone + differential
+ * renderer run unchanged on the skinnier segments.
  *
  * Why constant-area: with quantile bins, equal-row-count slots have
  * different widths. Uniform-width rendering would overweight wide,
@@ -46,11 +57,13 @@ import {
  * through with minimal adapting.
  */
 export interface PairedHistogramContinuousData {
-  /** Length 12 quantile-bin edges. */
-  binEdges: number[];
-  /** Length 11 — base density per bin (count / total / span). */
+  /** Length 12 — base quantile-bin edges. */
+  baseBinEdges: number[];
+  /** Length 12 — current quantile-bin edges (independent of base's). */
+  currentBinEdges: number[];
+  /** Length 11 — base density per base bin (count / total / span). */
   baseDensity: number[];
-  /** Length 11 — current density per bin. */
+  /** Length 11 — current density per current bin. */
   currentDensity: number[];
   baseTotal: number;
   currentTotal: number;
@@ -179,12 +192,47 @@ export function PairedHistogramContinuous({
   );
 }
 
+interface ContinuousSegment {
+  x: number;
+  width: number;
+  baseDensity: number;
+  currentDensity: number;
+  lo: number;
+  hi: number;
+}
+
 /**
- * Compute per-bin x / width / density given a quantile-bin payload and an
- * available chart width. Bars are positioned proportionally to their
- * quantile span — wide bins (sparse regions) get wide bars, narrow bins
- * (dense regions) get narrow bars. Heights remain proportional to density,
- * so the **area** of every bar reads as the row-proportion in that bin.
+ * Density of the bin containing value `v`, or 0 if `v` falls outside the
+ * env's range. Edges are ascending; bins are half-open `[edge[i], edge[i+1])`
+ * with the final bin closed on the right so the max value lands in-range.
+ * Callers only pass segment midpoints, which always sit strictly inside one
+ * bin of the env that contributed an edge — so the half-open/closed choice
+ * only matters for the other env's out-of-range tails (correctly → 0).
+ */
+function densityAt(edges: number[], density: number[], v: number): number {
+  if (v < edges[0] || v > edges[edges.length - 1]) return 0;
+  for (let i = 0; i < density.length; i += 1) {
+    if (v >= edges[i] && v < edges[i + 1]) return density[i];
+  }
+  // v === last edge: belongs to the final bin.
+  return density[density.length - 1];
+}
+
+/**
+ * Compute per-segment x / width / density for the **merged** edge grid.
+ *
+ * Base and current carry independent quantile edges, so they share no
+ * x-slots. We union both edge arrays into one ascending breakpoint set and
+ * emit a segment between each consecutive pair. Every segment lies wholly
+ * inside one base bin and one current bin, so both densities are constant
+ * across it — which is what lets the renderer keep the original
+ * agreement-zone (min) + differential (max − min) decomposition.
+ *
+ * Segments are positioned on a shared value axis spanning the union of both
+ * ranges, so widths track quantile span and the **area** of each bar reads
+ * as the row-proportion in that segment. Subdividing a bin onto the merged
+ * grid preserves its area (sub-segments sum back to the bin's area), so each
+ * env stays constant-area overall.
  *
  * File-level export (not in the package barrel) so the unit tests in this
  * directory can validate the geometry without rendering.
@@ -193,62 +241,74 @@ export function computeContinuousLayout(
   data: PairedHistogramContinuousData,
   width: number,
 ): {
-  bins: {
-    x: number;
-    width: number;
-    baseDensity: number;
-    currentDensity: number;
-    lo: number;
-    hi: number;
-  }[];
+  bins: ContinuousSegment[];
   maxDensity: number;
   minVal: number;
   maxVal: number;
 } {
-  const { binEdges, baseDensity, currentDensity } = data;
+  const { baseBinEdges, currentBinEdges, baseDensity, currentDensity } = data;
 
-  // Guard: payload must have N+1 edges for N bins, and both density
-  // arrays must agree on N. If anything's off, return an empty layout —
-  // the renderer falls back to an empty SVG above.
-  const binCount = baseDensity.length;
-  if (
-    binCount === 0 ||
-    binCount !== currentDensity.length ||
-    binEdges.length !== binCount + 1
-  ) {
+  // Guard: each env must have N+1 edges for N bins. Both must be internally
+  // consistent and non-empty. If either is off, return an empty layout — the
+  // renderer falls back to an empty SVG above.
+  const baseValid =
+    baseDensity.length > 0 && baseBinEdges.length === baseDensity.length + 1;
+  const currValid =
+    currentDensity.length > 0 &&
+    currentBinEdges.length === currentDensity.length + 1;
+  if (!baseValid || !currValid) {
     return { bins: [], maxDensity: 0, minVal: 0, maxVal: 0 };
   }
 
-  const minVal = binEdges[0];
-  const maxVal = binEdges[binEdges.length - 1];
+  const minVal = Math.min(baseBinEdges[0], currentBinEdges[0]);
+  const maxVal = Math.max(
+    baseBinEdges[baseBinEdges.length - 1],
+    currentBinEdges[currentBinEdges.length - 1],
+  );
   const totalSpan = maxVal - minVal;
 
-  // Degenerate range (all bins collapsed to a point): fall back to
-  // uniform-width slots so we still render something visible.
-  const useUniform = totalSpan <= 0 || !Number.isFinite(totalSpan);
+  const bins: ContinuousSegment[] = [];
 
-  const bins = [];
-  let cursor = 0;
-  for (let i = 0; i < binCount; i += 1) {
-    const lo = binEdges[i];
-    const hi = binEdges[i + 1];
-    const span = hi - lo;
-    const w = useUniform
-      ? width / binCount
-      : Math.max(0, (span / totalSpan) * width);
-    bins.push({
-      x: cursor,
-      width: w,
-      baseDensity: baseDensity[i],
-      currentDensity: currentDensity[i],
-      lo,
-      hi,
-    });
-    cursor += w;
+  // Degenerate range (everything collapsed to a point): fall back to
+  // uniform-width slots, index-aligning the two envs' bins, so we still
+  // render something visible.
+  if (totalSpan <= 0 || !Number.isFinite(totalSpan)) {
+    const n = Math.max(baseDensity.length, currentDensity.length);
+    const w = width / n;
+    for (let i = 0; i < n; i += 1) {
+      bins.push({
+        x: i * w,
+        width: w,
+        baseDensity: baseDensity[i] ?? 0,
+        currentDensity: currentDensity[i] ?? 0,
+        lo: minVal,
+        hi: maxVal,
+      });
+    }
+  } else {
+    // Merge both edge sets into one ascending, de-duplicated breakpoint
+    // array, then emit a segment between each consecutive pair.
+    const merged = Array.from(
+      new Set([...baseBinEdges, ...currentBinEdges]),
+    ).sort((a, b) => a - b);
+    for (let i = 0; i < merged.length - 1; i += 1) {
+      const lo = merged[i];
+      const hi = merged[i + 1];
+      if (hi <= lo) continue;
+      const mid = (lo + hi) / 2;
+      bins.push({
+        x: ((lo - minVal) / totalSpan) * width,
+        width: ((hi - lo) / totalSpan) * width,
+        baseDensity: densityAt(baseBinEdges, baseDensity, mid),
+        currentDensity: densityAt(currentBinEdges, currentDensity, mid),
+        lo,
+        hi,
+      });
+    }
   }
 
-  // Account for any rounding drift: stretch the last bin to the right edge.
-  // Applies in both quantile-proportional and uniform modes — floating-point
+  // Account for any rounding drift: stretch the last segment to the right
+  // edge. Applies in both merged and uniform modes — floating-point
   // accumulation can leave a sub-pixel gap either way.
   if (bins.length > 0) {
     const last = bins[bins.length - 1];
@@ -256,8 +316,9 @@ export function computeContinuousLayout(
   }
 
   const allDensities: number[] = [];
-  for (const d of baseDensity) allDensities.push(d);
-  for (const d of currentDensity) allDensities.push(d);
+  for (const b of bins) {
+    allDensities.push(b.baseDensity, b.currentDensity);
+  }
   const maxDensity = Math.max(1e-9, ...allDensities);
 
   return { bins, maxDensity, minVal, maxVal };

--- a/js/packages/ui/src/components/data/PairedHistogramContinuous.tsx
+++ b/js/packages/ui/src/components/data/PairedHistogramContinuous.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useId, useMemo } from "react";
+import { useIsDark } from "../../hooks/useIsDark";
+import { getChartBarColors, getChartThemeColors } from "../../theme";
+import { formatAsAbbreviatedNumber } from "../../utils/formatters";
+import {
+  BaselineRule,
+  CELL_HEIGHT,
+  CELL_WIDTH,
+  formatProportionTooltip,
+  PairedHistogramSvg,
+} from "./pairedHistogramCanvas";
+
+/**
+ * Small continuous paired-bar chart for high-cardinality quantitative data
+ * (order amounts, latency, file sizes) using **constant-area** rendering.
+ *
+ * This is the GA replacement for the prototype `PairedHistogramContinuousCell`,
+ * rewritten for the quantile-bin payload shipped by PR 2. The visual
+ * vocabulary is preserved (paired bars per bin, agreement zone +
+ * differential), but bar **width** now varies with the bin's quantile
+ * span and bar **height** with density, so the **area** of each bar reads
+ * directly as the proportion of rows in that bin.
+ *
+ * Why constant-area: with quantile bins, equal-row-count slots have
+ * different widths. Uniform-width rendering would overweight wide,
+ * sparse bins. Area = density × span gives every bar the same row-share
+ * meaning regardless of bin width.
+ *
+ * Why not reuse `HistogramChart`: HistogramChart unconditionally renders
+ * a title row + legend (~50 px overhead). At cell density (h≈28) there
+ * is no room left for the bars. HistogramChart still belongs on popover
+ * and detail surfaces where its title/legend/tooltip machinery is welcome —
+ * just not in a 140×28 grid cell.
+ *
+ * Bar palette + theme colors come from `getChartBarColors` /
+ * `getChartThemeColors` (canonical in `@datarecce/ui/theme`), so all
+ * chart surfaces stay in lockstep.
+ */
+
+/**
+ * Payload for the continuous cell. Matches `ProfileDistributionHistogramPayload`
+ * from the run API (snake_case wire format) so callers can pass results
+ * through with minimal adapting.
+ */
+export interface PairedHistogramContinuousData {
+  /** Length 12 quantile-bin edges. */
+  binEdges: number[];
+  /** Length 11 — base density per bin (count / total / span). */
+  baseDensity: number[];
+  /** Length 11 — current density per bin. */
+  currentDensity: number[];
+  baseTotal: number;
+  currentTotal: number;
+}
+
+export interface PairedHistogramContinuousProps {
+  data: PairedHistogramContinuousData;
+  /** Pixel width of the rendered SVG. Default `CELL_WIDTH` (140). */
+  width?: number;
+  /** Pixel height of the rendered SVG. Default `CELL_HEIGHT` (28). */
+  height?: number;
+  /** Render endpoint labels (min / max). Default false — bin range is
+   * shown on hover via the per-bar tooltip; in-chart labels eat too much
+   * vertical room at cell density. */
+  showEndpoints?: boolean;
+  /** Also render midpoint label between min and max. Default false. */
+  showMidpoint?: boolean;
+  /** Override default label formatter. Default: 1.2K-style abbreviation. */
+  formatValue?: (v: number) => string;
+  /** Optional CSS class. */
+  className?: string;
+  /** Accessible label override for the SVG. */
+  ariaLabel?: string;
+}
+
+/**
+ * PairedHistogramContinuous — constant-area paired-bar chart.
+ *
+ * @example
+ * ```tsx
+ * <PairedHistogramContinuous data={distribution} />
+ * ```
+ */
+export function PairedHistogramContinuous({
+  data,
+  width = CELL_WIDTH,
+  height = CELL_HEIGHT,
+  showEndpoints = false,
+  showMidpoint = false,
+  formatValue = formatAsAbbreviatedNumber,
+  className,
+  ariaLabel = "Paired baseline and current continuous distribution",
+}: PairedHistogramContinuousProps) {
+  const isDark = useIsDark();
+  const bars = getChartBarColors(isDark);
+  const theme = getChartThemeColors(isDark);
+  const baseFill = bars.base;
+  const currentFill = bars.current;
+  const baselineColor = theme.borderColor;
+  const labelColor = theme.textColor;
+
+  // SVG pattern IDs are document-global; useId() gives each cell instance
+  // its own ID so patterns don't collide between adjacent histograms.
+  const reactId = useId();
+  const patternId = `phc-overlap-${reactId.replace(/:/g, "")}`;
+
+  const layout = useMemo(() => {
+    return computeContinuousLayout(data, width);
+  }, [data, width]);
+
+  const labelHeight = showEndpoints ? 11 : 0;
+  const chartHeight = Math.max(8, height - labelHeight - 2);
+
+  // Empty / degenerate input — render an empty SVG so size is preserved.
+  if (layout.bins.length === 0) {
+    return (
+      <PairedHistogramSvg
+        width={width}
+        height={height}
+        className={className}
+        ariaLabel={ariaLabel}
+      />
+    );
+  }
+
+  return (
+    <PairedHistogramSvg
+      width={width}
+      height={height}
+      className={className}
+      ariaLabel={ariaLabel}
+    >
+      <defs>
+        <pattern
+          id={patternId}
+          patternUnits="userSpaceOnUse"
+          width={4}
+          height={4}
+        >
+          <rect x={0} y={0} width={2} height={2} fill={baseFill} />
+          <rect x={2} y={2} width={2} height={2} fill={baseFill} />
+          <rect x={2} y={0} width={2} height={2} fill={currentFill} />
+          <rect x={0} y={2} width={2} height={2} fill={currentFill} />
+        </pattern>
+      </defs>
+      {layout.bins.map((bin, i) => {
+        const baseH = (bin.baseDensity / layout.maxDensity) * chartHeight;
+        const currH = (bin.currentDensity / layout.maxDensity) * chartHeight;
+        const minH = Math.min(baseH, currH);
+        const maxH = Math.max(baseH, currH);
+        const diffFill = baseH > currH ? baseFill : currentFill;
+        // Bars touch (continuous data should read continuously); a tiny
+        // -0.25 px inset prevents adjacent bins from blurring into one
+        // shape at very tight slot widths.
+        const w = Math.max(0.5, bin.width - 0.25);
+        const hoverTitle = formatContinuousTooltip(bin, formatValue);
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable quantile order
+          <g key={i}>
+            {/* Invisible hit-target spanning the full slot height so hover
+             * picks up the tooltip even on very small bars. `fill="none"`
+             * + `pointerEvents="all"` keeps the rect pickable without
+             * painting any pixels. */}
+            <rect
+              x={bin.x}
+              y={0}
+              width={bin.width}
+              height={chartHeight}
+              fill="none"
+              pointerEvents="all"
+            >
+              <title>{hoverTitle}</title>
+            </rect>
+            {minH > 0 && (
+              <rect
+                x={bin.x}
+                y={chartHeight - minH}
+                width={w}
+                height={minH}
+                fill={`url(#${patternId})`}
+                pointerEvents="none"
+              />
+            )}
+            {maxH > minH && (
+              <rect
+                x={bin.x}
+                y={chartHeight - maxH}
+                width={w}
+                height={maxH - minH}
+                fill={diffFill}
+                pointerEvents="none"
+              />
+            )}
+          </g>
+        );
+      })}
+
+      <BaselineRule width={width} y={chartHeight} stroke={baselineColor} />
+
+      {showEndpoints && (
+        <g
+          fontFamily="system-ui, -apple-system, sans-serif"
+          fontSize={9}
+          fill={labelColor}
+        >
+          <text x={0} y={height - 1} textAnchor="start">
+            {formatValue(layout.minVal)}
+          </text>
+          {showMidpoint && (
+            <text x={width / 2} y={height - 1} textAnchor="middle">
+              {formatValue((layout.minVal + layout.maxVal) / 2)}
+            </text>
+          )}
+          <text x={width} y={height - 1} textAnchor="end">
+            {formatValue(layout.maxVal)}
+          </text>
+        </g>
+      )}
+    </PairedHistogramSvg>
+  );
+}
+
+/**
+ * Compute per-bin x / width / density given a quantile-bin payload and an
+ * available chart width. Bars are positioned proportionally to their
+ * quantile span — wide bins (sparse regions) get wide bars, narrow bins
+ * (dense regions) get narrow bars. Heights remain proportional to density,
+ * so the **area** of every bar reads as the row-proportion in that bin.
+ *
+ * Exported so tests + lineage pre-warm (PR 4) can validate the geometry
+ * without rendering.
+ */
+export function computeContinuousLayout(
+  data: PairedHistogramContinuousData,
+  width: number,
+): {
+  bins: {
+    x: number;
+    width: number;
+    baseDensity: number;
+    currentDensity: number;
+    lo: number;
+    hi: number;
+  }[];
+  maxDensity: number;
+  minVal: number;
+  maxVal: number;
+} {
+  const { binEdges, baseDensity, currentDensity } = data;
+
+  // Guard: payload must have N+1 edges for N bins, and both density
+  // arrays must agree on N. If anything's off, return an empty layout —
+  // the renderer falls back to an empty SVG above.
+  const binCount = baseDensity.length;
+  if (
+    binCount === 0 ||
+    binCount !== currentDensity.length ||
+    binEdges.length !== binCount + 1
+  ) {
+    return { bins: [], maxDensity: 0, minVal: 0, maxVal: 0 };
+  }
+
+  const minVal = binEdges[0];
+  const maxVal = binEdges[binEdges.length - 1];
+  const totalSpan = maxVal - minVal;
+
+  // Degenerate range (all bins collapsed to a point): fall back to
+  // uniform-width slots so we still render something visible.
+  const useUniform = totalSpan <= 0 || !Number.isFinite(totalSpan);
+
+  const bins = [];
+  let cursor = 0;
+  for (let i = 0; i < binCount; i += 1) {
+    const lo = binEdges[i];
+    const hi = binEdges[i + 1];
+    const span = hi - lo;
+    const w = useUniform
+      ? width / binCount
+      : Math.max(0, (span / totalSpan) * width);
+    bins.push({
+      x: cursor,
+      width: w,
+      baseDensity: baseDensity[i],
+      currentDensity: currentDensity[i],
+      lo,
+      hi,
+    });
+    cursor += w;
+  }
+
+  // Account for any rounding drift: stretch the last bin to the right edge.
+  // Applies in both quantile-proportional and uniform modes — floating-point
+  // accumulation can leave a sub-pixel gap either way.
+  if (bins.length > 0) {
+    const last = bins[bins.length - 1];
+    last.width = Math.max(0, width - last.x);
+  }
+
+  const allDensities: number[] = [];
+  for (const d of baseDensity) allDensities.push(d);
+  for (const d of currentDensity) allDensities.push(d);
+  const maxDensity = Math.max(1e-9, ...allDensities);
+
+  return { bins, maxDensity, minVal, maxVal };
+}
+
+function formatContinuousTooltip(
+  bin: {
+    lo: number;
+    hi: number;
+    baseDensity: number;
+    currentDensity: number;
+  },
+  fmt: (v: number) => string,
+): string {
+  const span = bin.hi - bin.lo;
+  // Area = density × span = proportion of rows in this quantile-bin.
+  const baseProp = span > 0 ? bin.baseDensity * span : 0;
+  const currProp = span > 0 ? bin.currentDensity * span : 0;
+  return formatProportionTooltip(
+    `${fmt(bin.lo)}–${fmt(bin.hi)}`,
+    baseProp,
+    currProp,
+  );
+}

--- a/js/packages/ui/src/components/data/PairedHistogramContinuous.tsx
+++ b/js/packages/ui/src/components/data/PairedHistogramContinuous.tsx
@@ -8,9 +8,10 @@ import {
   BaselineRule,
   CELL_HEIGHT,
   CELL_WIDTH,
+  CONTINUOUS_ARIA_LABEL,
   formatProportionTooltip,
   PairedHistogramSvg,
-} from "./pairedHistogramCanvas";
+} from "./PairedHistogramCanvas";
 
 /**
  * Small continuous paired-bar chart for high-cardinality quantitative data
@@ -57,26 +58,15 @@ export interface PairedHistogramContinuousData {
 
 export interface PairedHistogramContinuousProps {
   data: PairedHistogramContinuousData;
-  /** Pixel width of the rendered SVG. Default `CELL_WIDTH` (140). */
-  width?: number;
-  /** Pixel height of the rendered SVG. Default `CELL_HEIGHT` (28). */
-  height?: number;
-  /** Render endpoint labels (min / max). Default false — bin range is
-   * shown on hover via the per-bar tooltip; in-chart labels eat too much
-   * vertical room at cell density. */
-  showEndpoints?: boolean;
-  /** Also render midpoint label between min and max. Default false. */
-  showMidpoint?: boolean;
-  /** Override default label formatter. Default: 1.2K-style abbreviation. */
+  /** Override default tooltip-range formatter. Default: 1.2K-style abbreviation. */
   formatValue?: (v: number) => string;
   /** Optional CSS class. */
   className?: string;
-  /** Accessible label override for the SVG. */
-  ariaLabel?: string;
 }
 
 /**
- * PairedHistogramContinuous — constant-area paired-bar chart.
+ * PairedHistogramContinuous — constant-area paired-bar chart, fixed
+ * `CELL_WIDTH × CELL_HEIGHT` (140×28) for SchemaView cell density.
  *
  * @example
  * ```tsx
@@ -85,13 +75,8 @@ export interface PairedHistogramContinuousProps {
  */
 export function PairedHistogramContinuous({
   data,
-  width = CELL_WIDTH,
-  height = CELL_HEIGHT,
-  showEndpoints = false,
-  showMidpoint = false,
   formatValue = formatAsAbbreviatedNumber,
   className,
-  ariaLabel = "Paired baseline and current continuous distribution",
 }: PairedHistogramContinuousProps) {
   const isDark = useIsDark();
   const bars = getChartBarColors(isDark);
@@ -99,7 +84,6 @@ export function PairedHistogramContinuous({
   const baseFill = bars.base;
   const currentFill = bars.current;
   const baselineColor = theme.borderColor;
-  const labelColor = theme.textColor;
 
   // SVG pattern IDs are document-global; useId() gives each cell instance
   // its own ID so patterns don't collide between adjacent histograms.
@@ -107,31 +91,24 @@ export function PairedHistogramContinuous({
   const patternId = `phc-overlap-${reactId.replace(/:/g, "")}`;
 
   const layout = useMemo(() => {
-    return computeContinuousLayout(data, width);
-  }, [data, width]);
+    return computeContinuousLayout(data, CELL_WIDTH);
+  }, [data]);
 
-  const labelHeight = showEndpoints ? 11 : 0;
-  const chartHeight = Math.max(8, height - labelHeight - 2);
+  // 2 px breathing room at the bottom so the baseline doesn't sit flush.
+  const chartHeight = Math.max(8, CELL_HEIGHT - 2);
 
   // Empty / degenerate input — render an empty SVG so size is preserved.
   if (layout.bins.length === 0) {
     return (
       <PairedHistogramSvg
-        width={width}
-        height={height}
+        ariaLabel={CONTINUOUS_ARIA_LABEL}
         className={className}
-        ariaLabel={ariaLabel}
       />
     );
   }
 
   return (
-    <PairedHistogramSvg
-      width={width}
-      height={height}
-      className={className}
-      ariaLabel={ariaLabel}
-    >
+    <PairedHistogramSvg ariaLabel={CONTINUOUS_ARIA_LABEL} className={className}>
       <defs>
         <pattern
           id={patternId}
@@ -197,27 +174,7 @@ export function PairedHistogramContinuous({
         );
       })}
 
-      <BaselineRule width={width} y={chartHeight} stroke={baselineColor} />
-
-      {showEndpoints && (
-        <g
-          fontFamily="system-ui, -apple-system, sans-serif"
-          fontSize={9}
-          fill={labelColor}
-        >
-          <text x={0} y={height - 1} textAnchor="start">
-            {formatValue(layout.minVal)}
-          </text>
-          {showMidpoint && (
-            <text x={width / 2} y={height - 1} textAnchor="middle">
-              {formatValue((layout.minVal + layout.maxVal) / 2)}
-            </text>
-          )}
-          <text x={width} y={height - 1} textAnchor="end">
-            {formatValue(layout.maxVal)}
-          </text>
-        </g>
-      )}
+      <BaselineRule y={chartHeight} stroke={baselineColor} />
     </PairedHistogramSvg>
   );
 }
@@ -229,8 +186,8 @@ export function PairedHistogramContinuous({
  * (dense regions) get narrow bars. Heights remain proportional to density,
  * so the **area** of every bar reads as the row-proportion in that bin.
  *
- * Exported so tests + lineage pre-warm (PR 4) can validate the geometry
- * without rendering.
+ * File-level export (not in the package barrel) so the unit tests in this
+ * directory can validate the geometry without rendering.
  */
 export function computeContinuousLayout(
   data: PairedHistogramContinuousData,

--- a/js/packages/ui/src/components/data/PairedHistogramDiscrete.tsx
+++ b/js/packages/ui/src/components/data/PairedHistogramDiscrete.tsx
@@ -136,11 +136,10 @@ export interface PairedHistogramDiscreteProps {
 /**
  * Renderer-agnostic slot shape — the bar heights are pre-resolved so the
  * SVG body doesn't have to know whether they came from proportions or
- * rank positions. `displayValue` is the formatted-for-display string
- * (`formatValue(raw)`); the SVG body never sees the raw `unknown` value.
+ * rank positions. `hoverTitle` already carries the formatted display
+ * string, so the SVG body never sees the raw `unknown` value.
  */
 interface RenderSlot {
-  displayValue: string;
   baseH: number;
   currH: number;
   hoverTitle: string;
@@ -291,27 +290,27 @@ function computeRenderSlots(
 ): RenderSlot[] {
   if (data.mode === "ranks") {
     const { slots } = computeRanksSlots(data);
-    return slots.map((s) => {
-      const displayValue = formatValue(s.value);
-      return {
-        displayValue,
-        baseH: heightForRank(s.baseRank, data.k, chartHeight),
-        currH: heightForRank(s.currRank, data.k, chartHeight),
-        hoverTitle: formatRankTooltip(displayValue, s.baseRank, s.currRank),
-      };
-    });
+    return slots.map((s) => ({
+      baseH: heightForRank(s.baseRank, data.k, chartHeight),
+      currH: heightForRank(s.currRank, data.k, chartHeight),
+      hoverTitle: formatRankTooltip(
+        formatValue(s.value),
+        s.baseRank,
+        s.currRank,
+      ),
+    }));
   }
 
   const { slots, maxProp } = computeDiscreteSlots(data);
-  return slots.map((s) => {
-    const displayValue = formatValue(s.value);
-    return {
-      displayValue,
-      baseH: (s.baseProp / maxProp) * chartHeight,
-      currH: (s.currProp / maxProp) * chartHeight,
-      hoverTitle: formatProportionTooltip(displayValue, s.baseProp, s.currProp),
-    };
-  });
+  return slots.map((s) => ({
+    baseH: (s.baseProp / maxProp) * chartHeight,
+    currH: (s.currProp / maxProp) * chartHeight,
+    hoverTitle: formatProportionTooltip(
+      formatValue(s.value),
+      s.baseProp,
+      s.currProp,
+    ),
+  }));
 }
 
 /** Default `formatValue`: `String(v)`. Cheap, safe; the seam exists so

--- a/js/packages/ui/src/components/data/PairedHistogramDiscrete.tsx
+++ b/js/packages/ui/src/components/data/PairedHistogramDiscrete.tsx
@@ -1,0 +1,491 @@
+"use client";
+
+import { useMemo } from "react";
+import { useIsDark } from "../../hooks/useIsDark";
+import { getChartBarColors, getChartThemeColors } from "../../theme";
+import {
+  BaselineRule,
+  CELL_HEIGHT,
+  CELL_WIDTH,
+  formatProportionTooltip,
+  formatRankTooltip,
+  PairedHistogramSvg,
+} from "./pairedHistogramCanvas";
+
+/**
+ * Small categorical paired-bar chart for top-K low-cardinality data —
+ * both string-valued (country codes) and numeric-as-label (HTTP status
+ * codes). Cell-density sibling of `HistogramChart`/`TopKBarChart`; those
+ * keep their place on detail/popover surfaces where title + legend fit.
+ *
+ * This is the GA replacement for the prototype `PairedHistogramDiscreteCell`,
+ * rewritten for the top-K payload shipped by PR 2.
+ *
+ * Visual: paired bars per category slot. When one side's count is 0
+ * (value absent on that side), that bar simply doesn't render, leaving
+ * a visible gap that reads as "category absent on this side." This is
+ * the **gap-on-absent** semantic locked in DRC-3390.
+ *
+ * Two rendering modes share the same slot/bar layout:
+ *
+ *   - **counts** (default) — bars sized by per-side proportion. Used when
+ *     the backend can return both values and counts (e.g. DuckDB
+ *     `approx_top_k_counts`, Snowflake `APPROX_TOP_K`).
+ *   - **ranks**           — bars sized by rank position only, with
+ *     `height = (k - rank + 1) / k * chartHeight`. Used when the engine
+ *     only returns top-K values without counts (DuckDB `approx_top_k`).
+ *     Stable case reads as two side-by-side descending staircases; an
+ *     order shift makes current bars zig-zag against base's clean descent.
+ *
+ * Stage B's wire contract guarantees both sides use the same algorithm —
+ * if either side has no counts, both are returned as rank-only. The cell
+ * never has to mix counts on one side with ranks on the other.
+ *
+ * Bar palette + theme colors come from `getChartBarColors` /
+ * `getChartThemeColors` (canonical in `@datarecce/ui/theme`).
+ */
+
+/**
+ * Counts-mode payload. Matches `ProfileDistributionTopKPayload`
+ * from the run API (snake_case wire format) so callers can pass results
+ * through with minimal adapting.
+ */
+export interface PairedHistogramDiscreteCountsData {
+  /** Optional discriminator — absent or `"counts"` selects this mode. */
+  mode?: "counts";
+  /** Display order = union(baseTopK, currentTopK), backend-chosen.
+   * Caller may pre-sort (e.g. frequency-desc) for cell density.
+   *
+   * Element type is `unknown` to match Stage B's wire contract — values
+   * may arrive as strings, numbers, booleans, dates, NULL, etc. The
+   * renderer routes each value through `formatValue` to produce its
+   * display string. */
+  values: unknown[];
+  baseCounts: number[];
+  currentCounts: number[];
+  /** Denominator for per-slot proportions. Convention is the **column-wide**
+   * row count, not `sum(baseCounts)` — so a trimmed top-K renders bars
+   * whose proportions sum to <1 (the missing mass is the long tail). When
+   * trimmed is false (or absent), column total and sum-of-shown coincide.
+   * Stage B owns the wire-format contract; cells just consume what's passed. */
+  baseTotal: number;
+  currentTotal: number;
+  /** True when the original distribution had more values than K — caller
+   * passes this through from the payload's `trimmed` field. */
+  trimmed?: boolean;
+}
+
+/**
+ * Ranks-mode payload — used when the backend cannot return counts (the
+ * DuckDB `approx_top_k` path). Bar heights encode rank position only.
+ *
+ * Slot order is **baked in by the caller**: base's top-K in base-rank
+ * order, then values that appear only in current's top-K appended on the
+ * right (sorted by current rank ascending). The component renders the
+ * `values` array straight through — it does not re-sort.
+ */
+export interface PairedHistogramDiscreteRanksData {
+  /** Discriminator — selects rank-only rendering. */
+  mode: "ranks";
+  /** Display order = base's top-K in base-rank order, then values
+   *  in current's top-K but not base's, sorted by current rank.
+   *
+   * Element type is `unknown` to match Stage B's wire contract — values
+   * may arrive as strings, numbers, booleans, dates, NULL, etc. The
+   * renderer routes each value through `formatValue` to produce its
+   * display string. */
+  values: unknown[];
+  /** Per-value rank in base's top-K, 1-indexed. `null` = value not in
+   * base's top-K (no base bar drawn for that slot). */
+  baseRanks: (number | null)[];
+  /** Per-value rank in current's top-K, 1-indexed. `null` = value not
+   * in current's top-K (no current bar drawn for that slot). */
+  currentRanks: (number | null)[];
+  /** Max rank in top-K (e.g. 12). Drives bar-height scaling. */
+  k: number;
+  /** True when the original distribution had more values than K. */
+  trimmed?: boolean;
+}
+
+/**
+ * Discriminated union of the two supported payload shapes. Counts mode
+ * sizes bars by per-side proportion; ranks mode sizes by rank position.
+ */
+export type PairedHistogramDiscreteData =
+  | PairedHistogramDiscreteCountsData
+  | PairedHistogramDiscreteRanksData;
+
+export interface PairedHistogramDiscreteProps {
+  data: PairedHistogramDiscreteData;
+  /** Pixel width of the rendered SVG. Default `CELL_WIDTH` (140). */
+  width?: number;
+  /** Pixel height of the rendered SVG. Default `CELL_HEIGHT` (28). */
+  height?: number;
+  /** Render value labels below bars. Default false — values shown on hover
+   * via the per-bar tooltip; in-chart labels collide at any non-trivial
+   * cardinality. */
+  showLabels?: boolean;
+  /** Maximum chars per label before truncation. Default 4. */
+  labelMaxChars?: number;
+  /**
+   * Convert each raw value to its display string. Default: `String(v)`.
+   * Override to handle NULL nicely, abbreviate large numbers, format
+   * dates, etc.
+   *
+   * Stage B's payload contract types `values` as `unknown[]`; this hook
+   * is the cell's single seam for turning heterogeneous raw values into
+   * something legible. Stage C will dispatch on column type and pass the
+   * right formatter; the cell itself stays type-blind.
+   */
+  formatValue?: (v: unknown) => string;
+  /** Optional CSS class. */
+  className?: string;
+  /** Accessible label override for the SVG. */
+  ariaLabel?: string;
+}
+
+/**
+ * Renderer-agnostic slot shape — the bar heights are pre-resolved so the
+ * SVG body doesn't have to know whether they came from proportions or
+ * rank positions. `displayValue` is the formatted-for-display string
+ * (`formatValue(raw)`); the SVG body never sees the raw `unknown` value.
+ */
+interface RenderSlot {
+  displayValue: string;
+  baseH: number;
+  currH: number;
+  hoverTitle: string;
+}
+
+/**
+ * PairedHistogramDiscrete — paired-bar top-K chart with gap-on-absent
+ * semantics. Supports counts mode (proportion-sized bars) and ranks mode
+ * (rank-position-sized bars).
+ *
+ * @example
+ * ```tsx
+ * <PairedHistogramDiscrete data={topK} />
+ * ```
+ */
+export function PairedHistogramDiscrete({
+  data,
+  width = CELL_WIDTH,
+  height = CELL_HEIGHT,
+  showLabels = false,
+  labelMaxChars = 4,
+  formatValue = defaultFormatValue,
+  className,
+  ariaLabel = "Paired baseline and current categorical distribution",
+}: PairedHistogramDiscreteProps) {
+  const isDark = useIsDark();
+  const bars = getChartBarColors(isDark);
+  const theme = getChartThemeColors(isDark);
+  const baseFill = bars.base;
+  const currentFill = bars.current;
+  const baselineColor = theme.borderColor;
+  const labelColor = theme.textColor;
+  const trimColor = theme.secondaryTextColor;
+
+  const labelHeight = showLabels ? 12 : 0;
+  // 2 px breathing room between bars and the next visual element.
+  const chartHeight = Math.max(8, height - labelHeight - 2);
+
+  const renderSlots = useMemo(
+    () => computeRenderSlots(data, chartHeight, formatValue),
+    [data, chartHeight, formatValue],
+  );
+
+  // Empty payload — render the SVG frame so layout stays stable.
+  if (renderSlots.length === 0) {
+    return (
+      <PairedHistogramSvg
+        width={width}
+        height={height}
+        className={className}
+        ariaLabel={ariaLabel}
+      />
+    );
+  }
+
+  const slotWidth = width / Math.max(1, renderSlots.length);
+  // Slot layout: 10% padding each side, two bars side by side with a small
+  // gap. When one side's count is 0, that bar simply doesn't render —
+  // leaving a visible gap that signals "category absent on this side."
+  const slotPad = slotWidth * 0.1;
+  const innerW = slotWidth - slotPad * 2;
+  const gap = Math.max(1, Math.min(2, innerW * 0.1));
+  const pairBarW = Math.max(1, (innerW - gap) / 2);
+
+  return (
+    <PairedHistogramSvg
+      width={width}
+      height={height}
+      className={className}
+      ariaLabel={ariaLabel}
+    >
+      {renderSlots.map((s, i) => {
+        const slotX = i * slotWidth;
+        const baseX = slotX + slotPad;
+        const currX = slotX + slotPad + pairBarW + gap;
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable backend order
+          <g key={i}>
+            {/* Invisible hit-target spans the full slot — hovering either
+             * bar (or the gap where one is absent) shows the same tooltip
+             * identifying this value. `fill="none"` + `pointerEvents="all"`
+             * keeps the rect pickable without painting any pixels. */}
+            <rect
+              x={slotX}
+              y={0}
+              width={slotWidth}
+              height={chartHeight}
+              fill="none"
+              pointerEvents="all"
+            >
+              <title>{s.hoverTitle}</title>
+            </rect>
+            {s.baseH > 0 && (
+              <rect
+                x={baseX}
+                y={chartHeight - s.baseH}
+                width={pairBarW}
+                height={s.baseH}
+                fill={baseFill}
+                pointerEvents="none"
+              />
+            )}
+            {s.currH > 0 && (
+              <rect
+                x={currX}
+                y={chartHeight - s.currH}
+                width={pairBarW}
+                height={s.currH}
+                fill={currentFill}
+                pointerEvents="none"
+              />
+            )}
+          </g>
+        );
+      })}
+
+      <BaselineRule width={width} y={chartHeight} stroke={baselineColor} />
+
+      {showLabels && (
+        <g
+          fontFamily="system-ui, -apple-system, sans-serif"
+          fontSize={9}
+          fill={labelColor}
+          textAnchor="middle"
+        >
+          {renderSlots.map((s, i) => (
+            <text
+              // biome-ignore lint/suspicious/noArrayIndexKey: stable backend order
+              key={i}
+              x={i * slotWidth + slotWidth / 2}
+              y={chartHeight + 9}
+            >
+              {truncate(s.displayValue, labelMaxChars)}
+            </text>
+          ))}
+        </g>
+      )}
+
+      {data.trimmed && (
+        // Small chip-style background behind the marker so the text stays
+        // legible when a tall rightmost bar reaches the top of the chart.
+        // Semi-transparent (cc ≈ 80%) so it still reads as an overlay
+        // rather than a hard block. Background sourced from the theme's
+        // tooltip background so the chip blends with adjacent surfaces.
+        <g pointerEvents="none">
+          <rect
+            x={width - 38}
+            y={1}
+            width={37}
+            height={10}
+            fill={`${theme.tooltipBackgroundColor}cc`}
+            rx={2}
+            data-testid="trimmed-marker-bg"
+          />
+          <text
+            x={width - 1}
+            y={9}
+            fontFamily="system-ui, -apple-system, sans-serif"
+            fontSize={8}
+            fill={trimColor}
+            textAnchor="end"
+          >
+            trimmed
+          </text>
+        </g>
+      )}
+    </PairedHistogramSvg>
+  );
+}
+
+/**
+ * Bridge from the discriminated payload to the renderer-agnostic slot
+ * shape. Picks the right compute function and converts proportions /
+ * ranks into pixel heights so the SVG body is identical between modes.
+ *
+ * `formatValue` runs here, once per slot, so the SVG body only ever sees
+ * pre-formatted display strings (label truncation, tooltip prefix). The
+ * compute functions stay payload-typed (`value: unknown`).
+ */
+function computeRenderSlots(
+  data: PairedHistogramDiscreteData,
+  chartHeight: number,
+  formatValue: (v: unknown) => string,
+): RenderSlot[] {
+  if (data.mode === "ranks") {
+    const { slots } = computeRanksSlots(data);
+    return slots.map((s) => {
+      const displayValue = formatValue(s.value);
+      return {
+        displayValue,
+        baseH: heightForRank(s.baseRank, data.k, chartHeight),
+        currH: heightForRank(s.currRank, data.k, chartHeight),
+        hoverTitle: formatRankTooltip(displayValue, s.baseRank, s.currRank),
+      };
+    });
+  }
+
+  const { slots, maxProp } = computeDiscreteSlots(data);
+  return slots.map((s) => {
+    const displayValue = formatValue(s.value);
+    return {
+      displayValue,
+      baseH: (s.baseProp / maxProp) * chartHeight,
+      currH: (s.currProp / maxProp) * chartHeight,
+      hoverTitle: formatProportionTooltip(displayValue, s.baseProp, s.currProp),
+    };
+  });
+}
+
+/** Default `formatValue`: `String(v)`. Cheap, safe; the seam exists so
+ * Stage C can override it per column type. */
+function defaultFormatValue(v: unknown): string {
+  return String(v);
+}
+
+/**
+ * Rank-position → pixel height. Rank 1 fills the chart; rank k draws as
+ * `1/k * chartHeight`; `null` rank → 0 (bar omitted entirely).
+ */
+function heightForRank(
+  rank: number | null,
+  k: number,
+  chartHeight: number,
+): number {
+  if (rank === null || k <= 0) return 0;
+  return ((k - rank + 1) / k) * chartHeight;
+}
+
+/**
+ * Compute per-slot proportions + max prop given a counts-mode top-K
+ * payload.
+ *
+ * Exported so the layout can be unit-tested without rendering and so
+ * PR 4's lineage pre-warm can validate payloads cheaply.
+ */
+export function computeDiscreteSlots(data: PairedHistogramDiscreteCountsData): {
+  slots: {
+    value: unknown;
+    baseProp: number;
+    currProp: number;
+    baseCount: number;
+    currCount: number;
+  }[];
+  maxProp: number;
+} {
+  const { values, baseCounts, currentCounts, baseTotal, currentTotal } = data;
+
+  // Guard: counts arrays must match values.length. Anything off → empty slots.
+  // Array.isArray checks defend against malformed payloads (TS contract drift,
+  // partial-loading payloads) reaching the `.length` access — we'd rather render
+  // an empty SVG frame than crash the schema row.
+  if (
+    !Array.isArray(values) ||
+    !Array.isArray(baseCounts) ||
+    !Array.isArray(currentCounts) ||
+    values.length === 0 ||
+    values.length !== baseCounts.length ||
+    values.length !== currentCounts.length
+  ) {
+    return { slots: [], maxProp: 0 };
+  }
+
+  const slots = values.map((value, i) => {
+    const baseCount = baseCounts[i] ?? 0;
+    const currCount = currentCounts[i] ?? 0;
+    return {
+      value,
+      baseCount,
+      currCount,
+      baseProp: baseTotal > 0 ? baseCount / baseTotal : 0,
+      currProp: currentTotal > 0 ? currCount / currentTotal : 0,
+    };
+  });
+
+  const props: number[] = [];
+  for (const s of slots) {
+    props.push(s.baseProp);
+    props.push(s.currProp);
+  }
+  // Epsilon floor avoids div-by-zero in the renderer when every count is 0.
+  // Matches `computeContinuousLayout`'s maxDensity floor.
+  const maxProp = Math.max(1e-9, ...props);
+  return { slots, maxProp };
+}
+
+/**
+ * Compute per-slot ranks given a ranks-mode top-K payload. Slot order
+ * is preserved from `data.values` — Stage B's contract is that the
+ * caller has already arranged base-first, then current-only appended
+ * sorted by current rank. Values absent from both top-Ks are dropped
+ * defensively (the contract says they won't appear).
+ *
+ * Exported alongside `computeDiscreteSlots` for unit testing.
+ */
+export function computeRanksSlots(data: PairedHistogramDiscreteRanksData): {
+  slots: {
+    value: unknown;
+    baseRank: number | null;
+    currRank: number | null;
+  }[];
+} {
+  const { values, baseRanks, currentRanks } = data;
+
+  // Guard: rank arrays must match values.length. Anything off → empty slots.
+  // Array.isArray checks defend against malformed payloads (TS contract drift,
+  // partial-loading payloads) reaching the `.length` access — we'd rather render
+  // an empty SVG frame than crash the schema row.
+  if (
+    !Array.isArray(values) ||
+    !Array.isArray(baseRanks) ||
+    !Array.isArray(currentRanks) ||
+    values.length === 0 ||
+    values.length !== baseRanks.length ||
+    values.length !== currentRanks.length
+  ) {
+    return { slots: [] };
+  }
+
+  const slots = values
+    .map((value, i) => ({
+      value,
+      baseRank: baseRanks[i] ?? null,
+      currRank: currentRanks[i] ?? null,
+    }))
+    // Defensive: drop entries absent from both sides. Stage B promises
+    // this won't happen, but if it ever does we'd rather render an
+    // empty slot than draw a phantom value.
+    .filter((s) => s.baseRank !== null || s.currRank !== null);
+
+  return { slots };
+}
+
+function truncate(s: string, maxChars: number): string {
+  if (s.length <= maxChars) return s;
+  if (maxChars <= 1) return "…";
+  return `${s.slice(0, maxChars - 1)}…`;
+}

--- a/js/packages/ui/src/components/data/PairedHistogramDiscrete.tsx
+++ b/js/packages/ui/src/components/data/PairedHistogramDiscrete.tsx
@@ -7,10 +7,11 @@ import {
   BaselineRule,
   CELL_HEIGHT,
   CELL_WIDTH,
+  DISCRETE_ARIA_LABEL,
   formatProportionTooltip,
   formatRankTooltip,
   PairedHistogramSvg,
-} from "./pairedHistogramCanvas";
+} from "./PairedHistogramCanvas";
 
 /**
  * Small categorical paired-bar chart for top-K low-cardinality data —
@@ -117,16 +118,6 @@ export type PairedHistogramDiscreteData =
 
 export interface PairedHistogramDiscreteProps {
   data: PairedHistogramDiscreteData;
-  /** Pixel width of the rendered SVG. Default `CELL_WIDTH` (140). */
-  width?: number;
-  /** Pixel height of the rendered SVG. Default `CELL_HEIGHT` (28). */
-  height?: number;
-  /** Render value labels below bars. Default false — values shown on hover
-   * via the per-bar tooltip; in-chart labels collide at any non-trivial
-   * cardinality. */
-  showLabels?: boolean;
-  /** Maximum chars per label before truncation. Default 4. */
-  labelMaxChars?: number;
   /**
    * Convert each raw value to its display string. Default: `String(v)`.
    * Override to handle NULL nicely, abbreviate large numbers, format
@@ -140,8 +131,6 @@ export interface PairedHistogramDiscreteProps {
   formatValue?: (v: unknown) => string;
   /** Optional CSS class. */
   className?: string;
-  /** Accessible label override for the SVG. */
-  ariaLabel?: string;
 }
 
 /**
@@ -159,8 +148,9 @@ interface RenderSlot {
 
 /**
  * PairedHistogramDiscrete — paired-bar top-K chart with gap-on-absent
- * semantics. Supports counts mode (proportion-sized bars) and ranks mode
- * (rank-position-sized bars).
+ * semantics, fixed `CELL_WIDTH × CELL_HEIGHT` (140×28) for SchemaView
+ * cell density. Supports counts mode (proportion-sized bars) and ranks
+ * mode (rank-position-sized bars).
  *
  * @example
  * ```tsx
@@ -169,13 +159,8 @@ interface RenderSlot {
  */
 export function PairedHistogramDiscrete({
   data,
-  width = CELL_WIDTH,
-  height = CELL_HEIGHT,
-  showLabels = false,
-  labelMaxChars = 4,
   formatValue = defaultFormatValue,
   className,
-  ariaLabel = "Paired baseline and current categorical distribution",
 }: PairedHistogramDiscreteProps) {
   const isDark = useIsDark();
   const bars = getChartBarColors(isDark);
@@ -183,12 +168,10 @@ export function PairedHistogramDiscrete({
   const baseFill = bars.base;
   const currentFill = bars.current;
   const baselineColor = theme.borderColor;
-  const labelColor = theme.textColor;
   const trimColor = theme.secondaryTextColor;
 
-  const labelHeight = showLabels ? 12 : 0;
-  // 2 px breathing room between bars and the next visual element.
-  const chartHeight = Math.max(8, height - labelHeight - 2);
+  // 2 px breathing room at the bottom so the baseline doesn't sit flush.
+  const chartHeight = Math.max(8, CELL_HEIGHT - 2);
 
   const renderSlots = useMemo(
     () => computeRenderSlots(data, chartHeight, formatValue),
@@ -199,15 +182,13 @@ export function PairedHistogramDiscrete({
   if (renderSlots.length === 0) {
     return (
       <PairedHistogramSvg
-        width={width}
-        height={height}
+        ariaLabel={DISCRETE_ARIA_LABEL}
         className={className}
-        ariaLabel={ariaLabel}
       />
     );
   }
 
-  const slotWidth = width / Math.max(1, renderSlots.length);
+  const slotWidth = CELL_WIDTH / Math.max(1, renderSlots.length);
   // Slot layout: 10% padding each side, two bars side by side with a small
   // gap. When one side's count is 0, that bar simply doesn't render —
   // leaving a visible gap that signals "category absent on this side."
@@ -217,12 +198,7 @@ export function PairedHistogramDiscrete({
   const pairBarW = Math.max(1, (innerW - gap) / 2);
 
   return (
-    <PairedHistogramSvg
-      width={width}
-      height={height}
-      className={className}
-      ariaLabel={ariaLabel}
-    >
+    <PairedHistogramSvg ariaLabel={DISCRETE_ARIA_LABEL} className={className}>
       {renderSlots.map((s, i) => {
         const slotX = i * slotWidth;
         const baseX = slotX + slotPad;
@@ -268,46 +244,23 @@ export function PairedHistogramDiscrete({
         );
       })}
 
-      <BaselineRule width={width} y={chartHeight} stroke={baselineColor} />
-
-      {showLabels && (
-        <g
-          fontFamily="system-ui, -apple-system, sans-serif"
-          fontSize={9}
-          fill={labelColor}
-          textAnchor="middle"
-        >
-          {renderSlots.map((s, i) => (
-            <text
-              // biome-ignore lint/suspicious/noArrayIndexKey: stable backend order
-              key={i}
-              x={i * slotWidth + slotWidth / 2}
-              y={chartHeight + 9}
-            >
-              {truncate(s.displayValue, labelMaxChars)}
-            </text>
-          ))}
-        </g>
-      )}
+      <BaselineRule y={chartHeight} stroke={baselineColor} />
 
       {data.trimmed && (
         // Small chip-style background behind the marker so the text stays
         // legible when a tall rightmost bar reaches the top of the chart.
-        // Semi-transparent (cc ≈ 80%) so it still reads as an overlay
-        // rather than a hard block. Background sourced from the theme's
-        // tooltip background so the chip blends with adjacent surfaces.
         <g pointerEvents="none">
           <rect
-            x={width - 38}
+            x={CELL_WIDTH - 38}
             y={1}
             width={37}
             height={10}
-            fill={`${theme.tooltipBackgroundColor}cc`}
+            fill={theme.overlayBackgroundColor}
             rx={2}
             data-testid="trimmed-marker-bg"
           />
           <text
-            x={width - 1}
+            x={CELL_WIDTH - 1}
             y={9}
             fontFamily="system-ui, -apple-system, sans-serif"
             fontSize={8}
@@ -328,8 +281,8 @@ export function PairedHistogramDiscrete({
  * ranks into pixel heights so the SVG body is identical between modes.
  *
  * `formatValue` runs here, once per slot, so the SVG body only ever sees
- * pre-formatted display strings (label truncation, tooltip prefix). The
- * compute functions stay payload-typed (`value: unknown`).
+ * pre-formatted display strings. The compute functions stay payload-typed
+ * (`value: unknown`).
  */
 function computeRenderSlots(
   data: PairedHistogramDiscreteData,
@@ -370,6 +323,10 @@ function defaultFormatValue(v: unknown): string {
 /**
  * Rank-position → pixel height. Rank 1 fills the chart; rank k draws as
  * `1/k * chartHeight`; `null` rank → 0 (bar omitted entirely).
+ *
+ * Result is clamped to `[0, chartHeight]` so a Stage B contract violation
+ * (rank > k → negative height, rank ≤ 0 → over-tall) renders a
+ * well-formed bar instead of an SVG layout glitch.
  */
 function heightForRank(
   rank: number | null,
@@ -377,15 +334,16 @@ function heightForRank(
   chartHeight: number,
 ): number {
   if (rank === null || k <= 0) return 0;
-  return ((k - rank + 1) / k) * chartHeight;
+  const h = ((k - rank + 1) / k) * chartHeight;
+  return Math.max(0, Math.min(chartHeight, h));
 }
 
 /**
  * Compute per-slot proportions + max prop given a counts-mode top-K
  * payload.
  *
- * Exported so the layout can be unit-tested without rendering and so
- * PR 4's lineage pre-warm can validate payloads cheaply.
+ * File-level export (not in the package barrel) so the unit tests in
+ * this directory can validate the layout without rendering.
  */
 export function computeDiscreteSlots(data: PairedHistogramDiscreteCountsData): {
   slots: {
@@ -441,10 +399,14 @@ export function computeDiscreteSlots(data: PairedHistogramDiscreteCountsData): {
  * Compute per-slot ranks given a ranks-mode top-K payload. Slot order
  * is preserved from `data.values` — Stage B's contract is that the
  * caller has already arranged base-first, then current-only appended
- * sorted by current rank. Values absent from both top-Ks are dropped
- * defensively (the contract says they won't appear).
+ * sorted by current rank.
  *
- * Exported alongside `computeDiscreteSlots` for unit testing.
+ * Defensively drops entries absent from both top-Ks (Stage B's contract
+ * says they won't appear) and emits a `console.warn` so the contract
+ * violation surfaces in dev tools instead of vanishing silently.
+ *
+ * File-level export (not in the package barrel) so the unit tests in
+ * this directory can validate the layout without rendering.
  */
 export function computeRanksSlots(data: PairedHistogramDiscreteRanksData): {
   slots: {
@@ -470,22 +432,20 @@ export function computeRanksSlots(data: PairedHistogramDiscreteRanksData): {
     return { slots: [] };
   }
 
-  const slots = values
-    .map((value, i) => ({
-      value,
-      baseRank: baseRanks[i] ?? null,
-      currRank: currentRanks[i] ?? null,
-    }))
-    // Defensive: drop entries absent from both sides. Stage B promises
-    // this won't happen, but if it ever does we'd rather render an
-    // empty slot than draw a phantom value.
-    .filter((s) => s.baseRank !== null || s.currRank !== null);
-
+  const mapped = values.map((value, i) => ({
+    value,
+    baseRank: baseRanks[i] ?? null,
+    currRank: currentRanks[i] ?? null,
+  }));
+  const slots = mapped.filter(
+    (s) => s.baseRank !== null || s.currRank !== null,
+  );
+  if (slots.length < mapped.length) {
+    console.warn(
+      `[PairedHistogramDiscrete] computeRanksSlots: dropped ${
+        mapped.length - slots.length
+      } value(s) absent from both base and current top-K (Stage B contract violation).`,
+    );
+  }
   return { slots };
-}
-
-function truncate(s: string, maxChars: number): string {
-  if (s.length <= maxChars) return s;
-  if (maxChars <= 1) return "…";
-  return `${s.slice(0, maxChars - 1)}…`;
 }

--- a/js/packages/ui/src/components/data/ProfileDistributionUnsupportedBanner.tsx
+++ b/js/packages/ui/src/components/data/ProfileDistributionUnsupportedBanner.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import MuiAlert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
+
+/**
+ * One-time banner shown when the dbt adapter can't run the paired-
+ * distribution feature at all (e.g. Postgres, MySQL, SQLite,
+ * SQL Server < 2022). The backend signals this with a single
+ * `{status: "unsupported", reason: ...}` envelope rather than a per-
+ * column payload. DRC-3390 PR 3.
+ *
+ * The banner is intentionally low-key (MUI Alert "info" severity, dense
+ * padding) so it doesn't dominate the schema view when the feature is
+ * flag-enabled but unavailable on this warehouse. It carries the
+ * backend's `reason` string so users know *why* — usually "adapter
+ * lacks native HLL / approx_percentile / approx_top_k".
+ */
+
+export interface ProfileDistributionUnsupportedBannerProps {
+  /** Backend-provided explanation. Falls back to a generic message. */
+  reason?: string;
+  /** Optional adapter-type for a more specific message (e.g. "postgres"). */
+  adapterType?: string;
+  /** Optional CSS class override. */
+  className?: string;
+}
+
+const DEFAULT_REASON =
+  "This warehouse doesn't expose native HLL / approx-percentile / approx-top-k aggregates, so paired column distributions aren't available here.";
+
+export function ProfileDistributionUnsupportedBanner({
+  reason,
+  adapterType,
+  className,
+}: ProfileDistributionUnsupportedBannerProps) {
+  const message = reason ?? DEFAULT_REASON;
+  const title = adapterType
+    ? `Paired distributions unavailable on ${adapterType}`
+    : "Paired distributions unavailable on this adapter";
+  return (
+    <MuiAlert
+      severity="info"
+      variant="outlined"
+      className={className}
+      sx={{
+        fontSize: "12px",
+        py: 0.5,
+        px: 1,
+        "& .MuiAlert-message": { py: 0.5 },
+      }}
+      role="status"
+      aria-live="polite"
+      data-testid="profile-distribution-unsupported-banner"
+    >
+      <AlertTitle sx={{ fontSize: "12px", fontWeight: 600, mb: 0.25 }}>
+        {title}
+      </AlertTitle>
+      {message}
+    </MuiAlert>
+  );
+}

--- a/js/packages/ui/src/components/data/ProfileDistributionUnsupportedBanner.tsx
+++ b/js/packages/ui/src/components/data/ProfileDistributionUnsupportedBanner.tsx
@@ -44,7 +44,7 @@ export function ProfileDistributionUnsupportedBanner({
       variant="outlined"
       className={className}
       sx={{
-        fontSize: "12px",
+        fontSize: "0.75rem",
         py: 0.5,
         px: 1,
         "& .MuiAlert-message": { py: 0.5 },
@@ -53,7 +53,7 @@ export function ProfileDistributionUnsupportedBanner({
       aria-live="polite"
       data-testid="profile-distribution-unsupported-banner"
     >
-      <AlertTitle sx={{ fontSize: "12px", fontWeight: 600, mb: 0.25 }}>
+      <AlertTitle sx={{ fontSize: "0.75rem", fontWeight: 600, mb: 0.25 }}>
         {title}
       </AlertTitle>
       {message}

--- a/js/packages/ui/src/components/data/TopKBarChart.tsx
+++ b/js/packages/ui/src/components/data/TopKBarChart.tsx
@@ -18,7 +18,11 @@ import {
 } from "chart.js";
 import { Fragment, memo, useMemo } from "react";
 import { Bar } from "react-chartjs-2";
-import { getChartBarColors, getChartThemeColors } from "./HistogramChart";
+import { getChartBarColors, getChartThemeColors } from "../../theme";
+import {
+  formatAsAbbreviatedNumber,
+  formatIntervalMinMax,
+} from "../../utils/formatters";
 
 /** Rendered bar geometry — Chart.js plugin API types this as Element but bar datasets provide these fields at runtime */
 interface RenderedBarGeometry {
@@ -103,26 +107,6 @@ export interface TopKSummaryListProps {
   theme?: "light" | "dark";
   /** Optional CSS class */
   className?: string;
-}
-
-/**
- * Format number as abbreviated (K, M, B, T)
- */
-function formatAbbreviated(value: number): string {
-  if (value >= 1e12) return `${(value / 1e12).toFixed(1)}T`;
-  if (value >= 1e9) return `${(value / 1e9).toFixed(1)}B`;
-  if (value >= 1e6) return `${(value / 1e6).toFixed(1)}M`;
-  if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K`;
-  return String(value);
-}
-
-/**
- * Format as percentage
- */
-function formatPercent(value: number): string {
-  if (value > 0 && value <= 0.001) return "<0.1%";
-  if (value < 1 && value >= 0.999) return ">99.9%";
-  return `${(value * 100).toFixed(1)}%`;
 }
 
 /**
@@ -317,7 +301,7 @@ function TopKSummaryListComponent({
                   whiteSpace: "nowrap",
                 }}
               >
-                {formatAbbreviated(item.count)}
+                {formatAsAbbreviatedNumber(item.count)}
               </Typography>
             </Tooltip>
             <Typography
@@ -327,7 +311,7 @@ function TopKSummaryListComponent({
                 width: "4em",
               }}
             >
-              {formatPercent(item.count / data.valids)}
+              {formatIntervalMinMax(item.count / data.valids)}
             </Typography>
           </Box>
           <Divider />
@@ -495,7 +479,7 @@ function TopKBarChartComponent({
               const total =
                 context.dataset.label === "Base" ? baseTotal : currentTotal;
               const count = Math.round(proportion * total);
-              return `${context.dataset.label}: ${formatAbbreviated(count)} (${formatPercent(proportion)})`;
+              return `${context.dataset.label}: ${formatAsAbbreviatedNumber(count)} (${formatIntervalMinMax(proportion)})`;
             },
           },
         },
@@ -529,8 +513,8 @@ function TopKBarChartComponent({
           const count = Math.round(proportion * total);
 
           const barWidth = x - base;
-          const countText = formatAbbreviated(count);
-          const pctText = formatPercent(proportion);
+          const countText = formatAsAbbreviatedNumber(count);
+          const pctText = formatIntervalMinMax(proportion) ?? "";
           const countWidth = ctx.measureText(countText).width;
           const fitsInside = countWidth + 2 * pad < barWidth;
 

--- a/js/packages/ui/src/components/data/__tests__/HistogramChart.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/HistogramChart.test.tsx
@@ -12,11 +12,8 @@
 
 import { render } from "@testing-library/react";
 import { vi } from "vitest";
-import {
-  getChartBarColors,
-  getChartThemeColors,
-  HistogramChart,
-} from "../HistogramChart";
+import { getChartBarColors, getChartThemeColors } from "../../../theme";
+import { HistogramChart } from "../HistogramChart";
 
 // Mock Chart.js to avoid canvas rendering issues in tests
 vi.mock("react-chartjs-2", () => ({

--- a/js/packages/ui/src/components/data/__tests__/PairedHistogramContinuous.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/PairedHistogramContinuous.test.tsx
@@ -3,7 +3,8 @@
  * @description Tests for the constant-area paired histogram cell (DRC-3390 PR 3).
  *
  * Visual behavior covered:
- *   - One <g> per bin
+ *   - One <g> per merged-edge segment (base ∪ current edges)
+ *   - Per-segment densities looked up from each env's own bins
  *   - Bar widths track the quantile span (constant-area), not slot-uniform
  *   - Heights track density relative to max density across both envs
  *   - Differential rect colored by which env exceeds the other in that bin
@@ -25,28 +26,54 @@ vi.mock("../../../hooks/useIsDark", () => ({
   useIsDark: vi.fn(() => false),
 }));
 
-// 11 bins with quantile-driven widths: tight in the middle, wide at the
-// edges (typical for a long-tailed distribution where APPROX_PERCENTILE
-// hits 80% of the mass between bins 3 and 7).
+// Base and current on DIFFERENT edges (the post-#1398 contract). This is
+// the worked example from the PR discussion:
+//   base    [0:0.1, 10:0.6, 20:0.3, 40:0.1, 60]
+//   current [0:0.0,  5:0.2, 15:0.6, 30:0.2, 60]
+// Merged edges → [0, 5, 10, 15, 20, 30, 40, 60] → 7 segments. Each segment
+// carries the base density and current density of the bin it falls inside.
 const sampleData: PairedHistogramContinuousData = {
-  binEdges: [0, 10, 25, 50, 80, 120, 165, 220, 290, 400, 600, 1000],
-  baseDensity: [
-    0.01, 0.02, 0.04, 0.06, 0.08, 0.07, 0.05, 0.03, 0.015, 0.005, 0.001,
-  ],
-  currentDensity: [
-    0.02, 0.03, 0.045, 0.055, 0.085, 0.065, 0.04, 0.025, 0.012, 0.006, 0.0015,
-  ],
+  baseBinEdges: [0, 10, 20, 40, 60],
+  baseDensity: [0.1, 0.6, 0.3, 0.1],
+  currentBinEdges: [0, 5, 15, 30, 60],
+  currentDensity: [0.0, 0.2, 0.6, 0.2],
   baseTotal: 10_000,
   currentTotal: 12_000,
 };
 
+// Expected merged-grid segments for `sampleData` (PR-discussion worked
+// example). The renderer and layout must agree on these.
+const expectedSegments = [
+  { lo: 0, hi: 5, baseDensity: 0.1, currentDensity: 0.0 },
+  { lo: 5, hi: 10, baseDensity: 0.1, currentDensity: 0.2 },
+  { lo: 10, hi: 15, baseDensity: 0.6, currentDensity: 0.2 },
+  { lo: 15, hi: 20, baseDensity: 0.6, currentDensity: 0.6 },
+  { lo: 20, hi: 30, baseDensity: 0.3, currentDensity: 0.6 },
+  { lo: 30, hi: 40, baseDensity: 0.3, currentDensity: 0.2 },
+  { lo: 40, hi: 60, baseDensity: 0.1, currentDensity: 0.2 },
+];
+
 describe("PairedHistogramContinuous", () => {
-  it("renders one group per bin", () => {
+  it("renders one group per merged-edge segment", () => {
     const { container } = render(
       <PairedHistogramContinuous data={sampleData} />,
     );
     const groups = container.querySelectorAll("svg > g");
-    expect(groups.length).toBe(sampleData.baseDensity.length);
+    expect(groups.length).toBe(expectedSegments.length);
+  });
+
+  it("computeContinuousLayout: subdivides onto the merged edge grid with per-env densities", () => {
+    const layout = computeContinuousLayout(sampleData, 140);
+    expect(layout.bins.map((b) => [b.lo, b.hi])).toEqual(
+      expectedSegments.map((s) => [s.lo, s.hi]),
+    );
+    expect(layout.bins.map((b) => b.baseDensity)).toEqual(
+      expectedSegments.map((s) => s.baseDensity),
+    );
+    expect(layout.bins.map((b) => b.currentDensity)).toEqual(
+      expectedSegments.map((s) => s.currentDensity),
+    );
+    expect(layout.maxDensity).toBeCloseTo(0.6, 6);
   });
 
   it("renders at fixed cell-density dimensions (140x28)", () => {
@@ -85,8 +112,9 @@ describe("PairedHistogramContinuous", () => {
     // Single-bin payload: current density >> base density. Should produce
     // a single solid blue rect (no agreement zone since baseH would be 0).
     const data: PairedHistogramContinuousData = {
-      binEdges: [0, 10],
+      baseBinEdges: [0, 10],
       baseDensity: [0],
+      currentBinEdges: [0, 10],
       currentDensity: [0.5],
       baseTotal: 0,
       currentTotal: 5,
@@ -107,8 +135,9 @@ describe("PairedHistogramContinuous", () => {
     // rect should be solid orange. Scoped to "svg > g rect" so the
     // checkerboard <pattern> rects in <defs> don't pollute the assertion.
     const data: PairedHistogramContinuousData = {
-      binEdges: [0, 10],
+      baseBinEdges: [0, 10],
       baseDensity: [0.5],
+      currentBinEdges: [0, 10],
       currentDensity: [0],
       baseTotal: 5,
       currentTotal: 0,
@@ -123,8 +152,10 @@ describe("PairedHistogramContinuous", () => {
 
   it("handles bin-edge / density length mismatch by rendering an empty SVG", () => {
     const broken: PairedHistogramContinuousData = {
-      binEdges: [0, 1, 2],
+      // 3 edges but 4 densities — internally inconsistent base side.
+      baseBinEdges: [0, 1, 2],
       baseDensity: [1, 2, 3, 4],
+      currentBinEdges: [0, 1, 2, 3, 4],
       currentDensity: [1, 1, 1, 1],
       baseTotal: 10,
       currentTotal: 4,
@@ -137,8 +168,9 @@ describe("PairedHistogramContinuous", () => {
 
   it("handles a zero-span payload (degenerate column) by falling back to uniform widths", () => {
     const collapsed: PairedHistogramContinuousData = {
-      binEdges: [5, 5, 5],
+      baseBinEdges: [5, 5, 5],
       baseDensity: [0.5, 0.5],
+      currentBinEdges: [5, 5, 5],
       currentDensity: [0.5, 0.5],
       baseTotal: 2,
       currentTotal: 2,
@@ -186,7 +218,8 @@ describe("PairedHistogramContinuous", () => {
 
   it("computeContinuousLayout: empty payload returns empty bins", () => {
     const empty: PairedHistogramContinuousData = {
-      binEdges: [],
+      baseBinEdges: [],
+      currentBinEdges: [],
       baseDensity: [],
       currentDensity: [],
       baseTotal: 0,

--- a/js/packages/ui/src/components/data/__tests__/PairedHistogramContinuous.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/PairedHistogramContinuous.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * @file PairedHistogramContinuous.test.tsx
+ * @description Tests for the constant-area paired histogram cell (DRC-3390 PR 3).
+ *
+ * Visual behavior covered:
+ *   - One <g> per bin
+ *   - Bar widths track the quantile span (constant-area), not slot-uniform
+ *   - Heights track density relative to max density across both envs
+ *   - Differential rect colored by which env exceeds the other in that bin
+ *   - Agreement zone (min(base, current)) uses the checkerboard SVG pattern
+ *   - Light / dark theme bar colors
+ *   - Endpoint + midpoint labels
+ *   - Degenerate / zero / mismatched payloads don't crash
+ */
+
+import { render } from "@testing-library/react";
+import { vi } from "vitest";
+import { useIsDark } from "../../../hooks/useIsDark";
+import {
+  computeContinuousLayout,
+  PairedHistogramContinuous,
+  type PairedHistogramContinuousData,
+} from "../PairedHistogramContinuous";
+
+vi.mock("../../../hooks/useIsDark", () => ({
+  useIsDark: vi.fn(() => false),
+}));
+
+// 11 bins with quantile-driven widths: tight in the middle, wide at the
+// edges (typical for a long-tailed distribution where APPROX_PERCENTILE
+// hits 80% of the mass between bins 3 and 7).
+const sampleData: PairedHistogramContinuousData = {
+  binEdges: [0, 10, 25, 50, 80, 120, 165, 220, 290, 400, 600, 1000],
+  baseDensity: [
+    0.01, 0.02, 0.04, 0.06, 0.08, 0.07, 0.05, 0.03, 0.015, 0.005, 0.001,
+  ],
+  currentDensity: [
+    0.02, 0.03, 0.045, 0.055, 0.085, 0.065, 0.04, 0.025, 0.012, 0.006, 0.0015,
+  ],
+  baseTotal: 10_000,
+  currentTotal: 12_000,
+};
+
+describe("PairedHistogramContinuous", () => {
+  it("renders one group per bin", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} />,
+    );
+    const groups = container.querySelectorAll("svg > g");
+    expect(groups.length).toBe(sampleData.baseDensity.length);
+  });
+
+  it("uses default cell-density dimensions when not provided", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("140");
+    expect(svg?.getAttribute("height")).toBe("28");
+  });
+
+  it("respects custom width and height", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} width={240} height={92} />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("240");
+    expect(svg?.getAttribute("height")).toBe("92");
+  });
+
+  it("renders endpoint labels when showEndpoints is true", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} showEndpoints />,
+    );
+    const texts = Array.from(container.querySelectorAll("text"));
+    // Title <title> element is also a "text" node in some queries; filter
+    // to only the SVG <text> elements (which carry textContent).
+    const labels = texts.map((t) => t.textContent).filter(Boolean);
+    expect(labels).toContain("0");
+    expect(labels).toContain("1K");
+  });
+
+  it("does not render endpoint labels by default", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} />,
+    );
+    // Only the <title> for accessibility; no SVG <text> for axis labels.
+    const textNodes = container.querySelectorAll("svg > g text");
+    expect(textNodes.length).toBe(0);
+  });
+
+  it("renders midpoint when showMidpoint is true", () => {
+    const { container } = render(
+      <PairedHistogramContinuous
+        data={sampleData}
+        showEndpoints
+        showMidpoint
+      />,
+    );
+    const labels = Array.from(container.querySelectorAll("text")).map(
+      (t) => t.textContent,
+    );
+    expect(labels).toContain("500"); // midpoint of [0, 1000] — integer renders verbatim
+  });
+
+  it("light theme uses the light bar palette (#F6AD55 / #63B3ED)", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} />,
+    );
+    const fills = Array.from(container.querySelectorAll("svg rect")).map((r) =>
+      r.getAttribute("fill"),
+    );
+    expect(fills.some((f) => f === "#F6AD55")).toBe(true);
+    expect(fills.some((f) => f === "#63B3ED")).toBe(true);
+  });
+
+  it("dark theme uses the dark bar palette (#FBD38D / #90CDF4)", () => {
+    vi.mocked(useIsDark).mockReturnValueOnce(true);
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} />,
+    );
+    const fills = Array.from(container.querySelectorAll("svg rect")).map((r) =>
+      r.getAttribute("fill"),
+    );
+    expect(fills.some((f) => f === "#FBD38D")).toBe(true);
+    expect(fills.some((f) => f === "#90CDF4")).toBe(true);
+  });
+
+  it("differential rect is blue when current density exceeds base", () => {
+    // Single-bin payload: current density >> base density. Should produce
+    // a single solid blue rect (no agreement zone since baseH would be 0).
+    const data: PairedHistogramContinuousData = {
+      binEdges: [0, 10],
+      baseDensity: [0],
+      currentDensity: [0.5],
+      baseTotal: 0,
+      currentTotal: 5,
+    };
+    const { container } = render(<PairedHistogramContinuous data={data} />);
+    const fills = Array.from(container.querySelectorAll("svg rect"))
+      .map((r) => r.getAttribute("fill"))
+      // ignore pattern <rect> children (their fill is just a color but they
+      // live inside <defs>, not the chart area) and the invisible hit-target
+      // rects (fill="none").
+      .filter((f) => f && f !== "none");
+    // Only the differential rect should remain — it's blue (current dominates).
+    expect(fills).toContain("#63B3ED");
+  });
+
+  it("differential rect is orange when base density exceeds current", () => {
+    // Symmetric to the blue case — base dominates, so the only chart-area
+    // rect should be solid orange. Scoped to "svg > g rect" so the
+    // checkerboard <pattern> rects in <defs> don't pollute the assertion.
+    const data: PairedHistogramContinuousData = {
+      binEdges: [0, 10],
+      baseDensity: [0.5],
+      currentDensity: [0],
+      baseTotal: 5,
+      currentTotal: 0,
+    };
+    const { container } = render(<PairedHistogramContinuous data={data} />);
+    const fills = Array.from(container.querySelectorAll("svg > g rect"))
+      .map((r) => r.getAttribute("fill"))
+      .filter((f) => f && f !== "none");
+    expect(fills).toContain("#F6AD55");
+    expect(fills).not.toContain("#63B3ED");
+  });
+
+  it("handles bin-edge / density length mismatch by rendering an empty SVG", () => {
+    const broken: PairedHistogramContinuousData = {
+      binEdges: [0, 1, 2],
+      baseDensity: [1, 2, 3, 4],
+      currentDensity: [1, 1, 1, 1],
+      baseTotal: 10,
+      currentTotal: 4,
+    };
+    const { container } = render(<PairedHistogramContinuous data={broken} />);
+    // No bin groups rendered, but the SVG frame is still there.
+    expect(container.querySelectorAll("svg > g").length).toBe(0);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("handles a zero-span payload (degenerate column) by falling back to uniform widths", () => {
+    const collapsed: PairedHistogramContinuousData = {
+      binEdges: [5, 5, 5],
+      baseDensity: [0.5, 0.5],
+      currentDensity: [0.5, 0.5],
+      baseTotal: 2,
+      currentTotal: 2,
+    };
+    const layout = computeContinuousLayout(collapsed, 140);
+    expect(layout.bins.length).toBe(2);
+    // Uniform fallback: both bins same width.
+    expect(layout.bins[0].width).toBeCloseTo(70, 5);
+    expect(layout.bins[1].width).toBeCloseTo(70, 5);
+  });
+
+  it("hover-title carries percentage breakdown per bin", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} />,
+    );
+    const titles = Array.from(container.querySelectorAll("svg title")).map(
+      (t) => t.textContent,
+    );
+    // Most-common hover format: "10–25 [base: 30.0%, current: ...]" — at
+    // least one title should contain both percentages.
+    expect(
+      titles.some((t) => t?.includes("base:") && t.includes("current:")),
+    ).toBe(true);
+  });
+
+  it("uses custom formatter for endpoint labels", () => {
+    const { container } = render(
+      <PairedHistogramContinuous
+        data={sampleData}
+        showEndpoints
+        formatValue={(v) => `$${v}`}
+      />,
+    );
+    const labels = Array.from(container.querySelectorAll("text")).map(
+      (t) => t.textContent,
+    );
+    expect(labels).toContain("$0");
+    expect(labels).toContain("$1000");
+  });
+
+  it("computeContinuousLayout: bar widths sum to the available width", () => {
+    const layout = computeContinuousLayout(sampleData, 140);
+    const total = layout.bins.reduce((s, b) => s + b.width, 0);
+    expect(total).toBeCloseTo(140, 1);
+  });
+
+  it("computeContinuousLayout: empty payload returns empty bins", () => {
+    const empty: PairedHistogramContinuousData = {
+      binEdges: [],
+      baseDensity: [],
+      currentDensity: [],
+      baseTotal: 0,
+      currentTotal: 0,
+    };
+    const layout = computeContinuousLayout(empty, 140);
+    expect(layout.bins).toEqual([]);
+    expect(layout.maxDensity).toBe(0);
+  });
+
+  it("accepts className prop", () => {
+    const { container } = render(
+      <PairedHistogramContinuous data={sampleData} className="my-chart" />,
+    );
+    expect(container.querySelector("svg")?.getAttribute("class")).toBe(
+      "my-chart",
+    );
+  });
+
+  it("renders an accessible aria-label", () => {
+    const { container } = render(
+      <PairedHistogramContinuous
+        data={sampleData}
+        ariaLabel="customer order amount"
+      />,
+    );
+    expect(container.querySelector("svg")?.getAttribute("aria-label")).toBe(
+      "customer order amount",
+    );
+  });
+});

--- a/js/packages/ui/src/components/data/__tests__/PairedHistogramContinuous.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/PairedHistogramContinuous.test.tsx
@@ -9,7 +9,6 @@
  *   - Differential rect colored by which env exceeds the other in that bin
  *   - Agreement zone (min(base, current)) uses the checkerboard SVG pattern
  *   - Light / dark theme bar colors
- *   - Endpoint + midpoint labels
  *   - Degenerate / zero / mismatched payloads don't crash
  */
 
@@ -50,57 +49,13 @@ describe("PairedHistogramContinuous", () => {
     expect(groups.length).toBe(sampleData.baseDensity.length);
   });
 
-  it("uses default cell-density dimensions when not provided", () => {
+  it("renders at fixed cell-density dimensions (140x28)", () => {
     const { container } = render(
       <PairedHistogramContinuous data={sampleData} />,
     );
     const svg = container.querySelector("svg");
     expect(svg?.getAttribute("width")).toBe("140");
     expect(svg?.getAttribute("height")).toBe("28");
-  });
-
-  it("respects custom width and height", () => {
-    const { container } = render(
-      <PairedHistogramContinuous data={sampleData} width={240} height={92} />,
-    );
-    const svg = container.querySelector("svg");
-    expect(svg?.getAttribute("width")).toBe("240");
-    expect(svg?.getAttribute("height")).toBe("92");
-  });
-
-  it("renders endpoint labels when showEndpoints is true", () => {
-    const { container } = render(
-      <PairedHistogramContinuous data={sampleData} showEndpoints />,
-    );
-    const texts = Array.from(container.querySelectorAll("text"));
-    // Title <title> element is also a "text" node in some queries; filter
-    // to only the SVG <text> elements (which carry textContent).
-    const labels = texts.map((t) => t.textContent).filter(Boolean);
-    expect(labels).toContain("0");
-    expect(labels).toContain("1K");
-  });
-
-  it("does not render endpoint labels by default", () => {
-    const { container } = render(
-      <PairedHistogramContinuous data={sampleData} />,
-    );
-    // Only the <title> for accessibility; no SVG <text> for axis labels.
-    const textNodes = container.querySelectorAll("svg > g text");
-    expect(textNodes.length).toBe(0);
-  });
-
-  it("renders midpoint when showMidpoint is true", () => {
-    const { container } = render(
-      <PairedHistogramContinuous
-        data={sampleData}
-        showEndpoints
-        showMidpoint
-      />,
-    );
-    const labels = Array.from(container.querySelectorAll("text")).map(
-      (t) => t.textContent,
-    );
-    expect(labels).toContain("500"); // midpoint of [0, 1000] — integer renders verbatim
   });
 
   it("light theme uses the light bar palette (#F6AD55 / #63B3ED)", () => {
@@ -209,19 +164,18 @@ describe("PairedHistogramContinuous", () => {
     ).toBe(true);
   });
 
-  it("uses custom formatter for endpoint labels", () => {
+  it("uses custom formatValue in tooltip bin-range prefix", () => {
     const { container } = render(
       <PairedHistogramContinuous
         data={sampleData}
-        showEndpoints
         formatValue={(v) => `$${v}`}
       />,
     );
-    const labels = Array.from(container.querySelectorAll("text")).map(
-      (t) => t.textContent,
-    );
-    expect(labels).toContain("$0");
-    expect(labels).toContain("$1000");
+    const titles = Array.from(container.querySelectorAll("svg title"))
+      .map((t) => t.textContent ?? "")
+      // skip the accessible <title> at the top of the SVG
+      .filter((t) => t.includes("["));
+    expect(titles.some((t) => t.startsWith("$0"))).toBe(true);
   });
 
   it("computeContinuousLayout: bar widths sum to the available width", () => {
@@ -249,18 +203,6 @@ describe("PairedHistogramContinuous", () => {
     );
     expect(container.querySelector("svg")?.getAttribute("class")).toBe(
       "my-chart",
-    );
-  });
-
-  it("renders an accessible aria-label", () => {
-    const { container } = render(
-      <PairedHistogramContinuous
-        data={sampleData}
-        ariaLabel="customer order amount"
-      />,
-    );
-    expect(container.querySelector("svg")?.getAttribute("aria-label")).toBe(
-      "customer order amount",
     );
   });
 });

--- a/js/packages/ui/src/components/data/__tests__/PairedHistogramDiscrete.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/PairedHistogramDiscrete.test.tsx
@@ -1,0 +1,532 @@
+/**
+ * @file PairedHistogramDiscrete.test.tsx
+ * @description Tests for the top-K paired histogram cell with
+ * gap-on-absent semantics (DRC-3390 PR 3).
+ */
+
+import { render } from "@testing-library/react";
+import { vi } from "vitest";
+import { useIsDark } from "../../../hooks/useIsDark";
+import {
+  computeDiscreteSlots,
+  computeRanksSlots,
+  PairedHistogramDiscrete,
+  type PairedHistogramDiscreteData,
+  type PairedHistogramDiscreteRanksData,
+} from "../PairedHistogramDiscrete";
+
+vi.mock("../../../hooks/useIsDark", () => ({
+  useIsDark: vi.fn(() => false),
+}));
+
+const sampleData: PairedHistogramDiscreteData = {
+  values: ["US", "GB", "DE", "FR", "JP"],
+  baseCounts: [100, 50, 25, 10, 5],
+  currentCounts: [110, 40, 35, 8, 6],
+  baseTotal: 190,
+  currentTotal: 199,
+};
+
+describe("PairedHistogramDiscrete", () => {
+  it("renders one group per value", () => {
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    const groups = container.querySelectorAll("svg > g");
+    expect(groups.length).toBe(sampleData.values.length);
+  });
+
+  it("renders both bars when both sides have counts > 0", () => {
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    // Each slot: 1 invisible hit-target + base bar + current bar = 3 rects max.
+    const rects = container.querySelectorAll("svg > g rect");
+    expect(rects.length).toBeGreaterThan(sampleData.values.length);
+  });
+
+  it("leaves a gap (no rect) when one side count is 0 — added value", () => {
+    const data: PairedHistogramDiscreteData = {
+      values: ["new_only"],
+      baseCounts: [0],
+      currentCounts: [10],
+      baseTotal: 0,
+      currentTotal: 10,
+    };
+    const width = 140;
+    const { container } = render(
+      <PairedHistogramDiscrete data={data} width={width} />,
+    );
+    const visibleRects = Array.from(
+      container.querySelectorAll("svg > g rect"),
+    ).filter((r) => r.getAttribute("fill") !== "none");
+    // Only the current bar renders — no base bar means a visible gap on
+    // the base side of the slot.
+    expect(visibleRects.length).toBe(1);
+    const rect = visibleRects[0];
+    expect(rect.getAttribute("fill")).toBe("#63B3ED");
+    // Current bar sits on the right half of its slot (slot midpoint = width / 2
+    // when there's a single slot).
+    const x = Number.parseFloat(rect.getAttribute("x") ?? "0");
+    expect(x).toBeGreaterThan(width / 2);
+  });
+
+  it("leaves a gap when current side count is 0 — removed value", () => {
+    const data: PairedHistogramDiscreteData = {
+      values: ["legacy_only"],
+      baseCounts: [10],
+      currentCounts: [0],
+      baseTotal: 10,
+      currentTotal: 0,
+    };
+    const width = 140;
+    const { container } = render(
+      <PairedHistogramDiscrete data={data} width={width} />,
+    );
+    const visibleRects = Array.from(
+      container.querySelectorAll("svg > g rect"),
+    ).filter((r) => r.getAttribute("fill") !== "none");
+    expect(visibleRects.length).toBe(1);
+    const rect = visibleRects[0];
+    expect(rect.getAttribute("fill")).toBe("#F6AD55");
+    // Base bar sits on the left half of its slot.
+    const x = Number.parseFloat(rect.getAttribute("x") ?? "0");
+    expect(x).toBeLessThan(width / 2);
+  });
+
+  it("uses default cell-density dimensions when not provided", () => {
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("140");
+    expect(svg?.getAttribute("height")).toBe("28");
+  });
+
+  it("respects custom width and height", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={sampleData} width={220} height={100} />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("220");
+    expect(svg?.getAttribute("height")).toBe("100");
+  });
+
+  it("does not render value labels by default", () => {
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    expect(container.querySelectorAll("svg g text").length).toBe(0);
+  });
+
+  it("renders one label per value when showLabels is true", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={sampleData} showLabels />,
+    );
+    const labels = container.querySelectorAll("svg g text");
+    expect(labels.length).toBe(sampleData.values.length);
+    expect(Array.from(labels).map((l) => l.textContent)).toEqual(
+      sampleData.values,
+    );
+  });
+
+  it("truncates labels longer than labelMaxChars", () => {
+    const longData: PairedHistogramDiscreteData = {
+      ...sampleData,
+      values: ["United States", "Great Britain", "Germany", "France", "Japan"],
+    };
+    const { container } = render(
+      <PairedHistogramDiscrete data={longData} showLabels labelMaxChars={4} />,
+    );
+    const texts = Array.from(container.querySelectorAll("svg g text")).map(
+      (t) => t.textContent ?? "",
+    );
+    for (const t of texts) {
+      expect(t.length).toBeLessThanOrEqual(4);
+    }
+    // Each truncated label ends with the ellipsis character.
+    expect(texts.every((t) => t.endsWith("…"))).toBe(true);
+  });
+
+  it("renders trimmed marker when trimmed prop is set", () => {
+    const { queryByText } = render(
+      <PairedHistogramDiscrete data={{ ...sampleData, trimmed: true }} />,
+    );
+    expect(queryByText("trimmed")).toBeInTheDocument();
+  });
+
+  it("renders a chip-style background rect behind the trimmed marker so it stays legible over tall bars", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={{ ...sampleData, trimmed: true }} />,
+    );
+    const bg = container.querySelector("[data-testid='trimmed-marker-bg']");
+    expect(bg).toBeInTheDocument();
+    expect(bg?.tagName.toLowerCase()).toBe("rect");
+  });
+
+  it("does not render trimmed marker by default", () => {
+    const { queryByText } = render(
+      <PairedHistogramDiscrete data={sampleData} />,
+    );
+    expect(queryByText("trimmed")).not.toBeInTheDocument();
+  });
+
+  it("handles zero totals without dividing by zero", () => {
+    const zeroData: PairedHistogramDiscreteData = {
+      values: ["a", "b"],
+      baseCounts: [0, 0],
+      currentCounts: [0, 0],
+      baseTotal: 0,
+      currentTotal: 0,
+    };
+    const { container } = render(<PairedHistogramDiscrete data={zeroData} />);
+    // Hit-target rects (fill="none") still render so users can
+    // hover; no visible bar fills.
+    const visible = Array.from(container.querySelectorAll("svg > g rect"))
+      .map((r) => r.getAttribute("fill"))
+      .filter((f) => f && f !== "none");
+    expect(visible.length).toBe(0);
+  });
+
+  it("dark theme uses the dark palette", () => {
+    vi.mocked(useIsDark).mockReturnValueOnce(true);
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    const fills = Array.from(container.querySelectorAll("svg > g rect")).map(
+      (r) => r.getAttribute("fill"),
+    );
+    expect(fills.some((f) => f === "#FBD38D")).toBe(true);
+    expect(fills.some((f) => f === "#90CDF4")).toBe(true);
+  });
+
+  it("hover-title carries percentage breakdown per value", () => {
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    const titles = Array.from(container.querySelectorAll("svg title")).map(
+      (t) => t.textContent,
+    );
+    expect(
+      titles.some((t) => t?.includes("base:") && t?.includes("current:")),
+    ).toBe(true);
+    // The accessible title is also present.
+    expect(titles).toContain(
+      "Paired baseline and current categorical distribution",
+    );
+  });
+
+  it("computeDiscreteSlots: counts and values length mismatch returns empty", () => {
+    const broken: PairedHistogramDiscreteData = {
+      values: ["a", "b"],
+      baseCounts: [1, 2, 3],
+      currentCounts: [1, 2, 3],
+      baseTotal: 6,
+      currentTotal: 6,
+    };
+    const { slots } = computeDiscreteSlots(broken);
+    expect(slots).toEqual([]);
+  });
+
+  it("computeDiscreteSlots: empty values returns empty slots", () => {
+    const { slots, maxProp } = computeDiscreteSlots({
+      values: [],
+      baseCounts: [],
+      currentCounts: [],
+      baseTotal: 0,
+      currentTotal: 0,
+    });
+    expect(slots).toEqual([]);
+    expect(maxProp).toBe(0);
+  });
+
+  it("computeDiscreteSlots: max proportion floors above zero to avoid div-by-zero scales", () => {
+    const tiny: PairedHistogramDiscreteData = {
+      values: ["a"],
+      baseCounts: [0],
+      currentCounts: [0],
+      baseTotal: 0,
+      currentTotal: 0,
+    };
+    const { maxProp } = computeDiscreteSlots(tiny);
+    expect(maxProp).toBeGreaterThan(0);
+  });
+
+  it("accepts className prop", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={sampleData} className="my-cell" />,
+    );
+    expect(container.querySelector("svg")?.getAttribute("class")).toBe(
+      "my-cell",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// Ranks mode — rank-only rendering (DuckDB `approx_top_k` path)
+// ---------------------------------------------------------------------
+
+const sampleRanks: PairedHistogramDiscreteRanksData = {
+  mode: "ranks",
+  values: ["alpha", "beta", "gamma", "delta", "epsilon"],
+  baseRanks: [1, 2, 3, 4, 5],
+  currentRanks: [1, 2, 3, 4, 5],
+  k: 5,
+};
+
+describe("PairedHistogramDiscrete — ranks mode", () => {
+  it("renders one group per value in ranks mode", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={sampleRanks} />,
+    );
+    const groups = container.querySelectorAll("svg > g");
+    expect(groups.length).toBe(sampleRanks.values.length);
+  });
+
+  it("stable ranks produce matching base+current bar heights", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={sampleRanks} />,
+    );
+    // For each slot we expect one hit-target (fill=none) + one base bar
+    // + one current bar of equal height. Group rects by slot index.
+    const groups = container.querySelectorAll("svg > g");
+    for (const group of Array.from(groups)) {
+      const visible = Array.from(group.querySelectorAll("rect")).filter(
+        (r) => r.getAttribute("fill") !== "none",
+      );
+      expect(visible.length).toBe(2);
+      const h0 = Number.parseFloat(visible[0].getAttribute("height") ?? "0");
+      const h1 = Number.parseFloat(visible[1].getAttribute("height") ?? "0");
+      expect(h0).toBeCloseTo(h1);
+    }
+  });
+
+  it("rank 1 bar is taller than rank k bar", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={sampleRanks} />,
+    );
+    const groups = container.querySelectorAll("svg > g");
+    // First group renders rank 1; last group renders rank k.
+    const firstBars = Array.from(groups[0].querySelectorAll("rect")).filter(
+      (r) => r.getAttribute("fill") !== "none",
+    );
+    const lastBars = Array.from(
+      groups[groups.length - 1].querySelectorAll("rect"),
+    ).filter((r) => r.getAttribute("fill") !== "none");
+    const firstH = Number.parseFloat(
+      firstBars[0].getAttribute("height") ?? "0",
+    );
+    const lastH = Number.parseFloat(lastBars[0].getAttribute("height") ?? "0");
+    expect(firstH).toBeGreaterThan(lastH);
+  });
+
+  it("value present only in base top-K: no current bar", () => {
+    const data: PairedHistogramDiscreteRanksData = {
+      mode: "ranks",
+      values: ["base_only"],
+      baseRanks: [2],
+      currentRanks: [null],
+      k: 5,
+    };
+    const width = 140;
+    const { container } = render(
+      <PairedHistogramDiscrete data={data} width={width} />,
+    );
+    const visible = Array.from(
+      container.querySelectorAll("svg > g rect"),
+    ).filter((r) => r.getAttribute("fill") !== "none");
+    // Only base bar drawn — orange palette in light theme.
+    expect(visible.length).toBe(1);
+    expect(visible[0].getAttribute("fill")).toBe("#F6AD55");
+    // Base bar sits on the left half of its slot.
+    const x = Number.parseFloat(visible[0].getAttribute("x") ?? "0");
+    expect(x).toBeLessThan(width / 2);
+  });
+
+  it("value present only in current top-K: no base bar, sits on the right of the chart", () => {
+    const data: PairedHistogramDiscreteRanksData = {
+      mode: "ranks",
+      values: ["base_a", "base_b", "current_only"],
+      baseRanks: [1, 2, null],
+      currentRanks: [1, 2, 3],
+      k: 5,
+    };
+    const width = 150;
+    const { container } = render(
+      <PairedHistogramDiscrete data={data} width={width} />,
+    );
+    // The current-only slot is the last group (rightmost).
+    const groups = container.querySelectorAll("svg > g");
+    const lastBars = Array.from(
+      groups[groups.length - 1].querySelectorAll("rect"),
+    ).filter((r) => r.getAttribute("fill") !== "none");
+    expect(lastBars.length).toBe(1);
+    expect(lastBars[0].getAttribute("fill")).toBe("#63B3ED");
+    // And the slot itself is on the right two-thirds of the chart.
+    const lastSlotX = Number.parseFloat(lastBars[0].getAttribute("x") ?? "0");
+    expect(lastSlotX).toBeGreaterThan(width * (2 / 3));
+  });
+
+  it("tooltip shows both ranks when present", () => {
+    const { container } = render(
+      <PairedHistogramDiscrete data={sampleRanks} />,
+    );
+    const titles = Array.from(container.querySelectorAll("svg title")).map(
+      (t) => t.textContent ?? "",
+    );
+    expect(
+      titles.some(
+        (t) => t.includes("base rank:") && t.includes("current rank:"),
+      ),
+    ).toBe(true);
+  });
+
+  it("tooltip says 'not in current top-K' when current rank is null", () => {
+    const data: PairedHistogramDiscreteRanksData = {
+      mode: "ranks",
+      values: ["only_in_base"],
+      baseRanks: [1],
+      currentRanks: [null],
+      k: 5,
+    };
+    const { container } = render(<PairedHistogramDiscrete data={data} />);
+    const titles = Array.from(container.querySelectorAll("svg title")).map(
+      (t) => t.textContent ?? "",
+    );
+    expect(titles.some((t) => t.includes("not in current top-K"))).toBe(true);
+  });
+
+  it("tooltip says 'not in base top-K' when base rank is null", () => {
+    const data: PairedHistogramDiscreteRanksData = {
+      mode: "ranks",
+      values: ["only_in_current"],
+      baseRanks: [null],
+      currentRanks: [2],
+      k: 5,
+    };
+    const { container } = render(<PairedHistogramDiscrete data={data} />);
+    const titles = Array.from(container.querySelectorAll("svg title")).map(
+      (t) => t.textContent ?? "",
+    );
+    expect(titles.some((t) => t.includes("not in base top-K"))).toBe(true);
+  });
+
+  it("ranks-mode trimmed marker renders", () => {
+    const { queryByText } = render(
+      <PairedHistogramDiscrete data={{ ...sampleRanks, trimmed: true }} />,
+    );
+    expect(queryByText("trimmed")).toBeInTheDocument();
+  });
+
+  it("computeRanksSlots: empty values returns empty slots", () => {
+    const { slots } = computeRanksSlots({
+      mode: "ranks",
+      values: [],
+      baseRanks: [],
+      currentRanks: [],
+      k: 5,
+    });
+    expect(slots).toEqual([]);
+  });
+
+  it("computeRanksSlots: rank arrays length mismatch returns empty", () => {
+    const { slots } = computeRanksSlots({
+      mode: "ranks",
+      values: ["a", "b"],
+      baseRanks: [1],
+      currentRanks: [1, 2],
+      k: 5,
+    });
+    expect(slots).toEqual([]);
+  });
+
+  it("computeRanksSlots: slot ordering — base-first then current-only appended", () => {
+    // The compute function preserves the caller's order; this test
+    // documents that contract (Stage B is the one that bakes in the
+    // base-first / current-only-appended ordering).
+    const data: PairedHistogramDiscreteRanksData = {
+      mode: "ranks",
+      values: ["a", "b", "c", "new_d"],
+      baseRanks: [1, 2, 3, null],
+      currentRanks: [1, 3, null, 2],
+      k: 4,
+    };
+    const { slots } = computeRanksSlots(data);
+    expect(slots.map((s) => s.value)).toEqual(["a", "b", "c", "new_d"]);
+    // First slot has both ranks set; third slot has no current bar
+    // (currRank null); fourth slot has no base bar (baseRank null).
+    expect(slots[0]).toEqual({ value: "a", baseRank: 1, currRank: 1 });
+    expect(slots[2]).toEqual({ value: "c", baseRank: 3, currRank: null });
+    expect(slots[3]).toEqual({ value: "new_d", baseRank: null, currRank: 2 });
+  });
+
+  it("computeRanksSlots: drops entries absent from both sides defensively", () => {
+    const { slots } = computeRanksSlots({
+      mode: "ranks",
+      values: ["a", "ghost", "b"],
+      baseRanks: [1, null, 2],
+      currentRanks: [1, null, 2],
+      k: 3,
+    });
+    expect(slots.map((s) => s.value)).toEqual(["a", "b"]);
+  });
+
+  it("counts-mode payload without explicit mode still renders bars (back-compat)", () => {
+    // Existing callers don't pass `mode`; that path must keep working.
+    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
+    const groups = container.querySelectorAll("svg > g");
+    expect(groups.length).toBe(sampleData.values.length);
+  });
+});
+
+// ---------------------------------------------------------------------
+// formatValue — `values: unknown[]` contract seam (Stage B → Stage C)
+// ---------------------------------------------------------------------
+
+describe("PairedHistogramDiscrete — formatValue", () => {
+  it("applies default formatter (`String(v)`) when no formatValue prop is given", () => {
+    const data: PairedHistogramDiscreteData = {
+      values: [null, 42, "a"],
+      baseCounts: [10, 20, 30],
+      currentCounts: [12, 18, 35],
+      baseTotal: 60,
+      currentTotal: 65,
+    };
+    const { container } = render(<PairedHistogramDiscrete data={data} />);
+    const titles = Array.from(container.querySelectorAll("svg title")).map(
+      (t) => t.textContent ?? "",
+    );
+    // Default `String(v)` produces "null", "42", "a" verbatim in the
+    // tooltip prefix. These would be a wrapper's job to prettify in
+    // Stage C; the cell just round-trips whatever the formatter returns.
+    expect(titles.some((t) => t.includes("null ["))).toBe(true);
+    expect(titles.some((t) => t.includes("42 ["))).toBe(true);
+    expect(titles.some((t) => t.includes("a ["))).toBe(true);
+  });
+
+  it("applies custom formatValue prop to labels", () => {
+    const data: PairedHistogramDiscreteData = {
+      values: [null],
+      baseCounts: [10],
+      currentCounts: [12],
+      baseTotal: 10,
+      currentTotal: 12,
+    };
+    const { container } = render(
+      <PairedHistogramDiscrete
+        data={data}
+        showLabels
+        formatValue={() => "∅"}
+      />,
+    );
+    // Visible label uses the formatted string.
+    const labels = Array.from(container.querySelectorAll("svg g text")).map(
+      (t) => t.textContent,
+    );
+    expect(labels).toContain("∅");
+    // And so does the per-bar hover title (prefix).
+    const titles = Array.from(container.querySelectorAll("svg title")).map(
+      (t) => t.textContent ?? "",
+    );
+    expect(titles.some((t) => t.startsWith("∅ ["))).toBe(true);
+  });
+
+  it("default formatter handles boolean / number / string / null values without crashing", () => {
+    const data: PairedHistogramDiscreteData = {
+      values: ["s", 7, true, null, 1_500_000],
+      baseCounts: [1, 2, 3, 4, 5],
+      currentCounts: [5, 4, 3, 2, 1],
+      baseTotal: 15,
+      currentTotal: 15,
+    };
+    expect(() => render(<PairedHistogramDiscrete data={data} />)).not.toThrow();
+  });
+});

--- a/js/packages/ui/src/components/data/__tests__/PairedHistogramDiscrete.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/PairedHistogramDiscrete.test.tsx
@@ -7,6 +7,7 @@
 import { render } from "@testing-library/react";
 import { vi } from "vitest";
 import { useIsDark } from "../../../hooks/useIsDark";
+import { CELL_WIDTH } from "../PairedHistogramCanvas";
 import {
   computeDiscreteSlots,
   computeRanksSlots,
@@ -49,10 +50,7 @@ describe("PairedHistogramDiscrete", () => {
       baseTotal: 0,
       currentTotal: 10,
     };
-    const width = 140;
-    const { container } = render(
-      <PairedHistogramDiscrete data={data} width={width} />,
-    );
+    const { container } = render(<PairedHistogramDiscrete data={data} />);
     const visibleRects = Array.from(
       container.querySelectorAll("svg > g rect"),
     ).filter((r) => r.getAttribute("fill") !== "none");
@@ -61,10 +59,10 @@ describe("PairedHistogramDiscrete", () => {
     expect(visibleRects.length).toBe(1);
     const rect = visibleRects[0];
     expect(rect.getAttribute("fill")).toBe("#63B3ED");
-    // Current bar sits on the right half of its slot (slot midpoint = width / 2
+    // Current bar sits on the right half of its slot (slot midpoint = CELL_WIDTH / 2
     // when there's a single slot).
     const x = Number.parseFloat(rect.getAttribute("x") ?? "0");
-    expect(x).toBeGreaterThan(width / 2);
+    expect(x).toBeGreaterThan(CELL_WIDTH / 2);
   });
 
   it("leaves a gap when current side count is 0 — removed value", () => {
@@ -75,10 +73,7 @@ describe("PairedHistogramDiscrete", () => {
       baseTotal: 10,
       currentTotal: 0,
     };
-    const width = 140;
-    const { container } = render(
-      <PairedHistogramDiscrete data={data} width={width} />,
-    );
+    const { container } = render(<PairedHistogramDiscrete data={data} />);
     const visibleRects = Array.from(
       container.querySelectorAll("svg > g rect"),
     ).filter((r) => r.getAttribute("fill") !== "none");
@@ -87,57 +82,14 @@ describe("PairedHistogramDiscrete", () => {
     expect(rect.getAttribute("fill")).toBe("#F6AD55");
     // Base bar sits on the left half of its slot.
     const x = Number.parseFloat(rect.getAttribute("x") ?? "0");
-    expect(x).toBeLessThan(width / 2);
+    expect(x).toBeLessThan(CELL_WIDTH / 2);
   });
 
-  it("uses default cell-density dimensions when not provided", () => {
+  it("renders at fixed cell-density dimensions (140x28)", () => {
     const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
     const svg = container.querySelector("svg");
     expect(svg?.getAttribute("width")).toBe("140");
     expect(svg?.getAttribute("height")).toBe("28");
-  });
-
-  it("respects custom width and height", () => {
-    const { container } = render(
-      <PairedHistogramDiscrete data={sampleData} width={220} height={100} />,
-    );
-    const svg = container.querySelector("svg");
-    expect(svg?.getAttribute("width")).toBe("220");
-    expect(svg?.getAttribute("height")).toBe("100");
-  });
-
-  it("does not render value labels by default", () => {
-    const { container } = render(<PairedHistogramDiscrete data={sampleData} />);
-    expect(container.querySelectorAll("svg g text").length).toBe(0);
-  });
-
-  it("renders one label per value when showLabels is true", () => {
-    const { container } = render(
-      <PairedHistogramDiscrete data={sampleData} showLabels />,
-    );
-    const labels = container.querySelectorAll("svg g text");
-    expect(labels.length).toBe(sampleData.values.length);
-    expect(Array.from(labels).map((l) => l.textContent)).toEqual(
-      sampleData.values,
-    );
-  });
-
-  it("truncates labels longer than labelMaxChars", () => {
-    const longData: PairedHistogramDiscreteData = {
-      ...sampleData,
-      values: ["United States", "Great Britain", "Germany", "France", "Japan"],
-    };
-    const { container } = render(
-      <PairedHistogramDiscrete data={longData} showLabels labelMaxChars={4} />,
-    );
-    const texts = Array.from(container.querySelectorAll("svg g text")).map(
-      (t) => t.textContent ?? "",
-    );
-    for (const t of texts) {
-      expect(t.length).toBeLessThanOrEqual(4);
-    }
-    // Each truncated label ends with the ellipsis character.
-    expect(texts.every((t) => t.endsWith("…"))).toBe(true);
   });
 
   it("renders trimmed marker when trimmed prop is set", () => {
@@ -308,6 +260,48 @@ describe("PairedHistogramDiscrete — ranks mode", () => {
     expect(firstH).toBeGreaterThan(lastH);
   });
 
+  it("clamps invalid rank (rank > k → would be negative height) so no malformed rect renders", () => {
+    // Stage B contract violation: rank 7 > k 5 would compute a negative
+    // height. The clamp drops it to 0 — no <rect> emitted for that bar,
+    // and crucially no SVG with a negative `height` attribute.
+    const data: PairedHistogramDiscreteRanksData = {
+      mode: "ranks",
+      values: ["over_k"],
+      baseRanks: [7],
+      currentRanks: [null],
+      k: 5,
+    };
+    const { container } = render(<PairedHistogramDiscrete data={data} />);
+    const visibleHeights = Array.from(
+      container.querySelectorAll("svg > g rect"),
+    )
+      .filter((r) => r.getAttribute("fill") !== "none")
+      .map((r) => Number.parseFloat(r.getAttribute("height") ?? "0"));
+    expect(visibleHeights.every((h) => h >= 0)).toBe(true);
+  });
+
+  it("clamps invalid rank (rank ≤ 0 → would overflow chart height) to the chart height", () => {
+    // Stage B contract violation: rank 0 (or any rank below 1) would
+    // compute a bar taller than the chart. The clamp caps it at the
+    // chart height so the bar stays inside the SVG frame.
+    const data: PairedHistogramDiscreteRanksData = {
+      mode: "ranks",
+      values: ["under_one"],
+      baseRanks: [0],
+      currentRanks: [null],
+      k: 5,
+    };
+    const { container } = render(<PairedHistogramDiscrete data={data} />);
+    const visible = Array.from(
+      container.querySelectorAll("svg > g rect"),
+    ).filter((r) => r.getAttribute("fill") !== "none");
+    expect(visible.length).toBe(1);
+    // CELL_HEIGHT 28 - 2px padding = 26 max bar height.
+    const h = Number.parseFloat(visible[0].getAttribute("height") ?? "0");
+    expect(h).toBeLessThanOrEqual(26);
+    expect(h).toBeGreaterThan(0);
+  });
+
   it("value present only in base top-K: no current bar", () => {
     const data: PairedHistogramDiscreteRanksData = {
       mode: "ranks",
@@ -316,10 +310,7 @@ describe("PairedHistogramDiscrete — ranks mode", () => {
       currentRanks: [null],
       k: 5,
     };
-    const width = 140;
-    const { container } = render(
-      <PairedHistogramDiscrete data={data} width={width} />,
-    );
+    const { container } = render(<PairedHistogramDiscrete data={data} />);
     const visible = Array.from(
       container.querySelectorAll("svg > g rect"),
     ).filter((r) => r.getAttribute("fill") !== "none");
@@ -328,7 +319,7 @@ describe("PairedHistogramDiscrete — ranks mode", () => {
     expect(visible[0].getAttribute("fill")).toBe("#F6AD55");
     // Base bar sits on the left half of its slot.
     const x = Number.parseFloat(visible[0].getAttribute("x") ?? "0");
-    expect(x).toBeLessThan(width / 2);
+    expect(x).toBeLessThan(CELL_WIDTH / 2);
   });
 
   it("value present only in current top-K: no base bar, sits on the right of the chart", () => {
@@ -339,10 +330,7 @@ describe("PairedHistogramDiscrete — ranks mode", () => {
       currentRanks: [1, 2, 3],
       k: 5,
     };
-    const width = 150;
-    const { container } = render(
-      <PairedHistogramDiscrete data={data} width={width} />,
-    );
+    const { container } = render(<PairedHistogramDiscrete data={data} />);
     // The current-only slot is the last group (rightmost).
     const groups = container.querySelectorAll("svg > g");
     const lastBars = Array.from(
@@ -352,7 +340,7 @@ describe("PairedHistogramDiscrete — ranks mode", () => {
     expect(lastBars[0].getAttribute("fill")).toBe("#63B3ED");
     // And the slot itself is on the right two-thirds of the chart.
     const lastSlotX = Number.parseFloat(lastBars[0].getAttribute("x") ?? "0");
-    expect(lastSlotX).toBeGreaterThan(width * (2 / 3));
+    expect(lastSlotX).toBeGreaterThan(CELL_WIDTH * (2 / 3));
   });
 
   it("tooltip shows both ranks when present", () => {
@@ -448,15 +436,28 @@ describe("PairedHistogramDiscrete — ranks mode", () => {
     expect(slots[3]).toEqual({ value: "new_d", baseRank: null, currRank: 2 });
   });
 
-  it("computeRanksSlots: drops entries absent from both sides defensively", () => {
-    const { slots } = computeRanksSlots({
-      mode: "ranks",
-      values: ["a", "ghost", "b"],
-      baseRanks: [1, null, 2],
-      currentRanks: [1, null, 2],
-      k: 3,
+  it("computeRanksSlots: warns and drops entries absent from both sides defensively", () => {
+    // Stage B contract violation: a value with `null` on both sides
+    // should never appear in the payload. The cell drops it silently
+    // from the slot list but emits a console.warn so the violation
+    // surfaces in dev tools.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      /* swallow so vitest output stays clean */
     });
-    expect(slots.map((s) => s.value)).toEqual(["a", "b"]);
+    try {
+      const { slots } = computeRanksSlots({
+        mode: "ranks",
+        values: ["a", "ghost", "b"],
+        baseRanks: [1, null, 2],
+        currentRanks: [1, null, 2],
+        k: 3,
+      });
+      expect(slots.map((s) => s.value)).toEqual(["a", "b"]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain("PairedHistogramDiscrete");
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("counts-mode payload without explicit mode still renders bars (back-compat)", () => {
@@ -492,7 +493,7 @@ describe("PairedHistogramDiscrete — formatValue", () => {
     expect(titles.some((t) => t.includes("a ["))).toBe(true);
   });
 
-  it("applies custom formatValue prop to labels", () => {
+  it("applies custom formatValue prop to the tooltip prefix", () => {
     const data: PairedHistogramDiscreteData = {
       values: [null],
       baseCounts: [10],
@@ -501,18 +502,8 @@ describe("PairedHistogramDiscrete — formatValue", () => {
       currentTotal: 12,
     };
     const { container } = render(
-      <PairedHistogramDiscrete
-        data={data}
-        showLabels
-        formatValue={() => "∅"}
-      />,
+      <PairedHistogramDiscrete data={data} formatValue={() => "∅"} />,
     );
-    // Visible label uses the formatted string.
-    const labels = Array.from(container.querySelectorAll("svg g text")).map(
-      (t) => t.textContent,
-    );
-    expect(labels).toContain("∅");
-    // And so does the per-bar hover title (prefix).
     const titles = Array.from(container.querySelectorAll("svg title")).map(
       (t) => t.textContent ?? "",
     );

--- a/js/packages/ui/src/components/data/__tests__/ProfileDistributionUnsupportedBanner.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/ProfileDistributionUnsupportedBanner.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @file ProfileDistributionUnsupportedBanner.test.tsx
+ * @description Tests for the once-per-task unsupported-adapter banner (DRC-3390 PR 3).
+ */
+
+import { render } from "@testing-library/react";
+import { ProfileDistributionUnsupportedBanner } from "../ProfileDistributionUnsupportedBanner";
+
+describe("ProfileDistributionUnsupportedBanner", () => {
+  it("renders a generic message when no reason is supplied", () => {
+    const { getByTestId, getByText } = render(
+      <ProfileDistributionUnsupportedBanner />,
+    );
+    expect(
+      getByTestId("profile-distribution-unsupported-banner"),
+    ).toBeInTheDocument();
+    expect(
+      getByText(/paired column distributions aren't available here/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the backend reason verbatim when provided", () => {
+    const { getByText } = render(
+      <ProfileDistributionUnsupportedBanner reason="this dialect lacks APPROX_PERCENTILE" />,
+    );
+    expect(
+      getByText("this dialect lacks APPROX_PERCENTILE"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the adapter-type in the title when provided", () => {
+    const { getByText } = render(
+      <ProfileDistributionUnsupportedBanner adapterType="postgres" />,
+    );
+    expect(getByText(/postgres/i)).toBeInTheDocument();
+  });
+
+  it("uses role=status for screen readers (non-disruptive)", () => {
+    const { getByRole } = render(<ProfileDistributionUnsupportedBanner />);
+    expect(getByRole("status")).toBeInTheDocument();
+  });
+});

--- a/js/packages/ui/src/components/data/index.ts
+++ b/js/packages/ui/src/components/data/index.ts
@@ -5,15 +5,31 @@
 // AG Grid theme
 export { dataGridThemeDark, dataGridThemeLight } from "./agGridTheme";
 export {
-  type ChartBarColors,
-  type ChartThemeColors,
-  getChartBarColors,
-  getChartThemeColors,
   HistogramChart,
   type HistogramChartProps,
   type HistogramDataset,
   type HistogramDataType,
 } from "./HistogramChart";
+// Paired histograms for inline profile distribution (DRC-3390)
+export {
+  computeContinuousLayout,
+  PairedHistogramContinuous,
+  type PairedHistogramContinuousData,
+  type PairedHistogramContinuousProps,
+} from "./PairedHistogramContinuous";
+export {
+  computeDiscreteSlots,
+  computeRanksSlots,
+  PairedHistogramDiscrete,
+  type PairedHistogramDiscreteCountsData,
+  type PairedHistogramDiscreteData,
+  type PairedHistogramDiscreteProps,
+  type PairedHistogramDiscreteRanksData,
+} from "./PairedHistogramDiscrete";
+export {
+  ProfileDistributionUnsupportedBanner,
+  type ProfileDistributionUnsupportedBannerProps,
+} from "./ProfileDistributionUnsupportedBanner";
 // AG Grid wrapper with screenshot support
 export {
   type ColDef,

--- a/js/packages/ui/src/components/data/index.ts
+++ b/js/packages/ui/src/components/data/index.ts
@@ -12,14 +12,11 @@ export {
 } from "./HistogramChart";
 // Paired histograms for inline profile distribution (DRC-3390)
 export {
-  computeContinuousLayout,
   PairedHistogramContinuous,
   type PairedHistogramContinuousData,
   type PairedHistogramContinuousProps,
 } from "./PairedHistogramContinuous";
 export {
-  computeDiscreteSlots,
-  computeRanksSlots,
   PairedHistogramDiscrete,
   type PairedHistogramDiscreteCountsData,
   type PairedHistogramDiscreteData,

--- a/js/packages/ui/src/components/data/pairedHistogramCanvas.tsx
+++ b/js/packages/ui/src/components/data/pairedHistogramCanvas.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+/**
+ * Shared canvas primitives for the paired-histogram cell pair
+ * (`PairedHistogramContinuous` and `PairedHistogramDiscrete`).
+ *
+ * Both cells render the same outer shell — a fixed-size SVG with an
+ * accessible title and a baseline rule — and format their per-bar
+ * hover tooltips the same way. Keeping that shell in one place stops
+ * the two cells from drifting on size, ARIA semantics, or tooltip
+ * phrasing.
+ *
+ * The layout math, agreement-zone palette, and trimmed-marker glyph
+ * remain in each cell because they diverge structurally: quantile-span
+ * widths vs uniform-slot widths, checkerboard agreement vs paired
+ * side-by-side bars, etc.
+ */
+
+/** Default schema-row cell width (px). Tuned to the SchemaView column. */
+export const CELL_WIDTH = 140;
+
+/** Default schema-row cell height (px). Fits inside the current 35px schema row. */
+export const CELL_HEIGHT = 28;
+
+export interface PairedHistogramSvgProps {
+  width: number;
+  height: number;
+  className?: string;
+  ariaLabel: string;
+  children?: ReactNode;
+}
+
+/**
+ * Outer SVG frame used by both paired-histogram cells. Renders an
+ * accessible title and reserves the chart area; callers draw bins and
+ * decorations as children.
+ */
+export function PairedHistogramSvg({
+  width,
+  height,
+  className,
+  ariaLabel,
+  children,
+}: PairedHistogramSvgProps) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      style={{ display: "block", overflow: "visible" }}
+      role="img"
+      aria-label={ariaLabel}
+    >
+      <title>{ariaLabel}</title>
+      {children}
+    </svg>
+  );
+}
+
+export interface BaselineRuleProps {
+  width: number;
+  y: number;
+  stroke: string;
+}
+
+/**
+ * Horizontal rule drawn under the bars so empty slots still read as
+ * "this slot has zero bars" rather than "this slot doesn't exist".
+ */
+export function BaselineRule({ width, y, stroke }: BaselineRuleProps) {
+  return (
+    <line x1={0} y1={y} x2={width} y2={y} stroke={stroke} strokeWidth={0.5} />
+  );
+}
+
+/**
+ * Per-bar hover tooltip text: `<prefix> [base: X%, current: Y%]`.
+ * Both cells use this; centralizing means a copy tweak doesn't have to
+ * land twice. Always shows both sides — even 0% — because the divergence
+ * reads more directly than "only in X" framing.
+ *
+ * The proportions are **row-share**: for the discrete cell that's
+ * `count / total`; for the continuous cell the caller passes
+ * `density × span` (the bin's area-proportion of the data). Either way
+ * the percentage the user sees describes the share of rows in this bin,
+ * not the bar's pixel-area share of the chart (which depends on the
+ * chart's max-density normalization).
+ */
+export function formatProportionTooltip(
+  prefix: string,
+  baseProp: number,
+  currProp: number,
+): string {
+  const bp = `${(baseProp * 100).toFixed(1)}%`;
+  const cp = `${(currProp * 100).toFixed(1)}%`;
+  return `${prefix} [base: ${bp}, current: ${cp}]`;
+}
+
+/**
+ * Per-bar hover tooltip text for the rank-only paired histogram mode:
+ * `<prefix> [base rank: N, current rank: M]`. Either rank may be `null`
+ * — meaning the value isn't in that side's top-K — in which case that
+ * half of the bracket is replaced with "not in <side> top-K".
+ *
+ * Parallels `formatProportionTooltip` so the two cell modes have one
+ * place to tweak phrasing. Stays terse because the tooltip is rendered
+ * via SVG `<title>` and lives in a 28-px-tall cell.
+ */
+export function formatRankTooltip(
+  prefix: string,
+  baseRank: number | null,
+  currRank: number | null,
+): string {
+  const baseSeg =
+    baseRank === null ? "not in base top-K" : `base rank: ${baseRank}`;
+  const currSeg =
+    currRank === null ? "not in current top-K" : `current rank: ${currRank}`;
+  return `${prefix} [${baseSeg}, ${currSeg}]`;
+}

--- a/js/packages/ui/src/primitives.ts
+++ b/js/packages/ui/src/primitives.ts
@@ -314,14 +314,11 @@ export {
  * `InlineProfileDistributionCell` integration ships in Stage C.
  */
 export {
-  computeContinuousLayout,
   PairedHistogramContinuous,
   type PairedHistogramContinuousData,
   type PairedHistogramContinuousProps,
 } from "./components/data/PairedHistogramContinuous";
 export {
-  computeDiscreteSlots,
-  computeRanksSlots,
   PairedHistogramDiscrete,
   type PairedHistogramDiscreteCountsData,
   type PairedHistogramDiscreteData,

--- a/js/packages/ui/src/primitives.ts
+++ b/js/packages/ui/src/primitives.ts
@@ -297,15 +297,41 @@ export type {
  * HistogramDataType.
  */
 export {
-  type ChartBarColors,
-  type ChartThemeColors,
-  getChartBarColors,
-  getChartThemeColors,
   HistogramChart,
   type HistogramChartProps,
   type HistogramDataset,
   type HistogramDataType,
 } from "./components/data/HistogramChart";
+/**
+ * Paired-histogram cells for inline profile-distribution rendering (DRC-3390).
+ *
+ * @remarks
+ * `PairedHistogramContinuous` renders a quantile-bin, constant-area paired
+ * bar chart for continuous columns. `PairedHistogramDiscrete` renders a
+ * top-K paired bar chart with gap-on-absent semantics for categorical
+ * columns. `ProfileDistributionUnsupportedBanner` surfaces the once-per-task
+ * "adapter doesn't support this feature" envelope. The schema-row
+ * `InlineProfileDistributionCell` integration ships in Stage C.
+ */
+export {
+  computeContinuousLayout,
+  PairedHistogramContinuous,
+  type PairedHistogramContinuousData,
+  type PairedHistogramContinuousProps,
+} from "./components/data/PairedHistogramContinuous";
+export {
+  computeDiscreteSlots,
+  computeRanksSlots,
+  PairedHistogramDiscrete,
+  type PairedHistogramDiscreteCountsData,
+  type PairedHistogramDiscreteData,
+  type PairedHistogramDiscreteProps,
+  type PairedHistogramDiscreteRanksData,
+} from "./components/data/PairedHistogramDiscrete";
+export {
+  ProfileDistributionUnsupportedBanner,
+  type ProfileDistributionUnsupportedBannerProps,
+} from "./components/data/ProfileDistributionUnsupportedBanner";
 /**
  * Screenshot data grid primitives (AG Grid wrapper).
  *
@@ -327,7 +353,6 @@ export {
   ScreenshotDataGrid,
   type ScreenshotDataGridProps,
 } from "./components/data/ScreenshotDataGrid";
-
 /**
  * Top-K bar chart primitives (value distribution).
  *
@@ -340,6 +365,12 @@ export {
   type TopKDataset,
   type TopKItem,
 } from "./components/data/TopKBarChart";
+export {
+  type ChartBarColors,
+  type ChartThemeColors,
+  getChartBarColors,
+  getChartThemeColors,
+} from "./theme/chartTheme";
 
 // =============================================================================
 // SCHEMA PRIMITIVES

--- a/js/packages/ui/src/theme/chartTheme.ts
+++ b/js/packages/ui/src/theme/chartTheme.ts
@@ -1,5 +1,7 @@
 /**
- * Shared Chart.js theme utilities for dark mode support
+ * Shared chart theme utilities — single source of truth for both
+ * Chart.js-backed charts (`HistogramChart`, `TopKBarChart`) and the
+ * SVG-rendered paired histogram cells.
  */
 
 export interface ChartThemeColors {
@@ -8,6 +10,10 @@ export interface ChartThemeColors {
   borderColor: string;
   tooltipBackgroundColor: string;
   tooltipTextColor: string;
+  /** Text color for labels drawn inside bars (must contrast with pastel bar fills) */
+  barLabelColor: string;
+  /** Subdued text color for secondary labels like percentages */
+  secondaryTextColor: string;
 }
 
 /**
@@ -22,6 +28,8 @@ export function getChartThemeColors(isDark: boolean): ChartThemeColors {
     borderColor: isDark ? "#6b7280" : "#9ca3af",
     tooltipBackgroundColor: isDark ? "#1f2937" : "#ffffff",
     tooltipTextColor: isDark ? "#e5e7eb" : "#111827",
+    barLabelColor: isDark ? "#ffffff" : "#1f2937",
+    secondaryTextColor: isDark ? "#e5e7eb" : "#6b7280",
   };
 }
 
@@ -85,16 +93,29 @@ export const BASE_BAR_COLOR_DARK = "#FBD38D";
 export const CURRENT_BAR_COLOR_DARK_WITH_ALPHA = `${CURRENT_BAR_COLOR_DARK}A5`;
 export const BASE_BAR_COLOR_DARK_WITH_ALPHA = `${BASE_BAR_COLOR_DARK}A5`;
 
-// Info color
-export const INFO_VAL_COLOR = "#63B3ED";
-export const INFO_VAL_COLOR_DARK = "#90CDF4";
+// `info`-style accent color used by some chart legends. Equal to the current
+// bar color today but kept as a named export so consumers can pull a stable
+// "info" accent without binding to the base/current palette.
+export const INFO_VAL_COLOR = CURRENT_BAR_COLOR;
+export const INFO_VAL_COLOR_DARK = CURRENT_BAR_COLOR_DARK;
 
 /**
- * Get theme-aware bar colors for charts
- * @param isDark - Whether dark mode is active
- * @returns Object with current and base bar colors
+ * Bar colors for base/current comparison.
  */
-export function getBarColors(isDark: boolean) {
+export interface ChartBarColors {
+  current: string;
+  base: string;
+  currentWithAlpha: string;
+  baseWithAlpha: string;
+  /** Accent color for `info`-styled legends; matches `current` today. */
+  info: string;
+}
+
+/**
+ * Get theme-aware bar colors for charts.
+ * @param isDark - Whether dark mode is active
+ */
+export function getChartBarColors(isDark: boolean): ChartBarColors {
   return {
     current: isDark ? CURRENT_BAR_COLOR_DARK : CURRENT_BAR_COLOR,
     base: isDark ? BASE_BAR_COLOR_DARK : BASE_BAR_COLOR,

--- a/js/packages/ui/src/theme/chartTheme.ts
+++ b/js/packages/ui/src/theme/chartTheme.ts
@@ -14,6 +14,8 @@ export interface ChartThemeColors {
   barLabelColor: string;
   /** Subdued text color for secondary labels like percentages */
   secondaryTextColor: string;
+  /** Semi-transparent background for chips/badges drawn over bars (e.g. trimmed-top-K marker). */
+  overlayBackgroundColor: string;
 }
 
 /**
@@ -30,6 +32,8 @@ export function getChartThemeColors(isDark: boolean): ChartThemeColors {
     tooltipTextColor: isDark ? "#e5e7eb" : "#111827",
     barLabelColor: isDark ? "#ffffff" : "#1f2937",
     secondaryTextColor: isDark ? "#e5e7eb" : "#6b7280",
+    // 80% (cc) opacity: legible over a tall bar without reading as a hard block.
+    overlayBackgroundColor: isDark ? "#1f2937cc" : "#ffffffcc",
   };
 }
 

--- a/js/packages/ui/src/theme/index.ts
+++ b/js/packages/ui/src/theme/index.ts
@@ -24,7 +24,7 @@ export {
   CURRENT_BAR_COLOR_DARK,
   CURRENT_BAR_COLOR_DARK_WITH_ALPHA,
   CURRENT_BAR_COLOR_WITH_ALPHA,
-  getBarColors,
+  getChartBarColors,
   getChartThemeColors,
   getThemedPluginOptions,
   getThemedScaleOptions,

--- a/js/packages/ui/src/theme/index.ts
+++ b/js/packages/ui/src/theme/index.ts
@@ -19,6 +19,7 @@ export {
   BASE_BAR_COLOR_DARK_WITH_ALPHA,
   BASE_BAR_COLOR_WITH_ALPHA,
   // Chart theme utilities
+  type ChartBarColors,
   type ChartThemeColors,
   CURRENT_BAR_COLOR,
   CURRENT_BAR_COLOR_DARK,

--- a/js/packages/ui/src/types/index.ts
+++ b/js/packages/ui/src/types/index.ts
@@ -90,13 +90,10 @@ export type {
 // =============================================================================
 
 export type {
-  ChartBarColors,
-  ChartThemeColors,
   HistogramChartProps,
   HistogramDataset,
   HistogramDataType,
 } from "../components/data/HistogramChart";
-
 export type {
   TopKBarChartProps,
   TopKDataset,


### PR DESCRIPTION
  ## Summary

  Stage A of the [DRC-3390](https://linear.app/recce/issue/DRC-3390) paired-histograms 4-stage restructure. **Storybook-only, no API or backend
  dependency** — reviewers can clone this branch, run Storybook, and visually verify the chart cells in isolation.

  ## Why Stage A first

  Lowest-risk PR in the restructure: pure additive component-library work, no integration with `SchemaView`, no API plumbing, no Python. Reviewable
  in parallel with Stage B (which owns the backend + API contract). Supersedes the closed [#1391](https://github.com/DataRecce/recce/pull/1391)
  (lifted verbatim minus the wrapper + hook, which move to Stage C).

  ## Components shipped

  - **`PairedHistogramContinuous`** — quantile-bin **constant-area** paired histogram. Bar widths track quantile spans, heights track density, so
  bar area reads as the row-share in that bin. `formatValue` prop for caller-supplied label formatting.
  - **`PairedHistogramDiscrete`** — top-K paired histogram with two rendering modes (discriminated on `data.mode`):
    - **`mode: "counts"`** (default): paired bars sized by proportion, **gap-on-absent** semantics — a value with count 0 on one side simply doesn't
   render, leaving a visible empty half-slot.
    - **`mode: "ranks"`**: **rank-staircase** for DuckDB's counts-less `approx_top_k` payloads. Bar height = `(k − rank + 1) / k`; slots are
  base-rank-ordered with current-only values appended right. Stable case reads as two matching descending staircases; order changes show as current
  bars zig-zagging against base's smooth descent. Stage B guarantees both-or-neither (no mixed mode).
    - `formatValue?: (v: unknown) => string` prop for caller-supplied label formatting (NULL handling, numeric abbreviation, date rendering). Stage
  C dispatches per `column.type`.
  - **`ProfileDistributionUnsupportedBanner`** — one-time MUI Alert for `{status: "unsupported", reason}` envelopes (Postgres / MySQL / SQLite / SQL
   Server pre-2022).
  - Supporting infrastructure: `pairedHistogramCanvas.tsx` (shared SVG frame + baseline rule + tooltip formatters), `chartColors.ts` (theme/palette
  helpers extracted from `HistogramChart` so the leaf cells don't drag Chart.js into the bundle).

  `CELL_WIDTH = 140`, `CELL_HEIGHT = 28` — sized to fit inside the existing SchemaView row (`rowHeight = 35`).

## Test plan

- [x] `pnpm install` clean.
- [x] `pnpm --filter @datarecce/ui type:check` — no errors in new files (baseline CSS-module / `useTrackLineageRender` errors unchanged).
- [x] Vitest: 40 tests pass across the 3 new test files (`PairedHistogramContinuous`, `PairedHistogramDiscrete`, `ProfileDistributionUnsupportedBanner`).
- [x] `pnpm --filter @datarecce/storybook build` builds clean.
- [x] `pnpm --filter @datarecce/storybook storybook` (port 6006) — all 12 stories render.
- [x] Visual proofs:
  - Continuous `Cell — order amount` — bar widths visibly differ across bins (constant-area).
  - Continuous `Degenerate range` — flat checkerboard, no crash.
  - Discrete `Cell — gap-on-absent` — literal visual gaps where one side absent.
  - Discrete `Cell — trimmed top-K marker` — corner "trimmed" marker renders.
  - Storybook toolbar toggles dark theme — bar palette inverts on every story.

<img width="1144" height="160" alt="continuous-cell-added-column" src="https://github.com/user-attachments/assets/0ad74356-7918-408b-b763-76881b094fb5" />
<img width="1144" height="160" alt="continuous-cell-order-amount--dark" src="https://github.com/user-attachments/assets/1afe6576-a1f7-4f84-a8a2-f443fa667be4" />
<img width="1144" height="160" alt="continuous-cell-order-amount" src="https://github.com/user-attachments/assets/e6c8fc16-979c-4176-9816-1eba08615c9f" />
<img width="1144" height="160" alt="continuous-cell-stable" src="https://github.com/user-attachments/assets/d61e3d0e-0522-4ffe-adc6-cb7175141ab8" />
<img width="344" height="136" alt="continuous-degenerate" src="https://github.com/user-attachments/assets/0aa98233-5be6-4331-a93e-584c310e058e" />
<img width="1144" height="160" alt="discrete-cell-http-status" src="https://github.com/user-attachments/assets/1cd19758-7c6d-48b5-aca8-b953d181c4a7" />
<img width="1144" height="160" alt="discrete-cell-signup-source" src="https://github.com/user-attachments/assets/f01c56d0-144b-4437-8a1b-28dc19d1190f" />
<img width="1144" height="160" alt="discrete-cell-trimmed" src="https://github.com/user-attachments/assets/ca2dde8b-dcac-47ff-ba03-1c3766397b3a" />
<img width="1144" height="160" alt="discrete-cell-with-gaps--dark" src="https://github.com/user-attachments/assets/5d3b5747-6c8f-4802-aa88-464ecd1c7762" />
<img width="1144" height="160" alt="discrete-cell-with-gaps" src="https://github.com/user-attachments/assets/ace7fa8d-acc7-431c-acfc-82e8e0ef67e5" />

Ranked
<img width="589" height="77" alt="image" src="https://github.com/user-attachments/assets/69581ca2-baea-4adf-aac5-63e19073254e" />


To reproduce: `pnpm install && pnpm --filter @datarecce/storybook storybook` from `js/`, then open `Visualizations / Profile Distribution` in the Storybook sidebar.