### PR TITLE
fix(lineage): guard base/current in useModelColumns for added/removed nodes

### DIFF
--- a/js/packages/ui/src/api/info.ts
+++ b/js/packages/ui/src/api/info.ts
@@ -252,8 +252,9 @@ export interface ModelEnvDetail {
  */
 export interface ModelInfoResult {
   model: {
-    base: ModelEnvDetail;
-    current: ModelEnvDetail;
+    // optional: added nodes have no base, removed nodes have no current
+    base?: ModelEnvDetail;
+    current?: ModelEnvDetail;
   };
 }
 

--- a/js/packages/ui/src/hooks/__tests__/useModelColumns.test.tsx
+++ b/js/packages/ui/src/hooks/__tests__/useModelColumns.test.tsx
@@ -120,6 +120,56 @@ describe("useModelColumns", () => {
     expect(result.current.error).toBe(null);
   });
 
+  // Regression: guard against the crash on an added model (no base key).
+  it("returns current columns (no throw) for an added model with no base", async () => {
+    mockGetModelInfo.mockResolvedValue({
+      model: {
+        current: {
+          columns: {
+            id: { name: "id", type: "INT" },
+            name: { name: "name", type: "TEXT" },
+          },
+          primary_key: "id",
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useModelColumns(MODEL_NAME), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.columns.map((c) => c.name)).toEqual(["id", "name"]);
+    expect(result.current.primaryKey).toBe("id");
+    expect(result.current.error).toBe(null);
+  });
+
+  it("returns base columns (no throw) for a removed model with no current", async () => {
+    mockGetModelInfo.mockResolvedValue({
+      model: {
+        base: {
+          columns: { id: { name: "id", type: "INT" } },
+          primary_key: "id",
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useModelColumns(MODEL_NAME), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.columns.map((c) => c.name)).toEqual(["id"]);
+    expect(result.current.primaryKey).toBe("id");
+    expect(result.current.error).toBe(null);
+  });
+
   it("dedupes the /api/models/{id} fetch when a sibling useQuery shares the cache key (DRC-3343)", async () => {
     mockGetModelInfo.mockResolvedValue(fakeModelInfo);
 

--- a/js/packages/ui/src/hooks/useModelColumns.tsx
+++ b/js/packages/ui/src/hooks/useModelColumns.tsx
@@ -109,18 +109,18 @@ export function useModelColumns(
   });
 
   const { columns, primaryKey } = useMemo(() => {
+    // added nodes have no base, removed nodes have no current
     const modelInfo = data?.model;
-    if (!modelInfo?.base.columns || !modelInfo.current.columns) {
-      return {
-        columns: [] as NodeColumnData[],
-        primaryKey: modelInfo?.current.primary_key,
-      };
-    }
-    const baseColumns = Object.values(modelInfo.base.columns);
-    const currentColumns = Object.values(modelInfo.current.columns);
+    const baseColumns = modelInfo?.base?.columns
+      ? Object.values(modelInfo.base.columns)
+      : [];
+    const currentColumns = modelInfo?.current?.columns
+      ? Object.values(modelInfo.current.columns)
+      : [];
     return {
       columns: unionColumns(baseColumns, currentColumns),
-      primaryKey: modelInfo.current.primary_key,
+      primaryKey:
+        modelInfo?.current?.primary_key ?? modelInfo?.base?.primary_key,
     };
   }, [data]);
 


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

Clicking a newly-added model in the lineage view crashed with `TypeError: Cannot read properties of undefined (reading 'columns')`.

The model-info API omits a side's key when a node is missing from one environment of the diff (added → no `base`, removed → no `current`). `useModelColumns`'s `useMemo` guarded only `modelInfo` with optional chaining, then read `modelInfo.base.columns` directly — so `modelInfo.base` was `undefined` for an added model and reading `.columns` threw. TypeScript didn't catch it because `ModelInfoResult.model.base/current` were typed non-optional while the wire format omits one.

This PR builds the base/current column lists independently with optional chaining and unions them, and makes `ModelInfoResult.base/current` optional so the type matches the API. Added/removed models now render their columns instead of crashing (or showing an empty list).

**Which issue(s) this PR fixes**:

Linear DRC-3744

**Special notes for your reviewer**:

- No api_server change is needed: omitting the absent side's key is intentional and documented, and most frontend code already treats a missing key as no data (e.g. `modelDetail?.base?.columns ?? {}`). This hook was the one place that didn't.
- Reproduced the crash locally against the real base-less response shape, then confirmed the fixed build renders the added model's columns. `vitest related` green incl. the 2 new regression tests; `pnpm type:check` clean.

**Does this PR introduce a user-facing change?**:

Fix a crash when selecting an added or removed model in the lineage view; such models now display their columns.
