### PR TITLE
fix(server): enforce read-only/preview modes on REST API (DRC-3828)

### DIFF
--- a/recce/server.py
+++ b/recce/server.py
@@ -479,6 +479,92 @@ async def readiness_gate(request: Request, call_next):
     return await call_next(request)
 
 
+# Run types that execute a warehouse query. Blocked outside full "server" mode,
+# mirroring the blocked-tool set in mcp_server.py so REST and MCP agree.
+_QUERY_RUN_TYPES = frozenset(
+    {
+        "query",
+        "query_base",
+        "query_diff",
+        "value_diff",
+        "value_diff_detail",
+        "profile",
+        "profile_diff",
+        "profile_distribution",
+        "row_count",
+        "row_count_diff",
+        "top_k_diff",
+        "histogram_diff",
+    }
+)
+
+
+def _mode_block_reason(method, path, run_type, read_only, preview):
+    """Return a denial reason if server mode disallows the request, else None.
+
+    Preview (metadata-only) blocks query execution. Read-only additionally
+    blocks all state and checklist writes. Matches cli.py: read-only = "No run
+    query, no checklist"; preview = "No run query".
+    """
+    if not (read_only or preview):
+        return None
+
+    # Query execution — blocked in both preview and read-only.
+    if method == "POST" and path == "/api/runs" and run_type in _QUERY_RUN_TYPES:
+        return f"run type '{run_type}' executes a query"
+    if method == "POST" and path.startswith("/api/checks/") and path.endswith("/run"):
+        return "running a check executes a query"
+
+    # State and checklist writes — blocked in read-only only.
+    if read_only:
+        if method == "POST" and path in ("/api/save", "/api/save-as", "/api/rename", "/api/export"):
+            return "modifying server state"
+        if method in ("POST", "PATCH", "PUT", "DELETE") and path.startswith("/api/checks"):
+            return "modifying the checklist"
+    return None
+
+
+@app.middleware("http")
+async def enforce_server_mode(request: Request, call_next):
+    """Server-side enforcement of read-only / preview restrictions.
+
+    The frontend hides disallowed actions, but that is cosmetic. This gate is
+    the real security boundary for shared instances: without it, callers can
+    run arbitrary SQL and mutate state via the REST API regardless of mode.
+    """
+    flag = getattr(request.app.state, "flag", None) or {}
+    read_only = flag.get("read_only", False)
+    preview = flag.get("preview", False)
+
+    if read_only or preview:
+        method = request.method
+        path = request.url.path
+        run_type = None
+        # Only POST /api/runs needs body inspection; read it, then replay the
+        # bytes so the downstream handler can still parse the request.
+        if method == "POST" and path == "/api/runs":
+            body = await request.body()
+
+            async def _replay():
+                return {"type": "http.request", "body": body, "more_body": False}
+
+            request._receive = _replay
+            try:
+                run_type = json.loads(body or b"{}").get("type")
+            except (ValueError, AttributeError):
+                run_type = None
+
+        reason = _mode_block_reason(method, path, run_type, read_only, preview)
+        if reason:
+            mode = "read-only" if read_only else "preview"
+            return JSONResponse(
+                {"detail": f"This action is not allowed in {mode} mode ({reason})."},
+                status_code=403,
+            )
+
+    return await call_next(request)
+
+
 @app.middleware("http")
 async def disable_cache(request: Request, call_next):
     response = await call_next(request)

--- a/recce/server.py
+++ b/recce/server.py
@@ -514,6 +514,10 @@ def _mode_block_reason(method, path, run_type, read_only, preview):
         return f"run type '{run_type}' executes a query"
     if method == "POST" and path.startswith("/api/checks/") and path.endswith("/run"):
         return "running a check executes a query"
+    # Exporting a run re-executes its SQL against the warehouse (see
+    # run_api._execute_export_query), so it is query execution, not a plain read.
+    if method == "GET" and path.startswith("/api/runs/") and path.endswith("/export"):
+        return "exporting a run re-executes its query"
 
     # State and checklist writes — blocked in read-only only.
     if read_only:

--- a/recce/server.py
+++ b/recce/server.py
@@ -544,15 +544,10 @@ async def enforce_server_mode(request: Request, call_next):
         method = request.method
         path = request.url.path
         run_type = None
-        # Only POST /api/runs needs body inspection; read it, then replay the
-        # bytes so the downstream handler can still parse the request.
+        # Only POST /api/runs needs body inspection. Starlette's BaseHTTPMiddleware
+        # buffers the body, so reading it here does not starve the downstream handler.
         if method == "POST" and path == "/api/runs":
             body = await request.body()
