### PR TITLE
fix(lineage): restore per-environment schema in merged lineage (DRC-3975)

### DIFF
--- a/js/packages/ui/src/api/info.ts
+++ b/js/packages/ui/src/api/info.ts
@@ -75,6 +75,12 @@ export interface MergedNodeData {
   resource_type: string;
   package_name: string;
   schema?: string;
+  /**
+   * The base environment's schema, sent only when it differs from `schema`
+   * (which reports the current environment wherever the node exists there).
+   * Absent means "same as `schema`", not "unknown" (DRC-3975).
+   */
+  base_schema?: string;
   materialized?: string;
   tags?: string[];
   source_name?: string;

--- a/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
+++ b/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
@@ -56,6 +56,49 @@ describe("buildLineageGraph", () => {
     expect(node.data.materialized).toBe("table");
   });
 
+  test("resolves baseSchema from base_schema when the environments diverge", () => {
+    const lineage: MergedLineageResponse = {
+      nodes: {
+        "model.proj.orders": {
+          name: "orders",
+          resource_type: "model",
+          package_name: "proj",
+          schema: "ci_pr_1012",
+          base_schema: "prod_rpt",
+        },
+      },
+      edges: [],
+      metadata: { base: {}, current: {} },
+    };
+
+    const { nodes } = buildLineageGraph(lineage);
+
+    expect(nodes["model.proj.orders"].data.schema).toBe("ci_pr_1012");
+    expect(nodes["model.proj.orders"].data.baseSchema).toBe("prod_rpt");
+  });
+
+  test("falls back to schema for baseSchema when base_schema is absent", () => {
+    // Absent means "both environments share this schema" — and an older
+    // instance backend never sends the field at all, so the fallback is what
+    // keeps a newer UI correct against it.
+    const lineage: MergedLineageResponse = {
+      nodes: {
+        "model.proj.orders": {
+          name: "orders",
+          resource_type: "model",
+          package_name: "proj",
+          schema: "public",
+        },
+      },
+      edges: [],
+      metadata: { base: {}, current: {} },
+    };
+
+    const { nodes } = buildLineageGraph(lineage);
+
+    expect(nodes["model.proj.orders"].data.baseSchema).toBe("public");
+  });
+
   test("detects added, removed, and modified nodes via change_status", () => {
     const lineage: MergedLineageResponse = {
       nodes: {

--- a/js/packages/ui/src/contexts/lineage/types.ts
+++ b/js/packages/ui/src/contexts/lineage/types.ts
@@ -37,7 +37,14 @@ export type LineageGraphNode = Node<
     name: string;
     resourceType?: string;
     packageName?: string;
+    /** Schema in the current environment. */
     schema?: string;
+    /**
+     * Schema in the base environment — resolved, so it equals `schema` when
+     * both environments share one. Meaningless for an added node, which has
+     * no base environment.
+     */
+    baseSchema?: string;
     materialized?: string;
     changeStatus?: "added" | "removed" | "modified";
     change?: {

--- a/js/packages/ui/src/contexts/lineage/utils.ts
+++ b/js/packages/ui/src/contexts/lineage/utils.ts
@@ -121,6 +121,10 @@ export function buildLineageGraph(
         resourceType: merged.resource_type,
         packageName: merged.package_name,
         schema: merged.schema,
+        // The server omits base_schema when both environments share a schema,
+        // and an older instance backend never sends it at all — resolve the
+        // fallback once here so consumers don't each re-derive it (DRC-3975).
+        baseSchema: merged.base_schema ?? merged.schema,
         materialized: merged.materialized,
         changeStatus: coerceCllChangeStatus(merged.change_status),
         change: merged.change ?? undefined,

--- a/js/packages/ui/src/utils/envUtils.ts
+++ b/js/packages/ui/src/utils/envUtils.ts
@@ -11,6 +11,11 @@ import type { LineageGraph, LineageGraphNode } from "../contexts/lineage";
  * Iterates through all nodes in the lineage graph and collects
  * unique schema names from both base and current environments.
  *
+ * `data.schema` describes the current environment and `data.baseSchema` the
+ * base one; they only differ when the two environments live in different
+ * schemas. Reading a single field for both sets is the DRC-3975 regression —
+ * it showed the current schema in the panel's Base column for every project.
+ *
  * @param lineageGraph - The lineage graph data
  * @returns Tuple of [baseSchemas, currentSchemas] as Sets
  *
@@ -32,13 +37,12 @@ export function extractSchemas(
   if (lineageGraph?.nodes) {
     const nodes: LineageGraphNode[] = Object.values(lineageGraph.nodes);
     for (const node of nodes) {
-      if (node.data.schema) {
-        if (node.data.changeStatus !== "added") {
-          baseSchemas.add(node.data.schema);
-        }
-        if (node.data.changeStatus !== "removed") {
-          currentSchemas.add(node.data.schema);
-        }
+      const baseSchema = node.data.baseSchema ?? node.data.schema;
+      if (baseSchema && node.data.changeStatus !== "added") {
+        baseSchemas.add(baseSchema);
+      }
+      if (node.data.schema && node.data.changeStatus !== "removed") {
+        currentSchemas.add(node.data.schema);
       }
     }
   }

--- a/js/src/components/app/__tests__/EnvInfo.test.tsx
+++ b/js/src/components/app/__tests__/EnvInfo.test.tsx
@@ -726,8 +726,8 @@ describe("extractSchemas", () => {
     const lineageGraph = createMockLineageGraph();
     const [baseSchemas, currentSchemas] = extractSchemas(lineageGraph);
 
-    // With merged lineage, both nodes have no changeStatus so schemas
-    // appear in both base and current sets
+    // These nodes carry no baseSchema, which means both environments share
+    // one schema — so the same values land in both sets.
     expect(baseSchemas.size).toBe(2);
     expect(baseSchemas.has("schema_a")).toBe(true);
     expect(baseSchemas.has("schema_c")).toBe(true);
@@ -735,6 +735,36 @@ describe("extractSchemas", () => {
     expect(currentSchemas.size).toBe(2);
     expect(currentSchemas.has("schema_a")).toBe(true);
     expect(currentSchemas.has("schema_c")).toBe(true);
+  });
+
+  it("keeps the base and current schemas apart when they diverge", () => {
+    // DRC-3975: a base env in a different schema must not be overwritten by
+    // the current one — the regression this test pins showed the current
+    // schema in both columns of the Environment Information panel.
+    const lineageGraph = createMockLineageGraph();
+    lineageGraph.nodes.node1.data.baseSchema = "prod_rpt";
+    lineageGraph.nodes.node1.data.schema = "ci_pr_1012";
+    lineageGraph.nodes.node2.data.baseSchema = "prod_mart";
+    lineageGraph.nodes.node2.data.schema = "ci_pr_1012";
+
+    const [baseSchemas, currentSchemas] = extractSchemas(lineageGraph);
+
+    expect(Array.from(baseSchemas).sort()).toEqual(["prod_mart", "prod_rpt"]);
+    expect(Array.from(currentSchemas)).toEqual(["ci_pr_1012"]);
+  });
+
+  it("excludes an added node from the base set and a removed node from the current set", () => {
+    const lineageGraph = createMockLineageGraph();
+    lineageGraph.nodes.node1.data.changeStatus = "added";
+    lineageGraph.nodes.node1.data.schema = "ci_pr_1012";
+    lineageGraph.nodes.node2.data.changeStatus = "removed";
+    lineageGraph.nodes.node2.data.schema = "prod_rpt";
+    lineageGraph.nodes.node2.data.baseSchema = "prod_rpt";
+
+    const [baseSchemas, currentSchemas] = extractSchemas(lineageGraph);
+
+    expect(Array.from(baseSchemas)).toEqual(["prod_rpt"]);
+    expect(Array.from(currentSchemas)).toEqual(["ci_pr_1012"]);
   });
 
   it("handles undefined lineage graph", () => {

--- a/recce/models/lineage.py
+++ b/recce/models/lineage.py
@@ -41,6 +41,16 @@ def build_merged_lineage(lineage_diff: LineageDiff) -> MergedLineage:
                 if isinstance(mat, str):
                     merged.materialized = mat
 
+        # `schema` describes the preferred source — current whenever the node
+        # exists there — so a base env living in a different schema would be
+        # invisible to the client (DRC-3975). Carry it separately, but only when
+        # it actually differs: lineage payloads run to thousands of nodes and in
+        # most setups both envs share a schema, where `schema` already says it.
+        if base_node is not None and current_node is not None:
+            base_schema = base_node.get("schema")
+            if isinstance(base_schema, str) and base_schema != merged.schema_name:
+                merged.base_schema = base_schema
+
         node_diff = diff.get(node_id)
         if node_diff:
             merged.change_status = node_diff.change_status

--- a/recce/models/types.py
+++ b/recce/models/types.py
@@ -245,6 +245,10 @@ class MergedNode(BaseModel):
     resource_type: str
     package_name: str = ""
     schema_name: str | None = Field(None, alias="schema")
+    # The base environment's schema, sent only when it differs from `schema`
+    # (which reports the preferred source — current wherever the node exists
+    # there). Absent means "same as `schema`", not "unknown" (DRC-3975).
+    base_schema: str | None = None
     materialized: str | None = None
     tags: list[str] | None = None
     source_name: str | None = None

--- a/tests/test_merged_lineage.py
+++ b/tests/test_merged_lineage.py
@@ -227,6 +227,63 @@ class TestBuildMergedLineageNodes:
         assert merged.change.category == "non_breaking"
         assert merged.change.columns == {"col_x": "added"}
 
+    def test_diverging_base_schema_is_carried_alongside_current(self):
+        """The base environment's schema must survive the merge (DRC-3975).
+
+        `schema` carries the current environment (current is the preferred
+        source), so a base env in a different schema needs its own field or the
+        UI cannot tell the two environments apart.
+        """
+        base_node = {"name": "m", "resource_type": "model", "package_name": "pkg", "schema": "prod_rpt"}
+        curr_node = {"name": "m", "resource_type": "model", "package_name": "pkg", "schema": "ci_pr_1012"}
+        ld = _make_lineage_diff(
+            base_nodes={"model.pkg.m": base_node},
+            current_nodes={"model.pkg.m": curr_node},
+        )
+        merged = build_merged_lineage(ld).nodes["model.pkg.m"]
+        assert merged.schema_name == "ci_pr_1012"
+        assert merged.base_schema == "prod_rpt"
+        # The client reads the wire format, so assert the serialized shape too.
+        wire = merged.model_dump(by_alias=True, exclude_none=True)
+        assert wire["schema"] == "ci_pr_1012"
+        assert wire["base_schema"] == "prod_rpt"
+
+    def test_matching_base_schema_is_omitted(self):
+        """When both envs share a schema, base_schema stays off the wire.
+
+        Lineage payloads carry thousands of nodes, so the field is only spent
+        where it says something the client can't already infer from `schema`.
+        """
+        node = {"name": "a", "resource_type": "model", "package_name": "pkg", "schema": "public"}
+        ld = _make_lineage_diff(
+            base_nodes={"model.pkg.a": node},
+            current_nodes={"model.pkg.a": node},
+        )
+        merged = build_merged_lineage(ld).nodes["model.pkg.a"]
+        assert merged.base_schema is None
+        assert "base_schema" not in merged.model_dump(by_alias=True, exclude_none=True)
+
+    def test_added_node_has_no_base_schema(self):
+        """An added node has no base environment to report a schema for."""
+        node = {"name": "new_model", "resource_type": "model", "package_name": "pkg", "schema": "ci_pr_1012"}
+        ld = _make_lineage_diff(
+            current_nodes={"model.pkg.new_model": node},
+            diff={"model.pkg.new_model": {"change_status": "added"}},
+        )
+        merged = build_merged_lineage(ld).nodes["model.pkg.new_model"]
+        assert merged.base_schema is None
+
+    def test_removed_node_reports_its_base_schema(self):
+        """A removed node's only environment is base, so `schema` is already it."""
+        node = {"name": "old_model", "resource_type": "model", "package_name": "pkg", "schema": "prod_rpt"}
+        ld = _make_lineage_diff(
+            base_nodes={"model.pkg.old_model": node},
+            diff={"model.pkg.old_model": {"change_status": "removed"}},
+        )
+        merged = build_merged_lineage(ld).nodes["model.pkg.old_model"]
+        assert merged.schema_name == "prod_rpt"
+        assert merged.base_schema is None
+
     def test_extra_node_fields_ignored(self):
         node = {
             "name": "a",


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`fix`

**What this PR does / why we need it**:

The Environment Information panel rendered the same schema string in both the Base and Current columns, for every project, regardless of the real environments. A customer read this as "Recce is comparing my PR against itself".

Two changes on 2026-04-20 combined to cause it:

1. `build_merged_lineage` (DRC-3258) merges base + current into a single node with `source = current_node if current_node is not None else base_node`, so the base node's schema never reached the wire format.
2. `extractSchemas` (DRC-3260) then filled **both** the base and current sets from that one `node.data.schema`. Before DRC-3260 it read `node.data.data.base?.schema` and `node.data.data.current?.schema` separately.

First released in recce v1.45.0, so it has been live since late April.

**Backend.** `MergedNode` gains `base_schema`, populated only when the node exists in both environments *and* the base schema actually differs from `schema`. Absent means "same as `schema`", not "unknown" — that keeps the payload cost at zero for the common case where both environments share a schema, which matters because the reporting customer ships 4,616 nodes per lineage response.

Only the base side needs rescuing: `source` already prefers `current_node`, so `schema` *is* the current schema wherever the node exists in current. A second `current_schema` field would be dead weight.

**Frontend.** `base_schema` on `MergedNodeData`, `baseSchema` on `LineageGraphNode.data`, resolved once as `merged.base_schema ?? merged.schema` in `buildLineageGraph` so consumers don't each re-derive the fallback. `extractSchemas` reads `baseSchema` for the base set and `schema` for the current set.

That `??` fallback is deliberate, not defensive padding: the cloud web app talks to whatever recce version the instance image happens to carry, so a newer UI against an older backend keeps working instead of rendering an empty Base column. This exact version skew is how the customer landed on the bug.

**Which issue(s) this PR fixes**:

Closes DRC-3975

**Special notes for your reviewer**:

*Verified against production artifacts, not just fixtures.* For the reporting session the two environments are genuinely different — base `METRODATA_PROD` (schemas `rpt`/`mart`/`stg`/`int`/`core`, 779 catalog nodes) versus current `METRODATA_STG.PARADIME_TURBO_CI_PR_1012_BASE`. The platform was resolving them correctly all along; only the display was wrong. Worth knowing while reviewing, because it means this is a presentation fix and carries no risk to which environments Recce actually queries.

This also restores `schemas_match` in `EnvInfo.tsx`, which has been unconditionally `true` since v1.45.0 because both `schema_count`s and the equality check derived from the same collapsed sets. We had no telemetry signal for three months — worth a glance at that dashboard once this ships.

Tests were written first and confirmed failing for the right reason (`'MergedNode' object has no attribute 'base_schema'`; `expected undefined to be 'public'`) before any implementation. Coverage includes the diverging case, the identical case (asserting the field stays off the wire), added nodes, removed nodes, and the older-backend fallback.

Checks: `make format` clean, `make flake8` clean, `1556 passed, 5 skipped`; `pnpm lint` clean, `pnpm type:check` clean, `186 files / 3932 tests passed`.

Not covered here: I verified at the unit level, not by opening the panel against a live instance. The ideal end-to-end check is `recce server` against the two real manifests, which needs a frontend build plus a Snowflake connection for anything past lineage.

**Does this PR introduce a user-facing change?**:

```release-note
The Environment Information panel now shows the correct schema for the base environment. It previously repeated the current environment's schema in the Base column whenever the two environments used different schemas.
```
