### PR TITLE
fix(lineage): show change categories in launch sessions

### DIFF
--- a/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
+++ b/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
@@ -309,7 +309,7 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
   // Computed state
   const changeCategory = resolveChangeCategory(
     cll?.current.nodes[id]?.change_category,
-    data.change?.category,
+    newCllExperience ? undefined : data.change?.category,
   );
   const isHighlighted = isNodeHighlighted(id);
   const isSelected = isNodeSelected(id);
@@ -376,7 +376,8 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
       // Action display props
       actionTag={actionTag}
       showChangeAnalysis={
-        isShowingChangeAnalysis || changeCategory !== undefined
+        isShowingChangeAnalysis ||
+        (!newCllExperience && changeCategory !== undefined)
       }
       changeCategory={changeCategory}
       runsAggregatedTag={runsAggregatedTag}

--- a/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
+++ b/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
@@ -375,7 +375,9 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
       showContent={showContent}
       // Action display props
       actionTag={actionTag}
-      showChangeAnalysis={isShowingChangeAnalysis}
+      showChangeAnalysis={
+        isShowingChangeAnalysis || changeCategory !== undefined
+      }
       changeCategory={changeCategory}
       runsAggregatedTag={runsAggregatedTag}
       // Layout props

--- a/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
+++ b/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
@@ -31,9 +31,9 @@ import {
 import { useThemeColors } from "../../hooks";
 import { deltaPercentageString } from "../../utils";
 import { findByRunType } from "../run";
+import { resolveChangeCategory } from "./changeCategory";
 import {
   ActionTag,
-  type ChangeCategory,
   LineageNode,
   type NodeChangeStatus,
   type SelectMode,
@@ -307,8 +307,10 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
   );
 
   // Computed state
-  const changeCategory = cll?.current.nodes[id]
-    ?.change_category as ChangeCategory;
+  const changeCategory = resolveChangeCategory(
+    cll?.current.nodes[id]?.change_category,
+    data.change?.category,
+  );
   const isHighlighted = isNodeHighlighted(id);
   const isSelected = isNodeSelected(id);
   const isFocusedByImpactRadius =

--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -131,6 +131,13 @@ import { LineageViewTopBarOss as LineageViewTopBar } from "./topbar/LineageViewT
 /** Hide MiniMap when node count exceeds this threshold to reduce DOM pressure */
 export const MINIMAP_NODE_THRESHOLD = 500;
 
+export function nextFocusedNodeId(
+  currentNodeId: string | undefined,
+  clickedNodeId: string,
+): string | undefined {
+  return currentNodeId === clickedNodeId ? undefined : clickedNodeId;
+}
+
 /**
  * Compute impacted node IDs and column IDs in a single pass over the CLL data.
  *
@@ -851,7 +858,7 @@ export function PrivateLineageView(
 
     closeContextMenu();
     if (!selectMode) {
-      setFocusedNodeId(node.id);
+      setFocusedNodeId(nextFocusedNodeId(focusedNodeId, node.id));
       setFocusedHistory([]);
     } else if (selectMode === "action_result") {
       const action = multiNodeAction.actionState.actions[node.id];

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -2,6 +2,7 @@
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import Tab from "@mui/material/Tab";
@@ -18,6 +19,7 @@ import { IoClose } from "react-icons/io5";
 import type { NodeData } from "../../api/info";
 import { DisableTooltipMessages } from "../../constants";
 import { useThemeColors } from "../../hooks";
+import { getChangeCategoryLabel } from "./changeCategory";
 import type { ChangeCategory } from "./nodes";
 import { TreatmentChip } from "./TreatmentChip";
 import { getTitleRowTooltip, pickTitleChip } from "./wholeModelTreatment";
@@ -656,6 +658,9 @@ export function NodeView<TNode extends NodeViewNodeData>({
     },
     treatmentInputs,
   );
+  const changeCategoryLabel = newCllExperience
+    ? undefined
+    : getChangeCategoryLabel(node.data.change?.category);
 
   return (
     <Box
@@ -730,6 +735,15 @@ export function NodeView<TNode extends NodeViewNodeData>({
           <Box sx={{ color: "text.secondary", flexShrink: 0 }}>
             <ResourceTypeTag node={node} />
           </Box>
+        )}
+        {changeCategoryLabel && (
+          <Chip
+            data-testid="change-category-chip"
+            label={changeCategoryLabel}
+            size="small"
+            variant="outlined"
+            sx={{ flexShrink: 0 }}
+          />
         )}
         <IconButton size="small" onClick={onCloseNode} sx={{ flexShrink: 0 }}>
           <IoClose />

--- a/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.test.tsx
@@ -1,0 +1,164 @@
+import { render } from "@testing-library/react";
+import { vi } from "vitest";
+
+const { mockLineageNode, mockViewContext } = vi.hoisted(() => ({
+  mockLineageNode: vi.fn(),
+  mockViewContext: { current: undefined as unknown },
+}));
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>();
+  return {
+    ...actual,
+    useStore: (selector: (state: { transform: number[] }) => unknown) =>
+      selector({ transform: [0, 0, 1] }),
+  };
+});
+
+vi.mock("../../../contexts", () => ({
+  useLineageGraphContext: () => ({}),
+  useLineageViewContextSafe: () => mockViewContext.current,
+}));
+
+vi.mock("../../../hooks", () => ({
+  useThemeColors: () => ({
+    isDark: false,
+    text: { inverted: "white", secondary: "grey" },
+  }),
+}));
+
+vi.mock("../nodes", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../nodes")>();
+  return {
+    ...actual,
+    LineageNode: (props: unknown) => {
+      mockLineageNode(props);
+      return <div data-testid="lineage-node" />;
+    },
+  };
+});
+
+import type {
+  LineageGraphNode,
+  LineageViewContextType,
+} from "../../../contexts";
+import { GraphNode, type GraphNodeProps } from "../GraphNodeOss";
+
+function createViewContext(
+  overrides: Partial<LineageViewContextType> = {},
+): LineageViewContextType {
+  return {
+    interactive: true,
+    selectNode: vi.fn(),
+    selectMode: "normal",
+    focusedNode: undefined,
+    getNodeAction: vi.fn(),
+    getNodeColumnSet: vi.fn(() => new Set()),
+    isNodeHighlighted: vi.fn(() => false),
+    isNodeSelected: vi.fn(() => false),
+    isNodeShowingChangeAnalysis: vi.fn(() => false),
+    showContextMenu: vi.fn(),
+    viewOptions: {},
+    cll: {
+      current: { nodes: {}, columns: {}, parent_map: {}, child_map: {} },
+    },
+    impactedNodeIds: new Set(),
+    newCllExperience: false,
+    wholeModelChangedNodeIds: new Set(),
+    wholeModelImpactedNodeIds: new Set(),
+    ...overrides,
+  } as LineageViewContextType;
+}
+
+function createNodeProps(): GraphNodeProps {
+  const node: LineageGraphNode = {
+    id: "model.test.orders",
+    type: "lineageGraphNode",
+    position: { x: 0, y: 0 },
+    data: {
+      id: "model.test.orders",
+      name: "orders",
+      resourceType: "model",
+      changeStatus: "modified",
+      change: { category: "non_breaking" }, // wire-enum-ok
+      parents: {},
+      children: {},
+    },
+  };
+
+  return {
+    ...node,
+    selected: false,
+    dragging: false,
+    draggable: true,
+    selectable: true,
+    deletable: false,
+    isConnectable: false,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
+    zIndex: 0,
+  };
+}
+
+describe("GraphNode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the merged-lineage category in the legacy experience", () => {
+    mockViewContext.current = createViewContext();
+
+    render(<GraphNode {...createNodeProps()} />);
+
+    expect(mockLineageNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changeCategory: "non_breaking",
+        showChangeAnalysis: true,
+      }),
+    );
+  });
+
+  it("does not leak the merged-lineage category into the new CLL experience", () => {
+    mockViewContext.current = createViewContext({ newCllExperience: true });
+
+    render(<GraphNode {...createNodeProps()} />);
+
+    expect(mockLineageNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changeCategory: undefined,
+        showChangeAnalysis: false,
+      }),
+    );
+  });
+
+  it("preserves a fresh CLL category in the new CLL experience", () => {
+    mockViewContext.current = createViewContext({
+      newCllExperience: true,
+      cll: {
+        current: {
+          nodes: {
+            "model.test.orders": {
+              id: "model.test.orders",
+              name: "orders",
+              source_name: "",
+              resource_type: "model",
+              change_category: "partial_breaking", // wire-enum-ok
+            },
+          },
+          columns: {},
+          parent_map: {},
+          child_map: {},
+        },
+      },
+    });
+
+    render(<GraphNode {...createNodeProps()} />);
+
+    expect(mockLineageNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changeCategory: "partial_breaking",
+        showChangeAnalysis: false,
+      }),
+    );
+  });
+});

--- a/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.test.tsx
@@ -112,7 +112,7 @@ describe("GraphNode", () => {
 
     expect(mockLineageNode).toHaveBeenCalledWith(
       expect.objectContaining({
-        changeCategory: "non_breaking",
+        changeCategory: "non_breaking", // wire-enum-ok
         showChangeAnalysis: true,
       }),
     );
@@ -156,7 +156,7 @@ describe("GraphNode", () => {
 
     expect(mockLineageNode).toHaveBeenCalledWith(
       expect.objectContaining({
-        changeCategory: "partial_breaking",
+        changeCategory: "partial_breaking", // wire-enum-ok
         showChangeAnalysis: false,
       }),
     );

--- a/js/packages/ui/src/components/lineage/__tests__/LineageLegend.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageLegend.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LineageLegend } from "../legend";
+
+describe("LineageLegend", () => {
+  it("renders all change categories below the change statuses", () => {
+    render(<LineageLegend variant="changeStatus" />);
+
+    expect(screen.getByText("Change Categories")).toBeInTheDocument();
+    expect(screen.getByText("Model-Wide Change")).toBeInTheDocument();
+    expect(screen.getByText("Column Change")).toBeInTheDocument();
+    expect(screen.getByText("Additive Change")).toBeInTheDocument();
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it("does not add change categories to the transformation legend", () => {
+    render(<LineageLegend variant="transformation" />);
+
+    expect(screen.queryByText("Change Categories")).not.toBeInTheDocument();
+  });
+
+  it("leaves category treatment to the new CLL experience", () => {
+    render(<LineageLegend variant="changeStatus" newCllExperience />);
+
+    expect(screen.queryByText("Change Categories")).not.toBeInTheDocument();
+  });
+});

--- a/js/packages/ui/src/components/lineage/__tests__/LineageViewFocus.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageViewFocus.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { nextFocusedNodeId } from "../LineageViewOss";
+
+describe("nextFocusedNodeId", () => {
+  it("focuses a newly clicked node", () => {
+    expect(nextFocusedNodeId(undefined, "model.test.orders")).toBe(
+      "model.test.orders",
+    );
+  });
+
+  it("closes the detail panel when the focused node is clicked again", () => {
+    expect(
+      nextFocusedNodeId("model.test.orders", "model.test.orders"),
+    ).toBeUndefined();
+  });
+
+  it("moves focus when a different node is clicked", () => {
+    expect(nextFocusedNodeId("model.test.orders", "model.test.customers")).toBe(
+      "model.test.customers",
+    );
+  });
+});

--- a/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
@@ -121,6 +121,41 @@ function renderNodeView(
 // ============================================================================
 
 describe("NodeView", () => {
+  describe("change category", () => {
+    test.each([
+      ["breaking", "Model-Wide Change"], // wire-enum-ok
+      ["partial_breaking", "Column Change"], // wire-enum-ok
+      ["non_breaking", "Additive Change"], // wire-enum-ok
+      ["unknown", "Unknown"],
+    ])("renders the %s category chip", (category, label) => {
+      const node = createNode("model");
+      node.data.change = { category };
+
+      renderNodeView(node);
+
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+
+    test("does not render a category chip without category data", () => {
+      renderNodeView(createNode("model"));
+
+      expect(
+        screen.queryByTestId("change-category-chip"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("leaves category treatment to the new CLL experience", () => {
+      const node = createNode("model");
+      node.data.change = { category: "unknown" };
+
+      renderNodeView(node, undefined, { newCllExperience: true });
+
+      expect(
+        screen.queryByTestId("change-category-chip"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("source node schema display", () => {
     test("renders column schema for source nodes", () => {
       renderNodeView(createNode("source", testColumns), testColumns);

--- a/js/packages/ui/src/components/lineage/__tests__/changeCategory.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/changeCategory.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHANGE_CATEGORY_LABELS,
+  resolveChangeCategory,
+} from "../changeCategory";
+
+describe("change category", () => {
+  it.each([
+    ["breaking", "Model-Wide Change"], // wire-enum-ok
+    ["partial_breaking", "Column Change"], // wire-enum-ok
+    ["non_breaking", "Additive Change"], // wire-enum-ok
+    ["unknown", "Unknown"],
+  ] as const)("maps %s to %s", (category, label) => {
+    expect(CHANGE_CATEGORY_LABELS[category]).toBe(label);
+  });
+
+  it("prefers the fresh CLL category", () => {
+    expect(resolveChangeCategory("breaking", "unknown")).toBe("breaking"); // wire-enum-ok
+  });
+
+  it("falls back to the merged lineage category when CLL omits the node", () => {
+    expect(resolveChangeCategory(undefined, "unknown")).toBe("unknown");
+  });
+
+  it("ignores unsupported category values", () => {
+    expect(resolveChangeCategory("toString", "value_wide")).toBeUndefined();
+  });
+});

--- a/js/packages/ui/src/components/lineage/changeCategory.ts
+++ b/js/packages/ui/src/components/lineage/changeCategory.ts
@@ -1,0 +1,52 @@
+import type { ChangeCategory } from "./nodes/LineageNode";
+
+export const CHANGE_CATEGORY_LABELS: Record<ChangeCategory, string> = {
+  breaking: "Model-Wide Change", // wire-enum-ok
+  partial_breaking: "Column Change", // wire-enum-ok
+  non_breaking: "Additive Change", // wire-enum-ok
+  unknown: "Unknown",
+};
+
+export const CHANGE_CATEGORY_DETAILS: ReadonlyArray<{
+  category: ChangeCategory;
+  description: string;
+}> = [
+  {
+    category: "breaking", // wire-enum-ok
+    description: "Change affects the model as a whole",
+  },
+  {
+    category: "partial_breaking", // wire-enum-ok
+    description: "Change is scoped to specific columns",
+  },
+  {
+    category: "non_breaking", // wire-enum-ok
+    description: "Change only adds new columns or structure",
+  },
+  {
+    category: "unknown",
+    description: "Change category could not be determined",
+  },
+];
+
+function isChangeCategory(value: string | undefined): value is ChangeCategory {
+  return value !== undefined && Object.hasOwn(CHANGE_CATEGORY_LABELS, value);
+}
+
+export function getChangeCategoryLabel(
+  category: string | undefined,
+): string | undefined {
+  return isChangeCategory(category)
+    ? CHANGE_CATEGORY_LABELS[category]
+    : undefined;
+}
+
+export function resolveChangeCategory(
+  cllCategory: string | undefined,
+  lineageCategory: string | undefined,
+): ChangeCategory | undefined {
+  if (isChangeCategory(cllCategory)) {
+    return cllCategory;
+  }
+  return isChangeCategory(lineageCategory) ? lineageCategory : undefined;
+}

--- a/js/packages/ui/src/components/lineage/legend/LineageLegend.tsx
+++ b/js/packages/ui/src/components/lineage/legend/LineageLegend.tsx
@@ -4,6 +4,10 @@ import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import {
+  CHANGE_CATEGORY_DETAILS,
+  CHANGE_CATEGORY_LABELS,
+} from "../changeCategory";
 import { changeStatusColors, cllChangeStatusColors } from "../styles";
 
 /**
@@ -302,6 +306,48 @@ export function LineageLegend({
             content
           );
         })}
+
+      {variant === "changeStatus" && !newCllExperience && (
+        <Box
+          sx={{
+            mt: 1,
+            pt: 1,
+            borderTop: "1px solid",
+            borderColor: "divider",
+          }}
+        >
+          <Typography
+            variant="caption"
+            sx={{
+              display: "block",
+              fontWeight: 600,
+              mb: 0.5,
+              color: "text.secondary",
+            }}
+          >
+            Change Categories
+          </Typography>
+          {CHANGE_CATEGORY_DETAILS.map(({ category, description }) => {
+            const content = (
+              <Typography
+                key={category}
+                variant="body2"
+                sx={{ fontWeight: 600, mb: "2px" }}
+              >
+                {CHANGE_CATEGORY_LABELS[category]}
+              </Typography>
+            );
+
+            return showTooltips ? (
+              <Tooltip key={category} title={description} placement="right">
+                {content}
+              </Tooltip>
+            ) : (
+              content
+            );
+          })}
+        </Box>
+      )}
 
       {variant === "transformation" &&
         (items as TransformationLegendItem[]).map((item) => {

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -35,6 +35,7 @@ import {
   useState,
 } from "react";
 import { colors } from "../../../theme/colors";
+import { getChangeCategoryLabel } from "../changeCategory";
 import { DIM_FILTER } from "../config/zoomConstants";
 import {
   getIconForMaterialization,
@@ -172,13 +173,6 @@ export interface LineageNodeProps {
 // =============================================================================
 // CONSTANTS
 // =============================================================================
-
-const CHANGE_CATEGORY_LABELS: Record<ChangeCategory, string> = {
-  breaking: "Model-Wide Change",
-  non_breaking: "Additive Change",
-  partial_breaking: "Column Change",
-  unknown: "Unknown",
-};
 
 const DEFAULT_COLUMN_HEIGHT = 28;
 
@@ -476,7 +470,7 @@ function LineageNodeComponent({
     showChangeAnalysis &&
     changeCategory &&
     (!newCllExperience || changeCategory === "unknown")
-      ? CHANGE_CATEGORY_LABELS[changeCategory]
+      ? getChangeCategoryLabel(changeCategory)
       : null;
 
   return (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

- completes change-category support on the shared `LineagePageOss` surface used by Recce Cloud `/launch` sessions
- preserves an Unknown category from merged lineage data when CLL enrichment omits that node, while preferring fresh CLL categories when present
- adds the legacy-mode Change Categories legend and outlined detail-panel chip
- closes the detail panel when the focused graph node is clicked again
- keeps the new CLL experience's existing treatment surfaces unchanged

Companion to DataRecce/recce-cloud-infra#1564. After this PR is released as `@datarecce/ui`, PR 1564 should be updated to that package version for final browser verification.

**Which issue(s) this PR fixes**:

Closes DRC-3552

**Special notes for your reviewer**:

Manual QA on DataRecce/recce-cloud-infra#1564 exposed that `/launch` renders this shared package rather than the cloud-local lineage components. The focused test suite covers the `/info` fallback, all four labels, feature-mode isolation, and click-to-close behavior.

**Does this PR introduce a user-facing change?**:

Yes. Legacy lineage views now show Model-Wide Change, Column Change, Additive Change, and Unknown consistently on graph cards, in the legend, and in node details.

Generated with [Codex](https://codex.ai/).
