### PR TITLE
fix(test): merge duplicate mock in RunList test

### DIFF
--- a/js/src/components/run/__tests__/RunList.test.tsx
+++ b/js/src/components/run/__tests__/RunList.test.tsx
@@ -47,9 +47,6 @@ vi.mock("@datarecce/ui/contexts", () => ({
 
 vi.mock("@datarecce/ui/hooks", () => ({
   useIsDark: vi.fn(() => false),
-}));
-
-vi.mock("@datarecce/ui/hooks", () => ({
   useApiConfig: vi.fn(() => ({
     apiClient: {},
   })),


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix (test-only)

**What this PR does / why we need it**:

The `Release @datarecce/ui` workflow on `main` failed at the `Run tests` step ([run 27676949171](https://github.com/DataRecce/recce/actions/runs/27676949171)). All 28 tests in `js/src/components/run/__tests__/RunList.test.tsx` failed with:

> [vitest] No "useApiConfig" export is defined on the "@datarecce/ui/hooks" mock.

Root cause: the test declared `vi.mock("@datarecce/ui/hooks", ...)` twice. The second factory (exporting `useApiConfig`) replaced the first (exporting `useIsDark`), so the mocked module was missing exports. `RunListOss` calls `useApiConfig`, which was no longer present in the winning mock. This PR merges both exports into a single mock factory.

**Which issue(s) this PR fixes**:

Fixes the failing `Release @datarecce/ui` CI run on `main`.

**Special notes for your reviewer**:

Verified locally with `pnpm test` — full suite passes (181 files, 3979 tests).

**Does this PR introduce a user-facing change?**:

NONE
