### PR TITLE
test(lineage): hygiene cleanup from PR #1381 review (DRC-3525)

### DIFF
--- a/js/packages/ui/src/components/lineage/__tests__/cllPaletteSync.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/cllPaletteSync.test.ts
@@ -1,0 +1,168 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  cllAdditiveAccent,
+  cllAdditiveBadgeBg,
+  cllAdditiveBadgeFg,
+  cllChangedAccent,
+  cllChangedBadgeBg,
+  cllChangedBadgeFg,
+  cllChangeStatusBackgroundsDark,
+  cllChangeStatusBackgroundsLight,
+  cllChangeStatusColors,
+  cllImpactedAccent,
+  cllImpactedBadgeBg,
+  cllImpactedBadgeFg,
+} from "../styles";
+
+/**
+ * Single-source-of-truth guard for the CLL palette.
+ *
+ * The CLL colors are declared twice: as TS consts in `lineage/styles.tsx`
+ * (consumed by the React lineage canvas) and as `--schema-*` CSS custom
+ * properties in `schema/style.css` (consumed by the ag-grid schema view).
+ * Both files carry "keep in sync by hand — no build-time check" comments.
+ *
+ * This test IS that build-time check: it parses `schema/style.css` and asserts
+ * every TS const matches its CSS counterpart, so drift on either side fails CI.
+ * The TS consts are treated as canonical; the CSS values are verified against
+ * them. (A fuller consolidation — deriving the CSS vars from TS at runtime — is
+ * deferred; see DRC-3525.)
+ */
+
+const cssPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../schema/style.css",
+);
+const css = readFileSync(cssPath, "utf8");
+
+/** Extract `--name: value` declarations from the first block matching a header. */
+function block(header: RegExp): Record<string, string> {
+  const m = header.exec(css);
+  if (!m) throw new Error(`CSS block not found for header: ${header}`);
+  const open = css.indexOf("{", m.index);
+  const close = css.indexOf("}", open);
+  const body = css.slice(open + 1, close);
+  const vars: Record<string, string> = {};
+  for (const decl of body.split(";")) {
+    const i = decl.indexOf(":");
+    if (i === -1) continue;
+    const name = decl.slice(0, i).trim();
+    if (!name.startsWith("--")) continue;
+    vars[name] = decl.slice(i + 1).trim();
+  }
+  return vars;
+}
+
+const rootVars = block(/:root,\s*\.light\s*\{/);
+const darkVars = block(/\n\.dark\s*\{/);
+const cllVars = block(/\n\.cll-experience\s*\{/);
+const cllDarkVars = block(/\.dark \.cll-experience,/);
+
+/**
+ * Resolve a CSS var the way the cascade does inside `.cll-experience`:
+ * the `.cll-experience` override wins, otherwise the base `:root`/`.dark` value.
+ */
+const lightCll = (name: string) => cllVars[name] ?? rootVars[name];
+const darkCll = (name: string) => cllDarkVars[name] ?? darkVars[name];
+
+describe("CLL palette TS ↔ CSS sync (styles.tsx ↔ schema/style.css)", () => {
+  it("parses the expected CSS blocks", () => {
+    expect(Object.keys(rootVars).length).toBeGreaterThan(0);
+    expect(Object.keys(darkVars).length).toBeGreaterThan(0);
+    expect(Object.keys(cllVars).length).toBeGreaterThan(0);
+    expect(Object.keys(cllDarkVars).length).toBeGreaterThan(0);
+  });
+
+  it("accent colors match the *-accent vars", () => {
+    expect(cllChangeStatusColors.modified).toBe(
+      lightCll("--schema-color-changed-accent"),
+    );
+    expect(cllChangeStatusColors.modified).toBe(
+      darkCll("--schema-color-changed-accent"),
+    );
+    expect(cllChangeStatusColors.impacted).toBe(
+      lightCll("--schema-color-impacted-accent"),
+    );
+    expect(cllChangeStatusColors.impacted).toBe(
+      darkCll("--schema-color-impacted-accent"),
+    );
+    expect(cllChangeStatusColors.added).toBe(
+      lightCll("--schema-color-added-accent"),
+    );
+    expect(cllChangeStatusColors.removed).toBe(
+      lightCll("--schema-color-removed-accent"),
+    );
+  });
+
+  it("row backgrounds match the --schema-color-{changed,impacted,added,removed} vars", () => {
+    // light
+    expect(cllChangeStatusBackgroundsLight.modified).toBe(
+      lightCll("--schema-color-changed"),
+    );
+    expect(cllChangeStatusBackgroundsLight.impacted).toBe(
+      lightCll("--schema-color-impacted"),
+    );
+    expect(cllChangeStatusBackgroundsLight.added).toBe(
+      lightCll("--schema-color-added"),
+    );
+    expect(cllChangeStatusBackgroundsLight.removed).toBe(
+      lightCll("--schema-color-removed"),
+    );
+    // dark
+    expect(cllChangeStatusBackgroundsDark.modified).toBe(
+      darkCll("--schema-color-changed"),
+    );
+    expect(cllChangeStatusBackgroundsDark.impacted).toBe(
+      darkCll("--schema-color-impacted"),
+    );
+    expect(cllChangeStatusBackgroundsDark.added).toBe(
+      darkCll("--schema-color-added"),
+    );
+    expect(cllChangeStatusBackgroundsDark.removed).toBe(
+      darkCll("--schema-color-removed"),
+    );
+  });
+
+  it("impacted badge/accent tokens match the --schema-*impacted* vars", () => {
+    expect(cllImpactedAccent.light).toBe(
+      lightCll("--schema-color-impacted-accent"),
+    );
+    expect(cllImpactedAccent.dark).toBe(
+      darkCll("--schema-color-impacted-accent"),
+    );
+    expect(cllImpactedBadgeBg.light).toBe(
+      lightCll("--schema-badge-impacted-bg"),
+    );
+    expect(cllImpactedBadgeBg.dark).toBe(darkCll("--schema-badge-impacted-bg"));
+    expect(cllImpactedBadgeFg.light).toBe(
+      lightCll("--schema-badge-impacted-fg"),
+    );
+    expect(cllImpactedBadgeFg.dark).toBe(darkCll("--schema-badge-impacted-fg"));
+  });
+
+  it("changed badge/accent tokens match the --schema-*changed* vars", () => {
+    expect(cllChangedAccent).toBe(lightCll("--schema-color-changed-accent"));
+    expect(cllChangedAccent).toBe(darkCll("--schema-color-changed-accent"));
+    expect(cllChangedBadgeBg.light).toBe(lightCll("--schema-badge-changed-bg"));
+    expect(cllChangedBadgeBg.dark).toBe(darkCll("--schema-badge-changed-bg"));
+    expect(cllChangedBadgeFg.light).toBe(lightCll("--schema-badge-changed-fg"));
+    expect(cllChangedBadgeFg.dark).toBe(darkCll("--schema-badge-changed-fg"));
+  });
+
+  it("additive badge/accent tokens match the --schema-*added* vars", () => {
+    expect(cllAdditiveAccent.light).toBe(
+      lightCll("--schema-color-added-accent"),
+    );
+    // Intentional: the additive accent's *dark* value mirrors the added badge
+    // foreground (a brighter green), not --schema-color-added-accent (which
+    // stays the mid green in both modes).
+    expect(cllAdditiveAccent.dark).toBe(darkCll("--schema-badge-added-fg"));
+    expect(cllAdditiveBadgeBg.light).toBe(lightCll("--schema-badge-added-bg"));
+    expect(cllAdditiveBadgeBg.dark).toBe(darkCll("--schema-badge-added-bg"));
+    expect(cllAdditiveBadgeFg.light).toBe(lightCll("--schema-badge-added-fg"));
+    expect(cllAdditiveBadgeFg.dark).toBe(darkCll("--schema-badge-added-fg"));
+  });
+});

--- a/js/packages/ui/src/components/lineage/__tests__/computeWholeModelImpact.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/computeWholeModelImpact.test.ts
@@ -111,4 +111,33 @@ describe("computeWholeModelImpact", () => {
     expect(result.wholeModelImpactedNodeIds).toEqual(new Set(["a", "b"]));
     expect(result.wholeModelChangedNodeIds).toEqual(new Set(["a"]));
   });
+
+  it("does not bleed impact across disconnected components", () => {
+    // Component 1: a (changed) -> b
+    // Component 2: x -> y  (no change, no edge to component 1)
+    // The wave from `a` must stay inside its own component.
+    const graph = makeGraph([
+      ["a", "b"],
+      ["x", "y"],
+    ]);
+    const cll = makeCll(["a"], ["a", "b", "x", "y"]);
+    const result = computeWholeModelImpact(graph as any, cll as any);
+    expect(result.wholeModelImpactedNodeIds).toEqual(new Set(["a", "b"]));
+    expect(result.wholeModelChangedNodeIds).toEqual(new Set(["a"]));
+    expect(result.wholeModelImpactedNodeIds.has("x")).toBe(false);
+    expect(result.wholeModelImpactedNodeIds.has("y")).toBe(false);
+  });
+
+  it("handles a changed node absent from the lineage graph", () => {
+    // `ghost` is flagged breaking in the CLL but has no node in the
+    // lineage graph (CLL/graph can drift). It should still seed both sets,
+    // and the missing-node guard must skip its BFS expansion without throwing.
+    const graph = makeGraph([["a", "b"]]);
+    const cll = makeCll(["ghost"], ["a", "b", "ghost"]);
+    const result = computeWholeModelImpact(graph as any, cll as any);
+    expect(result.wholeModelChangedNodeIds).toEqual(new Set(["ghost"]));
+    expect(result.wholeModelImpactedNodeIds).toEqual(new Set(["ghost"]));
+    // No graph node for `ghost`, so nothing downstream is reached.
+    expect(result.wholeModelImpactedNodeIds.has("b")).toBe(false);
+  });
 });

--- a/js/packages/ui/src/components/lineage/__tests__/wholeModelTreatment.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/wholeModelTreatment.test.ts
@@ -77,7 +77,7 @@ describe("wholeModelTreatment tokens", () => {
       const mode = isDark ? "dark" : "light";
       it(`maps the green/additive palette in ${mode} mode`, () => {
         const res = pickGraphBadge(
-          { ...BASE, changeCategory: "non_breaking" },
+          { ...BASE, changeCategory: "non_breaking" }, // wire-enum-ok
           isDark,
         );
         expect(res?.kind).toBe("additive");
@@ -96,7 +96,7 @@ describe("wholeModelTreatment tokens", () => {
       const mode = isDark ? "dark" : "light";
       it(`reuses the brown/changed palette in ${mode} mode`, () => {
         const res = pickGraphBadge(
-          { ...BASE, changeCategory: "partial_breaking" },
+          { ...BASE, changeCategory: "partial_breaking" }, // wire-enum-ok
           isDark,
         );
         expect(res?.kind).toBe("column-changed");

--- a/js/packages/ui/src/components/lineage/__tests__/wholeModelTreatment.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/wholeModelTreatment.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  cllAdditiveAccent,
+  cllAdditiveBadgeBg,
+  cllAdditiveBadgeFg,
+  cllChangedAccent,
+  cllChangedBadgeBg,
+  cllChangedBadgeFg,
+  cllImpactedAccent,
+  cllImpactedBadgeBg,
+  cllImpactedBadgeFg,
+} from "../styles";
+import {
+  pickGraphBadge,
+  pickTitleChip,
+  type TreatmentInputs,
+} from "../wholeModelTreatment";
+
+/**
+ * Locks the visual tokens produced by `tokensForKind` (exercised through the
+ * public `pickTitleChip` / `pickGraphBadge` resolvers) against the shared CLL
+ * palette consts in `styles.tsx`, for every kind × (light / dark).
+ *
+ * These two surfaces are the only callers of `tokensForKind`, so asserting
+ * their `.tokens` output covers all five kinds and both modes. If the palette
+ * wiring drifts (wrong const, swapped light/dark), this fails loudly.
+ */
+
+const BASE: TreatmentInputs = {
+  newCllExperience: true,
+  isWholeModelChanged: false,
+  isWholeModelImpacted: false,
+  isImpacted: false,
+};
+
+describe("wholeModelTreatment tokens", () => {
+  describe("title chip — changed", () => {
+    for (const isDark of [false, true] as const) {
+      const mode = isDark ? "dark" : "light";
+      it(`maps the brown/changed palette in ${mode} mode`, () => {
+        const res = pickTitleChip(
+          { ...BASE, isWholeModelChanged: true },
+          isDark,
+        );
+        expect(res?.kind).toBe("changed");
+        expect(res?.tokens).toEqual({
+          stripeAccent: "var(--schema-color-changed-accent)",
+          fg: cllChangedBadgeFg[mode],
+          badgeBg: cllChangedBadgeBg[mode],
+          badgeBorder: cllChangedAccent,
+        });
+      });
+    }
+  });
+
+  describe("title chip — impacted", () => {
+    for (const isDark of [false, true] as const) {
+      const mode = isDark ? "dark" : "light";
+      it(`maps the amber/impacted palette in ${mode} mode`, () => {
+        const res = pickTitleChip(
+          { ...BASE, isWholeModelImpacted: true },
+          isDark,
+        );
+        expect(res?.kind).toBe("impacted");
+        expect(res?.tokens).toEqual({
+          stripeAccent: "var(--schema-color-impacted-accent)",
+          fg: cllImpactedBadgeFg[mode],
+          badgeBg: cllImpactedBadgeBg[mode],
+          badgeBorder: cllImpactedAccent[mode],
+        });
+      });
+    }
+  });
+
+  describe("graph badge — additive", () => {
+    for (const isDark of [false, true] as const) {
+      const mode = isDark ? "dark" : "light";
+      it(`maps the green/additive palette in ${mode} mode`, () => {
+        const res = pickGraphBadge(
+          { ...BASE, changeCategory: "non_breaking" },
+          isDark,
+        );
+        expect(res?.kind).toBe("additive");
+        expect(res?.tokens).toEqual({
+          stripeAccent: "var(--schema-color-added-accent)",
+          fg: cllAdditiveBadgeFg[mode],
+          badgeBg: cllAdditiveBadgeBg[mode],
+          badgeBorder: cllAdditiveAccent[mode],
+        });
+      });
+    }
+  });
+
+  describe("graph badge — column-changed", () => {
+    for (const isDark of [false, true] as const) {
+      const mode = isDark ? "dark" : "light";
+      it(`reuses the brown/changed palette in ${mode} mode`, () => {
+        const res = pickGraphBadge(
+          { ...BASE, changeCategory: "partial_breaking" },
+          isDark,
+        );
+        expect(res?.kind).toBe("column-changed");
+        expect(res?.tokens).toEqual({
+          stripeAccent: "var(--schema-color-changed-accent)",
+          fg: cllChangedBadgeFg[mode],
+          badgeBg: cllChangedBadgeBg[mode],
+          badgeBorder: cllChangedAccent,
+        });
+      });
+    }
+  });
+
+  describe("graph badge — column-impacted", () => {
+    for (const isDark of [false, true] as const) {
+      const mode = isDark ? "dark" : "light";
+      it(`reuses the amber/impacted palette in ${mode} mode`, () => {
+        const res = pickGraphBadge({ ...BASE, isImpacted: true }, isDark);
+        expect(res?.kind).toBe("column-impacted");
+        expect(res?.tokens).toEqual({
+          stripeAccent: "var(--schema-color-impacted-accent)",
+          fg: cllImpactedBadgeFg[mode],
+          badgeBg: cllImpactedBadgeBg[mode],
+          badgeBorder: cllImpactedAccent[mode],
+        });
+      });
+    }
+  });
+});

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -34,6 +34,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { colors } from "../../../theme/colors";
 import { DIM_FILTER } from "../config/zoomConstants";
 import {
   getIconForMaterialization,
@@ -367,10 +368,16 @@ function LineageNodeComponent({
   const borderWidth = "2px";
   const borderColor = colorChangeStatus;
 
+  // Themed surface + text colors, sourced from the shared `colors` design
+  // tokens (the codebase's dark-mode mechanism) and selected by the `isDark`
+  // prop — rather than inline hex literals. The dark card surface uses
+  // neutral[800] (#262626), matching the sibling LineageColumnNode card.
+  const paperBg = isDark ? colors.neutral[800] : colors.white;
+  const primaryText = isDark ? colors.white : colors.black;
+  const invertedText = isDark ? colors.black : colors.white;
+
   // Node background color logic
   const nodeBackgroundColor = (() => {
-    const paperBg = isDark ? "#1e1e1e" : "#ffffff";
-
     if (showContent) {
       if (selectMode === "selecting") {
         return isSelected ? colorChangeStatus : paperBg;
@@ -392,9 +399,6 @@ function LineageNodeComponent({
 
   // Text color logic
   const titleColor = (() => {
-    const primaryText = isDark ? "#ffffff" : "#000000";
-    const invertedText = isDark ? "#000000" : "#ffffff";
-
     if (selectMode === "selecting") {
       return isSelected ? invertedText : primaryText;
     }
@@ -405,9 +409,6 @@ function LineageNodeComponent({
   })();
 
   const iconColor = (() => {
-    const primaryText = isDark ? "#ffffff" : "#000000";
-    const invertedText = isDark ? "#000000" : "#ffffff";
-
     if (selectMode === "selecting") {
       return isSelected ? invertedText : primaryText;
     }
@@ -418,9 +419,6 @@ function LineageNodeComponent({
   })();
 
   const changeStatusIconColor = (() => {
-    const primaryText = isDark ? "#ffffff" : "#000000";
-    const invertedText = isDark ? "#000000" : "#ffffff";
-
     if (selectMode === "selecting") {
       return isSelected ? invertedText : colorChangeStatus;
     }

--- a/js/packages/ui/src/components/lineage/styles.tsx
+++ b/js/packages/ui/src/components/lineage/styles.tsx
@@ -711,7 +711,8 @@ export const changeStatusBackgroundsDark: Record<
  * CLL palette — muted brown/yellow variant used only inside the new CLL
  * experience (LineageNode, LineageColumnNode, LineageEdge, LineageCanvas
  * minimap, LineageLegend). Mirrors the `.cll-experience` overrides in
- * ../schema/style.css; keep both sides in sync (no build-time check).
+ * ../schema/style.css; the two are kept in sync by the guard test
+ * __tests__/cllPaletteSync.test.ts (fails CI on drift).
  */
 export const cllChangeStatusColors: Record<
   ChangeStatus | "unchanged" | "impacted",
@@ -749,7 +750,7 @@ export const cllChangeStatusBackgroundsDark: Record<
 /**
  * Impacted accent + badge palette. Mirrors `--schema-color-impacted-accent`
  * and `--schema-badge-impacted-{bg,fg}` in ../schema/style.css under
- * `.cll-experience` — keep both in sync by hand (no build-time check).
+ * `.cll-experience` — kept in sync by __tests__/cllPaletteSync.test.ts.
  */
 const IMPACTED_HUE_LIGHT = "252 211 77"; // matches cllChangeStatusColors.impacted
 
@@ -772,7 +773,7 @@ export const cllImpactedBadgeFg = {
 /**
  * Changed accent + badge palette. Mirrors `--schema-color-changed-accent`
  * and `--schema-badge-changed-{bg,fg}` in ../schema/style.css under
- * `.cll-experience` — keep both in sync by hand (no build-time check).
+ * `.cll-experience` — kept in sync by __tests__/cllPaletteSync.test.ts.
  */
 export const cllChangedAccent = cllChangeStatusColors.modified;
 
@@ -788,8 +789,8 @@ export const cllChangedBadgeFg = {
 
 /**
  * Additive accent + badge palette. Mirrors `--schema-color-added-accent`
- * and `--schema-badge-added-{bg,fg}` in ../schema/style.css — keep both in
- * sync by hand (no build-time check).
+ * and `--schema-badge-added-{bg,fg}` in ../schema/style.css — kept in sync
+ * by __tests__/cllPaletteSync.test.ts.
  */
 export const cllAdditiveAccent = {
   light: cllChangeStatusColors.added,

--- a/js/packages/ui/src/components/schema/style.css
+++ b/js/packages/ui/src/components/schema/style.css
@@ -5,8 +5,9 @@
  * Default palette is the long-standing pale yellow/orange "changed" hue.
  * The new CLL experience overrides "changed" with a deeper brown and adds
  * "impacted-accent" + impacted badge colors under the `.cll-experience`
- * selector below. JS counterparts live in ../lineage/styles.tsx — keep
- * them in sync by hand; there is no build-time check:
+ * selector below. JS counterparts live in ../lineage/styles.tsx and are kept
+ * in sync by the guard test ../lineage/__tests__/cllPaletteSync.test.ts
+ * (fails CI on drift):
  *   - cllChangeStatusColors / cllChangeStatusBackgrounds* — row & accent
  *   - cllImpactedAccent — --schema-color-impacted-accent
  *   - cllImpactedBadgeBg / cllImpactedBadgeFg — --schema-badge-impacted-*


### PR DESCRIPTION
## What this PR does

Clears the leftover hygiene items from the PR #1381 review (Linear DRC-3525). These are low-risk, self-contained chores — two new tests, one color-hardcoding cleanup, and a guard against a palette that was being kept in sync by hand. **No product behavior changes.**

## The items

**1. Test the whole-model badge colors.** The helper that picks the palette tokens for the lineage badges (`tokensForKind`) had no tests at all. Added one that locks its output for every badge kind in both light and dark mode, so a future color tweak can't silently break them.

**2. (Deferred) The `RECCE_WHOLE_MODEL_IMPACT` CLI test.** Skipped on purpose. That environment variable was never actually adopted — the real feature flag is `RECCE_NEW_CLL_EXPERIENCE` / `--new-cll-experience`. Writing a test for a name that doesn't exist would just bake in confusion. This needs a small product decision (point the test at the real flag, or drop the item), not a mechanical test, so it's left out for now.

**3. Two missing edge-case tests for impact propagation.** `computeWholeModelImpact` was covered for the common cases but not for (a) a lineage graph with disconnected pieces — impact shouldn't leak across them — or (b) a changed node that isn't in the graph at all, which shouldn't crash. Both added.

**4. Remove hardcoded colors from the lineage node.** `LineageNode.tsx` had raw hex values (`#1e1e1e`, `#ffffff`, `#000000`) repeated inline for the card background and text. Replaced them with the shared design tokens the rest of the lineage UI already uses, selected by the existing dark-mode flag. One small, deliberate normalization: the dark card moves from `#1e1e1e` to the shared neutral `#262626`, which matches the sibling node and MUI's dark surface — the old value was the odd one out. Visually imperceptible.

**5. Stop the CLL palette from silently drifting.** The palette is currently written twice — once as TypeScript constants for the React canvas, once as CSS variables for the schema grid — with a comment admitting the two are kept in sync by hand. Rather than the bigger refactor (generating one side from the other), this adds a test that parses the CSS and asserts the two match, so any future drift fails CI. The proper single-source fix (emit the CSS variables from the TS constants) touches the schema view, so it's left as a follow-up; the guard makes the duplication safe in the meantime.

## Tests
All green: 554 lineage tests pass (including the three new/updated files), `pnpm type:check` clean, Biome lint clean.

## User-facing changes
None — tests and internal color sourcing only. The dark lineage-node card shifts `#1e1e1e` → `#262626`, which is negligible and now consistent with its sibling nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
