### PR TITLE
fix(deps): constrain mcp optional dependency to 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-mcp = ["mcp>=1.23.0"]
+mcp = ["mcp~=1.23"]
 dev = [
     "pytest>=4.6",
     "pytest-asyncio>=0.23,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2422,7 +2422,7 @@ requires-dist = [
     { name = "isort", marker = "extra == 'dev'", specifier = ">=6.0.1" },
     { name = "itsdangerous" },
     { name = "jinja2" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.23.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = "~=1.23" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "packaging" },
     { name = "pandas", marker = "extra == 'dev'" },


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

fix (dependency constraint)

**What this PR does / why we need it**:

`mcp` 2.0.0 was released on PyPI with breaking changes. Our optional dependency was `mcp>=1.23.0`, which lets new installs pull in 2.0.0 and break `recce mcp-server`.

This changes the specifier to `mcp~=1.23`, which means `>=1.23, <2.0`:

- 1.22.0 → blocked (below floor)
- 1.23.0 – 1.29.0 → allowed (all current 1.x releases)
- 2.0.0 and its pre-releases → blocked

Verified with `packaging.specifiers.SpecifierSet` against real PyPI versions. `uv.lock` regenerated to match.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Note `~=1.23` (compatible with all 1.x) vs `~=1.23.0` (would lock to 1.23.x only) — the former is intended.

**Does this PR introduce a user-facing change?**:

```release-note
Pin the optional `mcp` dependency to 1.x (`mcp~=1.23`) to avoid breaking changes from mcp 2.0.0.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
