### PR TITLE
feat(lineage): document ADD/COLUMN graph badges in the changes legend (DRC-3466)

### DIFF
--- a/js/packages/storybook/stories/lineage/LineageLegend.stories.tsx
+++ b/js/packages/storybook/stories/lineage/LineageLegend.stories.tsx
@@ -32,7 +32,8 @@ export const ChangeStatus: Story = {
 
 /**
  * Change status legend inside the new CLL experience.
- * Muted brown/yellow palette, includes "Impacted".
+ * Muted brown/yellow palette, includes "Impacted", and documents the ADD /
+ * COLUMN graph badges the canvas nodes carry.
  */
 export const ChangeStatusCll: Story = {
   args: {
@@ -40,6 +41,25 @@ export const ChangeStatusCll: Story = {
     title: "Changes",
     showTooltips: true,
     newCllExperience: true,
+  },
+};
+
+/**
+ * Same legend in dark mode — the badge swatches take their tokens from
+ * `useIsDark()`, so this is where a light/dark token regression shows up.
+ */
+export const ChangeStatusCllDark: Story = {
+  args: {
+    variant: "changeStatus",
+    title: "Changes",
+    showTooltips: true,
+    newCllExperience: true,
+  },
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+  globals: {
+    theme: "dark",
   },
 };
 

--- a/js/packages/ui/src/components/lineage/__tests__/LineageLegend.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageLegend.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { LineageLegend } from "../legend";
+import { getGraphBadgeLegendEntries } from "../wholeModelTreatment";
 
 describe("LineageLegend", () => {
   it("renders all change categories below the change statuses", () => {
@@ -23,5 +24,88 @@ describe("LineageLegend", () => {
     render(<LineageLegend variant="changeStatus" newCllExperience />);
 
     expect(screen.queryByText("Change Categories")).not.toBeInTheDocument();
+  });
+
+  describe("graph badge rows (new CLL experience)", () => {
+    it("documents the ADD badge", () => {
+      render(<LineageLegend variant="changeStatus" newCllExperience />);
+
+      expect(screen.getByTestId("legend-treatment-additive")).toHaveTextContent(
+        "ADD",
+      );
+      expect(screen.getByText("Additive change")).toBeInTheDocument();
+    });
+
+    it("documents column-only change and column-only impact separately", () => {
+      render(<LineageLegend variant="changeStatus" newCllExperience />);
+
+      expect(
+        screen.getByTestId("legend-treatment-column-changed"),
+      ).toHaveTextContent("COLUMN");
+      expect(
+        screen.getByTestId("legend-treatment-column-impacted"),
+      ).toHaveTextContent("COLUMN");
+      expect(screen.getByText("Column-only change")).toBeInTheDocument();
+      expect(screen.getByText("Column-only impact")).toBeInTheDocument();
+    });
+
+    it("groups the badge rows under their own heading", () => {
+      render(<LineageLegend variant="changeStatus" newCllExperience />);
+
+      expect(screen.getByText("Badges")).toBeInTheDocument();
+    });
+
+    it("sources every row from the graph badge definitions", () => {
+      render(<LineageLegend variant="changeStatus" newCllExperience />);
+
+      const entries = getGraphBadgeLegendEntries(false);
+      expect(entries).toHaveLength(3);
+      for (const entry of entries) {
+        const swatch = screen.getByTestId(`legend-treatment-${entry.kind}`);
+        expect(swatch).toHaveTextContent(entry.text);
+        expect(swatch).toHaveAttribute("aria-label", entry.ariaLabel);
+        expect(screen.getByText(entry.tooltip)).toBeInTheDocument();
+      }
+    });
+
+    it("reads statuses first, then the badge block", () => {
+      const { container } = render(
+        <LineageLegend variant="changeStatus" newCllExperience />,
+      );
+
+      expect(container.textContent).toBe(
+        [
+          "+Added",
+          "-Removed",
+          "~Modified",
+          "!Impacted",
+          "Badges",
+          "ADDAdditive change",
+          "COLUMNColumn-only change",
+          "COLUMNColumn-only impact",
+        ].join(""),
+      );
+    });
+
+    it("omits the badge rows when the flag is off", () => {
+      render(<LineageLegend variant="changeStatus" />);
+
+      expect(screen.queryByText("Badges")).not.toBeInTheDocument();
+      expect(screen.queryByText("Additive change")).not.toBeInTheDocument();
+      expect(screen.queryByText("Column-only change")).not.toBeInTheDocument();
+      expect(screen.queryByText("Column-only impact")).not.toBeInTheDocument();
+      for (const entry of getGraphBadgeLegendEntries(false)) {
+        expect(
+          screen.queryByTestId(`legend-treatment-${entry.kind}`),
+        ).not.toBeInTheDocument();
+      }
+    });
+
+    it("omits the badge rows on the transformation legend", () => {
+      render(<LineageLegend variant="transformation" newCllExperience />);
+
+      expect(screen.queryByText("Badges")).not.toBeInTheDocument();
+      expect(screen.queryByText("Additive change")).not.toBeInTheDocument();
+    });
   });
 });

--- a/js/packages/ui/src/components/lineage/legend/LineageLegend.tsx
+++ b/js/packages/ui/src/components/lineage/legend/LineageLegend.tsx
@@ -4,11 +4,14 @@ import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import { useIsDark } from "../../../hooks/useIsDark";
 import {
   CHANGE_CATEGORY_DETAILS,
   CHANGE_CATEGORY_LABELS,
 } from "../changeCategory";
 import { changeStatusColors, cllChangeStatusColors } from "../styles";
+import { TreatmentChip } from "../TreatmentChip";
+import { getGraphBadgeLegendEntries } from "../wholeModelTreatment";
 
 /**
  * Legend item for change status
@@ -54,9 +57,10 @@ export interface LineageLegendProps {
   className?: string;
 
   /**
-   * When true, render the muted CLL palette and include the "Impacted" entry.
-   * When false (default), render the original Tailwind palette and omit
-   * "Impacted" — matching the legend OSS users have always seen.
+   * When true, render the muted CLL palette, include the "Impacted" entry,
+   * and document the graph badges the canvas nodes carry. When false
+   * (default), render the original Tailwind palette and omit both — matching
+   * the legend OSS users have always seen.
    * @default false
    */
   newCllExperience?: boolean;
@@ -200,9 +204,12 @@ function TransformationChip({
 /**
  * LineageLegend Component
  *
- * A pure presentation component for displaying legends in lineage visualizations.
+ * A presentation component for displaying legends in lineage visualizations.
  * Supports both change status legends (added/removed/modified) and
  * transformation type legends (passthrough/renamed/derived/source/unknown).
+ *
+ * Takes its colour mode from `useIsDark` rather than a prop, so the badge
+ * swatches pick the same light/dark tokens the graph badges do.
  *
  * @example Change status legend
  * ```tsx
@@ -241,6 +248,7 @@ export function LineageLegend({
   className,
   newCllExperience = false,
 }: LineageLegendProps) {
+  const isDark = useIsDark();
   const changeStatusItems = newCllExperience
     ? defaultChangeStatusItems
     : defaultChangeStatusItems.filter((item) => item.status !== "impacted");
@@ -346,6 +354,50 @@ export function LineageLegend({
               content
             );
           })}
+        </Box>
+      )}
+
+      {variant === "changeStatus" && newCllExperience && (
+        <Box
+          sx={{
+            mt: 1,
+            pt: 1,
+            borderTop: "1px solid",
+            borderColor: "divider",
+          }}
+        >
+          <Typography
+            variant="caption"
+            sx={{
+              display: "block",
+              fontWeight: 600,
+              mb: 0.5,
+              color: "text.secondary",
+            }}
+          >
+            Badges
+          </Typography>
+          {getGraphBadgeLegendEntries(isDark).map((entry) => (
+            <Box
+              key={entry.kind}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                mb: "4px",
+                "&:last-child": { mb: 0 },
+              }}
+            >
+              <TreatmentChip
+                tokens={entry.tokens}
+                testId={`legend-treatment-${entry.kind}`}
+                ariaLabel={entry.ariaLabel}
+              >
+                {entry.text}
+              </TreatmentChip>
+              <Typography variant="body2">{entry.tooltip}</Typography>
+            </Box>
+          ))}
         </Box>
       )}
 

--- a/js/packages/ui/src/components/lineage/wholeModelTreatment.ts
+++ b/js/packages/ui/src/components/lineage/wholeModelTreatment.ts
@@ -206,6 +206,36 @@ export function pickGraphBadge(
   };
 }
 
+/**
+ * Display order for the lineage legend's badge block. Fixed rather than
+ * derived from `Object.keys(GRAPH_BADGE_LABELS)` so the legend's reading
+ * order (benign → actionable) stays independent of the classifier's
+ * precedence order.
+ */
+const GRAPH_BADGE_LEGEND_ORDER: GraphBadgeKind[] = [
+  "additive",
+  "column-changed",
+  "column-impacted",
+];
+
+/**
+ * Every graph badge, resolved for display in the lineage legend. Unlike
+ * `pickGraphBadge` this takes no classification inputs — the legend documents
+ * all badges regardless of which ones the current graph happens to render.
+ *
+ * Both the copy and the tokens come from the same source the node badges use,
+ * so a legend swatch cannot drift from the badge it decodes.
+ */
+export function getGraphBadgeLegendEntries(
+  isDark: boolean,
+): GraphBadgeResolution[] {
+  return GRAPH_BADGE_LEGEND_ORDER.map((kind) => ({
+    kind,
+    ...GRAPH_BADGE_LABELS[kind],
+    tokens: tokensForKind(kind, isDark),
+  }));
+}
+
 // =============================================================================
 // Visual tokens
 // =============================================================================

--- a/js/packages/ui/src/components/lineage/wholeModelTreatment.ts
+++ b/js/packages/ui/src/components/lineage/wholeModelTreatment.ts
@@ -207,16 +207,23 @@ export function pickGraphBadge(
 }
 
 /**
- * Display order for the lineage legend's badge block. Fixed rather than
- * derived from `Object.keys(GRAPH_BADGE_LABELS)` so the legend's reading
- * order (benign → actionable) stays independent of the classifier's
- * precedence order.
+ * Reading order for the lineage legend's badge block (benign → actionable),
+ * kept separate from the classifier's precedence order.
  */
-const GRAPH_BADGE_LEGEND_ORDER: GraphBadgeKind[] = [
-  "additive",
-  "column-changed",
-  "column-impacted",
-];
+const GRAPH_BADGE_LEGEND_RANK: Record<GraphBadgeKind, number> = {
+  additive: 0,
+  "column-changed": 1,
+  "column-impacted": 2,
+};
+
+/**
+ * Derived from `GRAPH_BADGE_LABELS` rather than hand-listed, so a new
+ * `GraphBadgeKind` cannot reach the canvas without a legend row — the rank
+ * record above stops compiling until the new kind is ranked.
+ */
+const GRAPH_BADGE_LEGEND_ORDER: GraphBadgeKind[] = (
+  Object.keys(GRAPH_BADGE_LABELS) as GraphBadgeKind[]
+).sort((a, b) => GRAPH_BADGE_LEGEND_RANK[a] - GRAPH_BADGE_LEGEND_RANK[b]);
 
 /**
  * Every graph badge, resolved for display in the lineage legend. Unlike


### PR DESCRIPTION
Closes DRC-3466.

## Problem

With the new CLL experience on, lineage canvas nodes render `ADD` and `COLUMN` treatment badges next to the model name. The change-status legend on the same canvas listed only Added / Removed / Modified / Impacted, so users saw badges with no in-view key — right where they'd look to decode them. The only explanation was a hover tooltip covering the whole node title row.

(The originally-reported `ALL` badge no longer exists on the canvas; whole-model treatment moved to the NodeView title chip and stripe. This PR covers the badges that remain.)

## Change

**`wholeModelTreatment.ts`** — new `getGraphBadgeLegendEntries(isDark)` returning all three `GraphBadgeResolution`s in a fixed display order (benign → actionable), built from the same private `GRAPH_BADGE_LABELS` and `tokensForKind` the node badges use. `pickGraphBadge` and `pickTitleChip` are untouched.

**`legend/LineageLegend.tsx`** — behind `variant === "changeStatus" && newCllExperience`, append a divider, a `Badges` caption, and one row per badge. Swatches are `<TreatmentChip variant="badge">`, so they match the node badges exactly rather than approximating them.

Rendered order with the flag on:

```
● Added
● Removed
● Modified
● Impacted
──────────────────
BADGES
[ADD]     Additive change        (green)
[COLUMN]  Column-only change     (brown)
[COLUMN]  Column-only impact     (amber)
```

## Three decisions worth reviewing

**Two COLUMN rows, not one.** The issue left this open. `column-changed` and `column-impacted` share the `COLUMN` text but not the palette — brown vs amber — so a single row could only match half the badges a user actually sees. Two rows costs three lines of panel height and makes every swatch honest.

**Explanations are visible text, not tooltips.** The copy comes from each entry's `tooltip` field but renders inline. Fixing "you have to discover a hover" by adding another hover would have missed the point.

**`useIsDark()` rather than a new prop.** `LineageLegend` is a public `primitives.ts` export, so a required `isDark` prop would be a breaking API change. The hook matches sibling components (`NodeTag`, `ColumnLevelLineageControl`, `LineageViewTopBar`) and returns `false` outside a provider, so existing tests were unaffected. The component's "pure presentation" docstring was updated to say so.

Swatch testIds are `legend-treatment-<kind>`, deliberately **not** the node testIds — those end in `-badge`, and `LineageNode.test.tsx` / `NodeView.test.tsx` assert structurally that `[data-testid$="-badge"]` count is 0 for no-badge cases. Those queries are container-scoped so reuse couldn't break them today, but it would be a trap for any future full-view test.

## Acceptance criteria

| AC | Covered by |
|---|---|
| AC-1: `ADD` entry, chip matches node badge, explains additive change | `documents the ADD badge` |
| AC-2: column-only change and column-only impact both explained | `documents column-only change and column-only impact separately` |
| AC-3: flag off renders exactly as today | `omits the badge rows when the flag is off` + 3 pre-existing tests unchanged |
| AC-4: labels sourced from `GRAPH_BADGE_LABELS` | `sources every row from the graph badge definitions` |
| AC-5: flag-on and flag-off covered, existing tests pass | 7 new tests, 3 existing untouched |

Plus `reads statuses first, then the badge block`, a whole-legend `textContent` assertion that locks the approved layout.

## Verification

- `pnpm test` — 3982 passed, 5 skipped (187 files)
- `pnpm type:check` — clean
- `pnpm lint` — clean
- `scripts/check_wire_enum_literals.sh` — clean
- Storybook: `ChangeStatusCll` docstring updated; new `ChangeStatusCllDark` for the dark-mode tokens

## Scope

**Out:** `SchemaLegend` on the Columns tab (the wrong surface, per closed #1434). Badge behavior or classification changes (DRC-3814 / DRC-3815, which may later revise this legend's copy). A legend entry for the NodeView whole-model title chip.

**Follow-up worth filing:** the legend only renders when `isModelsChanged` is true, so a node can carry a `COLUMN` impact badge in states where no legend is on screen. Pre-existing, unrelated to this change, but it means the legend isn't a complete key in every state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
