### PR TITLE
docs(agents): rightsize always-loaded agent context, and correct two claims found in review

### DIFF
--- a/.claude/skills/recce-mcp-dev/SKILL.md
+++ b/.claude/skills/recce-mcp-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recce-mcp-dev
-description: Use when modifying recce/mcp_server.py, MCP tool handlers, error classification, or MCP-related tests. Also use when adding new MCP tools or changing tool response formats.
+description: Use when modifying recce/mcp_server.py, MCP tool handlers, error classification, or MCP-related tests. Also use when adding new MCP tools or changing tool response formats, or when adding a CheckDAO/RunDAO write in recce/apis/*_api.py (cloud-mode exceptions bypass `except RecceException`).
 ---
 
 # Recce MCP Server Development
@@ -17,9 +17,58 @@ Entry point `run_mcp_server()` pops `single_env` before passing kwargs to `load_
 
 **MCP SDK quirk** — Handler must **raise** for SDK to set `isError=True`.
 
-**Response contracts** — See CLAUDE.md. Additive `_meta` only. `summary.py`: guard with `is None`, not `dict.get(key, 0)`. N/A display includes reason: `"N/A (table_not_found)"`.
-
 **Single-env** — `_maybe_add_single_env_warning()` adds `_warning` to diff results. Descriptions get conditional note.
+
+## Response Contracts
+
+An MCP tool description **is** the agent contract; it MUST match the actual
+response format.
+
+- Prefer additive changes (`_meta` fields) over modifying existing field types.
+- Row count consumers: frontend (int), `run.py` (int comparison), `summary.py`
+  (int arithmetic), `RowCountDiffResultDiffer` (3-format compat), MCP agents
+  (description-guided).
+- `summary.py` row count gotcha: `base`/`curr` can be `None`
+  (TABLE_NOT_FOUND, PERMISSION_DENIED). Guard with an `is None` check before
+  arithmetic — `dict.get(key, 0)` does NOT protect when the key exists with a
+  `None` value. N/A display includes the reason: `"N/A (table_not_found)"`.
+- Format changes require both deterministic tests AND BQ/LLM eval to prove agent
+  behaviour unchanged.
+
+### Shared tool descriptions cover both backends
+
+`list_tools` is a single shared registry: the same `Tool(description=...)` is served in
+local and cloud mode, and `call_tool` routes to `CloudBackend.call_tool` whenever
+`self.backend` is set — before any local `_tool_*` branch is reached. Widening a tool's
+description therefore obliges **both** implementations — `RecceMCPServer._tool_*` and
+`CloudBackend._tool_*` — or the description must state what the other backend returns
+instead. A description promising a field that only one backend emits is a broken agent
+contract even when both implementations are individually correct.
+
+**Worked example**: `schema_diff`'s description promises a `schema_coverage` block.
+`CloudBackend._tool_schema_diff` satisfies it by emitting `_schema_coverage(None)` —
+status `unknown`, "coverage unassessed" — rather than omitting the key.
+
+Origin: PR #1484 review (DRC-3997). Same local/cloud divergence trap as the
+exception-type note below, in a different guise.
+
+## Cloud vs Local Mode Exception Types
+
+`CheckDAO` / `RunDAO` operations have cloud-mode and local-mode branches that
+raise DIFFERENT exception classes. `RecceCloudException` (defined in
+`recce/util/recce_cloud.py`) inherits from `Exception`, NOT from
+`RecceException`. When wrapping a DAO operation in `try / except RecceException`,
+cloud-mode failures escape the wrapper and break the consistent error contract.
+
+**Rule**: For DAO operations that may run in cloud mode, either:
+- Use `except (RecceException, RecceCloudException)` to catch both, OR
+- Move the DAO call OUTSIDE the typed-exception wrapper (mirrors
+  `_tool_create_check`'s structure, which keeps `update_check_by_id`
+  unguarded so cloud failures propagate as expected).
+
+**Where this matters**: any new code in `mcp_server.py` or `*_api.py` that
+adds a DAO write inside an existing `try / except RecceException` block.
+Origin: PR #1342 review (DRC-3307).
 
 ## Testing (Three Layers)
 
@@ -27,7 +76,15 @@ Entry point `run_mcp_server()` pops `single_env` before passing kwargs to `load_
 |-------|------|-------------|---------|---------|
 | Unit | `tests/test_mcp_server.py` | Mock `RecceContext` | CI (`pytest`) | Logic correctness — tool handlers, error classification, response format |
 | Integration | `tests/test_mcp_e2e.py` | `DbtTestHelper` + DuckDB (fixed data) | CI (`pytest`) | MCP protocol works end-to-end via anyio memory streams |
-| Smoke (E2E) | `/recce-mcp-e2e` skill | User's real dbt project + real database | Manual | All 8 tools return valid results against real data |
+| Smoke (E2E) | `/recce-mcp-e2e` skill | User's real dbt project + real database | Manual | The 8 tools that harness covers return valid results against real data |
+
+**Tool count — verify, don't assume.** `list_tools` registers **20** tools as of
+2026-08-01 (`grep -c 'Tool(' recce/mcp_server.py`). The `/recce-mcp-e2e` harness
+exercises 8 of them, so a green E2E run is **not** full-surface coverage. Not
+covered by that harness: `analyze_model`, `create_check`, `get_cll`, `get_model`,
+`get_server_info`, `histogram_diff`, `impact_analysis`, `select_nodes`,
+`set_backend`, `top_k_diff`, `value_diff`, `value_diff_detail`. Re-derive the
+count rather than trusting this line.
 
 Each new MCP feature or behavior change should be covered at all three layers.
 
@@ -73,7 +130,9 @@ If the user says yes, invoke `/recce-mcp-e2e`. If a dbt project path was used ea
 ## Pitfalls
 
 - `sentry_sdk` import: `# pragma: no cover` on except (CI always has it)
-- Python 3.9: `Union[X, Y]` not `X | Y`
+- Typing: `pyproject.toml` sets `requires-python = ">=3.10"` (classifiers 3.10–3.13),
+  so `X | Y` unions are fine. A previous version of this pitfall claimed a Python
+  3.9 floor requiring `Union[X, Y]`; that is obsolete.
 - Pre-commit: black/isort may reformat — re-stage and commit
 - `run.py` `schema_diff_should_be_approved()` try/except is intentional (ensures check creation)
 

--- a/.claude/skills/recce-mcp-dev/SKILL.md
+++ b/.claude/skills/recce-mcp-dev/SKILL.md
@@ -78,13 +78,25 @@ Origin: PR #1342 review (DRC-3307).
 | Integration | `tests/test_mcp_e2e.py` | `DbtTestHelper` + DuckDB (fixed data) | CI (`pytest`) | MCP protocol works end-to-end via anyio memory streams |
 | Smoke (E2E) | `/recce-mcp-e2e` skill | User's real dbt project + real database | Manual | The 8 tools that harness covers return valid results against real data |
 
-**Tool count — verify, don't assume.** `list_tools` registers **20** tools as of
-2026-08-01 (`grep -c 'Tool(' recce/mcp_server.py`). The `/recce-mcp-e2e` harness
-exercises 8 of them, so a green E2E run is **not** full-surface coverage. Not
-covered by that harness: `analyze_model`, `create_check`, `get_cll`, `get_model`,
+**Tool count — mode-dependent, verify per mode.** `list_tools` registers **at
+most 20** tools, and how many it actually returns depends on the server mode:
+
+| Gate | Count | Tools |
+|------|-------|-------|
+| always | 7 | `lineage_diff`, `schema_diff`, `get_model`, `get_cll`, `get_server_info`, `set_backend`, `select_nodes` |
+| `self.backend is None` (local only) | 1 | `analyze_model` |
+| `self.mode == RecceServerMode.server` | 12 | `row_count_diff`, `query`, `query_diff`, `profile_diff`, `value_diff`, `value_diff_detail`, `top_k_diff`, `histogram_diff`, `list_checks`, `run_check`, `create_check`, `impact_analysis` |
+
+So preview and read-only mode expose 8; cloud mode never exceeds 19. `grep -c
+'Tool(' recce/mcp_server.py` counts **code sites**, not any single session's
+surface — read the `if` guards around the `analyze_model` and server-mode blocks
+before quoting a number.
+
+The `/recce-mcp-e2e` harness exercises 8 tools (2 always-on + 6 server-mode diff
+tools), so a green E2E run is **not** full-surface coverage. Not covered by that
+harness: `analyze_model`, `create_check`, `get_cll`, `get_model`,
 `get_server_info`, `histogram_diff`, `impact_analysis`, `select_nodes`,
-`set_backend`, `top_k_diff`, `value_diff`, `value_diff_detail`. Re-derive the
-count rather than trusting this line.
+`set_backend`, `top_k_diff`, `value_diff`, `value_diff_detail`.
 
 Each new MCP feature or behavior change should be covered at all three layers.
 
@@ -125,7 +137,7 @@ If the user says yes, invoke `/recce-mcp-e2e`. If a dbt project path was used ea
 
 **Do NOT ask** after: test-only changes, comment/doc edits, import reordering.
 
-**This is separate from `tests/test_mcp_e2e.py`** — that file tests with DbtTestHelper + DuckDB in CI. `/recce-mcp-e2e` verifies all 8 tools against a real dbt project with a real database.
+**This is separate from `tests/test_mcp_e2e.py`** — that file tests with DbtTestHelper + DuckDB in CI. `/recce-mcp-e2e` verifies the 8 tools that harness covers (see the tool-count note above) against a real dbt project with a real database.
 
 ## Pitfalls
 

--- a/.claude/skills/recce-mcp-e2e/SKILL.md
+++ b/.claude/skills/recce-mcp-e2e/SKILL.md
@@ -5,7 +5,14 @@ description: Use when MCP server code is modified and needs full E2E verificatio
 
 # MCP E2E Verification
 
-Full-stack verification of all 8 MCP tools against a real dbt project.
+Full-stack verification against a real dbt project of the 8 MCP tools this harness
+covers: `lineage_diff`, `schema_diff`, `row_count_diff`, `query`, `query_diff`,
+`profile_diff`, `list_checks`, `run_check`.
+
+`list_tools` registers **20** tools (verify with `grep -c 'Tool(' recce/mcp_server.py`),
+so a green run here is a smoke test of the core diff surface, **not** full-surface
+coverage. Do not report it as "all tools verified". See the `recce-mcp-dev` skill for
+the uncovered list.
 
 ## When to Use
 

--- a/.claude/skills/recce-mcp-e2e/SKILL.md
+++ b/.claude/skills/recce-mcp-e2e/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recce-mcp-e2e
-description: Use when MCP server code is modified and needs full E2E verification against a real dbt project. Triggers after changes to recce/mcp_server.py, MCP tool handlers, single-env logic, or error classification. Also use before merging MCP PRs.
+description: Use when MCP server code is modified and needs smoke verification of the core diff tools against a real dbt project. Triggers after changes to recce/mcp_server.py, MCP tool handlers, single-env logic, or error classification. Also use before merging MCP PRs.
 ---
 
 # MCP E2E Verification
@@ -9,10 +9,12 @@ Full-stack verification against a real dbt project of the 8 MCP tools this harne
 covers: `lineage_diff`, `schema_diff`, `row_count_diff`, `query`, `query_diff`,
 `profile_diff`, `list_checks`, `run_check`.
 
-`list_tools` registers **20** tools (verify with `grep -c 'Tool(' recce/mcp_server.py`),
-so a green run here is a smoke test of the core diff surface, **not** full-surface
-coverage. Do not report it as "all tools verified". See the `recce-mcp-dev` skill for
-the uncovered list.
+`list_tools` registers **at most 20** tools, and the count is mode-dependent —
+7 always, `analyze_model` only in local mode, and 12 only in server mode, so
+preview and read-only mode expose 8. A green run here is a smoke test of the core
+diff surface, **not** full-surface coverage. Do not report it as "all tools
+verified". See the `recce-mcp-dev` skill for the per-mode breakdown and the
+uncovered list.
 
 ## When to Use
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,12 +47,16 @@ Things you would not infer from reading the tree:
 - **A biome version change aborts the commit.** `js/.husky/pre-commit` pins
   `@biomejs/biome` (DRC-3460) and requires a deliberate ack; the hook prints the
   exact steps.
-- **Only one hook system is active at a time.** `make install-dev` unsets
-  `core.hooksPath` (so `.git/hooks` + the Python `pre-commit` framework win, and the
-  biome guard is bypassed); `cd js && pnpm install` sets it to `js/.husky/_` (so
-  husky wins, and black/isort/flake8 are bypassed). Whichever ran last silently
-  disables the other. Check `git config --get core.hooksPath` before trusting a
-  clean commit.
+- **`core.hooksPath` decides which hooks run, and the two states are not equal.**
+  `cd js && pnpm install` sets it to `js/.husky/_`: husky runs the biome guard,
+  `pnpm lint:staged`, **and** chains into the Python `pre-commit` framework
+  (`js/.husky/pre-commit`, the templated block at the end) — everything runs.
+  `make install-dev` unsets it, so `.git/hooks/pre-commit` wins and the biome
+  guard plus frontend lint are silently lost; `.git/hooks/pre-commit` does not
+  chain back to husky. Check `git config --get core.hooksPath` before trusting a
+  clean commit; if it prints nothing, restore with
+  `git config core.hooksPath js/.husky/_`. Never "repair" the husky state by
+  running `make install-dev` — that is the strictly weaker configuration.
 - **New MCP tools:** `list_tools` is one shared registry serving both local and
   cloud backends, so a tool description obliges both implementations. See the
   `recce-mcp-dev` skill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,9 @@
 
 Instructions for AI coding agents working with this repository.
 
-## Project Overview
-
-Recce is a data validation and review tool for dbt projects. It helps data teams preview, validate, and ship data changes with confidence via lineage visualization, data diffing, and collaborative review.
-
-**Architecture:** Python backend (FastAPI CLI) + React frontend (Next.js static build) embedded in Python package.
+Recce is a data validation and review tool for dbt projects: lineage visualization,
+data diffing, collaborative review. Python backend (FastAPI CLI) + React frontend
+(Next.js static build) embedded in the Python package.
 
 ---
 
@@ -32,53 +30,32 @@ Recce is a data validation and review tool for dbt projects. It helps data teams
 
 ---
 
-## Essential Commands
+## Non-obvious conventions
 
-| Task | Command |
-|------|---------|
-| **Install Dev** | `make install-dev` |
-| **Run Server** | `recce server` |
-| **Format Python** | `make format` |
-| **Lint Python** | `make flake8` |
-| **Test Python** | `make test` |
-| **Frontend Dev** | `cd js && pnpm dev` |
-| **Frontend Build** | `cd js && pnpm run build` |
-| **Frontend Lint** | `cd js && pnpm lint:fix` |
-| **Frontend Test** | `cd js && pnpm test` |
-| **Type Check** | `cd js && pnpm type:check` |
-| **Deps Check (Python)** | `make deps-check-python` |
-| **Deps Check (Frontend)** | `make deps-check-frontend` |
-| **Deps Check (All)** | `make deps-check` |
-| **Coverage (targeted)** | `python -m pytest tests/test_foo.py --cov=recce.module --cov-report=term-missing` |
+Things you would not infer from reading the tree:
 
----
-
-## Repository Layout
-
-| Directory | Purpose |
-|-----------|---------|
-| `recce/` | Backend (Python): APIs, adapters, models, tasks, state |
-| `recce/data/` | GENERATED - embedded frontend (do not edit) |
-| `js/` | Frontend monorepo (Next.js + React) |
-| `js/app/` | OSS Next.js shell (routes/layouts only) |
-| `js/packages/ui/` | `@datarecce/ui` shared components/hooks/api |
-| `js/packages/storybook/` | Component stories and visual tests |
-| `tests/` | Python unit tests |
-| `integration_tests/` | dbt/SQLMesh integration tests |
-| `.claude/skills/` | Project-level Claude Code skills |
-
-## Where to Add Code
-
-| Change Type | Location |
-|-------------|----------|
-| New check type | `recce/tasks/` (extend Task class) |
-| API endpoint | `recce/apis/*_api.py` + `*_func.py` |
-| Data model | `recce/models/` (Pydantic) |
-| Platform adapter | `recce/adapter/` (extend BaseAdapter) |
-| State storage | `recce/state/` (extend RecceStateLoader) |
-| UI component (shared) | `js/packages/ui/src/components/` |
-| UI component (OSS-only) | `js/app/` |
-| API client | `js/packages/ui/src/api/` |
+- **Frontend:** pnpm only — never npm or npx. There is no root `package.json`;
+  run pnpm from `js/`.
+- **Python:** Black + isort + flake8 via the Makefile. There is **no Ruff config**
+  in this repo, despite Ruff being the norm elsewhere.
+- **Integration tests** need dbt artifacts at `integration_tests/dbt/target/manifest.json`
+  and `integration_tests/dbt/target-base/manifest.json`. Unit tests do not.
+- **`make test` can fail before pytest runs.** It depends on `install-dev`, whose
+  `git config --unset-all core.hooksPath` exits 5 when the key is unset. Check for
+  `make: *** [install-dev] Error` before believing a green result, or run
+  `python -m pytest tests/ -q` directly.
+- **A biome version change aborts the commit.** `js/.husky/pre-commit` pins
+  `@biomejs/biome` (DRC-3460) and requires a deliberate ack; the hook prints the
+  exact steps.
+- **Only one hook system is active at a time.** `make install-dev` unsets
+  `core.hooksPath` (so `.git/hooks` + the Python `pre-commit` framework win, and the
+  biome guard is bypassed); `cd js && pnpm install` sets it to `js/.husky/_` (so
+  husky wins, and black/isort/flake8 are bypassed). Whichever ran last silently
+  disables the other. Check `git config --get core.hooksPath` before trusting a
+  clean commit.
+- **New MCP tools:** `list_tools` is one shared registry serving both local and
+  cloud backends, so a tool description obliges both implementations. See the
+  `recce-mcp-dev` skill.
 
 ---
 
@@ -103,6 +80,14 @@ cd js && pnpm lint:fix && pnpm type:check && pnpm test && pnpm run build
 recce server  # Test integration
 ```
 
+Targeted Python coverage:
+```bash
+python -m pytest tests/test_foo.py --cov=recce.module --cov-report=term-missing
+```
+
+Other Makefile targets are discoverable with `make help` or by reading the
+`Makefile`; frontend scripts with `cd js && pnpm run`.
+
 ---
 
 ## Commit Conventions
@@ -119,28 +104,19 @@ git commit -s -m "feat(check): add timeline component"
 
 ---
 
-## Tech Stack
+## Where things live
 
-| Layer | Stack |
-|-------|-------|
-| Backend | Python 3.10-3.13, FastAPI, Click, Pydantic, dbt adapters, uv (package manager) |
-| Frontend | Node.js 24+, Next.js 16, React 19, TypeScript 5.9, MUI 7, Biome 2.4, Tailwind 4 |
-| Testing | pytest, Vitest, React Testing Library, Playwright |
-
----
-
-## Frontend Specifics
-
-For pnpm v11 quirks (`strictDepBuilds`, `allowBuilds`, Corepack pinning), Biome/Vitest tooling, `@datarecce/ui` publishing, and frontend style conventions, see **[js/CLAUDE.md](./js/CLAUDE.md)**.
+`recce/` backend (`tasks/` = check types, `apis/` = endpoints, `models/` =
+Pydantic, `adapter/` = platform adapters, `state/` = state loaders).
+`recce/data/` is generated — never edit. `js/app/` is the thin OSS shell;
+`js/packages/ui/` is `@datarecce/ui`, where shared components, hooks, and API
+clients belong.
 
 ## Common Pitfalls
 
 | Problem | Fix |
 |---------|-----|
 | Frontend changes not appearing | `cd js && pnpm run build` then restart `recce server` |
-| Python import errors | `make install-dev` (uses uv) |
-| Biome lint failures | `pnpm lint:fix` |
-| Type errors | `pnpm type:check` for details |
 | dbt artifact issues | Check `integration_tests/dbt/target` |
 
 ---
@@ -149,3 +125,4 @@ For pnpm v11 quirks (`strictDepBuilds`, `allowBuilds`, Corepack pinning), Biome/
 
 - **[CLAUDE.md](./CLAUDE.md)** - Claude-specific workflows and deep dives
 - **[js/CLAUDE.md](./js/CLAUDE.md)** - Frontend-specific instructions (pnpm, Biome, @datarecce/ui, style conventions)
+- **`docs/KNOWLEDGE_BASE.md`** - Architecture, code patterns, testing, debugging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@
 
 ## Working Preferences
 
+- Keep responses concise and action-oriented.
 - Ask clarifying questions before changes that alter product behavior.
 
 ## AI Agent Documentation
@@ -41,15 +42,18 @@ own line — GitHub's parser ignores the rest of a comma-separated list.
 
 ## PR Review Response
 
-The `pr-review-response` skill drives the loop. Two things it is easy to get wrong:
+The `recce-dev:pr-review-response` skill drives the loop (name it in full — a bare
+`pr-review-response` also resolves to a personal user-level skill). Two things it is
+easy to get wrong:
 
 - Fetching review comments **requires** `--paginate` (gh) or manual pagination — PRs here frequently have >30 comments.
 - Replying to a review comment uses `POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies`.
 
 ## Dependency Updates
 
-The `address-dependabot` skill drives consolidation. Non-obvious prerequisites and
-outputs:
+The `recce-dev:address-dependabot` skill drives consolidation (name it in full —
+the bare name collides with project- and user-level skills of the same name).
+Non-obvious prerequisites and outputs:
 
 - Requires `brew install dependabot` and a running Docker daemon.
 - `make deps-check` runs Dependabot locally and writes `deps-python.yml` and
@@ -66,8 +70,9 @@ cd js && pnpm install && pnpm lint && pnpm type:check && pnpm test && pnpm run b
 
 Response-format contracts, the shared local/cloud tool registry, and the
 cloud-vs-local exception-type trap are in the **`recce-mcp-dev`** skill — it loads
-when you touch `recce/mcp_server.py`, MCP tool handlers, error classification, or
-MCP tests. Read it before changing a tool description or response shape.
+when you touch `recce/mcp_server.py`, MCP tool handlers, error classification, MCP
+tests, or when you add a `CheckDAO`/`RunDAO` write in `recce/apis/*_api.py`. Read it
+before changing a tool description or response shape.
 
 ## Individual Preferences
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,25 +6,13 @@
 
 ## Quick Reference
 
-For detailed documentation beyond AGENTS.md essentials:
-
 → `docs/KNOWLEDGE_BASE.md` - Architecture, code patterns, frontend structure, testing, debugging
-→ `js/CLAUDE.md` - Frontend-specific instructions (pnpm, Biome, @datarecce/ui, style conventions)
+→ `js/CLAUDE.md` - Frontend conventions and tooling (Node via `nave`, Biome, Vitest, pnpm v11
+  quirks, Storybook imports, CSS color format, rem vs px, shell vs shared code)
 
-## Package Manager & Tooling
+## Working Preferences
 
-- **Frontend (from `js/`):** this monorepo uses **pnpm** — never npm or npx. Run `cd js && pnpm install`, `cd js && pnpm test`, `cd js && pnpm lint`. There is no root `package.json`; pnpm commands from the repo root will fail.
-- **Python (from repo root):** linting and formatting are **Black + isort + flake8**, driven by the Makefile — `make format`, `make check`, `make flake8`. Pre-commit hooks (`.pre-commit-config.yaml`) enforce the same. There is no Ruff configuration in this repo.
-- **Integration tests** require dbt artifacts at `integration_tests/dbt/target/manifest.json` and `integration_tests/dbt/target-base/manifest.json`. `make test` (unit tests) runs without external services.
-
-For frontend-specific tooling details (Node version via `nave`, Biome, Vitest, pnpm v11 quirks), see `js/CLAUDE.md`.
-
-## Claude-Specific Notes
-
-- Keep responses concise and action-oriented
-- Ask clarifying questions before changes that alter product behavior
-- Prefer updating shared UI code in `js/packages/ui`; keep `js/app` thin
-- Run `cd js && pnpm run build` before `recce server` when validating frontend changes
+- Ask clarifying questions before changes that alter product behavior.
 
 ## AI Agent Documentation
 
@@ -39,18 +27,6 @@ Use gitignored directories for temporary working documents:
 - When creating PR bodies with multi-line content, write to a temp file and pass `--body-file` instead of using heredocs (avoids quoting issues).
 - Verify the correct base branch before opening a PR (especially for extensions/multi-branch repos).
 
-## Dependency Update Workflow
-
-When asked to "update deps" or "check for updates":
-
-**Prerequisites:** `brew install dependabot` + Docker running
-
-0. **Scan:** `make deps-check` (runs Dependabot locally, outputs `deps-python.yml` and `deps-frontend.yml`)
-1. **Audit:** Frontend — see `js/CLAUDE.md` for `pnpm audit && pnpm outdated` workflow and overrides list. Python — `make deps-check-python`.
-2. **Present:** Group by SECURITY/MAJOR/MINOR with numbered list
-3. **Apply:** Frontend updates per `js/CLAUDE.md`; Python updates via `pyproject.toml`.
-4. **Verify:** Run all quality checks (`make test` for Python; `cd js && pnpm install && pnpm lint && pnpm type:check && pnpm test && pnpm run build` for frontend).
-
 ## Commit and PR Workflow
 
 **Commits:** Always use `--signoff` and include a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer (version pin optional — if included, use the current model)
@@ -60,58 +36,38 @@ When asked to "update deps" or "check for updates":
 - Type, description, linked issues
 - Reviewer notes, user-facing changes
 
-## PR Review Response Workflow
+When a PR closes more than one issue or PR, give each its own `Closes #N` on its
+own line — GitHub's parser ignores the rest of a comma-separated list.
 
-- When fetching PR review comments via GitHub API, always use `--paginate` (gh) or paginate manually — PRs frequently have >30 comments.
-- Use the correct GitHub API endpoint for replying to review comments: `POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies`.
-- For each review comment: validate the concern first, fix only real issues, run tests, commit, push, then reply individually.
+## PR Review Response
 
-## MCP Tool Response Contracts
+The `pr-review-response` skill drives the loop. Two things it is easy to get wrong:
 
-- MCP tool description = LLM agent contract. Description MUST match actual response format.
-- Prefer additive changes (`_meta` fields) over modifying existing field types in tool responses.
-- Row count consumers: frontend (int), `run.py` (int comparison), `summary.py` (int arithmetic), `RowCountDiffResultDiffer` (3-format compat), MCP agents (description-guided).
-- `summary.py` row count gotcha: `base`/`curr` can be `None` (TABLE_NOT_FOUND, PERMISSION_DENIED). Guard with `is None` check before arithmetic — `dict.get(key, 0)` does NOT protect when key exists with `None` value. N/A display includes reason: `"N/A (table_not_found)"`.
-- Format changes to MCP tool responses require both deterministic tests AND BQ/LLM eval to prove agent behavior unchanged.
+- Fetching review comments **requires** `--paginate` (gh) or manual pagination — PRs here frequently have >30 comments.
+- Replying to a review comment uses `POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies`.
 
-### Shared tool descriptions cover both backends
+## Dependency Updates
 
-`list_tools` is a single shared registry: the same `Tool(description=...)` is served in
-local and cloud mode, and `call_tool` routes to `CloudBackend.call_tool` whenever
-`self.backend` is set — before any local `_tool_*` branch is reached. Widening a tool's
-description therefore obliges **both** implementations — `RecceMCPServer._tool_*` and
-`CloudBackend._tool_*` — or the description must state what the other backend returns
-instead. A description promising a field that only one backend emits is a broken agent
-contract even when both implementations are individually correct.
+The `address-dependabot` skill drives consolidation. Non-obvious prerequisites and
+outputs:
 
-**Worked example**: `schema_diff`'s description promises a `schema_coverage` block.
-`CloudBackend._tool_schema_diff` satisfies it by emitting `_schema_coverage(None)` —
-status `unknown`, "coverage unassessed" — rather than omitting the key.
+- Requires `brew install dependabot` and a running Docker daemon.
+- `make deps-check` runs Dependabot locally and writes `deps-python.yml` and
+  `deps-frontend.yml`. `make deps-check-python` covers Python alone.
+- Python updates go through `pyproject.toml`; frontend updates follow `js/CLAUDE.md`.
 
-Origin: PR #1484 review (DRC-3997). Same local/cloud divergence trap as the
-"Cloud vs Local Mode Exception Types" note below, in a different guise.
+Verify a consolidated update with:
+```bash
+make test
+cd js && pnpm install && pnpm lint && pnpm type:check && pnpm test && pnpm run build
+```
 
-## Cloud vs Local Mode Exception Types
+## MCP Server Work
 
-`CheckDAO` / `RunDAO` operations have cloud-mode and local-mode branches that
-raise DIFFERENT exception classes. `RecceCloudException` (defined in
-`recce/util/recce_cloud.py`) inherits from `Exception`, NOT from
-`RecceException`. When wrapping a DAO operation in `try / except RecceException`,
-cloud-mode failures escape the wrapper and break the consistent error contract.
-
-**Rule**: For DAO operations that may run in cloud mode, either:
-- Use `except (RecceException, RecceCloudException)` to catch both, OR
-- Move the DAO call OUTSIDE the typed-exception wrapper (mirrors
-  `_tool_create_check`'s structure, which keeps `update_check_by_id`
-  unguarded so cloud failures propagate as expected).
-
-**Where this matters**: any new code in `mcp_server.py` or `*_api.py` that
-adds a DAO write inside an existing `try / except RecceException` block.
-Origin: PR #1342 review (DRC-3307).
-
-## Frontend Style Conventions
-
-See `js/CLAUDE.md` for frontend conventions (Storybook imports, CSS color format, rem vs px, shell vs shared code).
+Response-format contracts, the shared local/cloud tool registry, and the
+cloud-vs-local exception-type trap are in the **`recce-mcp-dev`** skill — it loads
+when you touch `recce/mcp_server.py`, MCP tool handlers, error classification, or
+MCP tests. Read it before changing a tool description or response shape.
 
 ## Individual Preferences
 


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`docs` — agent-context files only. No product code, no Python, no TypeScript.

**What this PR does / why we need it**:

`CLAUDE.md` and `AGENTS.md` load into every session; a skill body loads only when the
skill is invoked. The always-resident pair had drifted into a mix of stale facts and
material that is trivially derivable from `ls`, `make help`, or a manifest.

Two commits, kept separate so the second is reviewable on its own:

**1. `docs(agents): rightsize always-loaded agent context`**

- `AGENTS.md` — removed the Tech Stack table (it claimed MUI 7 / Biome 2.4; actual
  overrides are `@mui/material: ^9.0.0` and `@biomejs/biome: 2.5.5`, so it was
  actively wrong), the Repository Layout and Essential Commands tables (derivable
  from `ls` and `make help`, both verified to cover what was removed), and three
  Common Pitfalls rows that restated commands already in the Development Workflow
  block. Added a "Non-obvious conventions" section holding the pnpm and
  Black/isort/flake8 facts relocated from `CLAUDE.md` plus two gotchas that have
  each cost real debugging time.
- `CLAUDE.md` — moved the MCP response-format contracts and the cloud-vs-local
  exception-type trap into `recce-mcp-dev/SKILL.md`, leaving a pointer; compressed
  the dependency-update and PR-review procedures to skill pointers plus the
  prerequisites and API endpoints that are not in those skills.
- `recce-mcp-dev` — received the moved blocks; corrected the "All 8 tools" coverage
  claim; dropped the "Python 3.9: `Union[X, Y]`" pitfall, obsolete under
  `requires-python = ">=3.10"`.
- `recce-mcp-e2e` — named the 8 tools the harness actually covers.

`AGENTS.md`'s **Critical Constraints block is unchanged, byte for byte** (md5
`0e23fd0fb248e634318603cbb8f3ed34` before and after). No prohibition was narrowed,
no covered category dropped, no absolute softened.

**2. `docs(agents): correct hook-system and MCP tool-count claims`**

An adversarial review of commit 1 found two factual errors and four smaller gaps.
Every claim below was verified against the code, not inferred.

- **`AGENTS.md` said the two pre-commit systems were mutually exclusive, and that
  husky mode bypassed black/isort/flake8. Both false.** `js/.husky/pre-commit` ends
  in a committed `# start templated` block that `exec`s
  `pre-commit hook-impl --config=.pre-commit-config.yaml`. Confirmed by running
  `bash js/.husky/pre-commit` under `core.hooksPath=js/.husky/_` and watching
  black/isort/flake8 execute, and by `git show HEAD:js/.husky/pre-commit` — it is
  committed, not a local artifact. Husky mode is a superset (biome guard +
  `pnpm lint:staged` + all Python hooks); `make install-dev` is a strict downgrade,
  and `.git/hooks/pre-commit` has no chain back. The old text told the reader to
  "re-run whichever installer you need", which points at the one command that
  actually drops a guardrail.
- **`list_tools` does not register 20 tools unconditionally — 20 is the maximum.**
  7 register always, `analyze_model` only when `self.backend is None`, and 12 only
  when `self.mode == RecceServerMode.server`. Preview and read-only mode expose 8;
  cloud mode never exceeds 19. The prescribed `grep -c 'Tool('` recipe counts code
  sites rather than any session's surface, reproducing the class of error it was
  added to prevent. Replaced with a per-mode table in both skills.
- The **third** "all 8 tools" instance in `recce-mcp-dev` survived commit 1's
  correction.
- `recce-mcp-e2e`'s `description:` still promised "full E2E verification" while its
  body said the opposite — and the description is the part that stays resident.
- The `CLAUDE.md` MCP pointer omitted the `recce/apis/*_api.py` trigger that the
  skill description carries. `grep -rln 'except RecceException' recce/apis/` returns
  `run_api.py`, `check_api.py`, `check_events_api.py`, all three of which can regress.
- The two new skill pointers were ambiguous across three scopes (project, user,
  plugin) — now plugin-qualified.
- Restored "Keep responses concise and action-oriented", the one dropped line that
  is not reconstructible from `ls`, `make help`, or a manifest.

**Which issue(s) this PR fixes**:

None filed.

**Special notes for your reviewer**:

Verification run for this branch:

- `python -m pytest tests/ -q` → **1578 passed, 5 skipped**. No product code changed;
  this confirms the tree is clean.
- Tool inventory: `grep -c 'Tool(' recce/mcp_server.py` → 20, matching 20 unique
  `name="…"` values. The per-mode split was read off the `if` guards at
  `recce/mcp_server.py:929` (`self.backend is None`) and `:1071`
  (`self.mode == RecceServerMode.server`).
- E2E coverage: cross-checked each tool name against
  `.claude/skills/recce-mcp-e2e/test_mcp_e2e_template.py` — 8 present, 12 absent.
  The template itself is deliberately untouched so it stays runnable.
- `make help` (`Makefile:19`) was confirmed to print `make check`, `make mypy`,
  `make flake8` and `make deps-check-frontend`, i.e. everything the deleted Essential
  Commands table listed.
- Exception hierarchy: `RecceCloudException(Exception)` at
  `recce/util/recce_cloud.py:31` vs `RecceException(Exception)` at
  `recce/exceptions.py:1` — unrelated, as the skill states.

Two judgment calls worth a second opinion:

1. The `recce-dev:`-qualified skill names in `CLAUDE.md`. A bare
   `pr-review-response` currently resolves to a personal user-level skill; naming the
   plugin explicitly seemed right for a checked-in file, but revert if the team
   prefers the bare name.
2. Commit 1 removes `make check` from always-loaded context on the grounds that
   `make help` covers it. Verified true, but it is the one command that genuinely
   disappeared rather than being restated elsewhere.

Corresponding fixes to the local agent-memory files (the wrong hook claim, an
"every value drifted" overstatement that was really 8 of 9, and a cozempic durability
note that named a non-existent function) were applied outside the repo and are not
part of this diff.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
