### PR TITLE
refactor(api): declare catalog coverage response type

### DIFF
--- a/js/packages/ui/src/api/index.ts
+++ b/js/packages/ui/src/api/index.ts
@@ -62,6 +62,7 @@ export type { RecceServerFlags } from "./flag";
 export { getServerFlag, markRelaunchHintCompleted } from "./flag";
 // Server info API (lineage, environment, dbt metadata)
 export type {
+  CatalogCoverage,
   CatalogMetadata,
   GitInfo,
   LineageData,

--- a/js/packages/ui/src/api/info.test.ts
+++ b/js/packages/ui/src/api/info.test.ts
@@ -1,0 +1,28 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { CatalogCoverage, ServerInfoResult } from "./index";
+
+type CatalogStatus =
+  | "complete"
+  | "partial"
+  | "empty"
+  | "absent"
+  | "not_applicable"
+  | "unknown";
+
+describe("ServerInfoResult catalog coverage contract", () => {
+  it("exports the canonical optional and nullable cloud payload", () => {
+    expectTypeOf<CatalogCoverage>().toEqualTypeOf<{
+      status: CatalogStatus;
+      warn: boolean;
+      covered_count: number;
+      expected_count: number;
+      catalog_entry_count: number;
+      computed_at: string;
+    }>();
+
+    expectTypeOf<ServerInfoResult["catalog_coverage"]>().toEqualTypeOf<
+      CatalogCoverage | null | undefined
+    >();
+  });
+});

--- a/js/packages/ui/src/api/info.ts
+++ b/js/packages/ui/src/api/info.ts
@@ -159,6 +159,25 @@ export interface StateMetadata {
 }
 
 /**
+ * Catalog coverage fields returned by the cloud backend after artifact
+ * classification.
+ */
+export interface CatalogCoverage {
+  status:
+    | "complete"
+    | "partial"
+    | "empty"
+    | "absent"
+    | "not_applicable"
+    | "unknown";
+  warn: boolean;
+  covered_count: number;
+  expected_count: number;
+  catalog_entry_count: number;
+  computed_at: string;
+}
+
+/**
  * Session staleness fields returned by the backend when the PR session's
  * frozen-snapshot base may have diverged from the project's current shared base.
  * All fields are null for legacy sessions (pre-DRC-3309) or OSS mode.
@@ -227,6 +246,11 @@ export interface ServerInfoResult {
   support_tasks: Record<string, boolean>;
   /** Session staleness fields (cloud mode only, null for OSS / legacy sessions). */
   session_staleness?: SessionStaleness;
+  /**
+   * Catalog coverage fields in cloud mode. Omitted by OSS and legacy servers;
+   * null when the cloud session has not produced a conclusive classification.
+   */
+  catalog_coverage?: CatalogCoverage | null;
 }
 
 /**


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Refactor

**What this PR does / why we need it**:

Part 1 of DRC-3980. This declares the shared catalog coverage response contract before the cloud consumer is updated.

- catalog_coverage is optional for OSS/legacy responses
- catalog_coverage is nullable for never-classified cloud sessions
- runtime validation remains in Recce Cloud until the published package is consumed

**Which issue(s) this PR fixes**:

Part 1 of DRC-3980; this PR does not close the Linear issue.

**Special notes for your reviewer**:

The Cloud consumer will be updated after the shared package is published.

**Does this PR introduce a user-facing change?**:

NONE
