### PR TITLE
fix(mcp): cap lineage_diff view_mode=all and compact tool-result JSON (DRC-3758)

### DIFF
--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -55,7 +55,8 @@ SINGLE_ENV_WARNING = (
 # (MAX_MCP_OUTPUT_TOKENS, default 25,000 tokens). A full-project lineage on a large
 # warehouse overflowed at 527K chars (DRC-3756); the summary agent has no file
 # tools to read the SDK's file-pointer fallback, so the lineage silently vanished.
-# ~300 nodes keeps the worst-case serialized result under ~75% of the 25k cap.
+# ~300 nodes keeps the worst-case serialized result at ~58% of the 25k cap
+# (measured: ~43k chars / ~14.4k tokens for 300 long-id nodes, edges included).
 VIEW_ALL_MAX_NODES = 300
 
 
@@ -285,10 +286,8 @@ class CloudBackend:
 
         selected_nodes = {node_id: node for node_id, node in nodes.items() if node_id in selected}
 
-        # DRC-3758: bound view_mode="all" so the serialized result cannot exceed the
-        # Claude Agent SDK MCP output cap (see VIEW_ALL_MAX_NODES). Mirrors the
-        # local RecceMCPServer path. Keep changed + impacted nodes first; edges to
-        # dropped nodes are excluded by the id_to_idx guard below.
+        # DRC-3758: bound view_mode="all" (changed and impacted first) — see
+        # VIEW_ALL_MAX_NODES. Mirrors the local path; edges to dropped nodes excluded below.
         view_mode = arguments.get("view_mode", "changed_models")
         truncated = False
         total_node_count = len(selected_nodes)
@@ -651,7 +650,7 @@ class RecceMCPServer:
                                 "type": "string",
                                 "enum": ["changed_models", "all"],
                                 "default": "changed_models",
-                                "description": "View mode: 'changed_models' for only changed models (default), 'all' for all models. On large projects, 'all' is capped to the most relevant nodes (changed and impacted first); when capped, the result carries 'truncated', 'total_nodes', and 'returned_nodes'. Prefer 'changed_models', which already includes the impacted models.",
+                                "description": "View mode: 'changed_models' for only changed models (default), 'all' for all models. On large projects, 'all' is capped to the most relevant nodes (changed and impacted first); when capped, the result carries 'truncated', 'total_nodes', and 'returned_nodes'. Edges to dropped nodes are omitted to keep the graph consistent, so a returned node may have upstream/neighbors that are not shown — a capped graph's connectivity is not complete lineage. Prefer 'changed_models', which already includes the impacted models.",
                             },
                         },
                     },
@@ -1495,11 +1494,8 @@ class RecceMCPServer:
                         if materialized is not None:
                             nodes[node_id]["materialized"] = materialized
 
-        # DRC-3758: bound view_mode="all" so the serialized result cannot exceed the
-        # Claude Agent SDK MCP output cap (see VIEW_ALL_MAX_NODES). Keep the nodes
-        # that matter for analysis — changed + impacted — first, then fill to
-        # the cap. Edges to dropped nodes are excluded by the id_to_idx guard in the
-        # edge-building loop below, so the returned graph stays internally consistent.
+        # DRC-3758: bound view_mode="all" (changed and impacted first) — see
+        # VIEW_ALL_MAX_NODES. Edges to dropped nodes are excluded by the id_to_idx guard.
         truncated = False
         total_node_count = len(nodes)
         if view_mode == "all" and total_node_count > VIEW_ALL_MAX_NODES:

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -284,6 +284,25 @@ class CloudBackend:
         impacted = set((await self._request("POST", "select", json={"select": "state:modified+"})).get("nodes", []))
 
         selected_nodes = {node_id: node for node_id, node in nodes.items() if node_id in selected}
