### PR TITLE
fix(lineage): don't close a deep-linked run result before the graph builds (DRC-3532)

### DIFF
--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -118,6 +118,7 @@ import { toReactFlow } from "./lineage";
 import { NodeViewOss as NodeView } from "./NodeViewOss";
 import type { NodeChangeStatus } from "./nodes/LineageNode";
 import { patchLineageFromCll } from "./patchLineageDiffFromCll";
+import { shouldCloseOrphanedRunResult } from "./runResultVisibility";
 import SetupConnectionBanner from "./SetupConnectionBannerOss";
 import { BaseEnvironmentSetupNotification } from "./SingleEnvironmentQueryView";
 import {
@@ -1011,18 +1012,12 @@ export function PrivateLineageView(
       !!focusedNodeId || !!run,
     );
 
-    // Close the run result view if the run result node is not in the new nodes
-    if (
-      run &&
-      (isTopKDiffRun(run) ||
-        isProfileDiffRun(run) ||
-        isHistogramDiffRun(run) ||
-        isValueDiffRun(run) ||
-        isValueDiffDetailRun(run))
-    ) {
-      if (run.params?.model && !findNodeByName(run.params.model)) {
-        closeRunResult();
-      }
+    // Close the run result view if its model node is not in the new nodes —
+    // but NOT while the graph is still building (empty node set), so a run
+    // result deep-linked open before the first layout is not slammed shut
+    // (DRC-3532 race). See shouldCloseOrphanedRunResult.
+    if (shouldCloseOrphanedRunResult(run, nodes)) {
+      closeRunResult();
     }
 
     if (fitView) {

--- a/js/packages/ui/src/components/lineage/__tests__/runResultVisibility.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/runResultVisibility.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { Run } from "../../../api";
+import type { LineageGraphNodes } from "../../../contexts/lineage/types";
+import {
+  isNodeBoundRunResult,
+  shouldCloseOrphanedRunResult,
+} from "../runResultVisibility";
+
+// Minimal stand-ins carrying only the fields the predicates / guard read.
+const profileRun = (model: string) =>
+  ({ type: "profile_diff", params: { model } }) as unknown as Run;
+const rowCountRun = () =>
+  ({ type: "row_count_diff", params: {} }) as unknown as Run;
+const node = (name: string) =>
+  ({
+    id: name,
+    type: "lineageGraphNode",
+    data: { id: name, name },
+  }) as unknown as LineageGraphNodes;
+
+describe("isNodeBoundRunResult", () => {
+  it("is true for a node-bound run (profile_diff)", () => {
+    expect(isNodeBoundRunResult(profileRun("customers"))).toBe(true);
+  });
+
+  it("is false for a non-node-bound run (row_count_diff)", () => {
+    expect(isNodeBoundRunResult(rowCountRun())).toBe(false);
+  });
+
+  it("is false for no run", () => {
+    expect(isNodeBoundRunResult(undefined)).toBe(false);
+  });
+});
+
+describe("shouldCloseOrphanedRunResult", () => {
+  it("closes when the run's model is absent from a built graph", () => {
+    expect(
+      shouldCloseOrphanedRunResult(profileRun("customers"), [node("orders")]),
+    ).toBe(true);
+  });
+
+  it("keeps the result open when the run's model is present in the graph", () => {
+    expect(
+      shouldCloseOrphanedRunResult(profileRun("customers"), [
+        node("customers"),
+      ]),
+    ).toBe(false);
+  });
+
+  it("never closes a non-node-bound run, even with no matching node", () => {
+    expect(shouldCloseOrphanedRunResult(rowCountRun(), [])).toBe(false);
+  });
+
+  // DRC-3532 deep-link race: a node-bound run result can be opened (e.g. via a
+  // cloud `?id=` deep link calling showRunId) BEFORE the lineage graph's first
+  // layout, while the react-flow node set is still empty. The orphaned-model
+  // check must NOT fire in that window — otherwise it slams the just-opened run
+  // shut and the page shows bare lineage ("Ready to run query"), flaky across
+  // reloads. Once nodes exist, an absent model closes the pane as before.
+  it("does NOT close while the lineage graph has not been built yet (no nodes)", () => {
+    expect(shouldCloseOrphanedRunResult(profileRun("customers"), [])).toBe(
+      false,
+    );
+  });
+});

--- a/js/packages/ui/src/components/lineage/runResultVisibility.ts
+++ b/js/packages/ui/src/components/lineage/runResultVisibility.ts
@@ -11,14 +11,29 @@ import {
   type LineageGraphNodes,
 } from "../../contexts/lineage/types";
 
+/** The run types whose result is bound to a specific model node. */
+type NodeBoundRun = Run & {
+  type:
+    | "top_k_diff"
+    | "profile_diff"
+    | "histogram_diff"
+    | "value_diff"
+    | "value_diff_detail";
+};
+
 /**
  * A run result whose content is bound to a specific model node. Profile /
  * value / top-k / histogram / value-detail diffs render inside that model's
  * NodeView, so they only make sense while the model is part of the rendered
  * lineage. (row_count / query / query_diff results are NOT node-bound — they
  * render in their own pane regardless of the visible nodes.)
+ *
+ * Typed as a type guard so callers narrow `run` to `NodeBoundRun` and can read
+ * `run.params?.model` without casting away the discriminated-union typing.
  */
-export function isNodeBoundRunResult(run: Run | undefined): boolean {
+export function isNodeBoundRunResult(
+  run: Run | undefined,
+): run is NodeBoundRun {
   return (
     !!run &&
     (isTopKDiffRun(run) ||
@@ -41,10 +56,8 @@ export function shouldCloseOrphanedRunResult(
   if (!isNodeBoundRunResult(run)) {
     return false;
   }
-  // `run` is a node-bound run (checked above) whose params carry a `model`. The
-  // Run union as a whole doesn't expose `model` (query runs lack it), so read it
-  // through a narrow shape rather than fighting the union type.
-  const model = (run?.params as { model?: string } | undefined)?.model;
+  // `run` is now narrowed to a node-bound run, whose params carry `model`.
+  const model = run.params?.model;
   if (!model) {
     return false;
   }

--- a/js/packages/ui/src/components/lineage/runResultVisibility.ts
+++ b/js/packages/ui/src/components/lineage/runResultVisibility.ts
@@ -1,0 +1,60 @@
+import {
+  isHistogramDiffRun,
+  isProfileDiffRun,
+  isTopKDiffRun,
+  isValueDiffDetailRun,
+  isValueDiffRun,
+  type Run,
+} from "../../api";
+import {
+  isLineageGraphNode,
+  type LineageGraphNodes,
+} from "../../contexts/lineage/types";
+
+/**
+ * A run result whose content is bound to a specific model node. Profile /
+ * value / top-k / histogram / value-detail diffs render inside that model's
+ * NodeView, so they only make sense while the model is part of the rendered
+ * lineage. (row_count / query / query_diff results are NOT node-bound — they
+ * render in their own pane regardless of the visible nodes.)
+ */
+export function isNodeBoundRunResult(run: Run | undefined): boolean {
+  return (
+    !!run &&
+    (isTopKDiffRun(run) ||
+      isProfileDiffRun(run) ||
+      isHistogramDiffRun(run) ||
+      isValueDiffRun(run) ||
+      isValueDiffDetailRun(run))
+  );
+}
+
+/**
+ * Decide whether an open, node-bound run result should be closed because its
+ * model is no longer present in the rendered lineage (e.g. after a view-mode
+ * change filters the model out of the graph).
+ */
+export function shouldCloseOrphanedRunResult(
+  run: Run | undefined,
+  nodes: LineageGraphNodes[],
+): boolean {
+  if (!isNodeBoundRunResult(run)) {
+    return false;
+  }
+  // `run` is a node-bound run (checked above) whose params carry a `model`. The
+  // Run union as a whole doesn't expose `model` (query runs lack it), so read it
+  // through a narrow shape rather than fighting the union type.
+  const model = (run?.params as { model?: string } | undefined)?.model;
+  if (!model) {
+    return false;
+  }
+  // DRC-3532 deep-link race guard: while the lineage graph has not been built
+  // yet the node set is empty, so "model not found" means "not rendered yet",
+  // NOT "orphaned". A run result deep-linked open before the first layout (a
+  // cloud `?id=` calling showRunId) must not be closed in that window. Once
+  // nodes exist, an absent model is a genuine orphan and the pane closes.
+  if (nodes.length === 0) {
+    return false;
+  }
+  return !nodes.filter(isLineageGraphNode).some((n) => n.data.name === model);
+}


### PR DESCRIPTION
## Why (cross-repo context)

Found while wiring **recce-cloud's** inline run deep-links for **DRC-3532**
(`/launch/{sessionId}/runs?id={runId}` — a summary statement links straight to
the run the agent executed). The cloud drives the OSS run result open by calling
`showRunId` from a URL bridge **during initial page load**.

That external, early `showRunId` exposed a latent race in `LineageViewOss`:

- `refreshLayout` has a "close the run result if its model node isn't in the
  current nodes" safety check.
- `findNodeByName` reads the **react-flow `nodes` state**, which is empty until
  the first layout finishes building.
- If the run-detail fetch wins the race against that first layout, the check runs
  against an empty node set, finds nothing, and `closeRunResult()` slams the
  just-opened deep-linked run shut.

Result: the deep-link **intermittently** rendered bare lineage ("Ready to run
query") instead of the run — flaky across reloads. In OSS proper this check only
ever fired from user interaction *after* the layout existed, so it never
misbehaved; the cloud's external `showRunId` deep-link is what surfaces it.

## What

- Extract the close decision into `shouldCloseOrphanedRunResult(run, nodes)`.
- Guard it: while `nodes` is empty the graph simply hasn't rendered yet, so
  "model not found" means "not rendered", **not** "orphaned" — do not close.
  Once nodes exist, the original orphan-close behavior is unchanged.

## Test

`runResultVisibility.test.ts` — characterization tests for the existing behavior
plus the race-guard case (node-bound run + empty node set must not close).
Full `tsc --noEmit` + related vitest suite green.

## Reaching recce-cloud

recce-cloud carries a parallel cloud-side fix (gate the URL→`showRunId` bridge on
the lineage graph being built) so the product is fixed now; this OSS guard is the
deterministic root-cause fix and reaches the cloud on the next `@datarecce/ui`
bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
