### PR TITLE
chore(husky): add pre-commit guard for pinned @biomejs/biome version

### DIFF
--- a/js/.husky/pre-commit
+++ b/js/.husky/pre-commit
@@ -7,6 +7,64 @@ export GIT_WORK_TREE="$REPO_ROOT"
 # Reminder: All commits require --signoff (-s) for DCO compliance
 # The commit-msg hook will enforce this, but here's a heads up!
 
+# --- Pinned-dependency guard ---
+# Some deps are deliberately pinned for known upstream bugs. Dependabot
+# consolidations have silently re-bumped past similar pins in the sister
+# recce-cloud-infra repo (DRC-3460, PR #1333, PR #1376). This guard checks the
+# STAGED content of js/package.json and blocks the commit if a pinned dep has
+# drifted. Override after verifying upstream is fixed:
+#   ALLOW_BIOME_BUMP=1 git commit ...
+PINNED_PKG_JSON="js/package.json"
+if git diff --cached --name-only --diff-filter=ACMR | grep -qx "$PINNED_PKG_JSON"; then
+    # Pinned: @biomejs/biome → 2.4.15.
+    #
+    # Rationale: biome 2.4.12 through 2.4.16 have a deterministic Rust stack
+    # overflow on macOS arm64 when running TS-aware nursery rules
+    # (noFloatingPromises, noMisusedPromises, noUnnecessaryConditions).
+    # Upstream issue: biomejs/biome#10411 (closed, partial fix in #10442
+    # shipped in 2.4.16 2026-05-27). The sister recce-cloud-infra repo tested
+    # 2.4.16 locally on 2026-05-28 and CONFIRMED it still crashes — see
+    # DataRecce/recce-cloud-infra#1382 for the testing notes.
+    #
+    # The js/biome.json in this repo does NOT currently enable those rules,
+    # so 2.4.15 is safe here. But a silent dependabot bump past this version
+    # (or a future enabling of those rules) could regress us. Any change
+    # requires deliberate ack. When biome ships a release that confirms the
+    # full fix, update EXPECTED_BIOME in the same commit as the bump.
+    EXPECTED_BIOME="2.4.15"
+    STAGED_BIOME=$(git show ":$PINNED_PKG_JSON" \
+        | grep -E '"@biomejs/biome":' \
+        | sed -E 's/.*"@biomejs\/biome":[[:space:]]*"([^"]+)".*/\1/')
+    if [ -n "$STAGED_BIOME" ] && [ "$STAGED_BIOME" != "$EXPECTED_BIOME" ] && [ -z "$ALLOW_BIOME_BUMP" ]; then
+        echo "ERROR: @biomejs/biome is pinned to $EXPECTED_BIOME but the staged"
+        echo "       $PINNED_PKG_JSON sets it to $STAGED_BIOME."
+        echo ""
+        echo "Why this is pinned:"
+        echo "  DRC-3460 — biome 2.4.12 through 2.4.16 hit a deterministic Rust"
+        echo "  stack overflow on macOS arm64 when running TS-aware nursery rules"
+        echo "  (noFloatingPromises, noMisusedPromises, noUnnecessaryConditions)."
+        echo "  Upstream: biomejs/biome#10411 (closed, partial fix #10442 shipped"
+        echo "  in 2.4.16) — still crashes the sister recce-cloud-infra repo on"
+        echo "  2.4.16 as of 2026-05-28."
+        echo ""
+        echo "  This repo's js/biome.json does NOT currently enable those rules,"
+        echo "  but the sister recce-cloud-infra repo has been bitten by silent"
+        echo "  Dependabot-consolidation bumps twice (PRs #1333 and #1376). We"
+        echo "  require a deliberate ack for any biome version change here too."
+        echo ""
+        echo "Before bumping, verify on macOS arm64:"
+        echo "  1. cd js && pnpm install"
+        echo "  2. pnpm exec biome check --staged   # must NOT stack overflow"
+        echo "  3. pnpm exec biome check src/        # must NOT stack overflow"
+        echo ""
+        echo "If verified clean, override:"
+        echo "  ALLOW_BIOME_BUMP=1 git commit ..."
+        echo ""
+        echo "Then update EXPECTED_BIOME in this hook to the new pinned version."
+        exit 1
+    fi
+fi
+
 # Check if there are any staged TypeScript/JavaScript files in the js directory
 STAGED_JS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^js/" | grep -E '\.(ts|tsx|js|jsx|mjs)$' || true)
 

--- a/js/.husky/pre-commit
+++ b/js/.husky/pre-commit
@@ -10,12 +10,12 @@ export GIT_WORK_TREE="$REPO_ROOT"
 # --- Pinned-dependency guard ---
 # Some deps are deliberately pinned for known upstream bugs. Dependabot
 # consolidations have silently re-bumped past similar pins in the sister
-# recce-cloud-infra repo (DRC-3460, PR #1333, PR #1376). This guard checks the
+# recce-cloud-infra repo (DRC-3460, PR #1333, PR #1374). This guard checks the
 # STAGED content of js/package.json and blocks the commit if a pinned dep has
 # drifted. Override after verifying upstream is fixed:
 #   ALLOW_BIOME_BUMP=1 git commit ...
 PINNED_PKG_JSON="js/package.json"
