### PR TITLE
fix(ci): skip cloud smoke test for fork PRs

### DIFF
--- a/.github/workflows/integration-tests-cloud.yaml
+++ b/.github/workflows/integration-tests-cloud.yaml
@@ -65,6 +65,18 @@ jobs:
             exit 0
           fi
 
+          # Fork PRs never receive repository secrets/variables on the
+          # `pull_request` trigger, so RECCE_STATE_PASSWORD would be empty and
+          # `recce cloud upload-artifacts` fails with "Missing option --password".
+          # Skip the cloud test for any cross-repo PR regardless of the author's
+          # permission level — collaborator write access does not change the
+          # fork's secret/variable context.
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+            echo "authorized=false" >> $GITHUB_OUTPUT
+            echo "::warning::Cloud smoke test skipped for fork PR (secrets/variables unavailable). Run via workflow_dispatch from a maintainer branch if needed."
+            exit 0
+          fi
+
           PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.triggering_actor }}/permission --jq '.permission' 2>/dev/null || echo "none")
           if [[ "$PERMISSION" == "write" || "$PERMISSION" == "admin" ]]; then
             echo "authorized=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Type

Bug fix (CI)

## Description

Fork PRs run on the `pull_request` trigger **without** access to repository
secrets/variables. In the cloud smoke test workflow, `RECCE_STATE_PASSWORD`
comes from `${{ vars.RECCE_STATE_PASSWORD }}`, so on a fork PR it resolves to an
empty string and `recce cloud upload-artifacts` fails:

```
Error: Missing option '--password' / '-p'.
##[error]Process completed with exit code 2.
```

The existing `authorize` gate was supposed to skip the cloud test for forks, but
it only checked the **author's collaborator permission** (`gh api
.../collaborators/<actor>/permission`). A collaborator with write access opening
a PR from their own fork passes that check (`authorized=true`) and the job runs —
yet secret/variable availability is governed by the **fork origin of the event**,
not the author's permission level. So the job runs with an empty password and
fails.

### Fix

Add a cross-repo (fork) check in the `authorize` step, before the permission
check, so **any** fork PR is treated as `authorized=false`. The cloud test then
**skips cleanly** (matching the intended behavior for external contributors)
instead of failing. Maintainers can still run it for a fork branch via
`workflow_dispatch`.

## How surfaced

PR #1192 (a fork PR by a collaborator) fails the production cloud smoke test
while every same-repo PR — and `schedule`/`push` to main — passes. The dbt steps
all succeed; only the cloud-upload step fails on the missing password. This fix
takes effect for #1192 once it's rebased on updated main (the `pull_request`
workflow is read from the merge ref).

## Test plan

- [x] `yaml.safe_load` parses the workflow
- [ ] This PR is same-repo, so the cloud smoke test runs normally and should pass — confirming the fork branch doesn't break the authorized path
- [ ] A fork PR (e.g. #1192) now shows the cloud test as **skipping** rather than failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