-
-            async def _replay():
-                return {"type": "http.request", "body": body, "more_body": False}
-
-            request._receive = _replay
             try:
                 run_type = json.loads(body or b"{}").get("type")
             except (ValueError, AttributeError):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,18 @@ from recce.core import RecceContext
 from recce.state import CloudStateLoader
 
 
+@pytest.fixture(autouse=True)
+def _restore_app_state():
+    """The server command assigns to the shared module `app.state` (cli.py:1427),
+    sometimes a MagicMock via @patch. Restore it after each test so state does not
+    leak into later tests (e.g. tripping the mode-guard middleware)."""
+    from recce.server import app
+
+    orig = app.state
+    yield
+    app.state = orig
+
+
 def test_cmd_version():
     from recce import __version__
     from recce.cli import version

--- a/tests/test_server_mode_guard.py
+++ b/tests/test_server_mode_guard.py
@@ -24,6 +24,9 @@ def test_preview_blocks_query_execution_only():
     assert _blocked("POST", "/api/runs", "query", preview=True)
     assert _blocked("POST", "/api/runs", "value_diff", preview=True)
     assert _blocked("POST", "/api/checks/abc/run", preview=True)
+    # Exporting a run re-executes its SQL (run_api._execute_export_query), so it
+    # is query execution and must be blocked in preview.
+    assert _blocked("GET", "/api/runs/abc/export", preview=True)
     # Metadata runs stay allowed in preview (matches MCP keeping lineage/schema).
     assert not _blocked("POST", "/api/runs", "lineage_diff", preview=True)
     assert not _blocked("POST", "/api/runs", "schema_diff", preview=True)
@@ -43,6 +46,7 @@ def test_read_only_blocks_queries_and_writes():
     assert _blocked("POST", "/api/save-as", read_only=True)
     assert _blocked("POST", "/api/rename", read_only=True)
     assert _blocked("POST", "/api/export", read_only=True)
+    assert _blocked("GET", "/api/runs/abc/export", read_only=True)
     # Metadata runs and reads remain allowed even in read-only.
     assert not _blocked("POST", "/api/runs", "lineage_diff", read_only=True)
     assert not _blocked("GET", "/api/runs", read_only=True)

