### PR TITLE
feat(schema): document [ALL] and [ADD] badges in schema legend (DRC-3466)

### DIFF
--- a/js/packages/storybook/.storybook/preview.tsx
+++ b/js/packages/storybook/.storybook/preview.tsx
@@ -2,6 +2,7 @@ import { theme } from "@datarecce/ui/theme";
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
 import type { Preview } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "chartjs-adapter-date-fns";
 import { useEffect } from "react";
 
@@ -21,6 +22,13 @@ if (typeof window !== "undefined") {
 // The @datarecce/ui theme uses CSS-variables mode with `colorSchemeSelector:
 // "class"`, so a single theme drives both light and dark modes — the global
 // decorator below toggles the `.dark` class on <html>.
+
+// Components that read server flags (e.g. SchemaLegend via useRecceServerFlag)
+// use react-query, so stories need a QueryClient in context. Retries off so
+// mocked-endpoint stories settle immediately.
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
 
 const preview: Preview = {
   parameters: {
@@ -61,10 +69,12 @@ const preview: Preview = {
       }, [isDark]);
 
       return (
-        <MuiThemeProvider theme={theme}>
-          <CssBaseline />
-          <Story />
-        </MuiThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <MuiThemeProvider theme={theme}>
+            <CssBaseline />
+            <Story />
+          </MuiThemeProvider>
+        </QueryClientProvider>
       );
     },
   ],

--- a/js/packages/storybook/stories/schema/SchemaDiff.stories.tsx
+++ b/js/packages/storybook/stories/schema/SchemaDiff.stories.tsx
@@ -1,6 +1,7 @@
 import { SchemaLegend } from "@datarecce/ui/components";
 import { ScreenshotDataGrid } from "@datarecce/ui/primitives";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { mockServerFlags } from "../../.storybook/mocks/handlers";
 import {
   definitionChangedRows,
   generateWideSchema,
@@ -111,5 +112,29 @@ export const WideSchema: Story = {
     rowHeight: 35,
     getRowClass,
     className: "rdg-light",
+  },
+};
+
+/**
+ * DRC-3466 — with `new_cll_experience` on, the legend also documents the
+ * `[ALL]` whole-model and `[ADD]` additive badges (reusing the lineage-graph /
+ * NodeView treatment tokens). This story turns the flag on so the legend's two
+ * extra entries are visible for review.
+ */
+export const LegendWithWholeModelAndAdditive: Story = {
+  name: "Legend — [ALL] + [ADD] badges (new_cll_experience on)",
+  args: {
+    style: GRID_STYLE,
+    columns: schemaColumns,
+    rows: mixedDiffRows,
+    rowHeight: 35,
+    getRowClass,
+    className: "rdg-light",
+  },
+  beforeEach: () => {
+    mockServerFlags.new_cll_experience = true;
+    return () => {
+      mockServerFlags.new_cll_experience = false;
+    };
   },
 };

--- a/js/packages/ui/src/components/schema/SchemaView.tsx
+++ b/js/packages/ui/src/components/schema/SchemaView.tsx
@@ -24,6 +24,7 @@ import {
   useLineageViewContext,
   useRecceServerFlag,
 } from "../../contexts";
