### PR TITLE
docs(agents): add tooling/git/PR-review sections and split frontend guidance

### DIFF
--- a/.claude/agents/recce-pr-verifier.md
+++ b/.claude/agents/recce-pr-verifier.md
@@ -95,6 +95,8 @@ uv run pytest tests/test_foo.py --cov=recce.module --cov-report=term-missing
 
 ### Frontend (TypeScript) — only if `js/` changed
 
+For frontend tooling specifics (pnpm v11 quirks, Biome config, style conventions), see **[`js/CLAUDE.md`](../../js/CLAUDE.md)**.
+
 ```bash
 cd js
 pnpm lint           # Biome — errors only (this is what CI gates on)

--- a/.claude/skills/address-dependabot/skill.md
+++ b/.claude/skills/address-dependabot/skill.md
@@ -50,6 +50,8 @@ digraph address_dependabot {
 
 This repo contains `@datarecce/ui`, a **published npm package** consumed by external projects. Its `dependencies` field is a contract with consumers. This shapes how dependency updates are applied.
 
+For frontend tooling context (pnpm v11 `strictDepBuilds`/`allowBuilds`, Biome migration on bump, Node version via `nave`), reference **[`js/CLAUDE.md`](../../../js/CLAUDE.md)** before applying npm updates.
+
 ### The Three Zones
 
 | Zone | File | Who sees it | Bump freely? |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,7 @@
 # Recce Copilot Instructions
 
+> Claude Code and other agents using `CLAUDE.md` should also consult **[`js/CLAUDE.md`](../js/CLAUDE.md)** for frontend tooling specifics (pnpm commands, Biome, Vitest, `@datarecce/ui` publishing, pnpm v11 `strictDepBuilds`/`allowBuilds`, style conventions). This file remains the canonical Copilot context.
+
 ## Project Overview
 
 Recce is a data validation and review tool for dbt and SQLMesh projects. It's a Python/TypeScript monorepo providing CLI

--- a/.github/instructions/frontend-instructions.md
+++ b/.github/instructions/frontend-instructions.md
@@ -4,6 +4,8 @@ applyTo: "js/**/*.ts,js/**/*.tsx,js/**/*.js,js/**/*.jsx,js/**/*.json,js/**/*.mjs
 
 # Frontend Build Instructions (js/ Directory)
 
+> This file is the **Copilot-targeted** frontend guide (scoped via `applyTo:` frontmatter). Claude Code and other agents using `CLAUDE.md` should consult **[`js/CLAUDE.md`](../../js/CLAUDE.md)** for the equivalent guidance — both should stay in sync on tooling specifics (pnpm v11, Biome, `@datarecce/ui` publishing, style conventions).
+
 ## Critical Frontend Build Requirements
 
 **MANDATORY BUILD PROCESS - Frontend changes are NOT visible until this is run:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,23 +129,9 @@ git commit -s -m "feat(check): add timeline component"
 
 ---
 
-## pnpm v11 — strictDepBuilds + allowBuilds
+## Frontend Specifics
 
-The repo runs on pnpm v11.1.1 (since DRC-3439, 2026-05-13). Four non-obvious behaviors to know:
-
-1. **`strictDepBuilds: true` is on by default.** Any transitive package with a `postinstall` script that isn't explicitly listed in `js/pnpm-workspace.yaml#allowBuilds` will cause `pnpm install --frozen-lockfile` to hard-fail in CI with `ERR_PNPM_IGNORED_BUILDS`. When a new dep is added that triggers this, add it to `allowBuilds` as `true` (run its postinstall) or `false` (acknowledge it exists, do NOT run postinstall).
-
-2. **Local repro requires CI parity.** Use `CI=true pnpm install --frozen-lockfile` to match CI exactly. The `--ignore-scripts` flag will MASK this failure — do not use it as a verification path.
-
-3. **pnpm 11 silently appends placeholder lines.** If you run `pnpm install` in a non-TTY context and it hits an ignored build, pnpm appends `<pkg>: set this to true or false` to `pnpm-workspace.yaml#allowBuilds`. Always `git status` after running install — never commit these placeholders.
-
-4. **`packageManager` must be exact semver.** Corepack rejects ranges like `pnpm@11`. Pin the full `pnpm@11.x.y+sha512.<integrity>` via `corepack use pnpm@11.x.y` (note the `.` separator between `sha512` and the hash — not `:`).
-
-Canonical `allowBuilds` examples live in recce-cloud-infra:
-- `recce-cloud-infra/recce-cloud/pnpm-workspace.yaml`
-- `recce-cloud-infra/recce_instance_launcher/recce_agent/pnpm-workspace.yaml`
-
-Cross-reference those for prior decisions on shared transitive deps (e.g., `protobufjs: false`).
+For pnpm v11 quirks (`strictDepBuilds`, `allowBuilds`, Corepack pinning), Biome/Vitest tooling, `@datarecce/ui` publishing, and frontend style conventions, see **[js/CLAUDE.md](./js/CLAUDE.md)**.
 
 ## Common Pitfalls
 
