### PR TITLE
feat(query): allow copying values from SQL query results

### DIFF
--- a/js/packages/ui/src/components/data/ScreenshotDataGrid.tsx
+++ b/js/packages/ui/src/components/data/ScreenshotDataGrid.tsx
@@ -312,6 +312,11 @@ function _ScreenshotDataGrid<TData = DataGridRow>(
         suppressCellFocus={true}
         suppressRowHoverHighlight={false}
         animateRows={false}
+        // Native browser text selection so users can highlight a cell value and
+        // Ctrl/Cmd+C it. ensureDomOrder keeps selection order correct + a11y-safe.
+        // Community-only path; AG Grid's own clipboard module is Enterprise.
+        enableCellTextSelection={true}
+        ensureDomOrder={true}
         rowClass={rowClassName}
         noRowsOverlayComponent={noRowsOverlayComponent}
         onGridReady={(event) => {

--- a/js/packages/ui/src/components/data/__tests__/ScreenshotDataGrid.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/ScreenshotDataGrid.test.tsx
@@ -1,6 +1,6 @@
 // js/packages/ui/src/components/data/__tests__/ScreenshotDataGrid.test.tsx
 import { render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Capture the props AG Grid receives.
 const agGridProps = vi.fn();
@@ -31,6 +31,10 @@ vi.mock("../agGridTheme", () => ({
 import { ScreenshotDataGrid } from "../ScreenshotDataGrid";
 
 describe("ScreenshotDataGrid grid options", () => {
+  beforeEach(() => {
+    agGridProps.mockClear();
+  });
+
   it("enables native cell text selection by default", () => {
     render(<ScreenshotDataGrid columnDefs={[]} rowData={[]} />);
     const props = agGridProps.mock.calls[0][0];

--- a/js/packages/ui/src/components/data/__tests__/ScreenshotDataGrid.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/ScreenshotDataGrid.test.tsx
@@ -1,0 +1,52 @@
+// js/packages/ui/src/components/data/__tests__/ScreenshotDataGrid.test.tsx
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Capture the props AG Grid receives.
+const agGridProps = vi.fn();
+vi.mock("ag-grid-react", () => ({
+  AgGridReact: (props: Record<string, unknown>) => {
+    agGridProps(props);
+    return <div data-testid="ag-grid" />;
+  },
+}));
+// AllCommunityModule / ModuleRegistry are referenced at import time.
+vi.mock("ag-grid-community", () => ({
+  AllCommunityModule: {},
+  ModuleRegistry: { registerModules: vi.fn() },
+}));
+
+// Mock useIsDark hook so the component can render without theme providers.
+vi.mock("../../../hooks", () => ({
+  useIsDark: () => false,
+}));
+
+// Mock the CSS import (agGridStyles.css) and the theme module (agGridTheme).
+vi.mock("../agGridStyles.css", () => ({}));
+vi.mock("../agGridTheme", () => ({
+  dataGridThemeLight: "mocked-light-theme",
+  dataGridThemeDark: "mocked-dark-theme",
+}));
+
+import { ScreenshotDataGrid } from "../ScreenshotDataGrid";
+
+describe("ScreenshotDataGrid grid options", () => {
+  it("enables native cell text selection by default", () => {
+    render(<ScreenshotDataGrid columnDefs={[]} rowData={[]} />);
+    const props = agGridProps.mock.calls[0][0];
+    expect(props.enableCellTextSelection).toBe(true);
+    expect(props.ensureDomOrder).toBe(true);
+  });
+
+  it("lets callers override text selection via props", () => {
+    render(
+      <ScreenshotDataGrid
+        columnDefs={[]}
+        rowData={[]}
+        enableCellTextSelection={false}
+      />,
+    );
+    const props = agGridProps.mock.calls.at(-1)?.[0];
+    expect(props.enableCellTextSelection).toBe(false);
+  });
+});

--- a/js/packages/ui/src/components/query/QueryDiffResultView.tsx
+++ b/js/packages/ui/src/components/query/QueryDiffResultView.tsx
@@ -98,6 +98,7 @@ export const QueryDiffResultView = createResultView<
   typeGuard: isQueryDiffRunGuard,
   expectedRunType: "query_diff",
   screenshotWrapper: "grid",
+  enableRowSelection: true,
   emptyState: "No data",
   transformData: (
     run,

--- a/js/packages/ui/src/components/query/QueryResultView.tsx
+++ b/js/packages/ui/src/components/query/QueryResultView.tsx
@@ -80,6 +80,7 @@ export const QueryResultView = createResultView<
   typeGuard: isQueryOrQueryBaseRun,
   expectedRunType: "query",
   screenshotWrapper: "grid",
+  enableRowSelection: true,
   emptyState: "No data",
   transformData: (
     run,

--- a/js/packages/ui/src/components/result/__tests__/createResultView.rowSelection.test.tsx
+++ b/js/packages/ui/src/components/result/__tests__/createResultView.rowSelection.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const gridProps = vi.fn();
+vi.mock("../../data/ScreenshotDataGrid", () => ({
+  ScreenshotDataGrid: (props: Record<string, unknown>) => {
+    gridProps(props);
+    return <div data-testid="grid" />;
+  },
+  EmptyRowsRenderer: () => <div />,
+}));
+vi.mock("../../../hooks", () => ({ useIsDark: () => false }));
+
+import { createResultView } from "../createResultView";
+
+const View = createResultView({
+  displayName: "TestView",
+  typeGuard: (_run: unknown): _run is { v: number } => true,
+  expectedRunType: "test",
+  screenshotWrapper: "grid",
+  enableRowSelection: true,
+  transformData: () => ({ columns: [{ field: "v" }], rows: [{ v: 1 }] }),
+});
+
+describe("createResultView enableRowSelection", () => {
+  it("passes a multiRow rowSelection config to the grid when enabled", () => {
+    render(<View ref={createRef()} run={{ v: 1 }} />);
+    const props = gridProps.mock.calls.at(-1)?.[0];
+    expect(props.rowSelection).toEqual({
+      mode: "multiRow",
+      checkboxes: true,
+      headerCheckbox: true,
+      enableClickSelection: false,
+    });
+  });
+});

--- a/js/packages/ui/src/components/result/__tests__/createResultView.rowSelection.test.tsx
+++ b/js/packages/ui/src/components/result/__tests__/createResultView.rowSelection.test.tsx
@@ -34,4 +34,18 @@ describe("createResultView enableRowSelection", () => {
       enableClickSelection: false,
     });
   });
+
+  it("does not pass rowSelection when enableRowSelection is absent", () => {
+    const PlainView = createResultView({
+      displayName: "PlainView",
+      typeGuard: (_run: unknown): _run is { v: number } => true,
+      expectedRunType: "test",
+      screenshotWrapper: "grid",
+      transformData: () => ({ columns: [{ field: "v" }], rows: [{ v: 1 }] }),
+    });
+    gridProps.mockClear();
+    render(<PlainView ref={createRef()} run={{ v: 1 }} />);
+    const props = gridProps.mock.calls.at(-1)?.[0];
+    expect(props.rowSelection).toBeUndefined();
+  });
 });

--- a/js/packages/ui/src/components/result/createResultView.tsx
+++ b/js/packages/ui/src/components/result/createResultView.tsx
@@ -3,6 +3,7 @@
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import { amber } from "@mui/material/colors";
+import type { RowSelectionOptions } from "ag-grid-community";
 import { forwardRef, type ReactNode, type Ref, useMemo } from "react";
 import { PiWarning } from "react-icons/pi";
 
@@ -19,6 +20,18 @@ import type {
   ResultViewRef,
   WarningStyle,
 } from "./types";
+
+/**
+ * Community multi-row selection via a checkbox column. Checkbox-only
+ * (enableClickSelection: false) so row selection never conflicts with the
+ * native cell text selection enabled in ScreenshotDataGrid.
+ */
+const GRID_ROW_SELECTION: RowSelectionOptions = {
+  mode: "multiRow",
+  checkboxes: true,
+  headerCheckbox: true,
+  enableClickSelection: false,
+};
 
 /**
  * Renders a single warning with amber styling (icon + text).
@@ -156,6 +169,7 @@ export function createResultView<
     transformData,
     emptyState = "No data",
     conditionalEmptyState,
+    enableRowSelection,
   } = config;
 
   function ResultViewInner(
@@ -289,6 +303,7 @@ export function createResultView<
               ),
             }}
             defaultColumnOptions={data.defaultColumnOptions}
+            rowSelection={enableRowSelection ? GRID_ROW_SELECTION : undefined}
           />
           {data.footer}
         </Box>

--- a/js/packages/ui/src/components/result/types.ts
+++ b/js/packages/ui/src/components/result/types.ts
@@ -51,6 +51,12 @@ export interface ResultViewConfig<
     run: TRun,
     viewOptions?: TViewOptions,
   ) => ReactNode | null;
+  /**
+   * When true, enables AG Grid community multi-row selection (checkbox column)
+   * on the grid so users can copy a collection of rows. Default false. Only the
+   * query result views set this today (DRC-3622).
+   */
+  enableRowSelection?: boolean;
 }
 
 /**

--- a/js/packages/ui/src/components/run/RunResultPane.test.tsx
+++ b/js/packages/ui/src/components/run/RunResultPane.test.tsx
@@ -12,7 +12,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { Run } from "../../api";
 import { RunResultPane } from "./RunResultPane";
 
@@ -140,7 +140,7 @@ describe("RunResultPane sticky-cancel gating", () => {
     expect(headerText).not.toMatch(/Running・/);
   });
 
-  it("invokes copySelectedRows from the export menu", async () => {
+  test("invokes copySelectedRows from the export menu", async () => {
     const copySelectedRows = vi.fn().mockResolvedValue(undefined);
     renderWithProviders(
       <RunResultPane
@@ -167,7 +167,7 @@ describe("RunResultPane sticky-cancel gating", () => {
     expect(copySelectedRows).toHaveBeenCalledOnce();
   });
 
-  it("omits Copy Selected Rows when no handler is provided", async () => {
+  test("omits Copy Selected Rows when no handler is provided", async () => {
     renderWithProviders(
       <RunResultPane
         runId="run-1"

--- a/js/packages/ui/src/components/run/RunResultPane.test.tsx
+++ b/js/packages/ui/src/components/run/RunResultPane.test.tsx
@@ -141,6 +141,7 @@ describe("RunResultPane sticky-cancel gating", () => {
   });
 
   test("invokes copySelectedRows from the export menu", async () => {
+    const user = userEvent.setup();
     const copySelectedRows = vi.fn().mockResolvedValue(undefined);
     renderWithProviders(
       <RunResultPane
@@ -158,16 +159,15 @@ describe("RunResultPane sticky-cancel gating", () => {
         onCopyAsImage={vi.fn().mockResolvedValue(undefined)}
       />,
     );
-    await userEvent.click(
-      screen.getByRole("button", { name: /export|share/i }),
-    );
-    await userEvent.click(
+    await user.click(screen.getByRole("button", { name: /export|share/i }));
+    await user.click(
       screen.getByRole("menuitem", { name: /copy selected rows/i }),
     );
     expect(copySelectedRows).toHaveBeenCalledOnce();
   });
 
   test("omits Copy Selected Rows when no handler is provided", async () => {
+    const user = userEvent.setup();
     renderWithProviders(
       <RunResultPane
         runId="run-1"
@@ -182,9 +182,7 @@ describe("RunResultPane sticky-cancel gating", () => {
         onCopyAsImage={vi.fn().mockResolvedValue(undefined)}
       />,
     );
-    await userEvent.click(
-      screen.getByRole("button", { name: /export|share/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /export|share/i }));
     expect(
       screen.queryByRole("menuitem", { name: /copy selected rows/i }),
     ).toBeNull();

--- a/js/packages/ui/src/components/run/RunResultPane.test.tsx
+++ b/js/packages/ui/src/components/run/RunResultPane.test.tsx
@@ -10,8 +10,9 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import type { Run } from "../../api";
 import { RunResultPane } from "./RunResultPane";
 
@@ -137,5 +138,55 @@ describe("RunResultPane sticky-cancel gating", () => {
     const headerText = document.body.textContent ?? "";
     expect(headerText).toMatch(/Cancelled/);
     expect(headerText).not.toMatch(/Running・/);
+  });
+
+  it("invokes copySelectedRows from the export menu", async () => {
+    const copySelectedRows = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <RunResultPane
+        runId="run-1"
+        run={
+          { run_id: "run-1", type: "query", result: { columns: [] } } as never
+        }
+        csvExport={{
+          canExportCSV: true,
+          copyAsCSV: vi.fn().mockResolvedValue(undefined),
+          copyAsTSV: vi.fn().mockResolvedValue(undefined),
+          downloadAsCSV: vi.fn(),
+          copySelectedRows,
+        }}
+        onCopyAsImage={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /export|share/i }),
+    );
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: /copy selected rows/i }),
+    );
+    expect(copySelectedRows).toHaveBeenCalledOnce();
+  });
+
+  it("omits Copy Selected Rows when no handler is provided", async () => {
+    renderWithProviders(
+      <RunResultPane
+        runId="run-1"
+        run={
+          { run_id: "run-1", type: "query", result: { columns: [] } } as never
+        }
+        csvExport={{
+          canExportCSV: true,
+          copyAsCSV: vi.fn().mockResolvedValue(undefined),
+          downloadAsCSV: vi.fn(),
+        }}
+        onCopyAsImage={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /export|share/i }),
+    );
+    expect(
+      screen.queryByRole("menuitem", { name: /copy selected rows/i }),
+    ).toBeNull();
   });
 });

--- a/js/packages/ui/src/components/run/RunResultPane.tsx
+++ b/js/packages/ui/src/components/run/RunResultPane.tsx
@@ -50,6 +50,7 @@ import {
   PiDownloadSimple,
   PiImage,
   PiRepeat,
+  PiSelectionPlus,
   PiTable,
 } from "react-icons/pi";
 import YAML from "yaml";
@@ -88,6 +89,8 @@ export interface CSVExportProps {
   downloadAsTSV?: () => void;
   /** Download data as Excel file */
   downloadAsExcel?: () => void;
+  /** Copy the grid's currently selected rows as TSV to the clipboard */
+  copySelectedRows?: () => Promise<void>;
 }
 
 /**
@@ -456,6 +459,20 @@ const DefaultExportMenu = memo(
             </ListItemIcon>
             <ListItemText>Copy as CSV</ListItemText>
           </MenuItem>
+          {csvExport?.copySelectedRows && (
+            <MenuItem
+              onClick={async () => {
+                await csvExport.copySelectedRows?.();
+                handleClose();
+              }}
+              disabled={disableExport}
+            >
+              <ListItemIcon>
+                <PiSelectionPlus />
+              </ListItemIcon>
+              <ListItemText>Copy Selected Rows</ListItemText>
+            </MenuItem>
+          )}
           <MenuItem
             onClick={() => handleDownload(() => csvExport?.downloadAsCSV())}
             disabled={disableExport || !csvExport?.canExportCSV}

--- a/js/packages/ui/src/components/run/RunResultPane.tsx
+++ b/js/packages/ui/src/components/run/RunResultPane.tsx
@@ -465,7 +465,7 @@ const DefaultExportMenu = memo(
                 await csvExport.copySelectedRows?.();
                 handleClose();
               }}
-              disabled={disableExport}
+              disabled={disableExport} // intentionally omits canExportCSV — selection copy is independent of the full-result export gate
             >
               <ListItemIcon>
                 <PiSelectionPlus />

--- a/js/packages/ui/src/components/run/RunResultPaneOss.tsx
+++ b/js/packages/ui/src/components/run/RunResultPaneOss.tsx
@@ -40,6 +40,9 @@ import {
 } from "../../hooks";
 import { trackCopyToClipboard } from "../../lib/api/track";
 import { isHttpError } from "../../lib/fetchClient";
+import { copyToClipboard } from "../../utils";
+import { buildSelectedRowsTSV } from "../../utils/grid/buildSelectedRowsTSV";
+import type { DataGridHandle } from "../data/ScreenshotDataGrid";
 import { LearnHowLink, RecceNotification } from "../onboarding-guide";
 import { DualSqlEditor, SqlEditor } from "../query";
 import { toaster } from "../ui/Toaster";
@@ -159,6 +162,49 @@ export const PrivateLoadableRunView = ({
     viewOptions: viewOptions as Record<string, unknown>,
   });
 
+  // True only for run types whose grid has row selection enabled (query views).
+  const supportsRowCopy =
+    !!run?.type && ["query", "query_base", "query_diff"].includes(run.type);
+
+  // Copy the grid's currently selected rows as TSV. Reads the live grid API
+  // from the shared screenshot/result ref (DataGridHandle.api) at click time,
+  // so no selection state has to be threaded through the component tree.
+  const copySelectedRows = useCallback(async () => {
+    const api = (ref.current as DataGridHandle | null)?.api;
+    if (!api) return;
+    const tsv = buildSelectedRowsTSV(api);
+    if (!tsv) {
+      toaster.create({
+        title: "No rows selected",
+        description: "Select rows with the checkboxes, then copy.",
+        type: "info",
+        duration: 3000,
+      });
+      return;
+    }
+    try {
+      await copyToClipboard(tsv);
+      toaster.create({
+        title: "Copied to clipboard",
+        description: "Selected rows copied — paste into any spreadsheet",
+        type: "success",
+        duration: 2000,
+      });
+      trackCopyToClipboard({
+        type: run?.type ?? "unknown",
+        from: "run",
+      });
+    } catch (error) {
+      console.error("Failed to copy selected rows:", error);
+      toaster.create({
+        title: "Copy failed",
+        description: "Failed to copy to clipboard",
+        type: "error",
+        duration: 3000,
+      });
+    }
+  }, [ref, run?.type]);
+
   // Rerun handler
   const handleRerun = useCallback(() => {
     if (run) {
@@ -239,7 +285,10 @@ export const PrivateLoadableRunView = ({
       onCopyAsImage={handleCopyAsImage}
       onCopyMouseEnter={onMouseEnter}
       onCopyMouseLeave={onMouseLeave}
-      csvExport={csvExport}
+      csvExport={{
+        ...csvExport,
+        copySelectedRows: supportsRowCopy ? copySelectedRows : undefined,
+      }}
       // Checklist handlers
       onGoToCheck={handleGoToCheck}
       onAddToChecklist={handleAddToChecklist}

--- a/js/packages/ui/src/components/run/RunResultPaneOss.tsx
+++ b/js/packages/ui/src/components/run/RunResultPaneOss.tsx
@@ -192,7 +192,7 @@ export const PrivateLoadableRunView = ({
       });
       trackCopyToClipboard({
         type: run?.type ?? "unknown",
-        from: "run",
+        from: "run-selection",
       });
     } catch (error) {
       console.error("Failed to copy selected rows:", error);

--- a/js/packages/ui/src/lib/api/track.ts
+++ b/js/packages/ui/src/lib/api/track.ts
@@ -184,7 +184,7 @@ export function trackStateAction(props: StateActionProps) {
 }
 
 interface CopyToClipboardProps {
-  from: "run" | "check" | "lineage_view";
+  from: "run" | "run-selection" | "check" | "lineage_view";
   type: string;
 }
 

--- a/js/packages/ui/src/utils/grid/__tests__/buildSelectedRowsTSV.test.ts
+++ b/js/packages/ui/src/utils/grid/__tests__/buildSelectedRowsTSV.test.ts
@@ -1,0 +1,77 @@
+// js/packages/ui/src/utils/grid/__tests__/buildSelectedRowsTSV.test.ts
+import type { GridApi } from "ag-grid-community";
+import { describe, expect, it } from "vitest";
+import { buildSelectedRowsTSV } from "../buildSelectedRowsTSV";
+
+interface FakeNode {
+  id: string;
+}
+function fakeCol(colId: string, headerName?: string, field?: string) {
+  return {
+    getColId: () => colId,
+    getColDef: () => ({ headerName, field }),
+  };
+}
+function fakeApi(opts: {
+  nodes: FakeNode[];
+  columns: ReturnType<typeof fakeCol>[];
+  values?: Record<string, string>; // key `${nodeId}:${colId}`
+}): GridApi {
+  return {
+    getSelectedNodes: () => opts.nodes,
+    getAllDisplayedColumns: () => opts.columns,
+    getCellValue: ({
+      rowNode,
+      colKey,
+    }: {
+      rowNode: { id: string };
+      colKey: { getColId: () => string };
+    }) => opts.values?.[`${rowNode.id}:${colKey.getColId()}`],
+  } as unknown as GridApi;
+}
+
+describe("buildSelectedRowsTSV", () => {
+  it("returns null when no rows are selected", () => {
+    const api = fakeApi({ nodes: [], columns: [fakeCol("a", "A", "a")] });
+    expect(buildSelectedRowsTSV(api)).toBeNull();
+  });
+
+  it("excludes the AG Grid selection checkbox column", () => {
+    const api = fakeApi({
+      nodes: [{ id: "0" }],
+      columns: [
+        fakeCol("ag-Grid-SelectionColumn"),
+        fakeCol("id", "ID", "id"),
+        fakeCol("name", "Name", "name"),
+      ],
+      values: { "0:id": "42", "0:name": "alice" },
+    });
+    expect(buildSelectedRowsTSV(api)).toBe("ID\tName\r\n42\talice");
+  });
+
+  it("serializes multiple selected rows with formatted values", () => {
+    const api = fakeApi({
+      nodes: [{ id: "0" }, { id: "1" }],
+      columns: [fakeCol("id", "ID", "id"), fakeCol("v", "V", "v")],
+      values: { "0:id": "1", "0:v": "x", "1:id": "2", "1:v": "y" },
+    });
+    expect(buildSelectedRowsTSV(api)).toBe("ID\tV\r\n1\tx\r\n2\ty");
+  });
+
+  it("falls back to field then colId for header, empty string for missing value", () => {
+    const api = fakeApi({
+      nodes: [{ id: "0" }],
+      columns: [fakeCol("c1", undefined, "field1"), fakeCol("c2")],
+      values: {},
+    });
+    expect(buildSelectedRowsTSV(api)).toBe("field1\tc2\r\n\t");
+  });
+
+  it("returns null when only the selection column is displayed", () => {
+    const api = fakeApi({
+      nodes: [{ id: "0" }],
+      columns: [fakeCol("ag-Grid-SelectionColumn")],
+    });
+    expect(buildSelectedRowsTSV(api)).toBeNull();
+  });
+});

--- a/js/packages/ui/src/utils/grid/buildSelectedRowsTSV.ts
+++ b/js/packages/ui/src/utils/grid/buildSelectedRowsTSV.ts
@@ -1,0 +1,40 @@
+// js/packages/ui/src/utils/grid/buildSelectedRowsTSV.ts
+import type { GridApi } from "ag-grid-community";
+import { toTSV } from "../csv/format";
+
+/** colId AG Grid assigns to the auto-generated row-selection checkbox column. */
+const SELECTION_COLUMN_ID = "ag-Grid-SelectionColumn";
+
+/**
+ * Serialize the grid's currently selected rows to a TSV string (header row +
+ * one row per selected node), suitable for pasting into a spreadsheet.
+ *
+ * Returns null when there is no selection or no data columns. Works for both
+ * plain query grids and diff grids — values come from `getCellValue` with the
+ * column's formatter applied, so no per-shape logic is needed. The auto-added
+ * selection checkbox column is excluded.
+ */
+export function buildSelectedRowsTSV(api: GridApi): string | null {
+  const nodes = api.getSelectedNodes();
+  if (nodes.length === 0) return null;
+
+  const columns = api
+    .getAllDisplayedColumns()
+    .filter((col) => col.getColId() !== SELECTION_COLUMN_ID);
+  if (columns.length === 0) return null;
+
+  const headers = columns.map((col) => {
+    const def = col.getColDef();
+    return String(def.headerName ?? def.field ?? col.getColId());
+  });
+
+  const rows = nodes.map((node) =>
+    columns.map(
+      (col) =>
+        api.getCellValue({ rowNode: node, colKey: col, useFormatter: true }) ??
+        "",
+    ),
+  );
+
+  return toTSV(headers, rows);
+}


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`feat` — frontend enhancement (query results UX).

**What this PR does / why we need it**:

Lets users copy values directly from the SQL query results grid, removing the disconnected "Share → Copy as TXT → paste into editor → copy value" detour. Implemented with `ag-grid-community` v35 only — no Enterprise dependency (AG Grid's native clipboard module, `cellSelection` ranges, and right-click Copy menu are all Enterprise-only).

Two capabilities, confirmed with the reporter in #1414:

- **Single cell** — native cell text selection (`enableCellTextSelection` + `ensureDomOrder`) enabled globally in the shared `ScreenshotDataGrid`. Highlight a cell's text and Cmd/Ctrl+C.
- **Collection of rows** — an opt-in community multi-row checkbox selection on the two query result grids, plus a **Copy Selected Rows** item in the Export/Share menu that serializes the selected rows to TSV (pastes cleanly into a spreadsheet) and copies to the clipboard.

Design notes:
- Text selection is global (pure, overridable enhancement); row selection is **query-only**, gated behind a new `enableRowSelection` flag on the `createResultView` factory — other grids (lineage, profile, value-diff, row-count) are unchanged and get no checkbox column.
- Checkbox-only selection (`enableClickSelection: false`) so row selection never conflicts with cell text-drag selection.
- The copy action reads the live grid API from the existing forwarded `DataGridHandle` ref at click time (no selection state threaded through the tree) and reuses the existing `toTSV()` / `copyToClipboard()` primitives. Values are read via `getCellValue({ useFormatter: true })`, so plain and diff grids work without per-shape logic.

**Which issue(s) this PR fixes**:

Closes #1414
(Linear: DRC-3622)

**Special notes for your reviewer**:

- A new pure helper `buildSelectedRowsTSV(api)` (with unit tests) does the selection→TSV serialization; it filters out AG Grid's auto-generated selection column. The filtered colId `"ag-Grid-SelectionColumn"` was verified against the installed `ag-grid-community@35.3.0` source (`SELECTION_COLUMN_ID`).
- The pre-existing "Copy as Text"/"Copy as CSV" menu items (whole-result) are untouched; "Copy Selected Rows" is a distinct item gated on a handler that's only supplied for query run types.
- Quality gate: Biome lint clean, `tsc` clean, **3900** Vitest tests pass (5 pre-existing skips), production build succeeds.
- Interactive browser QA (cell-copy, checkbox row-copy, no checkbox on non-query grids) performed in `recce server`.
- Analytics: row-selection copies are tracked as `from: "run-selection"`.

**Does this PR introduce a user-facing change?**:

```release-note
You can now copy values directly from SQL query results: select text within a cell and copy it, or select rows with the new checkboxes and use Export/Share → Copy Selected Rows to copy them as spreadsheet-ready text.
```