-if git diff --cached --name-only --diff-filter=ACMR | grep -qx "$PINNED_PKG_JSON"; then
+if git diff --cached --name-only --diff-filter=ACM | grep -qx "$PINNED_PKG_JSON"; then
     # Pinned: @biomejs/biome → 2.4.15.
     #
     # Rationale: biome 2.4.12 through 2.4.16 have a deterministic Rust stack
@@ -32,10 +32,24 @@ if git diff --cached --name-only --diff-filter=ACMR | grep -qx "$PINNED_PKG_JSON
     # requires deliberate ack. When biome ships a release that confirms the
     # full fix, update EXPECTED_BIOME in the same commit as the bump.
     EXPECTED_BIOME="2.4.15"
+    # head -1 hardens against a future pnpm.overrides entry adding a second
+    # "@biomejs/biome": line. Fail-loud (below) if extraction is empty so a
+    # package.json reformat (or removed dep) can't silently disable the guard.
     STAGED_BIOME=$(git show ":$PINNED_PKG_JSON" \
         | grep -E '"@biomejs/biome":' \
+        | head -1 \
         | sed -E 's/.*"@biomejs\/biome":[[:space:]]*"([^"]+)".*/\1/')
-    if [ -n "$STAGED_BIOME" ] && [ "$STAGED_BIOME" != "$EXPECTED_BIOME" ] && [ -z "$ALLOW_BIOME_BUMP" ]; then
+    if [ -z "$STAGED_BIOME" ] && [ -z "$ALLOW_BIOME_BUMP" ]; then
+        echo "ERROR: Could not extract @biomejs/biome version from staged $PINNED_PKG_JSON."
+        echo "       The pinned-dependency guard expects a single-line entry like:"
+        echo "         \"@biomejs/biome\": \"X.Y.Z\""
+        echo ""
+        echo "       If the dep was intentionally removed or the file format changed,"
+        echo "       override and update this guard in the same commit:"
+        echo "         ALLOW_BIOME_BUMP=1 git commit ..."
+        exit 1
+    fi
+    if [ "$STAGED_BIOME" != "$EXPECTED_BIOME" ] && [ -z "$ALLOW_BIOME_BUMP" ]; then
         echo "ERROR: @biomejs/biome is pinned to $EXPECTED_BIOME but the staged"
         echo "       $PINNED_PKG_JSON sets it to $STAGED_BIOME."
         echo ""
@@ -49,7 +63,7 @@ if git diff --cached --name-only --diff-filter=ACMR | grep -qx "$PINNED_PKG_JSON
         echo ""
         echo "  This repo's js/biome.json does NOT currently enable those rules,"
         echo "  but the sister recce-cloud-infra repo has been bitten by silent"
-        echo "  Dependabot-consolidation bumps twice (PRs #1333 and #1376). We"
+        echo "  Dependabot-consolidation bumps twice (PRs #1333 and #1374). We"
         echo "  require a deliberate ack for any biome version change here too."
         echo ""
         echo "Before bumping, verify on macOS arm64:"


### PR DESCRIPTION
## Summary

The sister `recce-cloud-infra` repo has been bitten **twice** by Dependabot consolidations silently re-bumping a deliberate `@biomejs/biome` pin past a known macOS arm64 stack-overflow bug:

- DataRecce/recce-cloud-infra#1333 — original pin to 2.4.11 (DRC-3460)
- DataRecce/recce-cloud-infra#1374 — consolidation re-bumped to 2.4.15 (regression)
- DataRecce/recce-cloud-infra#1382 — re-pin and add the same guard (sibling PR)

Biome 2.4.12 through 2.4.15 hit a deterministic Rust stack overflow on macOS arm64 when running the TS-aware nursery rules (`noFloatingPromises`, `noMisusedPromises`, `noUnnecessaryConditions`).

## Upstream status

| What | Where | Status |
|---|---|---|
| Bug report | biomejs/biome#10411 | CLOSED, S-Bug-confirmed |
| Fix PR | biomejs/biome#10442 | Merged 2026-05-24 |
| Released in | biome 2.4.16 | Shipped 2026-05-27 (Latest) |

**Important:** 2.4.16 was tested on the sister recce-cloud-infra repo and **still crashes** — the upstream fix is partial. Details in DataRecce/recce-cloud-infra#1382.

The `js/biome.json` in this repo does **not** currently enable those rules, so we haven't been bitten here yet — but the same consolidation pattern applies, and silent bumps are easy to miss in lockfile-heavy PRs.

## Changes

- **`js/.husky/pre-commit`** — new pinned-dep guard, no functional change otherwise.
- **No biome version change.** This repo stays on 2.4.15 because the affected rules aren't enabled here.

### The guard

When `js/package.json` is part of the staged commit, the hook reads its staged content via `git show :js/package.json`, extracts the `@biomejs/biome` version, and compares against `EXPECTED_BIOME=2.4.15`. On mismatch it blocks the commit with a clear error pointing at the upstream issue, the infra-repo PRs, and the 2.4.16 testing finding, plus a 3-step Mac arm64 verification recipe.

Override for intentional bumps:

```bash
ALLOW_BIOME_BUMP=1 git commit ...
```

Then update `EXPECTED_BIOME` in the hook to the new pinned version in the same commit.

## Test plan

- [x] Staged a fake 2.4.99 version — hook fails with the expected DRC-3460 error message, exit 1
- [x] Same staged + `ALLOW_BIOME_BUMP=1` — hook passes, exit 0
- [x] No package.json change — guard is silent, existing `pnpm lint:staged` flow runs normally
- [x] No biome version change — package.json and lockfile untouched