+
+        # DRC-3758: bound view_mode="all" so the serialized result cannot exceed the
+        # Claude Agent SDK MCP output cap (see VIEW_ALL_MAX_NODES). Mirrors the
+        # local RecceMCPServer path. Keep changed + impacted nodes first; edges to
+        # dropped nodes are excluded by the id_to_idx guard below.
+        view_mode = arguments.get("view_mode", "changed_models")
+        truncated = False
+        total_node_count = len(selected_nodes)
+        if view_mode == "all" and total_node_count > VIEW_ALL_MAX_NODES:
+
+            def _node_priority(item: tuple) -> int:
+                node_id, node = item
+                is_changed = node.get("change_status") is not None
+                is_impacted = node_id in impacted
+                return 0 if (is_changed or is_impacted) else 1
+
+            selected_nodes = dict(sorted(selected_nodes.items(), key=_node_priority)[:VIEW_ALL_MAX_NODES])
+            truncated = True
+
         id_to_idx = {node_id: idx for idx, node_id in enumerate(selected_nodes.keys())}
         nodes_df = DataFrame.from_data(
             columns={
@@ -316,10 +335,15 @@ class CloudBackend:
             if source in id_to_idx and target in id_to_idx:
                 edge_rows.append((id_to_idx[source], id_to_idx[target]))
         edges_df = DataFrame.from_data(columns={"from": "integer", "to": "integer"}, data=edge_rows)
-        return {
+        result = {
             "nodes": nodes_df.model_dump(mode="json"),
             "edges": edges_df.model_dump(mode="json"),
         }
+        if truncated:
+            result["truncated"] = True
+            result["total_nodes"] = total_node_count
+            result["returned_nodes"] = len(selected_nodes)
+        return result
 
     async def _tool_schema_diff(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         info = await self._request("GET", "info")

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -50,6 +50,14 @@ SINGLE_ENV_WARNING = (
     "Run `dbt docs generate --target-path target-base` to enable diffing."
 )
 
+# DRC-3758: cap the node count returned by lineage_diff(view_mode="all") so the
+# serialized MCP result cannot exceed the Claude Agent SDK output cap
+# (MAX_MCP_OUTPUT_TOKENS, default 25,000 tokens). A full-project lineage on a large
+# warehouse overflowed at 527K chars (DRC-3756); the summary agent has no file
+# tools to read the SDK's file-pointer fallback, so the lineage silently vanished.
+# ~300 nodes keeps the worst-case serialized result under ~75% of the 25k cap.
+VIEW_ALL_MAX_NODES = 300
+
 
 class InstanceSpawningError(RuntimeError):
     """Raised when a Recce Cloud session instance is not ready yet."""
@@ -619,7 +627,7 @@ class RecceMCPServer:
                                 "type": "string",
                                 "enum": ["changed_models", "all"],
                                 "default": "changed_models",
-                                "description": "View mode: 'changed_models' for only changed models (default), 'all' for all models",
+                                "description": "View mode: 'changed_models' for only changed models (default), 'all' for all models. On large projects, 'all' is capped to the most relevant nodes (changed and impacted first); when capped, the result carries 'truncated', 'total_nodes', and 'returned_nodes'. Prefer 'changed_models', which already includes the impacted models.",
                             },
                         },
                     },
@@ -1373,7 +1381,7 @@ class RecceMCPServer:
                 self.mcp_logger.log_tool_call(name, log_arguments, result, duration_ms)
 
                 # Log outgoing response
-                response_json = json.dumps(result, indent=2)
+                response_json = json.dumps(result, separators=(",", ":"))
                 logger.info(f"[MCP] Tool response for {name} ({duration_ms:.2f}ms):")
                 # Truncate large responses for console readability
                 if len(response_json) > 1000:
@@ -1463,6 +1471,24 @@ class RecceMCPServer:
                         if materialized is not None:
                             nodes[node_id]["materialized"] = materialized
 
+        # DRC-3758: bound view_mode="all" so the serialized result cannot exceed the
+        # Claude Agent SDK MCP output cap (see VIEW_ALL_MAX_NODES). Keep the nodes
+        # that matter for analysis — changed + impacted — first, then fill to
+        # the cap. Edges to dropped nodes are excluded by the id_to_idx guard in the
+        # edge-building loop below, so the returned graph stays internally consistent.
+        truncated = False
+        total_node_count = len(nodes)
+        if view_mode == "all" and total_node_count > VIEW_ALL_MAX_NODES:
+
+            def _node_priority(item: tuple) -> int:
+                node_id = item[0]
+                is_changed = diff_info.get(node_id, {}).get("change_status") is not None
+                is_impacted = node_id in impacted_node_ids
+                return 0 if (is_changed or is_impacted) else 1
+
+            nodes = dict(sorted(nodes.items(), key=_node_priority)[:VIEW_ALL_MAX_NODES])
+            truncated = True
+
         # Create id to idx mapping
         id_to_idx = {node_id: idx for idx, node_id in enumerate(nodes.keys())}
 
@@ -1516,6 +1542,10 @@ class RecceMCPServer:
             "nodes": nodes_df.model_dump(mode="json"),
             "edges": edges_df.model_dump(mode="json"),
         }
+        if truncated:
+            result["truncated"] = True
+            result["total_nodes"] = total_node_count
+            result["returned_nodes"] = len(nodes)
 
         return result
 

