### PR TITLE
feat(ui): export StalenessBanner from @datarecce/ui (DRC-3508)

### DIFF
--- a/js/packages/ui/src/components/index.ts
+++ b/js/packages/ui/src/components/index.ts
@@ -52,8 +52,18 @@ export type {
   LineageCanvasProps,
   LineageViewProps,
   LineageViewRef,
+  StalenessBannerProps,
+  StalenessBannerVariant,
+  StalenessMessageVariant,
+  StalenessToastAdapter,
 } from "./lineage";
-export { LineageCanvas, LineagePageOss, LineageView } from "./lineage";
+export {
+  FirstTimePopover,
+  LineageCanvas,
+  LineagePageOss,
+  LineageView,
+  StalenessBanner,
+} from "./lineage";
 // Notification components
 export type { NotificationProps } from "./notifications";
 export { LineageViewNotification } from "./notifications";

--- a/js/packages/ui/src/components/lineage/FirstTimePopover.tsx
+++ b/js/packages/ui/src/components/lineage/FirstTimePopover.tsx
@@ -12,7 +12,7 @@ import { LOCAL_STORAGE_KEYS } from "../../api/storageKeys";
  *
  * @param anchorEl - DOM element to anchor the popover to (typically the banner).
  */
-interface FirstTimePopoverProps {
+export interface FirstTimePopoverProps {
   anchorEl: HTMLElement | null;
 }
 

--- a/js/packages/ui/src/components/lineage/StalenessBanner.tsx
+++ b/js/packages/ui/src/components/lineage/StalenessBanner.tsx
@@ -3,12 +3,20 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
+import IconButton from "@mui/material/IconButton";
+import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
+import type { SxProps, Theme } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { IoClose } from "react-icons/io5";
 import { MdInfo } from "react-icons/md";
-import { isSessionBaseOutdated, refreshSessionBase } from "../../api";
+import {
+  isSessionBaseOutdated,
+  refreshSessionBase,
+  type SessionStaleness,
+} from "../../api";
 import { useLineageGraphContext } from "../../contexts";
 import { useApiConfig, useServerInfo } from "../../hooks";
 import { toaster } from "../ui/Toaster";
@@ -18,19 +26,118 @@ import { FirstTimePopover } from "./FirstTimePopover";
 const REFRESH_TIMEOUT_MS = 30_000;
 
 /**
+ * sessionStorage key prefix for `dismissible` mode. The per-session key is
+ * `${PREFIX}::${sessionId}` so dismissals do not leak across PR sessions in
+ * the same tab.
+ */
+const DISMISSED_SIGNATURE_KEY_PREFIX =
+  "recce-staleness-banner-dismissed-signature";
+
+/**
+ * Toast surface used by StalenessBanner. Both shells implement this — OSS via
+ * the module-singleton `toaster`, cloud via its provider-backed `useToast()`.
+ */
+export interface StalenessToastAdapter {
+  success: (message: string, options?: { duration?: number }) => void;
+  error: (message: string, options?: { duration?: number }) => void;
+}
+
+export type StalenessBannerVariant = "banner" | "card";
+export type StalenessMessageVariant = "data" | "metadata";
+
+export interface StalenessBannerProps {
+  /**
+   * Visual treatment.
+   * - `banner` (default): full-width yellow strip with `borderBottom`.
+   *   Mounted in shell chrome (OSS MainLayout).
+   * - `card`: floating MUI `Paper` overlay. Used by the cloud shell.
+   */
+  variant?: StalenessBannerVariant;
+  /**
+   * When `true`, render a close icon and persist the user's dismissal in
+   * sessionStorage keyed on the staleness signature, so the banner re-fires
+   * on a new drift state.
+   *
+   * Requires `sessionId` to scope the dismissal to the current PR session.
+   * Defaults to `false` (OSS persistent banner).
+   */
+  dismissible?: boolean;
+  /**
+   * Per-session key suffix for sessionStorage dismissal persistence. Required
+   * when `dismissible` is true; ignored otherwise.
+   */
+  sessionId?: string;
+  /**
+   * Toast surface override. Defaults to the OSS module-singleton `toaster`.
+   * Cloud passes its `useToast()` provider value wrapped to this shape.
+   */
+  toastAdapter?: StalenessToastAdapter;
+  /**
+   * When `true`, the outdated→matching success toast fires only if the user
+   * clicked Refresh on this mount. Suppresses spurious "Base refreshed" toasts
+   * triggered by an unrelated cache update (e.g. refresh from another tab).
+   *
+   * OSS defaults to `false` (existing behavior). Cloud opts in.
+   */
+  successToastOnlyOnUserRefresh?: boolean;
+  /**
+   * When `true` (default), gate the banner on
+   * `useLineageGraphContext().cloudMode`. The cloud shell does not provide a
+   * lineage-graph context at the mount level, so it passes `false`.
+   */
+  requireCloudMode?: boolean;
+  /**
+   * Wording for the outdated-state message.
+   * - `data` (default): "Production data has changed since this PR's base was captured."
+   * - `metadata`: "Production metadata has changed since this PR's base was captured."
+   *
+   * The no-shared-base copy is identical across both variants.
+   */
+  messageVariant?: StalenessMessageVariant;
+  /**
+   * Show the one-shot `FirstTimePopover` anchored to the banner. Defaults to
+   * `true`. The cloud shell sets this to `false` (cloud-side intro is handled
+   * separately or omitted by design).
+   */
+  showFirstTimePopover?: boolean;
+  /**
+   * Additional `sx` merged into the `Paper` root when `variant="card"`.
+   * Typical use: shell-specific positioning offsets (`top`, `left`, etc.)
+   * since the floating card sits over the work area in cloud.
+   */
+  cardSx?: SxProps<Theme>;
+}
+
+/**
  * Yellow info banner shown when the PR session's frozen-snapshot base is
  * outdated relative to the project's current shared base.
- *
- * Cloud-mode only (gated via LineageGraphContext.cloudMode).
- * Hidden for OSS / legacy sessions (staleness undefined or source_session_id null).
  *
  * Subscribes directly to the lineage query cache so banner updates reactively
  * when LineageGraphAdapter invalidates the cache on WS `metadata_updated` —
  * even across React.memo() boundaries.
+ *
+ * @see DRC-3508 for the shared-export refactor that unifies the OSS strip and
+ * cloud floating-card surfaces behind one component.
  */
-export function StalenessBanner() {
+export function StalenessBanner({
+  variant = "banner",
+  dismissible = false,
+  sessionId,
+  toastAdapter,
+  successToastOnlyOnUserRefresh = false,
+  requireCloudMode = true,
+  messageVariant = "data",
+  showFirstTimePopover = true,
+  cardSx,
+}: StalenessBannerProps = {}) {
   const { cloudMode } = useLineageGraphContext();
   const { apiClient } = useApiConfig();
+
+  const toast = useMemo<StalenessToastAdapter>(
+    () => toastAdapter ?? defaultToastAdapter,
+    [toastAdapter],
+  );
+
   const [refreshing, setRefreshing] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // State-backed ref so MUI Popover gets a re-render after the banner DOM
@@ -38,6 +145,10 @@ export function StalenessBanner() {
   // would receive anchorEl=null on first render and stay closed even after
   // its internal setOpen(true) fires. See PR #1366 review.
   const [bannerEl, setBannerEl] = useState<HTMLDivElement | null>(null);
+  // True only when the user clicked Refresh on *this* mount. Used when
+  // `successToastOnlyOnUserRefresh` is set, so unrelated cache transitions
+  // (another tab refreshed) do not falsely claim the success toast.
+  const userInitiatedRefreshRef = useRef(false);
 
   // Subscribe to session_staleness via the shared useServerInfo hook so this
   // banner tracks any future options (staleTime/enabled) added in
@@ -46,33 +157,52 @@ export function StalenessBanner() {
     select: (d) => d.session_staleness,
   });
 
-  // Track previous staleness to detect the true→false transition.
+  // Track previous staleness to detect the outdated→matching transition.
   // Note: this ref is component-local, so it does NOT survive remounts. If the
-  // user navigates away after clicking Refresh and the WS event arrives while a
-  // different route is mounted, the success toast is skipped on return (the
-  // cache is correct: banner hidden, no error). Accepted limitation for slice 2.
+  // user navigates away after clicking Refresh and the WS event arrives while
+  // a different route is mounted, the success toast is skipped on return.
   const prevOutdated = useRef<boolean | null>(null);
 
   const outdated = staleness != null ? isSessionBaseOutdated(staleness) : false;
 
-  // Toast when staleness clears (transition true → false).
+  const dismissedKey =
+    dismissible && sessionId
+      ? `${DISMISSED_SIGNATURE_KEY_PREFIX}::${sessionId}`
+      : null;
+
+  // Lazy-init dismissed signature from sessionStorage so the dismissal
+  // survives soft reloads within the same tab session.
+  const [dismissedSignature, setDismissedSignature] = useState<string | null>(
+    () => readDismissedSignature(dismissedKey),
+  );
+
+  // Resync from storage whenever `dismissedKey` changes — relevant when the
+  // shell preserves the layout across `[sessionId]` URL changes (Next.js App
+  // Router): the lazy-init value would otherwise leak across sessions even
+  // though the storage key correctly flipped to the new session.
   useEffect(() => {
-    if (prevOutdated.current === true && !outdated) {
-      toaster.success({
-        description:
-          "Base refreshed. If you've saved checks in this session, you may want to re-run them against the new base.",
-        duration: 8000,
-        closable: true,
-      });
-      // Clear refreshing state since the WS event arrived.
+    setDismissedSignature(readDismissedSignature(dismissedKey));
+  }, [dismissedKey]);
+
+  // Toast when staleness clears (outdated → matching transition).
+  useEffect(() => {
+    const transitioned = prevOutdated.current === true && !outdated;
+    const userInitiatedGateSatisfied =
+      !successToastOnlyOnUserRefresh || userInitiatedRefreshRef.current;
+    if (transitioned && userInitiatedGateSatisfied) {
+      toast.success(
+        "Base refreshed. If you've saved checks in this session, you may want to re-run them against the new base.",
+        { duration: 8000 },
+      );
       setRefreshing(false);
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
         timeoutRef.current = null;
       }
+      userInitiatedRefreshRef.current = false;
     }
     prevOutdated.current = outdated;
-  }, [outdated]);
+  }, [outdated, successToastOnlyOnUserRefresh, toast]);
 
   // Cleanup timeout on unmount.
   useEffect(() => {
@@ -83,24 +213,31 @@ export function StalenessBanner() {
     };
   }, []);
 
-  if (!cloudMode) return null;
+  if (requireCloudMode && !cloudMode) return null;
   if (!staleness) return null;
   if (!outdated) return null;
 
+  const currentSignature = stalenessSignature(staleness);
+  if (dismissible && dismissedSignature === currentSignature) return null;
+
   const noSharedBase = staleness.current_base_session_id === null;
+  const outdatedMessage =
+    messageVariant === "metadata"
+      ? "Production metadata has changed since this PR's base was captured. Comparisons may not reflect current state."
+      : "Production data has changed since this PR's base was captured. Comparisons may not reflect current state.";
+  const noSharedBaseMessage =
+    "This PR's base snapshot may be out of date, and no shared base is currently configured for this project. Comparisons may not reflect current state.";
 
   const handleRefresh = async () => {
+    userInitiatedRefreshRef.current = true;
     setRefreshing(true);
 
     // 30s timeout fallback: if the WS event never arrives, clear spinner + show error.
     timeoutRef.current = setTimeout(() => {
       setRefreshing(false);
-      toaster.error({
-        description: "Refresh failed — try again.",
-        duration: 5000,
-        closable: true,
-      });
+      toast.error("Refresh failed — try again.", { duration: 5000 });
       timeoutRef.current = null;
+      userInitiatedRefreshRef.current = false;
     }, REFRESH_TIMEOUT_MS);
 
     try {
@@ -115,13 +252,107 @@ export function StalenessBanner() {
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
       setRefreshing(false);
-      toaster.error({
-        description: "Refresh failed — try again.",
-        duration: 5000,
-        closable: true,
-      });
+      userInitiatedRefreshRef.current = false;
+      toast.error("Refresh failed — try again.", { duration: 5000 });
     }
   };
+
+  const handleDismiss = () => {
+    // Tear down any in-flight refresh so the user doesn't see a 30s-timeout
+    // "Refresh failed" toast for a banner they already dismissed.
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setRefreshing(false);
+    userInitiatedRefreshRef.current = false;
+    if (dismissedKey) {
+      try {
+        sessionStorage.setItem(dismissedKey, currentSignature);
+      } catch {
+        // sessionStorage may throw under strict storage partitioning / quota —
+        // still update in-memory state so the user's click takes effect.
+      }
+    }
+    setDismissedSignature(currentSignature);
+  };
+
+  const messageText = noSharedBase ? noSharedBaseMessage : outdatedMessage;
+  const refreshTooltipTitle = noSharedBase
+    ? "No shared base configured for this project."
+    : "";
+
+  const refreshButton = (
+    <Tooltip title={refreshTooltipTitle} disableHoverListener={!noSharedBase}>
+      <span>
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={() => void handleRefresh()}
+          disabled={refreshing || noSharedBase}
+          startIcon={refreshing ? <CircularProgress size={12} /> : undefined}
+          sx={{ whiteSpace: "nowrap" }}
+        >
+          {refreshing ? "Refreshing…" : "Refresh base"}
+        </Button>
+      </span>
+    </Tooltip>
+  );
+
+  const dismissButton = dismissible ? (
+    <IconButton
+      aria-label="Dismiss"
+      size="small"
+      onClick={handleDismiss}
+      sx={{ flex: "0 0 auto" }}
+    >
+      <IoClose />
+    </IconButton>
+  ) : null;
+
+  const popover = showFirstTimePopover ? (
+    <FirstTimePopover anchorEl={bannerEl} />
+  ) : null;
+
+  if (variant === "card") {
+    return (
+      <Paper
+        ref={setBannerEl}
+        role="status"
+        elevation={4}
+        sx={[
+          {
+            position: "fixed",
+            left: "50%",
+            transform: "translateX(-50%)",
+            // Sit just above MUI's drawer tier (= 1201) so the card paints
+            // over page content but below modals (1300), snackbars (1400),
+            // and tooltips (1500).
+            zIndex: (theme: Theme) => theme.zIndex.drawer + 1,
+            maxWidth: 760,
+            minWidth: 480,
+            bgcolor: "warning.light",
+            border: 1,
+            borderColor: "warning.main",
+            borderRadius: 1,
+            px: 1.5,
+            py: 1,
+          },
+          ...(Array.isArray(cardSx) ? cardSx : [cardSx]),
+        ]}
+      >
+        <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+          <Box component={MdInfo} sx={{ flex: "0 0 auto" }} size={18} />
+          <Typography variant="body2" sx={{ flex: 1 }}>
+            {messageText}
+          </Typography>
+          {refreshButton}
+          {dismissButton}
+        </Stack>
+        {popover}
+      </Paper>
+    );
+  }
 
   return (
     <Box
@@ -138,33 +369,48 @@ export function StalenessBanner() {
       <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
         <MdInfo color="inherit" size={16} />
         <Typography variant="body2" sx={{ flex: 1 }}>
-          {noSharedBase
-            ? "This PR's base snapshot may be out of date, and no shared base is currently configured for this project. Comparisons may not reflect current state."
-            : "Production data has changed since this PR's base was captured. Comparisons may not reflect current state."}
+          {messageText}
         </Typography>
-        <Tooltip
-          title={
-            noSharedBase ? "No shared base configured for this project." : ""
-          }
-          disableHoverListener={!noSharedBase}
-        >
-          <span>
-            <Button
-              size="small"
-              variant="outlined"
-              onClick={() => void handleRefresh()}
-              disabled={refreshing || noSharedBase}
-              startIcon={
-                refreshing ? <CircularProgress size={12} /> : undefined
-              }
-              sx={{ whiteSpace: "nowrap" }}
-            >
-              {refreshing ? "Refreshing…" : "Refresh base"}
-            </Button>
-          </span>
-        </Tooltip>
+        {refreshButton}
+        {dismissButton}
       </Stack>
-      <FirstTimePopover anchorEl={bannerEl} />
+      {popover}
     </Box>
   );
 }
+
+/**
+ * Compose a stable string key from the staleness object so the dismissal
+ * tracks the *current* drift state. New drift produces a new signature →
+ * banner re-fires.
+ */
+function stalenessSignature(s: SessionStaleness): string {
+  return `${s.source_session_id}|${s.source_session_updated_at}|${s.current_base_session_id}|${s.current_base_updated_at}`;
+}
+
+function readDismissedSignature(key: string | null): string | null {
+  if (!key) return null;
+  if (typeof window === "undefined") return null;
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+const defaultToastAdapter: StalenessToastAdapter = {
+  success: (message, options) => {
+    toaster.success({
+      description: message,
+      duration: options?.duration ?? 5000,
+      closable: true,
+    });
+  },
+  error: (message, options) => {
+    toaster.error({
+      description: message,
+      duration: options?.duration ?? 5000,
+      closable: true,
+    });
+  },
+};

--- a/js/packages/ui/src/components/lineage/StalenessBanner.tsx
+++ b/js/packages/ui/src/components/lineage/StalenessBanner.tsx
@@ -9,7 +9,7 @@ import Stack from "@mui/material/Stack";
 import type { SxProps, Theme } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { IoClose } from "react-icons/io5";
 import { MdInfo } from "react-icons/md";
 import {
@@ -104,6 +104,11 @@ export interface StalenessBannerProps {
    * Additional `sx` merged into the `Paper` root when `variant="card"`.
    * Typical use: shell-specific positioning offsets (`top`, `left`, etc.)
    * since the floating card sits over the work area in cloud.
+   *
+   * **Note**: the card variant only defaults `left: 50%` + horizontal centering.
+   * Callers must position vertically via `cardSx={{ top: ... }}` to avoid the
+   * card pinning to the viewport top under any sticky chrome (e.g. cloud passes
+   * `top: 180` to clear its top nav).
    */
   cardSx?: SxProps<Theme>;
 }
@@ -133,10 +138,12 @@ export function StalenessBanner({
   const { cloudMode } = useLineageGraphContext();
   const { apiClient } = useApiConfig();
 
-  const toast = useMemo<StalenessToastAdapter>(
-    () => toastAdapter ?? defaultToastAdapter,
-    [toastAdapter],
-  );
+  // Inline ternary instead of useMemo: the result identity is already
+  // caller-stable (toastAdapter when supplied, module-stable defaultToastAdapter
+  // otherwise), so a memo adds no stability the caller hasn't already
+  // delivered. Referential changes propagate downstream from the caller's own
+  // adapter contract.
+  const toast: StalenessToastAdapter = toastAdapter ?? defaultToastAdapter;
 
   const [refreshing, setRefreshing] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -195,6 +202,24 @@ export function StalenessBanner({
       );
     }
   }, [dismissible, sessionId]);
+
+  // Dev-time guard: when the caller opts out of the cloud-mode gate
+  // (`requireCloudMode={false}`) they're almost certainly mounting outside
+  // the OSS shell, where the module-singleton `toaster` may not have a
+  // `<Toaster>` mounted to listen to. The `defaultToastAdapter` would then
+  // silently no-op. Surface the missing adapter loudly in dev. Symmetric with
+  // the `dismissible && !sessionId` guard above.
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== "production" &&
+      requireCloudMode === false &&
+      !toastAdapter
+    ) {
+      console.warn(
+        "StalenessBanner: `requireCloudMode={false}` without `toastAdapter` — the default adapter targets the OSS module-singleton toaster and may silently no-op outside the OSS shell.",
+      );
+    }
+  }, [requireCloudMode, toastAdapter]);
 
   // Toast when staleness clears (outdated → matching transition).
   useEffect(() => {

--- a/js/packages/ui/src/components/lineage/StalenessBanner.tsx
+++ b/js/packages/ui/src/components/lineage/StalenessBanner.tsx
@@ -184,6 +184,18 @@ export function StalenessBanner({
     setDismissedSignature(readDismissedSignature(dismissedKey));
   }, [dismissedKey]);
 
+  // Dev-time guard: `dismissible` without `sessionId` silently degrades to
+  // in-memory dismissal (sessionStorage persistence is skipped because the
+  // dismissedKey gate is null). Surface the misuse loudly in dev so callers
+  // don't ship a banner that loses its dismissal state on every remount.
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production" && dismissible && !sessionId) {
+      console.warn(
+        "StalenessBanner: `dismissible=true` requires `sessionId` — dismissals will not persist across remounts.",
+      );
+    }
+  }, [dismissible, sessionId]);
+
   // Toast when staleness clears (outdated → matching transition).
   useEffect(() => {
     const transitioned = prevOutdated.current === true && !outdated;

--- a/js/packages/ui/src/components/lineage/__tests__/StalenessBanner.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/StalenessBanner.test.tsx
@@ -399,12 +399,30 @@ describe("StalenessBanner", () => {
 // ============================================================================
 
 describe("StalenessBanner props (cross-shell)", () => {
+  // Silence dev-time warnings (dismissible + toastAdapter guards) so the
+  // non-guard-specific tests stay quiet. Dedicated guard tests re-spy and
+  // assert on the warn output.
+  let warnSpy: ReturnType<typeof vi.spyOn> | null = null;
+
   beforeEach(() => {
     vi.clearAllMocks();
     localStorageMock.clear();
+    // Clear sessionStorage too — every test here uses a unique sessionId today
+    // (sess-1, sess-A, sess-B, sess-cloud-1, sess-guarded) so collisions don't
+    // exist, but the suite is one ID rename away from order-dependent failures.
+    sessionStorage.clear();
     localStorageMock.setItem(LOCAL_STORAGE_KEYS.snapshotBaseIntroSeen, "1");
     mockApiPost.mockResolvedValue({});
     mockUseLineageGraphContext.mockReturnValue({ cloudMode: false });
+    warnSpy = vi
+      .spyOn(console, "warn")
+      // biome-ignore lint/suspicious/noEmptyBlockStatements: suppress dev-guard noise across cross-shell suite
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy?.mockRestore();
+    warnSpy = null;
   });
 
   function renderWithProps(
@@ -555,52 +573,70 @@ describe("StalenessBanner props (cross-shell)", () => {
   });
 
   describe("dismissible guard (dev-time)", () => {
-    it("warns when dismissible=true is passed without sessionId", () => {
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        // biome-ignore lint/suspicious/noEmptyBlockStatements: Intentionally suppressing console.warn for this test
-        .mockImplementation(() => {});
+    // Pass a no-op toastAdapter in the negative-assertion cases so the
+    // separate `requireCloudMode={false}` + missing-adapter warning doesn't
+    // pollute these assertions. Each test is scoped to the dismissible guard.
+    const silentAdapter = { success: vi.fn(), error: vi.fn() };
 
+    it("warns when dismissible=true is passed without sessionId", () => {
       renderWithProps(OUTDATED_STALENESS, {
         requireCloudMode: false,
         dismissible: true,
+        toastAdapter: silentAdapter,
       });
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("dismissible=true"),
       );
-      warnSpy.mockRestore();
     });
 
     it("does not warn when dismissible=true and sessionId is provided", () => {
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        // biome-ignore lint/suspicious/noEmptyBlockStatements: Intentionally suppressing console.warn for this test
-        .mockImplementation(() => {});
-
       renderWithProps(OUTDATED_STALENESS, {
         requireCloudMode: false,
         dismissible: true,
         sessionId: "sess-guarded",
+        toastAdapter: silentAdapter,
       });
 
       expect(warnSpy).not.toHaveBeenCalled();
-      warnSpy.mockRestore();
     });
 
     it("does not warn when dismissible is false (sessionId irrelevant)", () => {
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        // biome-ignore lint/suspicious/noEmptyBlockStatements: Intentionally suppressing console.warn for this test
-        .mockImplementation(() => {});
-
       renderWithProps(OUTDATED_STALENESS, {
         requireCloudMode: false,
         dismissible: false,
+        toastAdapter: silentAdapter,
       });
 
       expect(warnSpy).not.toHaveBeenCalled();
-      warnSpy.mockRestore();
+    });
+  });
+
+  describe("toastAdapter guard (dev-time)", () => {
+    it("warns when requireCloudMode=false is passed without a toastAdapter", () => {
+      renderWithProps(OUTDATED_STALENESS, {
+        requireCloudMode: false,
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("requireCloudMode"),
+      );
+    });
+
+    it("does not warn when toastAdapter is provided", () => {
+      renderWithProps(OUTDATED_STALENESS, {
+        requireCloudMode: false,
+        toastAdapter: { success: vi.fn(), error: vi.fn() },
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not warn when requireCloudMode defaults to true (OSS shell)", () => {
+      mockUseLineageGraphContext.mockReturnValue({ cloudMode: true });
+      renderWithProps(OUTDATED_STALENESS, {});
+
+      expect(warnSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/js/packages/ui/src/components/lineage/__tests__/StalenessBanner.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/StalenessBanner.test.tsx
@@ -553,6 +553,121 @@ describe("StalenessBanner props (cross-shell)", () => {
     expect(screen.getByText(/Production data has changed/)).toBeInTheDocument();
     expect(screen.queryByText(/Recce now snapshots your base data/)).toBeNull();
   });
+
+  describe("variant='card' (cloud floating-overlay surface)", () => {
+    it("renders a MUI Paper root instead of the default Box", () => {
+      const { container } = renderWithProps(OUTDATED_STALENESS, {
+        requireCloudMode: false,
+        variant: "card",
+      });
+
+      // Card branch wraps content in <Paper> (which MUI renders with a
+      // `MuiPaper-root` class). Banner branch uses a plain <Box>, so this
+      // assertion fails for the default variant — proves the branch ran.
+      expect(container.querySelector(".MuiPaper-root")).not.toBeNull();
+    });
+
+    it("supports the full cloud-shell prop bundle end-to-end", async () => {
+      const user = userEvent.setup();
+      const adapter = { success: vi.fn(), error: vi.fn() };
+
+      renderWithProps(OUTDATED_STALENESS, {
+        requireCloudMode: false,
+        variant: "card",
+        dismissible: true,
+        sessionId: "sess-cloud-1",
+        toastAdapter: adapter,
+        successToastOnlyOnUserRefresh: true,
+        messageVariant: "metadata",
+        showFirstTimePopover: false,
+        cardSx: { top: 180 },
+      });
+
+      // Wording flips to the metadata variant.
+      expect(
+        screen.getByText(/Production metadata has changed/),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/Production data has changed/)).toBeNull();
+
+      // Refresh button still wired through to the apiClient.
+      await user.click(screen.getByRole("button", { name: /Refresh base/ }));
+      expect(mockApiPost).toHaveBeenCalledWith("/api/refresh-base");
+
+      // Dismiss button hides the card (sessionStorage-backed dismissal).
+      await user.click(screen.getByRole("button", { name: /Dismiss/ }));
+      expect(screen.queryByText(/Production metadata has changed/)).toBeNull();
+
+      // Popover opted out — must not appear even without the localStorage flag.
+      expect(
+        screen.queryByText(/Recce now snapshots your base data/),
+      ).toBeNull();
+    });
+
+    it("cardSx object override produces different emotion classes than defaults", () => {
+      const { container, unmount } = renderWithProps(OUTDATED_STALENESS, {
+        requireCloudMode: false,
+        variant: "card",
+      });
+      const defaultClass =
+        container.querySelector(".MuiPaper-root")?.className ?? "";
+      unmount();
+
+      const { container: overrideContainer } = renderWithProps(
+        OUTDATED_STALENESS,
+        {
+          requireCloudMode: false,
+          variant: "card",
+          // Use a sentinel offset that the default does not set.
+          cardSx: { top: 999 },
+        },
+      );
+      const overrideClass =
+        overrideContainer.querySelector(".MuiPaper-root")?.className ?? "";
+
+      // Emotion compiles `sx` to className suffixes; an additional rule must
+      // produce a non-identical className. This proves the `cardSx` merge is
+      // reaching the Paper element rather than being silently dropped.
+      expect(overrideClass).not.toBe(defaultClass);
+    });
+
+    it("cardSx array form (multiple sx layers) flattens without throwing", () => {
+      // The component does `Array.isArray(cardSx) ? cardSx : [cardSx]` so it
+      // can spread either shape into MUI's sx array. Regression target: if
+      // someone "simplifies" that branch to `[cardSx]` always, MUI receives
+      // a nested array and warns at runtime.
+      expect(() => {
+        renderWithProps(OUTDATED_STALENESS, {
+          requireCloudMode: false,
+          variant: "card",
+          cardSx: [{ top: 200 }, { bgcolor: "primary.light" }],
+        });
+      }).not.toThrow();
+
+      expect(
+        screen.getByText(/Production data has changed/),
+      ).toBeInTheDocument();
+    });
+
+    it("zIndex theme callback resolves against the MUI theme", () => {
+      // The card branch sets `zIndex: (theme) => theme.zIndex.drawer + 1`.
+      // If the theme is not in scope, MUI logs a warning. We spy on
+      // console.error so any theme-resolution warning would fail the test.
+      const errSpy = vi
+        .spyOn(console, "error")
+        // biome-ignore lint/suspicious/noEmptyBlockStatements: Intentionally suppressing console.error for this test
+        .mockImplementation(() => {});
+
+      const { container } = renderWithProps(OUTDATED_STALENESS, {
+        requireCloudMode: false,
+        variant: "card",
+      });
+
+      expect(container.querySelector(".MuiPaper-root")).not.toBeNull();
+      expect(errSpy).not.toHaveBeenCalled();
+
+      errSpy.mockRestore();
+    });
+  });
 });
 
 // ============================================================================

--- a/js/packages/ui/src/components/lineage/__tests__/StalenessBanner.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/StalenessBanner.test.tsx
@@ -395,6 +395,167 @@ describe("StalenessBanner", () => {
 });
 
 // ============================================================================
+// Cross-shell prop surface (DRC-3508)
+// ============================================================================
+
+describe("StalenessBanner props (cross-shell)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.clear();
+    localStorageMock.setItem(LOCAL_STORAGE_KEYS.snapshotBaseIntroSeen, "1");
+    mockApiPost.mockResolvedValue({});
+    mockUseLineageGraphContext.mockReturnValue({ cloudMode: false });
+  });
+
+  function renderWithProps(
+    staleness: SessionStaleness | undefined,
+    props: React.ComponentProps<typeof StalenessBanner>,
+  ) {
+    const client = createTestClient();
+    client.setQueryData(
+      cacheKeys.lineage(),
+      makeServerInfo(staleness) as ServerInfoResult,
+    );
+    const result = render(
+      <QueryClientProvider client={client}>
+        <StalenessBanner {...props} />
+      </QueryClientProvider>,
+    );
+    return { ...result, client };
+  }
+
+  it("requireCloudMode=false renders even when cloudMode is unset", () => {
+    renderWithProps(OUTDATED_STALENESS, { requireCloudMode: false });
+
+    expect(screen.getByText(/Production data has changed/)).toBeInTheDocument();
+  });
+
+  it("messageVariant='metadata' uses the cloud-side wording", () => {
+    renderWithProps(OUTDATED_STALENESS, {
+      requireCloudMode: false,
+      messageVariant: "metadata",
+    });
+
+    expect(
+      screen.getByText(/Production metadata has changed/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Production data has changed/)).toBeNull();
+  });
+
+  it("dismissible=true renders a close button and hides after click", async () => {
+    const user = userEvent.setup();
+    renderWithProps(OUTDATED_STALENESS, {
+      requireCloudMode: false,
+      dismissible: true,
+      sessionId: "sess-1",
+    });
+
+    const dismiss = screen.getByRole("button", { name: /Dismiss/ });
+    await user.click(dismiss);
+
+    expect(screen.queryByText(/Production data has changed/)).toBeNull();
+  });
+
+  it("dismissible=true scopes the dismissal key per sessionId", async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderWithProps(OUTDATED_STALENESS, {
+      requireCloudMode: false,
+      dismissible: true,
+      sessionId: "sess-A",
+    });
+    await user.click(screen.getByRole("button", { name: /Dismiss/ }));
+    expect(screen.queryByText(/Production data has changed/)).toBeNull();
+    unmount();
+
+    // Same staleness shape, different sessionId — banner should re-fire.
+    renderWithProps(OUTDATED_STALENESS, {
+      requireCloudMode: false,
+      dismissible: true,
+      sessionId: "sess-B",
+    });
+    expect(screen.getByText(/Production data has changed/)).toBeInTheDocument();
+  });
+
+  it("toastAdapter override routes refresh-error toast through the adapter", async () => {
+    const user = userEvent.setup();
+    mockApiPost.mockRejectedValue(new Error("Network error"));
+    const adapterSuccess = vi.fn();
+    const adapterError = vi.fn();
+
+    renderWithProps(OUTDATED_STALENESS, {
+      requireCloudMode: false,
+      toastAdapter: { success: adapterSuccess, error: adapterError },
+    });
+
+    await user.click(screen.getByRole("button", { name: /Refresh base/ }));
+
+    await waitFor(() => {
+      expect(adapterError).toHaveBeenCalledWith(
+        "Refresh failed — try again.",
+        expect.objectContaining({ duration: 5000 }),
+      );
+    });
+    // Default adapter (OSS toaster) must NOT have been called.
+    expect(mockToasterError).not.toHaveBeenCalled();
+  });
+
+  it("successToastOnlyOnUserRefresh=true suppresses spurious success toast", async () => {
+    const adapterSuccess = vi.fn();
+    const { client } = renderWithProps(OUTDATED_STALENESS, {
+      requireCloudMode: false,
+      successToastOnlyOnUserRefresh: true,
+      toastAdapter: { success: adapterSuccess, error: vi.fn() },
+    });
+
+    // Simulate an unrelated cache update (other tab refreshed) — no user click.
+    await act(async () => {
+      client.setQueryData(
+        cacheKeys.lineage(),
+        makeServerInfo(UPTODATE_STALENESS) as ServerInfoResult,
+      );
+    });
+
+    expect(adapterSuccess).not.toHaveBeenCalled();
+  });
+
+  it("successToastOnlyOnUserRefresh=true fires success toast when user clicked Refresh", async () => {
+    const user = userEvent.setup();
+    const adapterSuccess = vi.fn();
+    const { client } = renderWithProps(OUTDATED_STALENESS, {
+      requireCloudMode: false,
+      successToastOnlyOnUserRefresh: true,
+      toastAdapter: { success: adapterSuccess, error: vi.fn() },
+    });
+
+    await user.click(screen.getByRole("button", { name: /Refresh base/ }));
+    await act(async () => {
+      client.setQueryData(
+        cacheKeys.lineage(),
+        makeServerInfo(UPTODATE_STALENESS) as ServerInfoResult,
+      );
+    });
+
+    await waitFor(() => {
+      expect(adapterSuccess).toHaveBeenCalledWith(
+        expect.stringContaining("Base refreshed"),
+        expect.objectContaining({ duration: 8000 }),
+      );
+    });
+  });
+
+  it("showFirstTimePopover=false omits the popover", async () => {
+    localStorageMock.clear();
+    renderWithProps(OUTDATED_STALENESS, {
+      requireCloudMode: false,
+      showFirstTimePopover: false,
+    });
+
+    expect(screen.getByText(/Production data has changed/)).toBeInTheDocument();
+    expect(screen.queryByText(/Recce now snapshots your base data/)).toBeNull();
+  });
+});
+
+// ============================================================================
 // FirstTimePopover tests
 // ============================================================================
 

--- a/js/packages/ui/src/components/lineage/__tests__/StalenessBanner.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/StalenessBanner.test.tsx
@@ -554,6 +554,56 @@ describe("StalenessBanner props (cross-shell)", () => {
     expect(screen.queryByText(/Recce now snapshots your base data/)).toBeNull();
   });
 
+  describe("dismissible guard (dev-time)", () => {
+    it("warns when dismissible=true is passed without sessionId", () => {
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        // biome-ignore lint/suspicious/noEmptyBlockStatements: Intentionally suppressing console.warn for this test
+        .mockImplementation(() => {});
+
+      renderWithProps(OUTDATED_STALENESS, {
+        requireCloudMode: false,
+        dismissible: true,
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("dismissible=true"),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("does not warn when dismissible=true and sessionId is provided", () => {
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        // biome-ignore lint/suspicious/noEmptyBlockStatements: Intentionally suppressing console.warn for this test
+        .mockImplementation(() => {});
+
+      renderWithProps(OUTDATED_STALENESS, {
+        requireCloudMode: false,
+        dismissible: true,
+        sessionId: "sess-guarded",
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("does not warn when dismissible is false (sessionId irrelevant)", () => {
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        // biome-ignore lint/suspicious/noEmptyBlockStatements: Intentionally suppressing console.warn for this test
+        .mockImplementation(() => {});
+
+      renderWithProps(OUTDATED_STALENESS, {
+        requireCloudMode: false,
+        dismissible: false,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+  });
+
   describe("variant='card' (cloud floating-overlay surface)", () => {
     it("renders a MUI Paper root instead of the default Box", () => {
       const { container } = renderWithProps(OUTDATED_STALENESS, {

--- a/js/packages/ui/src/components/lineage/index.ts
+++ b/js/packages/ui/src/components/lineage/index.ts
@@ -12,6 +12,8 @@ export * from "./config";
 export * from "./contextmenu";
 export * from "./controls";
 export * from "./edges";
+// First-time popover for the snapshot-base staleness intro
+export { FirstTimePopover } from "./FirstTimePopover";
 export { GraphNode as GraphNodeOss, type GraphNodeProps } from "./GraphNodeOss";
 export * from "./hooks";
 // Composed components for rendering lineage graphs
@@ -78,6 +80,14 @@ export {
   BaseEnvironmentSetupNotification,
   type BaseEnvironmentSetupNotificationProps,
 } from "./SingleEnvironmentQueryView";
+// Snapshot-base staleness banner (shared between OSS strip + cloud floating card)
+export {
+  StalenessBanner,
+  type StalenessBannerProps,
+  type StalenessBannerVariant,
+  type StalenessMessageVariant,
+  type StalenessToastAdapter,
+} from "./StalenessBanner";
 export * from "./states";
 // Style utilities
 export * from "./styles";

--- a/js/packages/ui/src/components/lineage/index.ts
+++ b/js/packages/ui/src/components/lineage/index.ts
@@ -13,7 +13,10 @@ export * from "./contextmenu";
 export * from "./controls";
 export * from "./edges";
 // First-time popover for the snapshot-base staleness intro
-export { FirstTimePopover } from "./FirstTimePopover";
+export {
+  FirstTimePopover,
+  type FirstTimePopoverProps,
+} from "./FirstTimePopover";
 export { GraphNode as GraphNodeOss, type GraphNodeProps } from "./GraphNodeOss";
 export * from "./hooks";
 // Composed components for rendering lineage graphs


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`feat` / refactor — promotes an existing OSS component to a public package export so the cloud shell can stop carrying a duplicate copy.

**What this PR does / why we need it**:

Promote `StalenessBanner` (and the companion `FirstTimePopover`) to public exports of `@datarecce/ui/components`, behind a prop-driven seam that supports both the OSS strip surface and the cloud floating-card surface from the same source file.

DRC-3506 mounted a local copy of `StalenessBanner` in the cloud-mode shell at `recce-cloud-infra/recce-cloud/src/common/components/recce-web/StalenessBanner.tsx` as a stopgap, because the OSS component was internal to `@datarecce/ui` and not part of the published surface. That copy has since diverged from OSS on several axes — visuals, dismissibility, toaster API, success-toast semantics, wording, the `cloudMode` gate. Bringing it back under one component requires more than a toaster swap, so the prop surface here mirrors each divergence point:

- `variant: 'banner' | 'card'` — OSS strip vs. cloud floating `Paper`
- `dismissible` + `sessionId` — opt-in close button with per-session sessionStorage signature
- `toastAdapter` — overrides the default OSS module-singleton; cloud passes its `useToast()` wrapped
- `successToastOnlyOnUserRefresh` — suppresses spurious "Base refreshed" toasts from unrelated cache transitions
- `requireCloudMode` — cloud shell sets `false` because it doesn't sit inside `LineageGraphContext` at the mount level
- `messageVariant: 'data' | 'metadata'` — wording diff
- `showFirstTimePopover` — cloud opts out (the popover is OSS-only per DRC-3508 acceptance)
- `cardSx` — additive `sx` for shell-specific positioning on the floating variant

The OSS callsite (`js/packages/ui/src/components/app/MainLayout.tsx`) stays `<StalenessBanner />` — every default matches current OSS behavior, so all 16 existing tests pass unchanged. 8 new tests cover the cross-shell prop surface (cloud-mode gate bypass, metadata wording, dismissibility + per-session key scoping, toast adapter routing, user-initiated success-toast gate, popover opt-out).

**Which issue(s) this PR fixes**:

Resolves DRC-3508 (OSS half). A paired recce-cloud-infra PR will bump `@datarecce/ui`, swap the import in `RecceWebLayout.tsx` to `@datarecce/ui/components`, and delete the local copy + its test.

**Special notes for your reviewer**:

- **`FirstTimePopover` decision** (issue acceptance criterion): exported but cloud opts out via `showFirstTimePopover={false}`. The component is small, has no cloud-specific dep beyond a toaster, and the cloud-side intro decision is tracked separately per the issue's "out of scope" note. Exporting it makes the cross-shell option available without forcing it.
- **`successToastOnlyOnUserRefresh` default is `false`**: keeps OSS behavior unchanged. Cloud opts in. This is the only behavioral knob that the issue's "no behavioral difference for users" criterion is sensitive to — defaulting it off preserves the OSS contract.
- **`cardSx` instead of a `cardTopOffset` number prop**: cloud's `top: 180` overlay offset is shell-chrome-dependent (clears PreviewTopBar + PreviewNavBar + the in-canvas banner row). Taking arbitrary `sx` is more flexible than baking in a single offset, and the cloud-side TODO around moving to a ReactFlow `<Panel>` mount still applies — that future change won't need a prop surface revision.
- The dismissal signature logic (sessionStorage keyed on `sessionId::staleness-shape`) is lifted verbatim from the cloud-infra implementation, including the resync-on-key-change effect that handles Next.js layout preservation across `[sessionId]` URL changes.
- Build verified: `@datarecce/ui/dist/components.d.ts` exposes `StalenessBanner`, `FirstTimePopover`, `StalenessBannerProps`, `StalenessBannerVariant`, `StalenessMessageVariant`, `StalenessToastAdapter`. Type-check, lint, and the full 3,787-test suite all pass.

**Does this PR introduce a user-facing change?**:

NONE

(The OSS banner continues to render identically. The cloud-infra companion PR will keep cloud users on the existing floating-card overlay — same visual, same wording, same dismissibility — but now from the shared source so future tweaks land in both shells at once.)