### PR TITLE
docs(mcp): require a widened tool description to cover both backends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,23 @@ When asked to "update deps" or "check for updates":
 - `summary.py` row count gotcha: `base`/`curr` can be `None` (TABLE_NOT_FOUND, PERMISSION_DENIED). Guard with `is None` check before arithmetic — `dict.get(key, 0)` does NOT protect when key exists with `None` value. N/A display includes reason: `"N/A (table_not_found)"`.
 - Format changes to MCP tool responses require both deterministic tests AND BQ/LLM eval to prove agent behavior unchanged.
 
+### Shared tool descriptions cover both backends
+
+`list_tools` is a single shared registry: the same `Tool(description=...)` is served in
+local and cloud mode, and `call_tool` routes to `CloudBackend.call_tool` whenever
+`self.backend` is set — before any local `_tool_*` branch is reached. Widening a tool's
+description therefore obliges **both** implementations — `RecceMCPServer._tool_*` and
+`CloudBackend._tool_*` — or the description must state what the other backend returns
+instead. A description promising a field that only one backend emits is a broken agent
+contract even when both implementations are individually correct.
+
+**Worked example**: `schema_diff`'s description promises a `schema_coverage` block.
+`CloudBackend._tool_schema_diff` satisfies it by emitting `_schema_coverage(None)` —
+status `unknown`, "coverage unassessed" — rather than omitting the key.
+
+Origin: PR #1484 review (DRC-3997). Same local/cloud divergence trap as the
+"Cloud vs Local Mode Exception Types" note below, in a different guise.
+
 ## Cloud vs Local Mode Exception Types
 
 `CheckDAO` / `RunDAO` operations have cloud-mode and local-mode branches that


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR. — docs-only change; no code touched, so no tests apply. Pre-commit ran clean (Black/isort/flake8 had no Python files to check).
- [x] DCO signed

**What type of PR is this?**

`docs` — adds one agent-context rule to `CLAUDE.md`. No behavior change.

**What this PR does / why we need it**:

The MCP tool registry is shared across backends, and that is easy to miss when
widening a tool description:

- `list_tools` (`recce/mcp_server.py:775`) builds one list of `Tool` objects. It
  branches on `self.mode` (`RecceServerMode`), never on `self.backend` — so the same
  `description=` string is served in local and cloud mode.
- `call_tool` (`recce/mcp_server.py:1575`) hits
  `elif self.backend is not None: await self.backend.call_tool(...)` ahead of every
  local `_tool_*` branch, so a cloud session never runs the local implementation the
  description was written against.

A description widened for `RecceMCPServer._tool_*` alone therefore still ships to
cloud-mode agents, promising a field they will never receive. This PR records that as
a rule under "MCP Tool Response Contracts", placed immediately before the existing
"Cloud vs Local Mode Exception Types" note — the same local/cloud divergence trap in a
different guise.

`schema_coverage` is cited as the worked example of satisfying the rule:
`CloudBackend._tool_schema_diff` emits `_schema_coverage(None)` (status `unknown`,
"coverage unassessed") rather than omitting the key.

**Which issue(s) this PR fixes**:

Closes DRC-3997

**Special notes for your reviewer**:

This is lens-gap promotion from the `/recce-dev:code-review-loop` run on #1484, which
found two blockers that shipped with a fully green suite. Three lenses were promoted so
the next run inherits the checks instead of relying on fresh eyes. Two were generic and
already landed in `recce-team`'s `code-review-loop/reference/passes.md` (Pass F); this
is the third, which is repo-specific and could not ride that PR.

Note on the origin: the issue describes `CloudBackend._tool_schema_diff` as returning a
bare `DataFrame` dump. That was true as reviewed but was fixed on the #1484 branch
(`f394014d`), so the rule ships with the *fixed* state as its example rather than the
broken one. Nothing here changes that code.

**Does this PR introduce a user-facing change?**:

```
NONE
```