--- a/tests/test_mcp_cloud_backend.py
+++ b/tests/test_mcp_cloud_backend.py
@@ -147,6 +147,42 @@ async def test_create_check_runs_lineage_diff_via_checks_run_endpoint(cloud_requ
 
 
 @pytest.mark.asyncio
+async def test_cloud_backend_lineage_diff_view_all_truncates(monkeypatch):
+    """DRC-3758: CloudBackend caps view_mode='all', keeping changed + impacted first."""
+    from recce.mcp_server import CloudBackend
+
+    monkeypatch.setattr("recce.mcp_server.VIEW_ALL_MAX_NODES", 2)
+
+    nodes = {
+        "a": {"name": "a", "resource_type": "model", "change_status": "modified"},
+        "b": {"name": "b", "resource_type": "model"},
+        "c": {"name": "c", "resource_type": "model"},
+    }
+
+    async def fake_request(method, path, **kwargs):
+        if path == "info":
+            return {"lineage": {"nodes": nodes, "edges": []}}
+        if path == "select":
+            return {"nodes": ["b"]}  # impacted set
+        return {}
+
+    async def fake_selected(arguments, _nodes):
+        return set(nodes.keys())  # view_mode="all" selects everything
+
+    backend = CloudBackend.__new__(CloudBackend)
+    backend._request = fake_request
+    backend._selected_nodes = fake_selected
+
+    result = await backend._tool_lineage_diff({"view_mode": "all"})
+
+    assert result["truncated"] is True
+    assert result["total_nodes"] == 3
+    assert result["returned_nodes"] == 2
+    kept = {row[1] for row in result["nodes"]["data"]}
+    assert kept == {"a", "b"}  # changed (a) + impacted (b) kept; unrelated (c) dropped
+
+
+@pytest.mark.asyncio
 async def test_recce_mcp_server_delegates_tool_calls_to_backend():
     backend = AsyncMock()
     backend.call_tool.return_value = {"ok": True}
@@ -161,7 +197,8 @@ async def test_recce_mcp_server_delegates_tool_calls_to_backend():
     result = await handler(request)
 
     backend.call_tool.assert_awaited_once_with("get_server_info", {})
-    assert result.root.content[0].text == '{\n  "ok": true\n}'
+    # DRC-3758: tool results are now serialized compactly (no indent).
+    assert result.root.content[0].text == '{"ok":true}'
 
 
 @pytest.mark.asyncio
@@ -334,7 +371,7 @@ async def test_unconfigured_server_blocks_normal_tools_but_allows_set_backend():
             params=CallToolRequestParams(name="get_server_info", arguments={}),
         )
     )
-    assert '"mode": "none"' in info.root.content[0].text
+    assert '"mode":"none"' in info.root.content[0].text
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_cloud_backend.py
+++ b/tests/test_mcp_cloud_backend.py
@@ -162,9 +162,7 @@ async def test_cloud_backend_lineage_diff_view_all_truncates(monkeypatch):
     async def fake_request(method, path, **kwargs):
         if path == "info":
             return {"lineage": {"nodes": nodes, "edges": []}}
-        if path == "select":
-            return {"nodes": ["b"]}  # impacted set
-        return {}
+        return {"nodes": ["b"]}  # path == "select": impacted set
 
     async def fake_selected(arguments, _nodes):
         return set(nodes.keys())  # view_mode="all" selects everything

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -120,6 +120,71 @@ class TestRecceMCPServer:
         mock_context.adapter.select_nodes.assert_called()
 
     @pytest.mark.asyncio
+    async def test_tool_lineage_diff_view_all_truncates(self, mcp_server, monkeypatch):
+        """DRC-3758: view_mode='all' caps node count, keeping changed + impacted first."""
+        monkeypatch.setattr("recce.mcp_server.VIEW_ALL_MAX_NODES", 2)
+
+        server, mock_context = mcp_server
+        mock_lineage_diff = MagicMock(spec=LineageDiff)
+        mock_lineage_diff.model_dump.return_value = {
+            "current": {
+                "nodes": {
+                    "model.p.a": {"name": "a", "resource_type": "model"},
+                    "model.p.b": {"name": "b", "resource_type": "model"},
+                    "model.p.c": {"name": "c", "resource_type": "model"},
+                },
+                "parent_map": {"model.p.a": [], "model.p.b": [], "model.p.c": []},
+            },
+            "diff": {"model.p.a": {"change_status": "modified"}},
+        }
+        mock_context.get_lineage_diff.return_value = mock_lineage_diff
+        # First call selects all nodes (view_mode="all"); second call returns impacted.
+        mock_context.adapter.select_nodes.side_effect = [
+            {"model.p.a", "model.p.b", "model.p.c"},
+            {"model.p.b"},
+        ]
+
+        result = await server._tool_lineage_diff({"view_mode": "all"})
+
+        # Truncated to the cap, with provenance markers
+        assert result["truncated"] is True
+        assert result["total_nodes"] == 3
+        assert result["returned_nodes"] == 2
+
+        # The changed (a) and impacted (b) nodes are kept; the unrelated node (c) is dropped
+        kept_ids = {row[1] for row in result["nodes"]["data"]}
+        assert kept_ids == {"model.p.a", "model.p.b"}
+
+    @pytest.mark.asyncio
+    async def test_tool_lineage_diff_changed_models_not_truncated(self, mcp_server, monkeypatch):
+        """DRC-3758: the cap applies only to view_mode='all', never changed_models."""
+        monkeypatch.setattr("recce.mcp_server.VIEW_ALL_MAX_NODES", 1)
+
+        server, mock_context = mcp_server
+        mock_lineage_diff = MagicMock(spec=LineageDiff)
+        mock_lineage_diff.model_dump.return_value = {
+            "current": {
+                "nodes": {
+                    "model.p.a": {"name": "a", "resource_type": "model"},
+                    "model.p.b": {"name": "b", "resource_type": "model"},
+                },
+                "parent_map": {"model.p.a": [], "model.p.b": []},
+            },
+            "diff": {},
+        }
+        mock_context.get_lineage_diff.return_value = mock_lineage_diff
+        mock_context.adapter.select_nodes.side_effect = [
+            {"model.p.a", "model.p.b"},
+            set(),
+        ]
+
+        result = await server._tool_lineage_diff({"view_mode": "changed_models"})
+
+        # No truncation markers even though count (2) exceeds the patched cap (1)
+        assert "truncated" not in result
+        assert len(result["nodes"]["data"]) == 2
+
+    @pytest.mark.asyncio
     async def test_tool_schema_diff(self, mcp_server):
         """Test the schema_diff tool"""
         server, mock_context = mcp_server


