### PR TITLE
fix(adapter): match DuckDB 1.5.x external-access denial wording

### DIFF
--- a/recce/exceptions.py
+++ b/recce/exceptions.py
@@ -37,7 +37,10 @@ class DuckDBExternalAccessBlocked(RecceException):
 _DUCKDB_EXTERNAL_ACCESS_DENIAL_MESSAGES = (
     "file system operations are disabled by configuration",
     "Loading external extensions is disabled through configuration",
+    # DuckDB <= 1.4.x
     "Cannot change enable_external_access setting while database is running",
+    # DuckDB >= 1.5.x reworded this denial
+    "Cannot enable external access while database is running",
 )
 
 


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`fix`

**What this PR does / why we need it**:

DuckDB 1.5.x reworded its external-access denial message:

| Version | Message |
|---------|---------|
| ≤ 1.4.x | `Cannot change enable_external_access setting while database is running` |
| ≥ 1.5.x | `Cannot enable external access while database is running` |

The pinned matcher in `recce/exceptions.py` only knew the old wording, so once CI resolved `duckdb==1.5.2` the raw error escaped unwrapped instead of becoming `DuckDBExternalAccessBlocked`, turning `main` red. Adds the new wording (keeps the old for DuckDB ≤ 1.4.x).

**Which issue(s) this PR fixes**:

Refs DRC-3578

**Special notes for your reviewer**:

Verified against both duckdb 1.4.4 and 1.5.2 — the `SET bypass` case fails without this change and passes with it.

**Does this PR introduce a user-facing change?**:

NONE