### PR TITLE
fix(mcp): do not report an unbuilt model's columns as removed

### DIFF
--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -382,12 +382,18 @@ class CloudBackend:
             for column, change_status in column_changes.items():
                 changes.append((node_id, column, change_status))
         limit = 100
-        return DataFrame.from_data(
+        result = DataFrame.from_data(
             columns={"node_id": "text", "column": "text", "change_status": "text"},
             data=changes[:limit],
             limit=limit,
             more=len(changes) > limit,
         ).model_dump(mode="json")
+        # The cloud session hands us the column changes it already computed but
+        # says nothing about which nodes it could not describe, so coverage is
+        # unassessed rather than complete. Emitted under the same key as the
+        # local path so the one shared tool description holds for both backends.
+        result["schema_coverage"] = _schema_coverage(None)
+        return result
 
     async def _tool_impact_analysis(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         info = await self._request("GET", "info")
@@ -436,6 +442,10 @@ class CloudBackend:
             "max_affected_row_count": 0,
             "confirmed_impacted_models": impacted_models,
             "confirmed_not_impacted_models": not_impacted_models,
+            # Metadata-only triage: the session reports the column changes it
+            # found but not what it failed to describe, so coverage is
+            # unassessed. Same key as the local path (see _schema_coverage).
+            "schema_coverage": _schema_coverage(None),
             "errors": [],
         }
 
@@ -832,12 +842,16 @@ class RecceMCPServer:
                     name="schema_diff",
                     description="Get the schema diff (column changes) between base and current environments. "
                     "Shows added, removed, and type-changed columns in compact dataframe format. "
-                    "Also returns schema_coverage. An empty `data` means 'no column changes' ONLY when "
-                    "schema_coverage.status is 'complete'. When it is 'partial', the models named in "
-                    "schema_coverage.unchecked_nodes have no column metadata on at least one side, so "
-                    "they were never compared — that is not evidence they are unchanged, and it is not "
-                    "evidence anything was removed. The commonest cause is a build that only builds what "
-                    "changed, but this tool does not observe the cause; do not report one as fact.",
+                    "Also returns schema_coverage, which says how much of the comparison could run. "
+                    "An empty `data` means 'no column changes' ONLY when schema_coverage.status is "
+                    "'complete'. When it is 'partial', the nodes listed in "
+                    "schema_coverage.unchecked_nodes — dbt node ids, e.g. 'model.<package>.<name>' — "
+                    "have no column metadata on at least one side, so they were never compared: that "
+                    "is not evidence they are unchanged, and it is not evidence anything was removed. "
+                    "The commonest cause is a build that only builds what changed, but this tool does "
+                    "not observe the cause; do not report one as fact. When it is 'unknown', coverage "
+                    "was not assessed at all (cloud-backed sessions), so an empty `data` is "
+                    "uncorroborated rather than verified.",
                     inputSchema={
                         "type": "object",
                         "properties": {
@@ -1450,6 +1464,18 @@ class RecceMCPServer:
 
                             Models with data_impact: 'potential' have unknown data impact — follow
                             the model's next_action field to investigate with profile_diff/query_diff.
+
+                            Schema results come with a coverage contract. A model's
+                            schema_changes: [] means it WAS compared and nothing changed;
+                            schema_changes: null means it was never compared, because one side has no
+                            column metadata — that is not evidence its schema is unchanged, and not
+                            evidence columns were removed. Top-level schema_coverage summarises this:
+                            'complete' = every impacted model was compared, 'partial' = the nodes in
+                            schema_coverage.unchecked_nodes were not, 'unknown' = the comparison did
+                            not run at all (see errors, or a cloud-backed session), so no
+                            schema_changes value on any model is corroborated. unchecked_nodes holds
+                            dbt node ids ('model.<package>.<name>') while confirmed_impacted_models
+                            entries key on the bare model name.
                         """
                         ).strip(),
                         inputSchema={
@@ -2323,6 +2349,8 @@ class RecceMCPServer:
                 "'potential' = no value_diff available (views, no PK, or skipped) "
                 "— follow the model's next_action to investigate. "
                 "Only models with next_action != null need further tool calls. "
+                "schema_changes: null means that model was never compared (see schema_coverage) — "
+                "not that its schema is unchanged; [] means compared and unchanged. "
                 "Note: incremental model value_diff may reflect "
                 "build window artifacts if not fully refreshed."
             ),

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -575,6 +575,60 @@ def _columns_comparable(base_node: dict, current_node: dict) -> bool:
     return bool(base_node.get("columns")) and bool(current_node.get("columns"))
 
 
+# Resource types dbt never describes in catalog.json, because the catalog
+# describes warehouse relations and these are not relations. See
+# `recce/adapter/dbt_adapter/__init__.py`, which builds them with no `columns`
+# key at all.
+_NON_RELATION_RESOURCE_TYPES = frozenset({"exposure", "metric", "semantic_model", "saved_query"})
+
+
+def _can_carry_catalog_columns(node: dict) -> bool:
+    """Whether the catalog could ever have described this node's columns.
+
+    Missing columns on a node dbt never catalogues are the normal state, not a
+    gap in what we checked. Exposures, metrics and semantic models are not
+    relations, and an ephemeral model is inlined as a CTE rather than
+    materialized, so none of them ever get a catalog entry. Counting them as
+    unchecked would pin `status` to "partial" on any project that owns one — a
+    genuinely clean schema_diff could then never be reported as verified — and
+    would spend the capped `unchecked_nodes` slots on nodes that were never
+    comparable to begin with.
+
+    A denylist, not an allowlist: a resource type we have not met, or a node
+    carrying no `resource_type` at all, still counts as a coverage gap. The
+    trade-off is deliberate. Skipping every node with no columns on *either*
+    side would also have covered these cases, but it would silently drop a model
+    that neither environment built — precisely the absence `unchecked_nodes`
+    exists to name — so we over-report a gap rather than hide one.
+    """
+    if node.get("resource_type") in _NON_RELATION_RESOURCE_TYPES:
+        return False
+    return (node.get("config") or {}).get("materialized") != "ephemeral"
+
+
+def _schema_coverage(unchecked_node_ids: Optional[List[str]]) -> Dict[str, Any]:
+    """Build the schema_coverage block shared by schema_diff and impact_analysis.
+
+    `None` means the comparison never ran — it raised, or the backend does not
+    report coverage. That is distinct from an empty list, which means the
+    comparison ran and found nothing it could not check.
+    """
+    if unchecked_node_ids is None:
+        return {
+            "status": "unknown",
+            "unchecked_nodes": [],
+            "unchecked_node_count": 0,
+            "more": False,
+        }
+    ordered = sorted(unchecked_node_ids)
+    return {
+        "status": "partial" if ordered else "complete",
+        "unchecked_nodes": ordered[:_UNCHECKED_NODE_LIMIT],
+        "unchecked_node_count": len(ordered),
+        "more": len(ordered) > _UNCHECKED_NODE_LIMIT,
+    }
+
+
 class RecceMCPServer:
     """MCP Server for Recce data validation tools"""
 
@@ -1744,9 +1798,13 @@ class RecceMCPServer:
             current_columns = current_node.get("columns") or {}
 
             # Skipped before the row cap so unverifiable rows can neither
-            # displace real changes nor inflate `more`.
+            # displace real changes nor inflate `more`. A node the catalog never
+            # describes is skipped without being named: it is not a gap in what
+            # we checked, and naming it would make `status` permanently
+            # "partial" on any project that owns one.
             if not _columns_comparable(base_node, current_node):
-                unchecked_nodes.append(node_id)
+                if _can_carry_catalog_columns(current_node):
+                    unchecked_nodes.append(node_id)
                 continue
 
             # Get column names in base and current
@@ -1791,13 +1849,7 @@ class RecceMCPServer:
         # that ignore it still see the unchanged shape, minus rows we cannot
         # stand behind. `data == []` means "no column changes" only when
         # `status` is "complete".
-        unchecked_nodes.sort()
-        result["schema_coverage"] = {
-            "status": "partial" if unchecked_nodes else "complete",
-            "unchecked_nodes": unchecked_nodes[:_UNCHECKED_NODE_LIMIT],
-            "unchecked_node_count": len(unchecked_nodes),
-            "more": len(unchecked_nodes) > _UNCHECKED_NODE_LIMIT,
-        }
+        result["schema_coverage"] = _schema_coverage(unchecked_nodes)
         return result
 
     async def _tool_row_count_diff(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -1981,12 +2033,7 @@ class RecceMCPServer:
         # Step 2b: Schema diff (compare columns between base and current)
         # Unknown until the step runs, so a failure below leaves it unknown
         # rather than claiming complete coverage.
-        schema_coverage = {
-            "status": "unknown",
-            "unchecked_nodes": [],
-            "unchecked_node_count": 0,
-            "more": False,
-        }
+        schema_coverage = _schema_coverage(None)
         try:
             base_nodes = lineage_diff.get("base", {}).get("nodes", {})
             current_nodes = lineage_diff.get("current", {}).get("nodes", {})
@@ -2000,16 +2047,30 @@ class RecceMCPServer:
                 base_node = base_nodes.get(node_id, {})
                 current_node = current_nodes.get(node_id, {})
 
-                # Same comparison as the schema_diff tool, so it needs the same
-                # guard. `None` rather than `[]`: an empty list reads as "checked,
-                # nothing changed", which is the claim we cannot make here.
-                if not _columns_comparable(base_node, current_node):
+                # The same absence guard as the schema_diff tool, but that tool
+                # compares only nodes present in BOTH lineages. Added and removed
+                # models reach this loop too, and a one-sided node is an
+                # observation, not an absence: a new model's columns really are
+                # all added, and a deleted model's really are all removed. Nodes
+                # the catalog never describes fall through as well — comparing
+                # two empty maps yields the honest empty result without claiming
+                # a coverage gap.
+                # `None` rather than `[]` for a real gap: an empty list reads as
+                # "checked, nothing changed", which is the claim we cannot make.
+                exists_in_both = bool(base_node) and bool(current_node)
+                if (
+                    exists_in_both
+                    and not _columns_comparable(base_node, current_node)
+                    and _can_carry_catalog_columns(current_node)
+                ):
                     model["schema_changes"] = None
                     schema_unchecked.append(node_id)
                     continue
 
-                base_cols = set(base_node.get("columns", {}).keys())
-                curr_cols = set(current_node.get("columns", {}).keys())
+                base_columns = base_node.get("columns") or {}
+                current_columns = current_node.get("columns") or {}
+                base_cols = set(base_columns.keys())
+                curr_cols = set(current_columns.keys())
 
                 changes = []
                 for col in curr_cols - base_cols:
@@ -2017,20 +2078,14 @@ class RecceMCPServer:
                 for col in base_cols - curr_cols:
                     changes.append({"column": col, "change_status": "removed"})
                 for col in base_cols & curr_cols:
-                    base_type = base_nodes[node_id]["columns"][col].get("type")
-                    curr_type = current_nodes[node_id]["columns"][col].get("type")
+                    base_type = base_columns[col].get("type")
+                    curr_type = current_columns[col].get("type")
                     if base_type != curr_type:
                         changes.append({"column": col, "change_status": "modified"})
 
                 model["schema_changes"] = changes
 
-            schema_unchecked.sort()
-            schema_coverage = {
-                "status": "partial" if schema_unchecked else "complete",
-                "unchecked_nodes": schema_unchecked[:_UNCHECKED_NODE_LIMIT],
-                "unchecked_node_count": len(schema_unchecked),
-                "more": len(schema_unchecked) > _UNCHECKED_NODE_LIMIT,
-            }
+            schema_coverage = _schema_coverage(schema_unchecked)
         except Exception as e:
             errors.append({"step": "schema_diff", "message": str(e)})
 

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -567,6 +567,10 @@ def _columns_comparable(base_node: dict, current_node: dict) -> bool:
     Emptiness counts as absence: a relation with no columns cannot exist, so an
     empty map means the catalog never described the model rather than that it
     lost everything.
+
+    What this observes is the absence, not its cause. A selective build is the
+    commonest reason but not the only one, so callers must not turn a False here
+    into a claim about what the user's pipeline did.
     """
     return bool(base_node.get("columns")) and bool(current_node.get("columns"))
 
@@ -776,9 +780,10 @@ class RecceMCPServer:
                     "Shows added, removed, and type-changed columns in compact dataframe format. "
                     "Also returns schema_coverage. An empty `data` means 'no column changes' ONLY when "
                     "schema_coverage.status is 'complete'. When it is 'partial', the models named in "
-                    "schema_coverage.unchecked_nodes were not built by this run, so their columns were "
-                    "never compared — that is not evidence they are unchanged, and it is not evidence "
-                    "anything was removed.",
+                    "schema_coverage.unchecked_nodes have no column metadata on at least one side, so "
+                    "they were never compared — that is not evidence they are unchanged, and it is not "
+                    "evidence anything was removed. The commonest cause is a build that only builds what "
+                    "changed, but this tool does not observe the cause; do not report one as fact.",
                     inputSchema={
                         "type": "object",
                         "properties": {

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -551,6 +551,11 @@ class MCPLogger:
         self._write_log(log_entry)
 
 
+# Bounds the node names schema_diff names as unverifiable. Independent of the
+# row cap so an under-catalogued project cannot crowd out the changes it did find.
+_UNCHECKED_NODE_LIMIT = 50
+
+
 class RecceMCPServer:
     """MCP Server for Recce data validation tools"""
 
@@ -1704,13 +1709,26 @@ class RecceMCPServer:
 
         # Build schema changes
         schema_changes = []
+        unchecked_nodes = []
 
         for node_id in nodes_to_compare:
             base_node = base_nodes.get(node_id, {})
             current_node = current_nodes.get(node_id, {})
 
-            base_columns = base_node.get("columns", {})
-            current_columns = current_node.get("columns", {})
+            base_columns = base_node.get("columns") or {}
+            current_columns = current_node.get("columns") or {}
+
+            # Column data comes from the catalog while the node itself comes
+            # from the manifest, so a run that did not build this model leaves
+            # one side without columns. Comparing anyway would turn "we never
+            # looked" into a full set of added or removed columns. Emptiness
+            # counts as absence: a relation with no columns cannot exist, so an
+            # empty map means the catalog never described it. Skipped before the
+            # row cap so unverifiable rows can neither displace real changes nor
+            # inflate `more`.
+            if not base_columns or not current_columns:
+                unchecked_nodes.append(node_id)
+                continue
 
             # Get column names in base and current
             base_col_names = set(base_columns.keys())
@@ -1747,7 +1765,21 @@ class RecceMCPServer:
             limit=limit,
             more=has_more,
         )
-        return diff_df.model_dump(mode="json")
+        result = diff_df.model_dump(mode="json")
+
+        # Carried alongside the frame rather than inside it: `DataFrame` backs
+        # every tool's payload, and coverage only means something here. Consumers
+        # that ignore it still see the unchanged shape, minus rows we cannot
+        # stand behind. `data == []` means "no column changes" only when
+        # `status` is "complete".
+        unchecked_nodes.sort()
+        result["schema_coverage"] = {
+            "status": "partial" if unchecked_nodes else "complete",
+            "unchecked_nodes": unchecked_nodes[:_UNCHECKED_NODE_LIMIT],
+            "unchecked_node_count": len(unchecked_nodes),
+            "more": len(unchecked_nodes) > _UNCHECKED_NODE_LIMIT,
+        }
+        return result
 
     async def _tool_row_count_diff(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute row count diff task"""

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -556,6 +556,21 @@ class MCPLogger:
 _UNCHECKED_NODE_LIMIT = 50
 
 
+def _columns_comparable(base_node: dict, current_node: dict) -> bool:
+    """Whether the two sides carry enough column data to be compared at all.
+
+    Nodes come from the manifest but their columns come from the catalog, so a
+    model a selective build did not rebuild arrives with no column data on the
+    current side. Differencing the two sets anyway turns "we never looked" into
+    a full sweep of added or removed columns.
+
+    Emptiness counts as absence: a relation with no columns cannot exist, so an
+    empty map means the catalog never described the model rather than that it
+    lost everything.
+    """
+    return bool(base_node.get("columns")) and bool(current_node.get("columns"))
+
+
 class RecceMCPServer:
     """MCP Server for Recce data validation tools"""
 
@@ -758,7 +773,12 @@ class RecceMCPServer:
                 Tool(
                     name="schema_diff",
                     description="Get the schema diff (column changes) between base and current environments. "
-                    "Shows added, removed, and type-changed columns in compact dataframe format.",
+                    "Shows added, removed, and type-changed columns in compact dataframe format. "
+                    "Also returns schema_coverage. An empty `data` means 'no column changes' ONLY when "
+                    "schema_coverage.status is 'complete'. When it is 'partial', the models named in "
+                    "schema_coverage.unchecked_nodes were not built by this run, so their columns were "
+                    "never compared — that is not evidence they are unchanged, and it is not evidence "
+                    "anything was removed.",
                     inputSchema={
                         "type": "object",
                         "properties": {
@@ -1718,15 +1738,9 @@ class RecceMCPServer:
             base_columns = base_node.get("columns") or {}
             current_columns = current_node.get("columns") or {}
 
-            # Column data comes from the catalog while the node itself comes
-            # from the manifest, so a run that did not build this model leaves
-            # one side without columns. Comparing anyway would turn "we never
-            # looked" into a full set of added or removed columns. Emptiness
-            # counts as absence: a relation with no columns cannot exist, so an
-            # empty map means the catalog never described it. Skipped before the
-            # row cap so unverifiable rows can neither displace real changes nor
-            # inflate `more`.
-            if not base_columns or not current_columns:
+            # Skipped before the row cap so unverifiable rows can neither
+            # displace real changes nor inflate `more`.
+            if not _columns_comparable(base_node, current_node):
                 unchecked_nodes.append(node_id)
                 continue
 
@@ -1960,17 +1974,37 @@ class RecceMCPServer:
                 node_id_by_name[node_info["name"]] = node_id
 
         # Step 2b: Schema diff (compare columns between base and current)
+        # Unknown until the step runs, so a failure below leaves it unknown
+        # rather than claiming complete coverage.
+        schema_coverage = {
+            "status": "unknown",
+            "unchecked_nodes": [],
+            "unchecked_node_count": 0,
+            "more": False,
+        }
         try:
             base_nodes = lineage_diff.get("base", {}).get("nodes", {})
             current_nodes = lineage_diff.get("current", {}).get("nodes", {})
 
+            schema_unchecked = []
             for model in impacted_models:
                 node_id = node_id_by_name.get(model["name"])
                 if not node_id:
                     continue
 
-                base_cols = set(base_nodes.get(node_id, {}).get("columns", {}).keys())
-                curr_cols = set(current_nodes.get(node_id, {}).get("columns", {}).keys())
+                base_node = base_nodes.get(node_id, {})
+                current_node = current_nodes.get(node_id, {})
+
+                # Same comparison as the schema_diff tool, so it needs the same
+                # guard. `None` rather than `[]`: an empty list reads as "checked,
+                # nothing changed", which is the claim we cannot make here.
+                if not _columns_comparable(base_node, current_node):
+                    model["schema_changes"] = None
+                    schema_unchecked.append(node_id)
+                    continue
+
+                base_cols = set(base_node.get("columns", {}).keys())
+                curr_cols = set(current_node.get("columns", {}).keys())
 
                 changes = []
                 for col in curr_cols - base_cols:
@@ -1984,6 +2018,14 @@ class RecceMCPServer:
                         changes.append({"column": col, "change_status": "modified"})
 
                 model["schema_changes"] = changes
+
+            schema_unchecked.sort()
+            schema_coverage = {
+                "status": "partial" if schema_unchecked else "complete",
+                "unchecked_nodes": schema_unchecked[:_UNCHECKED_NODE_LIMIT],
+                "unchecked_node_count": len(schema_unchecked),
+                "more": len(schema_unchecked) > _UNCHECKED_NODE_LIMIT,
+            }
         except Exception as e:
             errors.append({"step": "schema_diff", "message": str(e)})
 
@@ -2228,6 +2270,7 @@ class RecceMCPServer:
             "max_affected_row_count": max_affected,
             "confirmed_impacted_models": impacted_models,
             "confirmed_not_impacted_models": not_impacted_models,
+            "schema_coverage": schema_coverage,
             "errors": errors,
         }
         return self._maybe_add_single_env_warning(result)

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -847,13 +847,20 @@ class TestSchemaDiffE2E:
         assert coverage["status"] == "partial"
         assert "model.recce_test.not_rebuilt" in coverage["unchecked_nodes"]
 
-        # The same comparison is duplicated inside impact_analysis, so the same
-        # model must not come back as a wholesale drop through that tool either.
+        # impact_analysis runs the same comparison, so the same model must not
+        # come back as a wholesale drop through that tool either. Asserted on the
+        # model directly rather than inside a loop, so the model going missing
+        # from the blast radius fails instead of passing vacuously, and on an
+        # exact status, because "unknown" would mean the schema step raised.
         impact = await server._tool_impact_analysis({})
-        for model in impact["confirmed_impacted_models"]:
-            if model["name"] == "not_rebuilt":
-                assert model["schema_changes"] is None, "impact_analysis compared a model the run did not build"
-        assert impact["schema_coverage"]["status"] in ("partial", "unknown")
+        by_name = {model["name"]: model for model in impact["confirmed_impacted_models"]}
+        assert "not_rebuilt" in by_name, "not_rebuilt dropped out of the blast radius"
+        assert (
+            by_name["not_rebuilt"]["schema_changes"] is None
+        ), "impact_analysis compared a model the run did not build"
+        assert impact["errors"] == []
+        assert impact["schema_coverage"]["status"] == "partial"
+        assert "model.recce_test.not_rebuilt" in impact["schema_coverage"]["unchecked_nodes"]
 
     @pytest.mark.asyncio
     async def test_schema_diff_no_changes(self, mcp_e2e_with_data):

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -523,7 +523,9 @@ class TestImpactAnalysisErrorResilience:
         helper.add_unique_test("model.recce_test.orders", "orders", "id")
 
         # Corrupt base node columns to force schema-diff to raise AttributeError
-        # (columns=None → None.keys() fails), while keeping classification intact
+        # (a str has no .keys()), while keeping classification intact. It has to
+        # be a non-empty non-mapping: absent, None and empty all mean "this model
+        # was not built by this run", which is now handled rather than raised.
         from unittest.mock import MagicMock
 
         original_fn = server.context.get_lineage_diff
@@ -532,7 +534,7 @@ class TestImpactAnalysisErrorResilience:
             result = original_fn()
             data = result.model_dump(mode="json")
             for nid in list(data.get("base", {}).get("nodes", {}).keys()):
-                data["base"]["nodes"][nid]["columns"] = None
+                data["base"]["nodes"][nid]["columns"] = "not-a-mapping"
             mock_result = MagicMock()
             mock_result.model_dump.return_value = data
             return mock_result
@@ -796,6 +798,62 @@ class TestSchemaDiffE2E:
         changes = result["data"]
         assert len(changes) >= 1
         assert any("email" in str(row) for row in changes)
+        assert result["schema_coverage"]["status"] == "complete"
+
+    @pytest.mark.asyncio
+    async def test_model_missing_from_current_catalog_is_not_reported_as_removed(self, mcp_e2e):
+        """A selective build catalogues only what it rebuilt.
+
+        Passing no current columns leaves the model in the current manifest with
+        no catalog entry, which is what a run that skipped it produces. Every
+        base column then looks dropped unless the comparison declines to run.
+        """
+        server, helper = mcp_e2e
+        # Changed upstream, so the model below lands in the blast radius the way
+        # a downstream model does in a real selective build.
+        helper.create_model(
+            "upstream",
+            unique_id="model.recce_test.upstream",
+            base_csv="""\
+                id,name
+                1,Alice""",
+            curr_csv="""\
+                id,name
+                1,Alice
+                2,Bob""",
+            base_columns={"id": "INTEGER", "name": "VARCHAR"},
+            curr_columns={"id": "INTEGER", "name": "VARCHAR"},
+        )
+        helper.create_model(
+            "not_rebuilt",
+            unique_id="model.recce_test.not_rebuilt",
+            depends_on=["model.recce_test.upstream"],
+            base_csv="""\
+                id,name
+                1,Alice""",
+            curr_csv="""\
+                id,name
+                1,Alice""",
+            base_columns={"id": "INTEGER", "name": "VARCHAR"},
+            curr_columns=None,
+        )
+
+        result = await server._tool_schema_diff({})
+
+        assert not [
+            row for row in result["data"] if row[2] == "removed"
+        ], "columns of a model absent from the current catalog were reported as removed"
+        coverage = result["schema_coverage"]
+        assert coverage["status"] == "partial"
+        assert "model.recce_test.not_rebuilt" in coverage["unchecked_nodes"]
+
+        # The same comparison is duplicated inside impact_analysis, so the same
+        # model must not come back as a wholesale drop through that tool either.
+        impact = await server._tool_impact_analysis({})
+        for model in impact["confirmed_impacted_models"]:
+            if model["name"] == "not_rebuilt":
+                assert model["schema_changes"] is None, "impact_analysis compared a model the run did not build"
+        assert impact["schema_coverage"]["status"] in ("partial", "unknown")
 
     @pytest.mark.asyncio
     async def test_schema_diff_no_changes(self, mcp_e2e_with_data):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -13,7 +13,11 @@ from mcp.types import (  # noqa: E402
 )
 
 from recce.core import RecceContext  # noqa: E402
-from recce.mcp_server import RecceMCPServer, run_mcp_server  # noqa: E402
+from recce.mcp_server import (  # noqa: E402
+    _UNCHECKED_NODE_LIMIT,
+    RecceMCPServer,
+    run_mcp_server,
+)
 from recce.models.types import LineageDiff  # noqa: E402
 from recce.server import RecceServerMode  # noqa: E402
 from recce.tasks.histogram import HistogramDiffTask  # noqa: E402
@@ -314,6 +318,109 @@ class TestRecceMCPServer:
         assert "model.project.not_rebuilt" in coverage["unchecked_nodes"]
         assert "model.project.empty_entry" in coverage["unchecked_nodes"]
         assert coverage["unchecked_node_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_tool_schema_diff_coverage_ignores_nodes_the_catalog_never_describes(self, mcp_server):
+        """A node dbt never catalogues is not a coverage gap.
+
+        `catalog.json` describes warehouse relations. Exposures, metrics and
+        semantic models are not relations — the dbt adapter builds them with no
+        `columns` key at all — and an ephemeral model is inlined as a CTE, so it
+        is excluded from the catalog too. Counting them as unchecked would pin
+        `status` to "partial" on any project that owns one, so a genuinely clean
+        schema_diff could never be reported as verified, and the capped
+        `unchecked_nodes` list would fill with nodes that were never comparable.
+        """
+        server, mock_context = mcp_server
+
+        both_sides = {
+            "model.project.clean": {
+                "id": "model.project.clean",
+                "name": "clean",
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "columns": {"id": {"name": "id", "type": "text"}},
+            },
+            "exposure.project.dash": {
+                "id": "exposure.project.dash",
+                "name": "dash",
+                "resource_type": "exposure",
+                "config": {},
+            },
+            "metric.project.revenue": {
+                "id": "metric.project.revenue",
+                "name": "revenue",
+                "resource_type": "metric",
+                "config": {},
+            },
+            "semantic_model.project.orders_sm": {
+                "id": "semantic_model.project.orders_sm",
+                "name": "orders_sm",
+                "resource_type": "semantic_model",
+                "config": {},
+            },
+            "model.project.inlined": {
+                "id": "model.project.inlined",
+                "name": "inlined",
+                "resource_type": "model",
+                "config": {"materialized": "ephemeral"},
+            },
+        }
+
+        mock_lineage_diff = MagicMock(spec=LineageDiff)
+        mock_lineage_diff.model_dump.return_value = {
+            "base": {"nodes": both_sides},
+            "current": {"nodes": both_sides},
+        }
+        mock_context.get_lineage_diff.return_value = mock_lineage_diff
+
+        result = await server._tool_schema_diff({})
+
+        assert result["data"] == []
+        coverage = result["schema_coverage"]
+        assert coverage["unchecked_nodes"] == []
+        assert coverage["unchecked_node_count"] == 0
+        assert coverage["status"] == "complete", "a clean project was reported as only partially checked"
+
+    @pytest.mark.asyncio
+    async def test_tool_schema_diff_coverage_truncates_at_the_node_limit(self, mcp_server):
+        """Past the cap, `unchecked_nodes` truncates and `more` says so.
+
+        The full count still reports, so a consumer can tell a truncated list
+        from an exhaustive one.
+        """
+        server, mock_context = mcp_server
+
+        node_ids = [f"model.project.m{i:03d}" for i in range(_UNCHECKED_NODE_LIMIT + 5)]
+
+        def node(node_id, *, catalogued):
+            n = {
+                "id": node_id,
+                "name": node_id.rsplit(".", 1)[-1],
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+            }
+            if catalogued:
+                n["columns"] = {"id": {"name": "id", "type": "text"}}
+            return n
+
+        mock_lineage_diff = MagicMock(spec=LineageDiff)
+        mock_lineage_diff.model_dump.return_value = {
+            "base": {"nodes": {nid: node(nid, catalogued=True) for nid in node_ids}},
+            # Nothing was rebuilt, so no node has a current catalog entry.
+            "current": {"nodes": {nid: node(nid, catalogued=False) for nid in node_ids}},
+        }
+        mock_context.get_lineage_diff.return_value = mock_lineage_diff
+
+        result = await server._tool_schema_diff({})
+
+        coverage = result["schema_coverage"]
+        assert coverage["status"] == "partial"
+        assert coverage["unchecked_node_count"] == len(node_ids)
+        assert len(coverage["unchecked_nodes"]) == _UNCHECKED_NODE_LIMIT
+        assert coverage["more"] is True
+        # Sorted, so the truncation is a stable prefix rather than dict order.
+        assert coverage["unchecked_nodes"] == sorted(node_ids)[:_UNCHECKED_NODE_LIMIT]
 
     @pytest.mark.asyncio
     async def test_tool_query(self, mcp_server):
@@ -2979,6 +3086,135 @@ class TestImpactAnalysisBehavior:
         assert "max_affected_row_count" in result
         assert "total_affected_row_count" not in result
         assert "suggested_deep_dives" not in result
+
+    ONE_SIDED_LINEAGE_DIFF_DATA = {
+        "base": {
+            "nodes": {
+                "model.project.deleted_model": {
+                    "name": "deleted_model",
+                    "resource_type": "model",
+                    "config": {"materialized": "table"},
+                    "columns": {
+                        "id": {"type": "INTEGER"},
+                        "gone": {"type": "TEXT"},
+                    },
+                },
+            },
+            "parent_map": {},
+        },
+        "current": {
+            "nodes": {
+                "model.project.new_model": {
+                    "name": "new_model",
+                    "resource_type": "model",
+                    "config": {"materialized": "table"},
+                    "columns": {
+                        "id": {"type": "INTEGER"},
+                        "new_col": {"type": "TEXT"},
+                    },
+                },
+            },
+            "parent_map": {},
+        },
+        "diff": {
+            "model.project.new_model": {"change_status": "added"},
+            "model.project.deleted_model": {"change_status": "removed"},
+        },
+    }
+
+    @pytest.mark.asyncio
+    async def test_one_sided_models_keep_their_column_changes(self, mcp_server):
+        """An added or removed model is an observation, not a coverage gap.
+
+        schema_diff pre-filters to nodes present in BOTH lineages, so a one-sided
+        node never reaches its absence guard. impact_analysis has no such filter:
+        an added model has no base side and a removed model has no current side,
+        which looks exactly like a model the run did not build. But a new model's
+        columns really are all added and a deleted model's really are all removed
+        — reporting those as unchecked discards real findings.
+        """
+        server, mock_context = mcp_server
+
+        mock_context.get_lineage_diff.return_value = MagicMock(
+            model_dump=MagicMock(return_value=self.ONE_SIDED_LINEAGE_DIFF_DATA)
+        )
+
+        adapter = MagicMock()
+
+        def mock_select_nodes(select=""):
+            if select == "state:modified":
+                return set()
+            return {"model.project.new_model", "model.project.deleted_model"}
+
+        adapter.select_nodes.side_effect = mock_select_nodes
+        adapter.get_model.return_value = {}
+        mock_context.adapter = adapter
+
+        with (
+            patch("recce.mcp_server.sentry_metrics", None),
+            patch.object(RowCountDiffTask, "execute", return_value={}),
+        ):
+            result = await server._tool_impact_analysis({"skip_value_diff": True})
+
+        assert result["errors"] == []
+        by_name = {model["name"]: model for model in result["confirmed_impacted_models"]}
+        assert set(by_name) == {"new_model", "deleted_model"}
+
+        added = by_name["new_model"]["schema_changes"]
+        assert added is not None, "an added model's columns were reported as unchecked"
+        assert sorted(change["column"] for change in added) == ["id", "new_col"]
+        assert {change["change_status"] for change in added} == {"added"}
+
+        removed = by_name["deleted_model"]["schema_changes"]
+        assert removed is not None, "a removed model's columns were reported as unchecked"
+        assert sorted(change["column"] for change in removed) == ["gone", "id"]
+        assert {change["change_status"] for change in removed} == {"removed"}
+
+        coverage = result["schema_coverage"]
+        assert coverage["unchecked_nodes"] == []
+        assert coverage["status"] == "complete", "one-sided models were counted as a coverage gap"
+
+    @pytest.mark.asyncio
+    async def test_ephemeral_model_is_not_a_coverage_gap(self, mcp_server):
+        """An ephemeral model is inlined as a CTE, so it never enters the catalog.
+
+        It reaches impact_analysis like any other model, but "no columns on
+        either side" is its normal state rather than something the run skipped.
+        """
+        server, mock_context = mcp_server
+
+        ephemeral_node = {
+            "name": "inlined",
+            "resource_type": "model",
+            "config": {"materialized": "ephemeral"},
+        }
+        mock_context.get_lineage_diff.return_value = MagicMock(
+            model_dump=MagicMock(
+                return_value={
+                    "base": {"nodes": {"model.project.inlined": ephemeral_node}, "parent_map": {}},
+                    "current": {"nodes": {"model.project.inlined": ephemeral_node}, "parent_map": {}},
+                    "diff": {},
+                }
+            )
+        )
+
+        adapter = MagicMock()
+        adapter.select_nodes.side_effect = lambda select="": (
+            set() if select == "state:modified" else {"model.project.inlined"}
+        )
+        adapter.get_model.return_value = {}
+        mock_context.adapter = adapter
+
+        with (
+            patch("recce.mcp_server.sentry_metrics", None),
+            patch.object(RowCountDiffTask, "execute", return_value={}),
+        ):
+            result = await server._tool_impact_analysis({"skip_value_diff": True})
+
+        assert result["errors"] == []
+        coverage = result["schema_coverage"]
+        assert coverage["unchecked_nodes"] == []
+        assert coverage["status"] == "complete", "an ephemeral model was counted as a coverage gap"
 
 
 class TestLocalModeRunBacked:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -239,6 +239,83 @@ class TestRecceMCPServer:
         mock_context.get_lineage_diff.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_tool_schema_diff_does_not_report_an_unbuilt_model_as_removed(self, mcp_server):
+        """A model the run did not rebuild must not read as a column drop.
+
+        `_build_lineage` in the dbt adapter builds every node from the manifest
+        but assigns `columns` only when the catalog holds that node, so a
+        selective build leaves an unrebuilt model present on both sides with no
+        `columns` key on the current side. Comparing the two column sets then
+        turns "we never looked" into "every column was dropped".
+
+        Node keys below mirror what that builder emits, so the absent-`columns`
+        shape is the producer's, not the test's invention.
+        """
+        server, mock_context = mcp_server
+
+        def node(name, *, columns=None):
+            n = {
+                "id": f"model.project.{name}",
+                "name": name,
+                "resource_type": "model",
+                "package_name": "project",
+                "schema": "analytics",
+                "config": {"materialized": "view"},
+                "checksum": {"name": "sha256", "checksum": "abc"},
+                "raw_code": "select 1",
+            }
+            if columns is not None:
+                n["columns"] = {c: {"name": c, "type": "text"} for c in columns}
+            return n
+
+        mock_lineage_diff = MagicMock(spec=LineageDiff)
+        mock_lineage_diff.model_dump.return_value = {
+            "base": {
+                "nodes": {
+                    "model.project.not_rebuilt": node("not_rebuilt", columns=["a", "b", "c"]),
+                    "model.project.rebuilt": node("rebuilt", columns=["kept", "dropped"]),
+                    "model.project.empty_entry": node("empty_entry", columns=["x", "y"]),
+                },
+            },
+            "current": {
+                "nodes": {
+                    # Absent from this run's catalog, so the builder never set
+                    # the key at all.
+                    "model.project.not_rebuilt": node("not_rebuilt"),
+                    "model.project.rebuilt": node("rebuilt", columns=["kept"]),
+                    # Catalogued but described nothing. A relation with no
+                    # columns cannot exist, so this is the same gap wearing a
+                    # different shape and must not read as a wholesale drop.
+                    "model.project.empty_entry": node("empty_entry", columns=[]),
+                },
+            },
+        }
+        mock_context.get_lineage_diff.return_value = mock_lineage_diff
+
+        result = await server._tool_schema_diff({})
+
+        removed = [row for row in result["data"] if row[2] == "removed"]
+
+        assert not [row for row in removed if row[0] == "model.project.not_rebuilt"], (
+            "columns of a model that was not rebuilt were reported as removed"
+        )
+        assert not [row for row in removed if row[0] == "model.project.empty_entry"], (
+            "columns of a model with an empty catalog entry were reported as removed"
+        )
+
+        # A real drop on a model that WAS rebuilt still reports, so the guard
+        # cannot be satisfied by suppressing everything.
+        assert ["model.project.rebuilt", "dropped", "removed"] in result["data"]
+
+        # A reduced `data` has to stay distinguishable from a verified zero,
+        # otherwise the false positive is traded for a false negative.
+        coverage = result["schema_coverage"]
+        assert coverage["status"] == "partial"
+        assert "model.project.not_rebuilt" in coverage["unchecked_nodes"]
+        assert "model.project.empty_entry" in coverage["unchecked_nodes"]
+        assert coverage["unchecked_node_count"] == 2
+
+    @pytest.mark.asyncio
     async def test_tool_query(self, mcp_server):
         """Test the query tool"""
         server, _ = mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -296,12 +296,12 @@ class TestRecceMCPServer:
 
         removed = [row for row in result["data"] if row[2] == "removed"]
 
-        assert not [row for row in removed if row[0] == "model.project.not_rebuilt"], (
-            "columns of a model that was not rebuilt were reported as removed"
-        )
-        assert not [row for row in removed if row[0] == "model.project.empty_entry"], (
-            "columns of a model with an empty catalog entry were reported as removed"
-        )
+        assert not [
+            row for row in removed if row[0] == "model.project.not_rebuilt"
+        ], "columns of a model that was not rebuilt were reported as removed"
+        assert not [
+            row for row in removed if row[0] == "model.project.empty_entry"
+        ], "columns of a model with an empty catalog entry were reported as removed"
 
         # A real drop on a model that WAS rebuilt still reports, so the guard
         # cannot be satisfied by suppressing everything.


### PR DESCRIPTION
## What was wrong

`schema_diff` compares each node's base and current column sets. Nodes come from the manifest, columns come from the catalog. A model that a selective build did not rebuild is therefore present on both sides with no column data on the current side, and every base column falls into `base - current` and is reported `removed`.

A customer merge request was told that 39 columns had been dropped from an unmodified model and that this was a possible schema regression. Nothing had been dropped. The same session's node-level metadata recorded that model as unchanged, so two of our own outputs contradicted each other and the customer was shown the wrong one. The claim was prominent, carried a "investigate before merge" action, and reproduced across two runs — the second summary cited the repetition as corroboration, which a deterministic bug will always supply.

## The change

A node is skipped when either side has no column data, and an empty column map counts as absence — a relation with no columns cannot exist, so an empty map means the catalog never described the model rather than that it lost everything.

Skipping happens before the row cap, so unverifiable rows can neither displace real changes nor inflate `more`.

Suppression on its own would trade a false positive for a false negative: both runtime prompts read an empty `data` as an affirmative "zero column changes". So the response carries a `schema_coverage` sibling — `status`, `unchecked_nodes`, `unchecked_node_count`, `more` — and one contract: **`data == []` means "no column changes" only when `status` is `complete`.** It sits beside the frame rather than inside `DataFrame`, which backs every tool's payload and has no business carrying a notion that means something only here.

## Verification

Driven with lineage nodes rebuilt from the incident session's own base and current manifests and catalogs, using the adapter's rule (node from the manifest, columns only when the catalog has that node), and with the tool arguments taken verbatim from that run's trace:

| | rows for the affected model | `schema_coverage` |
|---|---|---|
| before | **39, all `removed`** | absent |
| after | **0** | `partial`, model named in `unchecked_nodes` |

247 tests pass across `test_mcp_server.py`, `test_mcp_e2e.py` and `test_mcp_cloud_backend.py`. The new test takes its node shape from what the dbt adapter actually emits rather than a hand-authored one — an earlier attempt at this fix elsewhere passed its tests against a node shape the real producer cannot emit, and shipped nothing.

## Scope and known limits

- All in-server call sites route through this function, so the direct tool, `run_check`, and the check/report paths are covered together.
- `CloudBackend._tool_schema_diff` is a different implementation reading the instance lineage payload, and is deliberately untouched. On that path an unbuilt model contributes no rows at all, so it produces a silent omission rather than a false alarm. Tracked separately.
- **A genuine column drop on a model the run did not build is not reported as a drop.** It cannot be: the change has not been applied to the warehouse, so there is nothing to observe. The node still carries its node-level change status, and the model is named in `unchecked_nodes`, so the gap is stated rather than hidden.
- The `sqlmesh` adapter always attaches columns from the model definition, so it has no catalog-absence case and its behaviour is unchanged.
- **The consuming prompts need the matching half.** Until they are taught what `partial` means, an empty `data` still reads to them as a verified zero. That half lives in the consumer repo and should land in the same image build as this.