+import { useThemeColors } from "../../hooks";
 import { useInlineProfileDistribution } from "../../hooks/useInlineProfileDistribution";
 import { trackColumnLevelLineage } from "../../lib/api/track";
 import type {
@@ -36,12 +37,41 @@ import {
   ScreenshotDataGrid,
 } from "../../primitives";
 import { ProfileDistributionUnsupportedBanner } from "../data/ProfileDistributionUnsupportedBanner";
+import { TreatmentChip } from "../lineage/TreatmentChip";
+import { pickGraphBadge, pickTitleChip } from "../lineage/wholeModelTreatment";
 import { createDataGridFromData } from "../ui/dataGrid";
 import type { SchemaDistributionData } from "../ui/dataGrid/schemaCells";
 import { getColumnChangeStatus } from "./getColumnChangeStatus";
 import { selectInlineProfileScope } from "./selectInlineProfileScope";
 
 export function SchemaLegend() {
+  const { isDark } = useThemeColors();
+  const { data: serverFlags } = useRecceServerFlag();
+  const newCllExperience = serverFlags?.new_cll_experience ?? false;
+
+  // Reuse the same resolution + token palette that the lineage graph and
+  // NodeView header use, so the legend chips match the in-product badges.
+  // Gated on the same flag that controls whether the badges render at all.
+  const wholeModelChip = pickTitleChip(
+    {
+      newCllExperience,
+      isWholeModelChanged: false,
+      isWholeModelImpacted: true,
+      isImpacted: true,
+    },
+    isDark,
+  );
+  const additiveBadge = pickGraphBadge(
+    {
+      newCllExperience,
+      isWholeModelChanged: false,
+      isWholeModelImpacted: false,
+      isImpacted: true,
+      changeCategory: "non_breaking",
+    },
+    isDark,
+  );
+
   return (
     <Box
       sx={{
@@ -69,6 +99,25 @@ export function SchemaLegend() {
         </span>{" "}
         changed
       </span>
+      {wholeModelChip && (
+        <Box component="span" sx={{ display: "inline-flex", gap: 0.5 }}>
+          <TreatmentChip tokens={wholeModelChip.tokens} ariaLabel="whole-model">
+            ALL
+          </TreatmentChip>{" "}
+          whole-model — every row in this model can be affected
+        </Box>
+      )}
+      {additiveBadge && (
+        <Box component="span" sx={{ display: "inline-flex", gap: 0.5 }}>
+          <TreatmentChip
+            tokens={additiveBadge.tokens}
+            ariaLabel={additiveBadge.ariaLabel}
+          >
+            {additiveBadge.text}
+          </TreatmentChip>{" "}
+          additive — adds a column; existing rows unchanged
+        </Box>
+      )}
     </Box>
   );
 }

--- a/js/packages/ui/src/components/schema/SchemaView.tsx
+++ b/js/packages/ui/src/components/schema/SchemaView.tsx
@@ -67,7 +67,7 @@ export function SchemaLegend() {
       isWholeModelChanged: false,
       isWholeModelImpacted: false,
       isImpacted: true,
-      changeCategory: "non_breaking",
+      changeCategory: "non_breaking", // wire-enum-ok: pickGraphBadge keys the additive badge off the legacy ChangeCategory enum
     },
     isDark,
   );

--- a/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
+++ b/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
@@ -17,7 +17,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NodeData } from "../../../api";
 import { theme } from "../../../theme";
-import { SchemaView } from "../SchemaView";
+import { SchemaLegend, SchemaView } from "../SchemaView";
 
 const { flags, distribution, lineageViewContext } = vi.hoisted(() => ({
   flags: {
@@ -124,5 +124,41 @@ describe("SchemaView inline-profile wiring", () => {
     // changed-columns default is restored, so the button returns.
     rerender(wrap(model("model.shop.customers")));
     expect(screen.getByRole("button", BUTTON)).toBeInTheDocument();
+  });
+});
+
+const wrapLegend = () => (
+  <ThemeProvider theme={theme}>
+    <CssBaseline />
+    <SchemaLegend />
+  </ThemeProvider>
+);
+
+describe("SchemaLegend", () => {
+  it("always shows the added / removed / changed entries", () => {
+    render(wrapLegend());
+    expect(screen.getByText("added")).toBeInTheDocument();
+    expect(screen.getByText("removed")).toBeInTheDocument();
+    expect(screen.getByText("changed")).toBeInTheDocument();
+  });
+
+  it("documents the whole-model and additive badges when new_cll_experience is on", () => {
+    flags.current = { new_cll_experience: true };
+    render(wrapLegend());
+    expect(screen.getByLabelText("whole-model")).toHaveTextContent("ALL");
+    expect(screen.getByLabelText("additive change")).toHaveTextContent("ADD");
+    expect(
+      screen.getByText(/every row in this model can be affected/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/adds a column; existing rows unchanged/),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the whole-model and additive badges when new_cll_experience is off", () => {
+    flags.current = { new_cll_experience: false };
+    render(wrapLegend());
+    expect(screen.queryByLabelText("whole-model")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("additive change")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Type

- [x] Enhancement

## Description

The Columns tab shows a small legend above the schema grid that explains the change markers a column can carry. Recently we added two newer lineage markers that render on the grid when the new CLL experience is enabled — `[ALL]` (whole-model) and `[ADD]` (additive) — but the legend never documented them. Users saw those badges with no in-product explanation of what they meant.

This PR extends the legend to cover both. The existing `+ added` / `- removed` / `~ changed` entries are unchanged; two new entries appear alongside them:

- **`[ALL]` whole-model** — every row in this model can be affected
- **`[ADD]` additive** — adds a column; existing rows unchanged

The chips reuse the exact styling and color tokens the lineage graph and the NodeView header already use (via `pickTitleChip` / `pickGraphBadge` + `TreatmentChip`), so the legend matches the badges a user actually sees on the canvas — no new colors were introduced. Both new entries are gated on the `new_cll_experience` server flag, the same flag that controls whether the badges render at all, so the legend never documents a marker the user can't see.

This is documentation for the CLL badge set that is being redesigned in DRC-3813 / DRC-3814 / DRC-3815; the copy and tokens here will track that work.

## Notes for reviewers

Two supporting fixes ride along with the legend change:

1. **Wire-enum lint allowlist.** The `check_wire_enum_literals.sh` guard (DRC-3553) flagged the legend's `changeCategory: "non_breaking"` as a legacy enum literal. It genuinely has to stay legacy: `pickGraphBadge`'s classifier keys the additive badge off the legacy `ChangeCategory` union (`"non_breaking"` → `additive`), and that union only accepts `breaking` / `non_breaking` / `partial_breaking` / `unknown` — the v2 term isn't a valid value there. The line is annotated with the sanctioned `// wire-enum-ok` marker rather than changed.
2. **Storybook QueryClient provider.** `SchemaLegend` now reads the server flag through `useRecceServerFlag` (react-query), and the Schema story's decorator renders `<SchemaLegend />` directly. Without a `QueryClientProvider` in the Storybook preview, every schema story threw "No QueryClient set". The preview now wraps all stories in a shared `QueryClient`, which restores the schema stories and lets the new legend entries render for review.

## Linked issues

- Closes DRC-3466 — Schema legend should cover the `[ALL]` and `[ADD]` badges
- Documents badges being redesigned in DRC-3813 / DRC-3814 / DRC-3815
- Follow-up from DRC-3341

## How tested

- `SchemaView` / `SchemaLegend` unit tests (8/8 pass): the always-on added/removed/changed entries; the whole-model and additive entries present with the correct copy and aria-labels when `new_cll_experience` is on; both hidden when it's off.
- `pnpm type:check` — clean.
- `biome check` — clean on all changed files.
- `check_wire_enum_literals.sh origin/main` — exits 0.
- Legend rendered in Storybook (new `LegendWithWholeModelAndAdditive` story) and captured below.

## Screenshots

<!-- screenshots: attach here — drag-drop the PNGs saved locally at /tmp/pr-1434-screenshots/legend-strip.png (tight legend) and /tmp/pr-1434-screenshots/legend-light-full.png (legend above the schema grid) -->

The Columns-tab legend with `new_cll_experience` enabled, now including the `[ALL]` and `[ADD]` entries.

## User-facing changes

The Columns-tab legend now explains the `[ALL]` and `[ADD]` badges when the new CLL experience is enabled. No behavior change to the badges themselves.

## Checklist

- [x] Tests added/updated and passing
- [x] DCO sign-off on commits
