### PR TITLE
fix(mcp): warn about dbt selector grammar in select param descriptions

### DIFF
--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -53,6 +53,15 @@ SINGLE_ENV_WARNING = (
     "Run `dbt docs generate --target-path target-base` to enable diffing."
 )
 
+# Guards against agents comma-joining distinct model names in `select`, which dbt reads
+# as an intersection and silently resolves to an empty diff (looks like "no changes").
+SELECTOR_SYNTAX_NOTE = (
+    "Combine selectors with a SPACE for union (OR) or a COMMA for intersection (AND); "
+    "this applies to all selector arguments. "
+    "When targeting by model name: comma-joining distinct names matches nothing "
+    "(no node is all of them at once), and bare names match exactly (use 'name*' for prefix matching)."
+)
+
 # DRC-3758: cap the node count returned by lineage_diff(view_mode="all") to keep the
 # serialized MCP result within the Claude Agent SDK output cap (MAX_MCP_OUTPUT_TOKENS,
 # default 25,000 tokens). Only the node count is bounded — edge count is assumed to
@@ -717,7 +726,8 @@ class RecceMCPServer:
                                     "Valid state selectors: state:new, state:old, state:modified, state:unmodified. "
                                     "Use '+' suffix for downstream: state:modified+ "
                                     "NOTE: 'state:added' is INVALID - use 'state:new'. "
-                                    "Example: '1+state:modified+' for modified models with 1 upstream"
+                                    "Example: '1+state:modified+' for modified models with 1 upstream. "
+                                    + SELECTOR_SYNTAX_NOTE
                                 ),
                             },
                             "exclude": {
@@ -752,7 +762,7 @@ class RecceMCPServer:
                                 "description": (
                                     "dbt selector syntax to filter models. "
                                     "Valid state selectors: state:new, state:old, state:modified, state:unmodified. "
-                                    "NOTE: 'state:added' is INVALID - use 'state:new'."
+                                    "NOTE: 'state:added' is INVALID - use 'state:new'. " + SELECTOR_SYNTAX_NOTE
                                 ),
                             },
                             "exclude": {
@@ -935,7 +945,7 @@ class RecceMCPServer:
                                 "description": (
                                     "dbt selector syntax to filter models. "
                                     "Valid state selectors: state:new, state:old, state:modified, state:unmodified. "
-                                    "NOTE: 'state:added' is INVALID - use 'state:new'."
+                                    "NOTE: 'state:added' is INVALID - use 'state:new'. " + SELECTOR_SYNTAX_NOTE
                                 ),
                             },
                             "exclude": {
@@ -1009,7 +1019,8 @@ class RecceMCPServer:
                                             "Sub-selectors: state:modified.body, .configs, .relation, .persisted_descriptions, .macros, .contract. "
                                             "Use '+' suffix for downstream deps: state:modified+ "
                                             "IMPORTANT: 'state:added' is INVALID - use 'state:new' instead. "
-                                            "Example: 'state:new,config.materialized:table' or 'state:modified+'"
+                                            "Example: 'state:new,config.materialized:table' or 'state:modified+'. "
+                                            + SELECTOR_SYNTAX_NOTE
                                         ),
                                     },
                                     "exclude": {
@@ -1365,7 +1376,8 @@ class RecceMCPServer:
                                     "description": (
                                         "dbt selector syntax. Default: data-affecting changes only "
                                         "(body + macros + contract and their downstream). "
-                                        "Use 'state:modified+' to include all changes including config."
+                                        "Use 'state:modified+' to include all changes including config. "
+                                        + SELECTOR_SYNTAX_NOTE
                                     ),
                                 },
                                 "skip_value_diff": {

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1859,6 +1859,29 @@ class TestMCPServerSingleEnv:
                 note_text not in tool.description
             ), f"Tool '{tool.name}' should not have single-env note in normal mode"
 
+    @pytest.mark.asyncio
+    async def test_select_param_descriptions_warn_selector_grammar(self, mcp_server):
+        """Every tool exposing a `select` param must warn about dbt selector grammar:
+        a comma is intersection, so comma-joining distinct model names silently returns empty."""
+        from mcp.types import ListToolsRequest
+
+        server, _ = mcp_server
+        handler = server.server.request_handlers[ListToolsRequest]
+        result = await handler(ListToolsRequest(method="tools/list"))
+        tools = result.root.tools
+
+        checked = 0
+        for tool in tools:
+            select = tool.inputSchema.get("properties", {}).get("select")
+            if select is None:
+                continue
+            checked += 1
+            assert (
+                "intersection (AND)" in select["description"]
+            ), f"Tool '{tool.name}' select description must warn about comma=intersection"
+
+        assert checked >= 5, f"expected >=5 tools with a select param, found {checked}"
+
 
 class TestErrorClassification:
     """Test the _classify_db_error method and call_tool error handling"""
@@ -3140,9 +3163,7 @@ class TestLocalModeRunBacked:
         up to the raise."""
         from recce.models.types import RunStatus
 
-        with patch.object(
-            QueryDiffTask, "execute", side_effect=Exception('Referenced column "bad_col" not found')
-        ):
+        with patch.object(QueryDiffTask, "execute", side_effect=Exception('Referenced column "bad_col" not found')):
             result = await TestCallToolHandler._invoke_call_tool(
                 server, "query_diff", {"sql_template": "SELECT bad_col", "primary_keys": ["id"]}
             )


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`fix`

**What this PR does / why we need it**:

The MCP `select` string feeds dbt's node-selection grammar, where a comma means intersection. Agents comma-join distinct model names (e.g. `a,b`), so dbt intersects them → zero nodes → an empty diff indistinguishable from "no changes" → silent under-reporting (seen in production). Since `select` is passed to dbt verbatim, the fix is in the description contract: warn on every `select` param that a comma is intersection, a space is union, and bare names are exact.

**Which issue(s) this PR fixes**:

DRC-3834

**Special notes for your reviewer**:

- Grammar verified against dbt docs (Core 1.11): space=union, comma=intersection, bare name=exact, wildcard needs `*`.

**Does this PR introduce a user-facing change?**:

NONE