### PR DESCRIPTION
## Problem (root cause of DataRecce/recce-cloud-infra DRC-3756)

`lineage_diff` with `view_mode: "all"` returns the entire project DAG. On a large warehouse this overflowed the Claude Agent SDK MCP output cap (`MAX_MCP_OUTPUT_TOKENS`, default 25,000 tokens) at **527,044 characters**. The Recce summary agent runs MCP-only (no file tools), so it cannot read the SDK's "output saved to file" fallback — the lineage silently vanished and the PR summary broke.

## Fix — two bounds, applied to BOTH backends

1. **Cap `view_mode: "all"`** at `VIEW_ALL_MAX_NODES` (300) in **both** `RecceMCPServer._tool_lineage_diff` (local mode) **and** `CloudBackend._tool_lineage_diff` (cloud mode) — `call_tool` delegates to the cloud backend before the local path, so both must be capped. Keeps the nodes that matter for analysis — **changed + impacted first** — then fills to the cap. When capped, the result carries `truncated`, `total_nodes`, and `returned_nodes`. Edges to dropped nodes are excluded by the existing `id_to_idx` guard, so the graph stays consistent. `changed_models` is **never** capped (already bounded to the impact set).
2. **Compact tool-result JSON** — drop `indent=2` for tight separators in the single `call_tool` serialization point. Consumers `json.loads` the payload, so it is runtime-safe; two `test_mcp_cloud_backend.py` tests that string-matched the pretty form were updated to the compact form (the full mcp suite was checked for other string-match breakage).

## Why cap = 300 (measured, not guessed)

Hard limit = Claude Code `MAX_MCP_OUTPUT_TOKENS` default **25,000 tokens**. Measured serialized size of a capped 300-node result with the compact separators this PR ships:

| node_id length | chars | est. tokens (~3 chars/tok) | % of 25k cap |
|---|---|---|---|
| realistic ~45 | 32,726 | ~10,900 | 44% |
| worst-case ~80 | 43,226 | ~14,400 | 58% |

Even worst-case stays at ~58% of the cap — comfortable headroom, cannot overflow.

## Tests

223 mcp tests pass (`test_mcp_server.py` + `test_mcp_cloud_backend.py` + `test_mcp_e2e.py`), including new coverage that:
- `view_mode: "all"` truncates to the cap, keeping changed + impacted and dropping unrelated nodes, with the `truncated` / `total_nodes` / `returned_nodes` markers — for **both** the local and cloud backends;
- `changed_models` is not capped even when its count exceeds the cap.

`black` / `isort` / `flake8` clean.

## Review

codex review, 2 rounds: round 1 caught (a) `CloudBackend._tool_lineage_diff` was uncapped and (b) the compact-JSON change broke two string-match tests — both fixed; round 2 found **0 findings**.

Known edge case (accepted): if more than 300 nodes are themselves changed/impacted, some are still dropped; the markers report the counts but not which class was trimmed.

## Cross-repo

This is the root-cause fix; it pairs with two recce-cloud-infra changes for the same incident (Linear DRC-3756):
- the summary-agent runner guard that makes an oversized-output run fail loud instead of silently empty (DRC-3756, recce-cloud-infra #1479);
- the agent prompt that steers `lineage_diff` to `changed_models` and forbids `view_mode: "all"` (DRC-3757, recce-cloud-infra #1480).

Resolves Linear DRC-3758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
