### PR TITLE
fix(ci): bump twine to >=7 so PyPI uploads accept Metadata-Version 2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,9 @@ dev = [
     "pre-commit>=4.2.0",
     "pytest-mypy",
     "pytest-cov",
-    "twine",
+    # twine<7 monkeypatches packaging to cap Metadata-Version at 2.4, which
+    # rejects the 2.5 metadata current hatchling emits (DRC-4132).
+    "twine>=7",
     "tox",
     "tox-uv",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
     "pytest-mypy",
     "pytest-cov",
     # twine<7 monkeypatches packaging to cap Metadata-Version at 2.4, which
-    # rejects the 2.5 metadata current hatchling emits (DRC-4132).
+    # rejects the 2.5 metadata current hatchling emits.
     "twine>=7",
     "tox",
     "tox-uv",

--- a/uv.lock
+++ b/uv.lock
@@ -807,7 +807,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -2583,7 +2583,7 @@ requires-dist = [
     { name = "sqlglot", specifier = ">=27.29.0,<31.0" },
     { name = "tox", marker = "extra == 'dev'" },
     { name = "tox-uv", marker = "extra == 'dev'" },
-    { name = "twine", marker = "extra == 'dev'" },
+    { name = "twine", marker = "extra == 'dev'", specifier = ">=7" },
     { name = "uvicorn" },
     { name = "watchdog" },
     { name = "websockets" },
@@ -2893,8 +2893,8 @@ name = "secretstorage"
 version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version < '3.12' or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "python_full_version < '3.12' or sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/8a/ed6747b1cc723c81f526d4c12c1b1d43d07190e1e8258dbf934392fc850e/secretstorage-3.4.1.tar.gz", hash = "sha256:a799acf5be9fb93db609ebaa4ab6e8f1f3ed5ae640e0fa732bfea59e9c3b50e8", size = 19871, upload-time = "2025-11-11T11:30:23.798Z" }
 wheels = [
@@ -3103,7 +3103,7 @@ wheels = [
 
 [[package]]
 name = "twine"
-version = "6.2.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "id" },
@@ -3116,9 +3116,9 @@ dependencies = [
     { name = "rich" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/3c/58f808a359700f39a967dffede33efeac809262c03303fa3eec6afff8f49/twine-7.0.0.tar.gz", hash = "sha256:85cdb29c518efef867360ae4acd4b0dfd61c8654a22fca08e6f8539f05022177", size = 215032, upload-time = "2026-07-27T15:59:00.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/ddcdc06225eaad6de0e48e1002b06d919dbde20582d0662c7af51308e5d6/twine-7.0.0-py3-none-any.whl", hash = "sha256:b854164df26db268af05f49aa5c0344b10e27a494343ff05b1e0bad3b135f5a7", size = 43204, upload-time = "2026-07-27T15:58:59.26Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

`fix` / CI

**What this PR does / why we need it**:

The nightly PyPI release has been failing at the upload step for both packages:

```
ERROR    InvalidDistribution: Invalid distribution metadata: '2.5' is not a
         valid metadata version
```

Failing run: https://github.com/DataRecce/recce/actions/runs/31554418260/job/93983773260

Nothing in the repo changed. Two unpinned moving parts lined up:

1. `hatchling` is a build requirement, so `uv build` fetches the latest into an isolated env on every run. Current hatchling emits `Metadata-Version: 2.5`.
2. The locked `twine==6.2.0` monkeypatches `packaging.metadata._VALID_METADATA_VERSIONS` to its own hardcoded list that stops at `2.4` (the "Monkeypatch Metadata 2.0 support" block in `twine/package.py`). So it rejected the dist even though the locked `packaging==26.2` already accepts 2.5.

`twine 7.0.0` removed that monkeypatch and defers to `packaging`. This PR bumps `twine` to `>=7` in the `dev` extra and relocks. twine 7 requires Python >=3.10; the release jobs already `uv sync --python 3.10`.

This unblocks all four upload steps, which share the root workspace lock:

- `.github/workflows/nightly.yaml:119` (recce-nightly)
- `.github/workflows/nightly.yaml:209` (recce-cloud-nightly)
- `.github/workflows/release.yaml:77` (recce)
- `.github/workflows/release.yaml:136` (recce-cloud)

**Which issue(s) this PR fixes**:

Closes DRC-4132

**Special notes for your reviewer**:

Verified against the relocked env, reproducing the exact command shape that failed in CI:

```
$ uv run twine --version
twine version 7.0.0 (... packaging: 26.2)

$ uv build --package recce-cloud
$ unzip -p dist/*.whl '*/METADATA' | head -1
Metadata-Version: 2.5

$ uv run twine check dist/*
Checking recce_cloud-1.32.0.dev0-py3-none-any.whl: PASSED
Checking recce_cloud-1.32.0.dev0.tar.gz: PASSED
```

Before the bump, the same `twine check` failed with the CI error. The only lockfile movement is `twine 6.2.0 -> 7.0.0`.

Two follow-ups deliberately left out of this PR, tracked on DRC-4132:

- This class of break will recur. `hatchling` is unpinned in `[build-system] requires`, `astral-sh/setup-uv` runs `version: "latest"`, and twine floats. Pinning hatchling would make release builds reproducible.
- `uv publish` would drop twine from the release path entirely, but it does not read `.pypirc` — it would need a `UV_PUBLISH_TOKEN` secret instead of the current `PYPI` pypirc secret.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