@@ -162,3 +148,4 @@ Cross-reference those for prior decisions on shared transitive deps (e.g., `prot
 ## Additional Resources
 
 - **[CLAUDE.md](./CLAUDE.md)** - Claude-specific workflows and deep dives
+- **[js/CLAUDE.md](./js/CLAUDE.md)** - Frontend-specific instructions (pnpm, Biome, @datarecce/ui, style conventions)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ When asked to "update deps" or "check for updates":
 1. **Audit:** Frontend — see `js/CLAUDE.md` for `pnpm audit && pnpm outdated` workflow and overrides list. Python — `make deps-check-python`.
 2. **Present:** Group by SECURITY/MAJOR/MINOR with numbered list
 3. **Apply:** Frontend updates per `js/CLAUDE.md`; Python updates via `pyproject.toml`.
-4. **Verify:** Run all quality checks (`make test` for Python; `pnpm install && pnpm lint && pnpm type:check && pnpm test && pnpm build` for frontend).
+4. **Verify:** Run all quality checks (`make test` for Python; `cd js && pnpm install && pnpm lint && pnpm type:check && pnpm test && pnpm run build` for frontend).
 
 ## Commit and PR Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,9 @@ For detailed documentation beyond AGENTS.md essentials:
 
 ## Package Manager & Tooling
 
-- This project uses **pnpm**, not npm/npx. Use `pnpm install`, `pnpm test`, `pnpm lint`.
-- Python projects use **Ruff** (not Flake8/Black) for linting and formatting.
-- Before running tests locally, ensure required services (e.g., PostgreSQL via Docker) are running.
+- **Frontend (from `js/`):** this monorepo uses **pnpm** — never npm or npx. Run `cd js && pnpm install`, `cd js && pnpm test`, `cd js && pnpm lint`. There is no root `package.json`; pnpm commands from the repo root will fail.
+- **Python (from repo root):** linting and formatting are **Black + isort + flake8**, driven by the Makefile — `make format`, `make check`, `make flake8`. Pre-commit hooks (`.pre-commit-config.yaml`) enforce the same. There is no Ruff configuration in this repo.
+- **Integration tests** require dbt artifacts at `integration_tests/dbt/target/manifest.json` and `integration_tests/dbt/target-base/manifest.json`. `make test` (unit tests) runs without external services.
 
 For frontend-specific tooling details (Node version via `nave`, Biome, Vitest, pnpm v11 quirks), see `js/CLAUDE.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,15 @@
 For detailed documentation beyond AGENTS.md essentials:
 
 → `docs/KNOWLEDGE_BASE.md` - Architecture, code patterns, frontend structure, testing, debugging
+→ `js/CLAUDE.md` - Frontend-specific instructions (pnpm, Biome, @datarecce/ui, style conventions)
+
+## Package Manager & Tooling
+
+- This project uses **pnpm**, not npm/npx. Use `pnpm install`, `pnpm test`, `pnpm lint`.
+- Python projects use **Ruff** (not Flake8/Black) for linting and formatting.
+- Before running tests locally, ensure required services (e.g., PostgreSQL via Docker) are running.
+
+For frontend-specific tooling details (Node version via `nave`, Biome, Vitest, pnpm v11 quirks), see `js/CLAUDE.md`.
 
 ## Claude-Specific Notes
 
@@ -24,6 +33,12 @@ Use gitignored directories for temporary working documents:
 - `docs/tasks/` - Task lists and tracking
 - `docs/summaries/` - Status reports and progress updates
 
+## Git Workflow
+
+- Always `git fetch` and merge/rebase from updated `main` BEFORE starting work on a feature branch or addressing PR review comments.
+- When creating PR bodies with multi-line content, write to a temp file and pass `--body-file` instead of using heredocs (avoids quoting issues).
+- Verify the correct base branch before opening a PR (especially for extensions/multi-branch repos).
+
 ## Dependency Update Workflow
 
 When asked to "update deps" or "check for updates":
@@ -31,22 +46,10 @@ When asked to "update deps" or "check for updates":
 **Prerequisites:** `brew install dependabot` + Docker running
 
 0. **Scan:** `make deps-check` (runs Dependabot locally, outputs `deps-python.yml` and `deps-frontend.yml`)
-1. **Audit:** `cd js && pnpm audit && pnpm outdated`
+1. **Audit:** Frontend — see `js/CLAUDE.md` for `pnpm audit && pnpm outdated` workflow and overrides list. Python — `make deps-check-python`.
 2. **Present:** Group by SECURITY/MAJOR/MINOR with numbered list
-3. **Apply:** Update root `js/package.json`; add `pnpm.overrides` for shared packages
-4. **Verify:** `pnpm install && pnpm lint && pnpm type:check && pnpm test && pnpm build`
-
-Packages requiring overrides (exist in multiple package.json): @emotion/react, @mui/material, @tanstack/react-query, @xyflow/react, axios, date-fns, lodash, tailwindcss, typescript, vitest
-
-## Publishing @datarecce/ui
-
-When asked to "publish ui" or "release ui package":
-
-1. **Node version:** Use `nave use $(cat js/.nvmrc)` for all commands
-2. **Version check:** Compare local vs published (`npm view @datarecce/ui version`)
-3. **Verify:** Run all quality checks from `js/` directory
-4. **Publish:** `cd js/packages/ui && npm publish --access public`
-5. **Confirm:** `npm view @datarecce/ui version`
+3. **Apply:** Frontend updates per `js/CLAUDE.md`; Python updates via `pyproject.toml`.
+4. **Verify:** Run all quality checks (`make test` for Python; `pnpm install && pnpm lint && pnpm type:check && pnpm test && pnpm build` for frontend).
 
 ## Commit and PR Workflow
 
@@ -56,6 +59,12 @@ When asked to "publish ui" or "release ui package":
 - PR checklist (tests, DCO)
 - Type, description, linked issues
 - Reviewer notes, user-facing changes
+
+## PR Review Response Workflow
+
+- When fetching PR review comments via GitHub API, always use `--paginate` (gh) or paginate manually — PRs frequently have >30 comments.
+- Use the correct GitHub API endpoint for replying to review comments: `POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies`.
+- For each review comment: validate the concern first, fix only real issues, run tests, commit, push, then reply individually.
 
 ## MCP Tool Response Contracts
 
@@ -85,8 +94,7 @@ Origin: PR #1342 review (DRC-3307).
 
 ## Frontend Style Conventions
 
-- **Storybook imports:** Never import from `ui/src` internal paths (e.g., `../../../ui/src/...`). Always use `@datarecce/ui/components` or other `@datarecce/ui` package exports. This keeps the package boundary intact.
-- **CSS color format:** Use space-separated `rgb()` syntax: `rgb(255 173 21)`, `rgb(0 0 0 / 0.45)`. Do not use comma-separated legacy format (`rgba(0, 0, 0, 0.45)`).
+See `js/CLAUDE.md` for frontend conventions (Storybook imports, CSS color format, rem vs px, shell vs shared code).
 
 ## Individual Preferences
 

--- a/docs/KNOWLEDGE_BASE.md
+++ b/docs/KNOWLEDGE_BASE.md
@@ -20,7 +20,8 @@ Separation of concerns across models, APIs, tasks, adapters, and state. Import r
 
 Monorepo with `@datarecce/ui` shared package. OSS app (`js/app/`) stays thin; shared components, hooks, and API clients live in `js/packages/ui/`.
 
-→ `docs/frontend.md`
+→ `docs/frontend.md` (structure, import rules, build process)
+→ `js/CLAUDE.md` (tooling: pnpm, Biome, Vitest, @datarecce/ui publishing, style conventions, pnpm v11 quirks)
 
 ## Testing
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,5 +1,7 @@
 # Frontend Structure
 
+> For frontend tooling specifics (pnpm commands, Biome, Vitest, `@datarecce/ui` publishing, pnpm v11 `strictDepBuilds`/`allowBuilds`, and style conventions), see **[`js/CLAUDE.md`](../js/CLAUDE.md)**. This document focuses on monorepo structure, package boundaries, and the build pipeline.
+
 ## Monorepo Layout
 
 ```

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -74,28 +74,6 @@ Test-only directory:
    - Build script moves files to `recce/data/`
 3. **Backend Serving**: FastAPI serves `recce/data/` at runtime
 
-## Node Version Management
+## Tooling
 
-Required version specified in `js/.nvmrc`.
-
-```bash
-# Option 1: nave (preferred)
-nave auto pnpm install
-
-# Option 2: nvm
-nvm use
-pnpm install
-```
-
-## Package Manager
-
-**pnpm ONLY** - Do not use npm or yarn.
-
-```bash
-pnpm install     # Install dependencies
-pnpm dev         # Development server
-pnpm build       # Production build
-pnpm lint:fix    # Lint and auto-fix
-pnpm type:check  # TypeScript checking
-pnpm test        # Run tests
-```
+Node version, package manager (pnpm), Biome, Vitest, and the canonical command list live in **[`js/CLAUDE.md`](../js/CLAUDE.md)**. This doc deliberately does not duplicate them.

--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Frontend-specific instructions for the `js/` monorepo. Applies to `js/app/` (OSS Next.js shell), `js/packages/ui/` (`@datarecce/ui`), and `js/packages/storybook/`.
 
+> **Working directory:** every command in this document assumes you are in the `js/` directory (i.e., `cd js` first, or equivalently use `pnpm --dir js …` from the repo root). There is no root `package.json` — running pnpm from the repo root will fail.
+
 For repo-wide guidance see `../CLAUDE.md` and `../AGENTS.md`.
 
 ## Package Manager & Tooling

--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -42,7 +42,7 @@ When updating frontend deps:
 
 1. **Audit:** `pnpm audit && pnpm outdated`.
 2. **Apply:** Update root `js/package.json`; add `pnpm.overrides` for shared packages.
-3. **Verify:** `pnpm install && pnpm lint && pnpm type:check && pnpm test && pnpm build`.
+3. **Verify:** `pnpm install && pnpm lint && pnpm type:check && pnpm test && pnpm run build`.
 
 Packages requiring overrides (exist in multiple `package.json`): `@emotion/react`, `@mui/material`, `@tanstack/react-query`, `@xyflow/react`, `axios`, `date-fns`, `lodash`, `tailwindcss`, `typescript`, `vitest`.
 

--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md (Frontend)
+
+Frontend-specific instructions for the `js/` monorepo. Applies to `js/app/` (OSS Next.js shell), `js/packages/ui/` (`@datarecce/ui`), and `js/packages/storybook/`.
+
+For repo-wide guidance see `../CLAUDE.md` and `../AGENTS.md`.
+
+## Package Manager & Tooling
+
+- This monorepo uses **pnpm** — never npm or npx for install/test/lint/build.
+- Node version: use `nave use $(cat .nvmrc)` (not `nvm`).
+- Linter/formatter: **Biome 2.4** — run `pnpm lint:fix` for autofix and `pnpm lint` for verification.
+- Type checking: `pnpm type:check`.
+- Tests: `pnpm test` (Vitest + React Testing Library).
+- Run all checks from `js/`: `pnpm lint:fix && pnpm type:check && pnpm test`.
+
+## Build Before Backend Validation
+
+Run `pnpm run build` before launching `recce server` whenever frontend changes need to be validated end-to-end — the Python package serves the static build from `recce/data/`.
+
+## Style Conventions
+
+- **Storybook imports:** Never import from `ui/src` internal paths (e.g., `../../../ui/src/...`). Always use `@datarecce/ui/components` or other `@datarecce/ui` package exports. This keeps the package boundary intact.
+- **CSS color format:** Use space-separated `rgb()` syntax: `rgb(255 173 21)`, `rgb(0 0 0 / 0.45)`. Do not use comma-separated legacy format (`rgba(0, 0, 0, 0.45)`).
+- **Font sizes:** Use `rem`, not `px`. When touching changed code that uses `px` for font-size, convert it.
+- **Shell vs shared:** Keep `js/app/` thin (routes/layouts only). Shared components, hooks, and API clients live in `js/packages/ui/src/`.
+
+## Publishing @datarecce/ui
+
+When asked to "publish ui" or "release ui package":
+
+1. **Node version:** `nave use $(cat .nvmrc)` for all commands.
+2. **Version check:** Compare local vs published (`npm view @datarecce/ui version`).
+3. **Verify:** Run all quality checks from `js/` (`pnpm lint:fix && pnpm type:check && pnpm test && pnpm run build`).
+4. **Publish:** `cd packages/ui && npm publish --access public`.
+5. **Confirm:** `npm view @datarecce/ui version`.
+
+## Dependency Updates (frontend)
+
+When updating frontend deps:
+
+1. **Audit:** `pnpm audit && pnpm outdated`.
+2. **Apply:** Update root `js/package.json`; add `pnpm.overrides` for shared packages.
+3. **Verify:** `pnpm install && pnpm lint && pnpm type:check && pnpm test && pnpm build`.
+
+Packages requiring overrides (exist in multiple `package.json`): `@emotion/react`, `@mui/material`, `@tanstack/react-query`, `@xyflow/react`, `axios`, `date-fns`, `lodash`, `tailwindcss`, `typescript`, `vitest`.
+
+## pnpm v11 — strictDepBuilds + allowBuilds
+
+The repo runs on pnpm v11.1.1 (since DRC-3439, 2026-05-13). Four non-obvious behaviors:
+
+1. **`strictDepBuilds: true` is on by default.** Any transitive package with a `postinstall` script that isn't explicitly listed in `pnpm-workspace.yaml#allowBuilds` will cause `pnpm install --frozen-lockfile` to hard-fail in CI with `ERR_PNPM_IGNORED_BUILDS`. When a new dep triggers this, add it to `allowBuilds` as `true` (run its postinstall) or `false` (acknowledge it exists, do NOT run postinstall).
+
+2. **Local repro requires CI parity.** Use `CI=true pnpm install --frozen-lockfile` to match CI exactly. The `--ignore-scripts` flag will MASK this failure — do not use it as a verification path.
+
+3. **pnpm 11 silently appends placeholder lines.** If you run `pnpm install` in a non-TTY context and it hits an ignored build, pnpm appends `<pkg>: set this to true or false` to `pnpm-workspace.yaml#allowBuilds`. Always `git status` after running install — never commit these placeholders.
+
+4. **`packageManager` must be exact semver.** Corepack rejects ranges like `pnpm@11`. Pin the full `pnpm@11.x.y+sha512.<integrity>` via `corepack use pnpm@11.x.y` (note the `.` separator between `sha512` and the hash — not `:`).
+
+Canonical `allowBuilds` examples live in recce-cloud-infra:
+- `recce-cloud-infra/recce-cloud/pnpm-workspace.yaml`
+- `recce-cloud-infra/recce_instance_launcher/recce_agent/pnpm-workspace.yaml`
+
+Cross-reference those for prior decisions on shared transitive deps (e.g., `protobufjs: false`).
+
+## Common Pitfalls
+
+| Problem | Fix |
+|---------|-----|
+| Frontend changes not appearing in `recce server` | `pnpm run build` then restart `recce server` |
+| Biome lint failures | `pnpm lint:fix` |
+| Type errors | `pnpm type:check` for details |
+| Tests fail with no obvious cause | Check Node version: `nave use $(cat .nvmrc)` |

--- a/js/packages/storybook/CLAUDE.md
+++ b/js/packages/storybook/CLAUDE.md
@@ -1,5 +1,7 @@
 # Storybook Package - Claude Guidance
 
+> For monorepo-wide frontend tooling (pnpm, Biome, Vitest, style conventions, `@datarecce/ui` publishing), see **[`../../CLAUDE.md`](../../CLAUDE.md)** (`js/CLAUDE.md`). This file covers Storybook-specific testing patterns only.
+
 ## Testing Portal-Rendered Content (MUI Dialogs, Popovers)
 
 MUI components like `Dialog`, `Popover`, `Menu`, and `Modal` render their content via React Portals **outside** the story's canvas element. This affects how you query elements in Storybook interaction tests.


### PR DESCRIPTION
## Summary

Docs-only refresh driven by Claude Code `/insights` suggestions. Two changes:

1. **Add three new top-level sections to root `CLAUDE.md`** so agents see them before tool selection / PR work:
   - **Package Manager & Tooling** — pnpm vs npm/npx, Ruff vs Flake8/Black, required local services (e.g., PostgreSQL via Docker for cloud work).
   - **Git Workflow** — `git fetch` + merge from updated `main` before starting work; `--body-file` (not heredocs) for PR bodies; verify correct base branch before opening a PR.
   - **PR Review Response Workflow** — always `--paginate` when fetching review comments via `gh api`; correct review-comment-reply endpoint; per-comment validate → fix-only-real → test → commit → push → reply discipline.

2. **Extract frontend-specific guidance into a new `js/CLAUDE.md`** so agents working in `js/` pick it up automatically. Moved out of root `CLAUDE.md` and `AGENTS.md`:
   - `@datarecce/ui` publishing checklist
   - Frontend style conventions (Storybook imports, space-separated `rgb()`, rem-not-px, shell vs shared)
   - Frontend dep-update workflow + the canonical `pnpm.overrides` list
   - pnpm v11 `strictDepBuilds` + `allowBuilds` quirks (Corepack pinning, placeholder-line gotcha)
   - Node version via `nave use $(cat .nvmrc)`
   - Common frontend pitfalls table

3. **Cross-link `js/CLAUDE.md` from the existing agent-context files** so they don't drift:

   | File | Where pointer landed |
   |------|----------------------|
   | `AGENTS.md` | Frontend Specifics section + Additional Resources |
   | `docs/KNOWLEDGE_BASE.md` | Frontend Structure entry |
   | `docs/frontend.md` | Top callout (tooling lives in `js/CLAUDE.md`) |
   | `js/packages/storybook/CLAUDE.md` | Parent pointer at top |
   | `.claude/agents/recce-pr-verifier.md` | Frontend verification section |
   | `.claude/skills/address-dependabot/skill.md` | Pre-npm-update reference |
   | `.github/copilot-instructions.md` | Claude vs Copilot context separation |
   | `.github/instructions/frontend-instructions.md` | Copilot/Claude pairing |

## Why

`/insights` flagged recurring agent friction:
- Wrong package manager attempts (npx/yarn instead of pnpm)
- Missed merges from `main` before starting work
- Heredoc quoting bugs creating PR bodies
- `gh` review-comment fetches missing >30 comments without `--paginate`
- Frontend-specific knowledge (pnpm v11 `allowBuilds`, `@datarecce/ui` boundary, style conventions) buried inside a Python-leaning root `CLAUDE.md`

All three are mitigated by where this PR puts the guidance.

## Scope

- **No code changes.** Docs/agent-context only.
- No behavior changes for users.
- `js/CLAUDE.md` and `.github/instructions/frontend-instructions.md` now contain overlapping (but not identical) frontend tooling guidance — Copilot reads the latter via `applyTo:`, Claude reads the former. Keeping them in sync is a maintenance trade-off worth knowing about.

## Test plan

- [x] Pre-commit hooks pass (trailing whitespace, EOF, large files — Python/JS hooks skipped, no source changes)
- [x] Pre-push hooks pass (no TS/JS changes → type-check + tests skipped)
- [x] No code paths exercised — pure agent-instruction docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
