### PR TITLE
fix(lineage): show impact coloring in the minimap (DRC-3250)

### DIFF
--- a/js/packages/ui/src/components/lineage/LineageCanvas.tsx
+++ b/js/packages/ui/src/components/lineage/LineageCanvas.tsx
@@ -24,7 +24,7 @@ import {
 import { LineageColumnNode } from "./columns";
 import { LineageEdge, type LineageEdgeData } from "./edges";
 import { LineageNode, type LineageNodeData } from "./nodes";
-import { cllChangeStatusColors } from "./styles";
+import { getNodeChangeStyle } from "./styles";
 
 export interface LineageCanvasProps {
   /** Nodes to display */
@@ -155,8 +155,17 @@ export function LineageCanvas({
         {showMiniMap && (
           <MiniMap
             nodeColor={(node) => {
+              // Copy the node card's accent color from the shared source of
+              // truth so the minimap can't drift from the canvas. Impact lives
+              // on `node.data` in this stack (the OSS stack reads it from
+              // context instead), so impacted-but-unchanged nodes are amber
+              // here too (DRC-3250). Mirrors LineageNode's resolution.
               const data = node.data as LineageNodeData;
-              return cllChangeStatusColors[data.changeStatus ?? "unchanged"];
+              return getNodeChangeStyle({
+                changeStatus: data.changeStatus,
+                isImpacted: data.isImpacted,
+                newCllExperience: data.newCllExperience,
+              }).color;
             }}
           />
         )}

--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -97,9 +97,9 @@ import {
   EXPLORE_MIN_ZOOM,
   edgeTypes,
   FIT_VIEW_PADDING,
-  getNodeColor,
   initialNodes,
   LEGIBLE_MIN_ZOOM,
+  makeGetNodeColor,
   nodeTypes,
 } from "./config";
 import {
@@ -508,6 +508,14 @@ export function PrivateLineageView(
     wholeModelChangedNodeIds,
     publish: publishImpactSets,
   } = usePublishedImpactSets();
+
+  // MiniMap node coloring. Mirror the canvas: in the new CLL experience,
+  // impacted-but-unchanged nodes are amber, so thread the impacted set through
+  // instead of coloring by change status alone (DRC-3250).
+  const minimapNodeColor = useMemo(
+    () => makeGetNodeColor({ impactedNodeIds, newCllExperience }),
+    [impactedNodeIds, newCllExperience],
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Intentionally only run when lineageGraph changes (initial load/refetch).
   useLayoutEffect(() => {
@@ -1546,7 +1554,7 @@ export function PrivateLineageView(
             </Panel>
             {nodes.length <= MINIMAP_NODE_THRESHOLD && (
               <MiniMap
-                nodeColor={getNodeColor}
+                nodeColor={minimapNodeColor}
                 nodeStrokeWidth={3}
                 zoomable
                 pannable

--- a/js/packages/ui/src/components/lineage/config/__tests__/nodeTypes.test.ts
+++ b/js/packages/ui/src/components/lineage/config/__tests__/nodeTypes.test.ts
@@ -8,12 +8,15 @@
  * `getNodeChangeStyle(...).color` for the equivalent state (the single source
  * of truth `LineageNode` also renders from). The one thing the minimap can't
  * read off `node.data` is impact, so we also check the impacted set is honored.
+ * The unchanged-node case is additionally pinned against a literal palette
+ * value (not just `getNodeChangeStyle`) so a future drift is caught.
  */
 
 import { describe, expect, it } from "vitest";
 import type { LineageGraphNode } from "../../../../contexts/lineage/types";
+import { colors } from "../../../../theme";
 import { getNodeChangeStyle, getStyleForImpacted } from "../../styles";
-import { getNodeColor, makeGetNodeColor } from "../nodeTypes";
+import { makeGetNodeColor } from "../nodeTypes";
 
 // Minimal node factory — only `id` and `data.changeStatus` matter here.
 function makeNode(id: string, changeStatus?: string): LineageGraphNode {
@@ -82,16 +85,19 @@ describe("makeGetNodeColor", () => {
     });
   });
 
-  describe("getNodeColor (impact-agnostic default)", () => {
-    it("colors by change status only", () => {
-      expect(getNodeColor(makeNode("m", "modified"))).toBe(
-        getNodeChangeStyle({ changeStatus: "modified" }).color,
-      );
+  describe("unchanged-node color (literal pin, DRC-3250)", () => {
+    // The pre-refactor getNodeColor returned colors.neutral[400] for a node
+    // with no changeStatus. Routing through getNodeChangeStyle now resolves
+    // "unchanged" to colors.neutral[500] in both palettes — an intentional,
+    // accepted shift. Pin the literal so any future palette change is caught.
+    it("paints an unchanged node neutral[500] in the new experience", () => {
+      const getColor = makeGetNodeColor({ newCllExperience: true });
+      expect(getColor(makeNode("plain"))).toBe(colors.neutral[500]);
     });
 
-    it("does not honor impact (no impacted set bound)", () => {
-      // The default has no impacted set, so an unchanged node is never amber.
-      expect(getNodeColor(makeNode("m"))).toBe(getNodeChangeStyle({}).color);
+    it("paints an unchanged node neutral[500] in the legacy experience", () => {
+      const getColor = makeGetNodeColor({});
+      expect(getColor(makeNode("plain"))).toBe(colors.neutral[500]);
     });
   });
 });

--- a/js/packages/ui/src/components/lineage/config/__tests__/nodeTypes.test.ts
+++ b/js/packages/ui/src/components/lineage/config/__tests__/nodeTypes.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @file nodeTypes.test.ts
+ * @description Tests for the MiniMap node-color factory (DRC-3250).
+ *
+ * The MiniMap must show the same color the node card renders. Rather than
+ * re-deriving the palette/impacted logic, `makeGetNodeColor` copies the node's
+ * color via the shared `getNodeChangeStyle` — so these tests assert it equals
+ * `getNodeChangeStyle(...).color` for the equivalent state (the single source
+ * of truth `LineageNode` also renders from). The one thing the minimap can't
+ * read off `node.data` is impact, so we also check the impacted set is honored.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { LineageGraphNode } from "../../../../contexts/lineage/types";
+import { getNodeChangeStyle, getStyleForImpacted } from "../../styles";
+import { getNodeColor, makeGetNodeColor } from "../nodeTypes";
+
+// Minimal node factory — only `id` and `data.changeStatus` matter here.
+function makeNode(id: string, changeStatus?: string): LineageGraphNode {
+  return {
+    id,
+    data: { id, changeStatus },
+  } as unknown as LineageGraphNode;
+}
+
+describe("makeGetNodeColor", () => {
+  describe("new CLL experience", () => {
+    const impactedNodeIds = new Set(["impacted_model"]);
+    const getColor = makeGetNodeColor({
+      impactedNodeIds,
+      newCllExperience: true,
+    });
+
+    it("paints an impacted, otherwise-unchanged node amber (matches the card)", () => {
+      expect(getColor(makeNode("impacted_model"))).toBe(
+        getStyleForImpacted().color,
+      );
+    });
+
+    it("does not paint a non-impacted unchanged node amber", () => {
+      expect(getColor(makeNode("plain_model"))).toBe(
+        getNodeChangeStyle({ newCllExperience: true }).color,
+      );
+    });
+
+    it("prefers the change-status color over impact when the node changed", () => {
+      // A node can be both changed and in the impacted set — its own change wins,
+      // exactly as the card resolves it.
+      expect(getColor(makeNode("impacted_model", "modified"))).toBe(
+        getNodeChangeStyle({
+          changeStatus: "modified",
+          isImpacted: true,
+          newCllExperience: true,
+        }).color,
+      );
+    });
+
+    it("uses the muted cll palette for changed nodes", () => {
+      expect(getColor(makeNode("added_model", "added"))).toBe(
+        getNodeChangeStyle({ changeStatus: "added", newCllExperience: true })
+          .color,
+      );
+    });
+  });
+
+  describe("legacy experience (newCllExperience: false)", () => {
+    const getColor = makeGetNodeColor({
+      impactedNodeIds: new Set(["impacted_model"]),
+      newCllExperience: false,
+    });
+
+    it("ignores the impacted set entirely", () => {
+      expect(getColor(makeNode("impacted_model"))).toBe(
+        getNodeChangeStyle({}).color,
+      );
+    });
+
+    it("uses the default palette for changed nodes", () => {
+      expect(getColor(makeNode("modified_model", "modified"))).toBe(
+        getNodeChangeStyle({ changeStatus: "modified" }).color,
+      );
+    });
+  });
+
+  describe("getNodeColor (impact-agnostic default)", () => {
+    it("colors by change status only", () => {
+      expect(getNodeColor(makeNode("m", "modified"))).toBe(
+        getNodeChangeStyle({ changeStatus: "modified" }).color,
+      );
+    });
+
+    it("does not honor impact (no impacted set bound)", () => {
+      // The default has no impacted set, so an unchanged node is never amber.
+      expect(getNodeColor(makeNode("m"))).toBe(getNodeChangeStyle({}).color);
+    });
+  });
+});

--- a/js/packages/ui/src/components/lineage/config/index.ts
+++ b/js/packages/ui/src/components/lineage/config/index.ts
@@ -1,7 +1,6 @@
 // Configuration for LineageView ReactFlow setup
 export {
   edgeTypes,
-  getNodeColor,
   initialNodes,
   makeGetNodeColor,
   type NodeColorOptions,

--- a/js/packages/ui/src/components/lineage/config/index.ts
+++ b/js/packages/ui/src/components/lineage/config/index.ts
@@ -3,6 +3,8 @@ export {
   edgeTypes,
   getNodeColor,
   initialNodes,
+  makeGetNodeColor,
+  type NodeColorOptions,
   nodeTypes,
 } from "./nodeTypes";
 

--- a/js/packages/ui/src/components/lineage/config/nodeTypes.ts
+++ b/js/packages/ui/src/components/lineage/config/nodeTypes.ts
@@ -64,13 +64,3 @@ export const makeGetNodeColor =
       newCllExperience,
     }).color;
   };
-
-/**
- * Default impact-agnostic node color. Kept for callers that don't have the
- * CLL impacted set; equivalent to the original change-status-only coloring.
- * Used by MiniMap for node coloring.
- *
- * @param node - The lineage graph node
- * @returns Hex color string
- */
-export const getNodeColor = makeGetNodeColor();

--- a/js/packages/ui/src/components/lineage/config/nodeTypes.ts
+++ b/js/packages/ui/src/components/lineage/config/nodeTypes.ts
@@ -1,9 +1,8 @@
 import type { LineageGraphNode } from "../../../contexts/lineage/types";
-import { colors } from "../../../theme";
 import { GraphColumnNode } from "../GraphColumnNodeOss";
 import GraphEdge from "../GraphEdgeOss";
 import { GraphNode } from "../GraphNodeOss";
-import { getIconForChangeStatus } from "../styles";
+import { getNodeChangeStyle } from "../styles";
 
 /**
  * Node types configuration for ReactFlow.
@@ -28,14 +27,50 @@ export const edgeTypes = {
 export const initialNodes: LineageGraphNode[] = [];
 
 /**
- * Get the color for a node based on its change status.
+ * Inputs that let the MiniMap mirror the canvas's CLL coloring. Both come
+ * from the lineage view context (`usePublishedImpactSets` + the
+ * `new_cll_experience` server flag).
+ */
+export interface NodeColorOptions {
+  /**
+   * Node IDs that are impacted by an upstream change (the amber nodes in the
+   * new CLL experience). Matches `LineageViewContextType.impactedNodeIds`.
+   */
+  impactedNodeIds?: Set<string>;
+  /** Whether the new CLL experience is active (`new_cll_experience` flag). */
+  newCllExperience?: boolean;
+}
+
+/**
+ * Build a MiniMap node-color function that copies the canvas node card's color.
+ *
+ * The color decision (impacted-amber vs change-status, muted "cll" palette in
+ * the new experience) lives in one place — `getNodeChangeStyle`, which
+ * `LineageNode` also renders from — so the minimap can't drift from the graph.
+ * The only thing the minimap can't read off the node is its impact state
+ * (`GraphNodeOss` pulls that from context, not `node.data`), so the impacted
+ * set is threaded in here (DRC-3250).
+ *
+ * @param options - Impacted-node set and CLL-experience flag from context.
+ * @returns A `nodeColor` callback for `<MiniMap>`.
+ */
+export const makeGetNodeColor =
+  (options: NodeColorOptions = {}) =>
+  (node: LineageGraphNode): string => {
+    const { impactedNodeIds, newCllExperience } = options;
+    return getNodeChangeStyle({
+      changeStatus: node.data.changeStatus,
+      isImpacted: newCllExperience ? impactedNodeIds?.has(node.id) : false,
+      newCllExperience,
+    }).color;
+  };
+
+/**
+ * Default impact-agnostic node color. Kept for callers that don't have the
+ * CLL impacted set; equivalent to the original change-status-only coloring.
  * Used by MiniMap for node coloring.
  *
  * @param node - The lineage graph node
  * @returns Hex color string
  */
-export const getNodeColor = (node: LineageGraphNode): string => {
-  return node.data.changeStatus
-    ? getIconForChangeStatus(node.data.changeStatus).hexColor
-    : colors.neutral[400];
-};
+export const getNodeColor = makeGetNodeColor();

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -36,10 +36,9 @@ import {
 } from "react";
 import { DIM_FILTER } from "../config/zoomConstants";
 import {
-  getIconForChangeStatus,
   getIconForMaterialization,
   getIconForResourceType,
-  getStyleForImpacted,
+  getNodeChangeStyle,
 } from "../styles";
 import { TreatmentChip } from "../TreatmentChip";
 import { getTitleRowTooltip, pickGraphBadge } from "../wholeModelTreatment";
@@ -351,19 +350,17 @@ function LineageNodeComponent({
   const showColumns = columnCount > 0;
   const hasAction = selectMode === "action_result" && actionTag;
 
-  // Get icons and colors — impacted only when not already changed
-  const isUnchanged = !changeStatus || changeStatus === "unchanged";
+  // Get icons and colors — impacted only when not already changed. This is the
+  // node's authoritative accent color; the MiniMap copies it via the same
+  // helper so the two stay in lockstep (DRC-3250).
   const {
     icon: IconChangeStatus,
     color: colorChangeStatus,
     backgroundColor: backgroundColorChangeStatus,
-  } = newCllExperience && isImpacted && isUnchanged
-    ? getStyleForImpacted(isDark)
-    : getIconForChangeStatus(
-        changeStatus,
-        isDark,
-        newCllExperience ? "cll" : "default",
-      );
+  } = getNodeChangeStyle(
+    { changeStatus, isImpacted, newCllExperience },
+    isDark,
+  );
   const { icon: ResourceIcon } =
     resourceType === "model" && materialized
       ? getIconForMaterialization(materialized)

--- a/js/packages/ui/src/components/lineage/styles.tsx
+++ b/js/packages/ui/src/components/lineage/styles.tsx
@@ -527,6 +527,35 @@ export function getStyleForImpacted(isDark?: boolean): ChangeStatusStyle {
 }
 
 /**
+ * Resolve a lineage node's accent style (color + background + icon) from its
+ * change/impact state. This is the single source of truth for a node card's
+ * color: `LineageNode` renders from it, and the MiniMap copies the resulting
+ * color so the canvas and the minimap can never drift apart.
+ *
+ * In the new CLL experience a node with no change of its own but downstream of
+ * an upstream change is "impacted" (amber); otherwise the change status drives
+ * the color, using the muted "cll" palette inside the new experience.
+ */
+export function getNodeChangeStyle(
+  state: {
+    changeStatus?: ChangeStatus;
+    isImpacted?: boolean;
+    newCllExperience?: boolean;
+  },
+  isDark?: boolean,
+): ChangeStatusStyle {
+  const { changeStatus, isImpacted, newCllExperience } = state;
+  const isUnchanged = !changeStatus || changeStatus === "unchanged";
+  return newCllExperience && isImpacted && isUnchanged
+    ? getStyleForImpacted(isDark)
+    : getIconForChangeStatus(
+        changeStatus,
+        isDark,
+        newCllExperience ? "cll" : "default",
+      );
+}
+
+/**
  * Get icon and color for a resource type
  *
  * @param resourceType - The resource type (model, source, seed, etc.)


### PR DESCRIPTION
## Type
- [x] Bug fix

## Description

The lineage minimap colored nodes by **change status only**, so in the new CLL experience (`--new-cll-experience`) **impacted-but-unchanged** nodes — amber on the canvas — showed up neutral grey in the minimap. The minimap and canvas disagreed.

Root cause: in the OSS stack, a node's impact state isn't on `node.data` — `GraphNodeOss` reads it from the lineage context (`impactedNodeIds`). The minimap's `getNodeColor` had no access to that set, so it couldn't reflect impact.

### Fix

Single source of truth for a node's accent color:

- **`styles.tsx`** — new `getNodeChangeStyle({ changeStatus, isImpacted, newCllExperience })` that resolves the impacted-amber vs change-status color (muted "cll" palette in the new experience). This is the decision that previously lived inline in `LineageNode`.
- **`LineageNode.tsx`** — now renders from `getNodeChangeStyle` (no behavior change).
- **`config/nodeTypes.ts`** — `makeGetNodeColor({ impactedNodeIds, newCllExperience })` *copies* the node's color via the same helper; `getNodeColor` kept as the impact-agnostic default.
- **`LineageViewOss.tsx`** — memoizes a minimap color fn over `impactedNodeIds` + `newCllExperience`.

So the minimap no longer re-derives palette logic — it asks the same helper the node renders from, and the two can't drift.

## How tested

- New unit test `config/__tests__/nodeTypes.test.ts` asserts `makeGetNodeColor(...) === getNodeChangeStyle(...).color` across impacted / changed / unchanged + legacy-experience cases.
- `pnpm type:check` clean; `pnpm lint` clean; full frontend suite green (1924 passed).
- **Verified live** against jaffle_shop with `--new-cll-experience --whole-model-impact --impact-at-startup`: minimap renders **51 amber impacted** + 5 brown (modified) + 5 grey (unchanged), all matching `getNodeChangeStyle` and the canvas. Previously the 51 impacted were neutral.

## User-facing changes

In the new CLL experience, the lineage minimap now reflects impacted (amber) nodes, matching the main graph and the legend.

## Scope note

This fixes the **OSS production** view (`LineageViewOss`). The parallel `@datarecce/ui` `LineageCanvas` minimap is unchanged — it has no live consumer (neither the OSS app nor cloud render it), and `LineageView` doesn't wire impact data into nodes.

## Checklist
- [x] Tests pass
- [x] DCO sign-off

Closes DRC-3250

<img width="1001" height="683" alt="image" src="https://github.com/user-attachments/assets/50a7f2e2-2fbb-4bfc-a40c-12d6b8c50fd4" />