--- a/tests/test_server_mode_guard.py
+++ b/tests/test_server_mode_guard.py
@@ -3,6 +3,8 @@
 Mirrors the blocked-tool logic in mcp_server.py. See DRC-3828.
 """
 
+import json
+
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
@@ -62,8 +64,11 @@ def _client(flag):
 
     @app.post("/api/runs")
     async def runs(request: Request):
-        body = await request.json()  # proves the replayed body survived the gate
-        return {"echoed_type": body.get("type")}
+        raw = await request.body()  # proves the body survived the gate
+        try:
+            return {"echoed_type": json.loads(raw).get("type")}
+        except ValueError:
+            return {"echoed_type": None}
 
     return TestClient(app)
 
@@ -80,3 +85,12 @@ def test_middleware_allows_metadata_run_and_preserves_body():
     resp = _client({"read_only": True}).post("/api/runs", json={"type": "lineage_diff"})
     assert resp.status_code == 200
     assert resp.json() == {"echoed_type": "lineage_diff"}
+
+
+def test_middleware_tolerates_malformed_body():
+    # A non-JSON body must not crash the gate; run_type stays None, so the
+    # request is not treated as a query and passes through (not 403).
+    resp = _client({"read_only": True}).post(
+        "/api/runs", content=b"not json", headers={"Content-Type": "application/json"}
+    )
+    assert resp.status_code == 200

--- a/tests/test_server_mode_guard.py
+++ b/tests/test_server_mode_guard.py
@@ -1,0 +1,78 @@
+"""Server-side enforcement of read-only / preview modes on the REST API.
+
+Mirrors the blocked-tool logic in mcp_server.py. See DRC-3828.
+"""
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from recce.server import _mode_block_reason, enforce_server_mode
+
+
+def _blocked(method, path, run_type=None, *, read_only=False, preview=False):
+    return _mode_block_reason(method, path, run_type, read_only, preview) is not None
+
+
+def test_server_mode_allows_everything():
+    # Full server mode: nothing is gated.
+    assert not _blocked("POST", "/api/runs", "query")
+    assert not _blocked("POST", "/api/save")
+    assert not _blocked("DELETE", "/api/checks/abc")
+
+
+def test_preview_blocks_query_execution_only():
+    assert _blocked("POST", "/api/runs", "query", preview=True)
+    assert _blocked("POST", "/api/runs", "value_diff", preview=True)
+    assert _blocked("POST", "/api/checks/abc/run", preview=True)
+    # Metadata runs stay allowed in preview (matches MCP keeping lineage/schema).
+    assert not _blocked("POST", "/api/runs", "lineage_diff", preview=True)
+    assert not _blocked("POST", "/api/runs", "schema_diff", preview=True)
+    # Preview still permits checklist edits and state writes.
+    assert not _blocked("POST", "/api/checks", preview=True)
+    assert not _blocked("POST", "/api/save", preview=True)
+
+
+def test_read_only_blocks_queries_and_writes():
+    assert _blocked("POST", "/api/runs", "query", read_only=True)
+    assert _blocked("POST", "/api/checks/abc/run", read_only=True)
+    assert _blocked("POST", "/api/checks", read_only=True)
+    assert _blocked("PATCH", "/api/checks/abc", read_only=True)
+    assert _blocked("DELETE", "/api/checks/abc", read_only=True)
+    assert _blocked("POST", "/api/checks/reorder", read_only=True)
+    assert _blocked("POST", "/api/save", read_only=True)
+    assert _blocked("POST", "/api/save-as", read_only=True)
+    assert _blocked("POST", "/api/rename", read_only=True)
+    assert _blocked("POST", "/api/export", read_only=True)
+    # Metadata runs and reads remain allowed even in read-only.
+    assert not _blocked("POST", "/api/runs", "lineage_diff", read_only=True)
+    assert not _blocked("GET", "/api/runs", read_only=True)
+    assert not _blocked("GET", "/api/checks", read_only=True)
+    assert not _blocked("POST", "/api/runs/search", read_only=True)
+
+
+def _client(flag):
+    """Tiny app wearing the real middleware, with an echo route for /api/runs."""
+    app = FastAPI()
+    app.state.flag = flag
+    app.middleware("http")(enforce_server_mode)
+
+    @app.post("/api/runs")
+    async def runs(request: Request):
+        body = await request.json()  # proves the replayed body survived the gate
+        return {"echoed_type": body.get("type")}
+
+    return TestClient(app)
+
+
+def test_middleware_blocks_query_run_in_read_only():
+    resp = _client({"read_only": True}).post("/api/runs", json={"type": "query"})
+    assert resp.status_code == 403
+    assert "read-only" in resp.json()["detail"]
+
+
+def test_middleware_allows_metadata_run_and_preserves_body():
+    # Allowed request must pass the gate AND still reach the handler with an
+    # intact body — this is what verifies the body-replay works.
+    resp = _client({"read_only": True}).post("/api/runs", json={"type": "lineage_diff"})
+    assert resp.status_code == 200
+    assert resp.json() == {"echoed_type": "lineage_diff"}


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`fix` / security

**What this PR does / why we need it**:

Read-only and preview server modes were enforced **only in the frontend**. The REST API had no server-side guard, so any unauthenticated caller could bypass the sharing boundary by hitting the endpoints directly — run arbitrary SQL via `POST /api/runs`, create/modify/delete checks, and `save`/`rename`/`export` state — despite `read_only: true`. The MCP server already gates these operations by mode (`mcp_server.py`); this PR brings the REST API in line.

Adds an `enforce_server_mode` HTTP middleware in `recce/server.py`:

- **Preview (metadata-only)** blocks query execution: `POST /api/runs` of a warehouse-query run type, and `POST /api/checks/{id}/run`.
- **Read-only** additionally blocks checklist mutations (`POST`/`PATCH`/`DELETE` under `/api/checks*`) and state writes (`/api/save`, `/api/save-as`, `/api/rename`, `/api/export`).
- Metadata runs (`lineage_diff`, `schema_diff`) and all `GET` reads remain allowed, so preview/read-only UIs keep working.

The blocked run-type set mirrors the blocked-tool set in `mcp_server.py` so REST and MCP agree. Denials return `403` with a human-readable reason.

**Which issue(s) this PR fixes**:

Fixes DRC-3828 (external security report).

**Special notes for your reviewer**:

- The gate is one central function `_mode_block_reason(...)` (pure, unit-tested) plus a thin middleware. Only `POST /api/runs` needs body inspection (run type is in the body); the body is read and replayed downstream so handlers still parse it.
- `tests/test_server_mode_guard.py` covers the full policy matrix plus one `TestClient` run that verifies the body-replay doesn't break the real handler.
- Deliberately left allowed: `GET /api/runs/{id}/export` (exporting an existing run's already-visible results) and `POST /api/runs/{id}/cancel`. Say if you'd rather gate those too.
- Not addressed here (tracked as follow-ups in DRC-3828): optional API auth, request logging, rate limiting.

**Does this PR introduce a user-facing change?**:

```release-note
Read-only and preview server modes are now enforced server-side on the REST API. Query execution and state/checklist mutations that were previously blocked only in the UI are now rejected with HTTP 403 in the corresponding modes.
```
