### PR TITLE
feat(cloud): add list-orgs and list-projects commands

### DIFF
--- a/recce_cloud/recce_cloud/cli.py
+++ b/recce_cloud/recce_cloud/cli.py
@@ -339,8 +339,7 @@ def init(org, project, status, clear):
         # Filter out archived projects
         project_choices = []
         for p in projects:
-            # Skip archived projects (check status field and archived flags)
-            if p.get("status") == "archived" or p.get("archived") or p.get("is_archived"):
+            if _is_archived_project(p):
                 continue
             project_id = str(p.get("id"))
             project_name = p.get("name") or p.get("slug") or project_id
@@ -1017,6 +1016,195 @@ def list_sessions_cmd(session_type, output_json):
         adapter = session.get("adapter_type", "-")
 
         table.add_row(name or "(unnamed)", session_id, s_type, created_at, adapter or "-")
+
+    console.print(table)
+    sys.exit(0)
+
+
+def _require_api_token(console: Console) -> str:
+    """Return the API token, or exit with code 2 if the user is not authenticated."""
+    from recce_cloud.auth.profile import get_api_token
+
+    token = os.getenv("RECCE_API_TOKEN") or get_api_token()
+    if not token:
+        console.print("[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in")
+        console.print("Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first")
+        sys.exit(2)
+    return token
+
+
+def _is_archived_project(project: dict) -> bool:
+    return bool(project.get("status") == "archived" or project.get("archived") or project.get("is_archived"))
+
+
+@cloud_cli.command(name="list-orgs", cls=TrackedCommand)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output in JSON format",
+)
+def list_orgs_cmd(output_json):
+    """
+    List the organizations you have access to.
+
+    \b
+    Requires:
+    - RECCE_API_TOKEN env var or 'recce-cloud login'
+
+    \b
+    Examples:
+      # List organizations
+      recce-cloud list-orgs
+    \b
+      # Output as JSON (for scripts and agents)
+      recce-cloud list-orgs --json
+    """
+    from rich.table import Table
+
+    from recce_cloud.api.client import RecceCloudClient
+
+    console = Console()
+    token = _require_api_token(console)
+
+    try:
+        orgs = RecceCloudClient(token).list_organizations()
+    except Exception as e:
+        logger.debug("Failed to list organizations: %s", e, exc_info=True)
+        console.print(f"[red]Error:[/red] Failed to list organizations: {e}")
+        sys.exit(2)
+
+    if output_json:
+        # The rich console wraps output past 80 columns, and reads a value
+        # like "[dim]" as a style tag. Both damage the JSON.
+        click.echo(json.dumps(orgs, indent=2, default=str))
+        sys.exit(0)
+
+    if not orgs:
+        console.print("[yellow]No organizations found[/yellow]")
+        console.print(f"Please create an organization at {get_base_url()} first")
+        sys.exit(0)
+
+    table = Table(title=f"Organizations ({len(orgs)} total)")
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Name")
+
+    for org in orgs:
+        table.add_row(
+            str(org.get("id", "-")),
+            org.get("display_name") or org.get("name") or "-",
+        )
+
+    console.print(table)
+    sys.exit(0)
+
+
+@cloud_cli.command(name="list-projects", cls=TrackedCommand)
+@click.option(
+    "--org",
+    help="Organization ID or name (default: the configured organization)",
+)
+@click.option(
+    "--all",
+    "show_archived",
+    is_flag=True,
+    help="Include archived projects",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output in JSON format",
+)
+def list_projects_cmd(org, show_archived, output_json):
+    """
+    List the projects in an organization.
+
+    \b
+    Requires:
+    - RECCE_API_TOKEN env var or 'recce-cloud login'
+    - An organization from --org, RECCE_ORG, or 'recce-cloud init'
+
+    \b
+    Examples:
+      # List projects in the configured organization
+      recce-cloud list-projects
+    \b
+      # List projects in a specific organization
+      recce-cloud list-projects --org myorg
+    \b
+      # Output as JSON (for scripts and agents)
+      recce-cloud list-projects --org 42 --json
+    """
+    from rich.table import Table
+
+    from recce_cloud.api.client import RecceCloudClient
+    from recce_cloud.config.resolver import resolve_org_id
+
+    console = Console()
+    token = _require_api_token(console)
+
+    org_ref = org or resolve_org_id()
+    if not org_ref:
+        console.print("[red]Error:[/red] No organization specified")
+        console.print(
+            "Pass --org, set the RECCE_ORG environment variable, " "or run 'recce-cloud init' to bind this directory"
+        )
+        console.print("Run 'recce-cloud list-orgs' to see the available organizations")
+        sys.exit(2)
+
+    try:
+        client = RecceCloudClient(token)
+        org_obj = client.get_organization(org_ref)
+        if not org_obj:
+            console.print(f"[red]Error:[/red] Organization '{org_ref}' not found or you don't have access")
+            sys.exit(2)
+        org_id = org_obj.get("id")
+        if not org_id:
+            console.print(f"[red]Error:[/red] Organization '{org_ref}' response missing ID")
+            sys.exit(2)
+        projects = client.list_projects(org_id)
+    except Exception as e:
+        logger.debug("Failed to list projects: %s", e, exc_info=True)
+        console.print(f"[red]Error:[/red] Failed to list projects: {e}")
+        sys.exit(2)
+
+    all_projects = projects
+    if not show_archived:
+        projects = [p for p in all_projects if not _is_archived_project(p)]
+
+    if output_json:
+        click.echo(json.dumps(projects, indent=2, default=str))
+        sys.exit(0)
+
+    org_display = org_obj.get("display_name") or org_obj.get("name") or org_ref
+
+    if not projects:
+        if all_projects:
+            console.print(f"[yellow]No active projects found in {org_display}[/yellow]")
+            console.print("Pass --all to include archived projects")
+        else:
+            console.print(f"[yellow]No projects found in {org_display}[/yellow]")
+            console.print(f"Please create a project at {get_base_url()} first")
+        sys.exit(0)
+
+    console.print(f"[cyan]Organization:[/cyan] {org_display} (id={org_id})")
+    console.print()
+
+    table = Table(title=f"Projects ({len(projects)} total)")
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Name")
+    table.add_column("Repository", style="dim")
+    table.add_column("Status", style="green")
+
+    for project in projects:
+        repository = project.get("repository") or {}
+        table.add_row(
+            str(project.get("id", "-")),
+            project.get("display_name") or project.get("name") or "-",
+            repository.get("full_name") or "-",
+            "archived" if _is_archived_project(project) else "active",
+        )
 
     console.print(table)
     sys.exit(0)

--- a/recce_cloud/recce_cloud/cli.py
+++ b/recce_cloud/recce_cloud/cli.py
@@ -40,9 +40,7 @@ from recce_cloud.upload import (
 logging.basicConfig(
     level=logging.INFO,
     format="%(message)s",
-    handlers=[
-        RichHandler(console=Console(stderr=True), show_time=False, show_path=False)
-    ],
+    handlers=[RichHandler(console=Console(stderr=True), show_time=False, show_path=False)],
 )
 logger = logging.getLogger(__name__)
 
@@ -115,16 +113,10 @@ def login(token, status):
     if status:
         is_logged_in, email = check_login_status()
         if is_logged_in:
-            console.print(
-                f"[green]✓[/green] Logged in as [cyan]{email or 'Unknown'}[/cyan]"
-            )
+            console.print(f"[green]✓[/green] Logged in as [cyan]{email or 'Unknown'}[/cyan]")
             token_value = get_api_token()
             if token_value:
-                masked = (
-                    f"{token_value[:8]}...{token_value[-4:]}"
-                    if len(token_value) > 12
-                    else "***"
-                )
+                masked = f"{token_value[:8]}...{token_value[-4:]}" if len(token_value) > 12 else "***"
                 console.print(f"  Token: {masked} (valid)")
         else:
             console.print("[yellow]Not logged in[/yellow]")
@@ -134,9 +126,7 @@ def login(token, status):
     # Check if already logged in
     is_logged_in, email = check_login_status()
     if is_logged_in:
-        console.print(
-            f"[green]✓[/green] Already logged in as [cyan]{email or 'Unknown'}[/cyan]"
-        )
+        console.print(f"[green]✓[/green] Already logged in as [cyan]{email or 'Unknown'}[/cyan]")
         if not click.confirm("Do you want to re-authenticate?", default=False):
             sys.exit(0)
 
@@ -154,9 +144,7 @@ def login(token, status):
         sys.exit(0)
     else:
         console.print()
-        console.print(
-            "[yellow]Tip:[/yellow] For headless environments, use 'recce-cloud login --token <token>'"
-        )
+        console.print("[yellow]Tip:[/yellow] For headless environments, use 'recce-cloud login --token <token>'")
         sys.exit(1)
 
 
@@ -235,9 +223,7 @@ def init(org, project, status, clear):
     token = os.getenv("RECCE_API_TOKEN") or get_api_token()
     if not token:
         console.print("[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in")
-        console.print(
-            "Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first"
-        )
+        console.print("Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first")
         sys.exit(1)
 
     # Status check mode
@@ -267,9 +253,7 @@ def init(org, project, status, clear):
 
     # Validate flag combinations
     if (org and not project) or (project and not org):
-        console.print(
-            "[red]Error:[/red] Both --org and --project must be provided together"
-        )
+        console.print("[red]Error:[/red] Both --org and --project must be provided together")
         sys.exit(1)
 
     # Get user email for binding metadata
@@ -283,9 +267,7 @@ def init(org, project, status, clear):
             api = RecceCloudClient(token)
             org_obj = api.get_organization(org)
             if not org_obj:
-                console.print(
-                    f"[red]Error:[/red] Organization '{org}' not found or you don't have access"
-                )
+                console.print(f"[red]Error:[/red] Organization '{org}' not found or you don't have access")
                 sys.exit(1)
 
             # Use org ID for project lookup (API requires ID)
@@ -341,9 +323,7 @@ def init(org, project, status, clear):
             console.print(f"  {i}. {display_name}")
 
         org_idx = click.prompt("Enter number", type=click.IntRange(1, len(org_choices)))
-        selected_org_id, selected_org_name, selected_org_display = org_choices[
-            org_idx - 1
-        ]
+        selected_org_id, selected_org_name, selected_org_display = org_choices[org_idx - 1]
 
         # List projects (use org_id for API call)
         console.print()
@@ -351,9 +331,7 @@ def init(org, project, status, clear):
         projects = api.list_projects(selected_org_id)
 
         if not projects:
-            console.print(
-                f"[yellow]No projects found in {selected_org_display}[/yellow]"
-            )
+            console.print(f"[yellow]No projects found in {selected_org_display}[/yellow]")
             console.print(f"Please create a project at {get_base_url()} first")
             sys.exit(1)
 
@@ -362,11 +340,7 @@ def init(org, project, status, clear):
         project_choices = []
         for p in projects:
             # Skip archived projects (check status field and archived flags)
-            if (
-                p.get("status") == "archived"
-                or p.get("archived")
-                or p.get("is_archived")
-            ):
+            if p.get("status") == "archived" or p.get("archived") or p.get("is_archived"):
                 continue
             project_id = str(p.get("id"))
             project_name = p.get("name") or p.get("slug") or project_id
@@ -374,9 +348,7 @@ def init(org, project, status, clear):
             project_choices.append((project_id, display_name))
 
         if not project_choices:
-            console.print(
-                f"[yellow]No active projects found in {selected_org_display}[/yellow]"
-            )
+            console.print(f"[yellow]No active projects found in {selected_org_display}[/yellow]")
             console.print(f"Please create a project at {get_base_url()} first")
             sys.exit(1)
 
@@ -386,9 +358,7 @@ def init(org, project, status, clear):
         for i, (_, display_name) in enumerate(project_choices, 1):
             console.print(f"  {i}. {display_name}")
 
-        project_idx = click.prompt(
-            "Enter number", type=click.IntRange(1, len(project_choices))
-        )
+        project_idx = click.prompt("Enter number", type=click.IntRange(1, len(project_choices)))
         selected_project_id, selected_project_display = project_choices[project_idx - 1]
 
         # Save binding using IDs (immutable) instead of slugs (can be renamed)
@@ -412,9 +382,7 @@ def init(org, project, status, clear):
     except Exception as e:
         logger.debug("Unexpected error during init: %s", e, exc_info=True)
         console.print(f"[red]Error:[/red] An unexpected error occurred: {e}")
-        console.print(
-            "  Try running 'recce-cloud login' again or check your network connection."
-        )
+        console.print("  Try running 'recce-cloud login' again or check your network connection.")
         sys.exit(1)
 
 
@@ -453,32 +421,24 @@ def _get_production_session_id(console: Console, token: str) -> Optional[str]:
             if session.get("is_base"):
                 session_id = session.get("id")
                 if not session_id:
-                    console.print(
-                        "[red]Error:[/red] Production session found but has no ID"
-                    )
+                    console.print("[red]Error:[/red] Production session found but has no ID")
                     return None
                 session_name = session.get("name") or "(unnamed)"
-                session_id_display = (
-                    session_id[:8] if len(session_id) >= 8 else session_id
-                )
+                session_id_display = session_id[:8] if len(session_id) >= 8 else session_id
                 console.print(
                     f"[cyan]Info:[/cyan] Found production session '{session_name}' (ID: {session_id_display}...)"
                 )
                 return session_id
 
         console.print("[red]Error:[/red] No production session found")
-        console.print(
-            "Create a production session first using 'recce-cloud upload --type prod' or via CI pipeline"
-        )
+        console.print("Create a production session first using 'recce-cloud upload --type prod' or via CI pipeline")
         return None
 
     except RecceCloudException as e:
         console.print(f"[red]Error:[/red] Failed to fetch sessions: {e}")
         return None
     except Exception as e:
-        logger.debug(
-            "Unexpected error in _get_production_session_id: %s", e, exc_info=True
-        )
+        logger.debug("Unexpected error in _get_production_session_id: %s", e, exc_info=True)
         console.print(f"[red]Error:[/red] Unexpected error: {e}")
         console.print("  Check your network connection and try again.")
         return None
@@ -572,13 +532,16 @@ def upload(
     console = Console()
 
     # Track upload-specific properties
-    track("cli_upload_started", {
-        "has_session_id": session_id is not None,
-        "has_session_name": session_name is not None,
-        "session_type": session_type,
-        "dry_run": dry_run,
-        "session_base": session_base,
-    })
+    track(
+        "cli_upload_started",
+        {
+            "has_session_id": session_id is not None,
+            "has_session_name": session_name is not None,
+            "session_type": session_type,
+            "dry_run": dry_run,
+            "session_base": session_base,
+        },
+    )
 
     # 1. Auto-detect CI environment information
     console.rule("CI Environment Detection", style="blue")
@@ -613,15 +576,11 @@ def upload(
             if ci_info.session_type:
                 info_table.append(f"[cyan]Session Type:[/cyan] {ci_info.session_type}")
             if ci_info.commit_sha:
-                info_table.append(
-                    f"[cyan]Commit SHA:[/cyan] {ci_info.commit_sha[:8]}..."
-                )
+                info_table.append(f"[cyan]Commit SHA:[/cyan] {ci_info.commit_sha[:8]}...")
             if ci_info.base_branch:
                 info_table.append(f"[cyan]Base Branch:[/cyan] {ci_info.base_branch}")
             if ci_info.source_branch:
-                info_table.append(
-                    f"[cyan]Source Branch:[/cyan] {ci_info.source_branch}"
-                )
+                info_table.append(f"[cyan]Source Branch:[/cyan] {ci_info.source_branch}")
             if ci_info.repository:
                 info_table.append(f"[cyan]Repository:[/cyan] {ci_info.repository}")
 
@@ -637,9 +596,7 @@ def upload(
     # 2. Validate artifacts exist
     if not verify_artifacts_path(target_path):
         console.print(f"[red]Error:[/red] Invalid target path: {target_path}")
-        console.print(
-            "Please provide a valid target path containing manifest.json and catalog.json."
-        )
+        console.print("Please provide a valid target path containing manifest.json and catalog.json.")
         sys.exit(3)
 
     manifest_path = os.path.join(target_path, "manifest.json")
@@ -649,28 +606,20 @@ def upload(
     try:
         adapter_type = get_adapter_type(manifest_path)
     except Exception as e:
-        console.print(
-            "[red]Error:[/red] Failed to parse adapter type from manifest.json"
-        )
+        console.print("[red]Error:[/red] Failed to parse adapter type from manifest.json")
         console.print(f"Reason: {e}")
         sys.exit(3)
 
     # 4. Early validation: --session-base + --type prod is not allowed
     if session_base and session_type == "prod":
-        console.print(
-            "[red]Error:[/red] --session-base cannot be used with --type prod."
-        )
-        console.print(
-            "Production sessions use the shared project base. Session base is for PR and dev sessions only."
-        )
+        console.print("[red]Error:[/red] --session-base cannot be used with --type prod.")
+        console.print("Production sessions use the shared project base. Session base is for PR and dev sessions only.")
         sys.exit(2)
 
     # 5. Handle dry-run mode (before authentication or API calls)
     if dry_run:
         console.rule("Dry Run Summary", style="yellow")
-        console.print(
-            "[yellow]Dry run mode enabled - no actual upload will be performed[/yellow]"
-        )
+        console.print("[yellow]Dry run mode enabled - no actual upload will be performed[/yellow]")
         console.print()
 
         # Display platform information if detected
@@ -708,14 +657,10 @@ def upload(
             if ci_info and ci_info.platform in ["github-actions", "gitlab-ci"]:
                 console.print("  • Platform-specific APIs will be used")
             else:
-                console.print(
-                    "  • [yellow]Warning: Platform not supported for auto-session creation[/yellow]"
-                )
+                console.print("  • [yellow]Warning: Platform not supported for auto-session creation[/yellow]")
             # Warn if auto-detected "dev" would be blocked
             if ci_info and ci_info.session_type == "dev" and session_type is None:
-                console.print(
-                    "  • [red]Blocked: feature branch with no PR/MR detected[/red]"
-                )
+                console.print("  • [red]Blocked: feature branch with no PR/MR detected[/red]")
 
         console.print()
         console.print("[cyan]Files to upload:[/cyan]")
@@ -774,12 +719,8 @@ def _run_upload_workflow(
 
         token = os.getenv("RECCE_API_TOKEN") or get_api_token()
         if not token:
-            console.print(
-                "[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in"
-            )
-            console.print(
-                "Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first"
-            )
+            console.print("[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in")
+            console.print("Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first")
             raise UploadError("No RECCE_API_TOKEN provided and not logged in")
 
         upload_to_existing_session(
@@ -800,12 +741,8 @@ def _run_upload_workflow(
 
         token = os.getenv("RECCE_API_TOKEN") or get_api_token()
         if not token:
-            console.print(
-                "[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in"
-            )
-            console.print(
-                "Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first"
-            )
+            console.print("[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in")
+            console.print("Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first")
             raise UploadError("No RECCE_API_TOKEN provided and not logged in")
 
         upload_with_session_name(
@@ -825,18 +762,12 @@ def _run_upload_workflow(
         # Block auto-detected "dev" sessions (feature branch push with no PR)
         # session_type (the CLI param) is None when user didn't pass --type
         if ci_info and ci_info.session_type == "dev" and session_type is None:
-            console.print(
-                "[red]Error:[/red] No pull request detected and branch is not main/master"
-            )
+            console.print("[red]Error:[/red] No pull request detected and branch is not main/master")
             console.print()
-            console.print(
-                "This happens when CI runs on a branch push without an open PR/MR."
-            )
+            console.print("This happens when CI runs on a branch push without an open PR/MR.")
             console.print()
             console.print("Options:")
-            console.print(
-                "  1. Use [bold]--pr <number>[/bold] if a PR/MR exists but wasn't auto-detected"
-            )
+            console.print("  1. Use [bold]--pr <number>[/bold] if a PR/MR exists but wasn't auto-detected")
             console.print("  2. Use [bold]--type prod[/bold] for production uploads")
             console.print(
                 "  3. Use [bold]--session-name <name>[/bold] or [bold]--session-id <id>[/bold] for explicit targeting"
@@ -857,12 +788,8 @@ def _run_upload_workflow(
             elif ci_info.platform == "gitlab-ci":
                 provider = "gitlab"
             else:
-                console.print(
-                    f"[red]Error:[/red] Unsupported CI platform: {ci_info.platform}"
-                )
-                console.print(
-                    "RECCE_API_TOKEN is supported on GitHub Actions and GitLab CI."
-                )
+                console.print(f"[red]Error:[/red] Unsupported CI platform: {ci_info.platform}")
+                console.print("RECCE_API_TOKEN is supported on GitHub Actions and GitLab CI.")
                 raise UploadError(f"Unsupported CI platform: {ci_info.platform}")
 
             console.print("[cyan]Info:[/cyan] Using RECCE_API_TOKEN for authentication")
@@ -889,13 +816,9 @@ def _run_upload_workflow(
         elif ci_info and ci_info.access_token:
             token = ci_info.access_token
             if ci_info.platform == "github-actions":
-                console.print(
-                    "[cyan]Info:[/cyan] Using GITHUB_TOKEN for platform-specific authentication"
-                )
+                console.print("[cyan]Info:[/cyan] Using GITHUB_TOKEN for platform-specific authentication")
             elif ci_info.platform == "gitlab-ci":
-                console.print(
-                    "[cyan]Info:[/cyan] Using CI_JOB_TOKEN for platform-specific authentication"
-                )
+                console.print("[cyan]Info:[/cyan] Using CI_JOB_TOKEN for platform-specific authentication")
 
             upload_with_platform_apis(
                 console,
@@ -916,9 +839,7 @@ def _run_upload_workflow(
                 raise UploadError("No production session found")
 
             if session_base:
-                console.print(
-                    "[red]Error:[/red] --session-base cannot be used with --type prod."
-                )
+                console.print("[red]Error:[/red] --session-base cannot be used with --type prod.")
                 console.print(
                     "Production sessions use the shared project base. Session base is for PR and dev sessions only."
                 )
@@ -936,20 +857,12 @@ def _run_upload_workflow(
 
         # Error with guidance
         else:
-            console.print(
-                "[red]Error:[/red] No authentication method found for auto-upload"
-            )
+            console.print("[red]Error:[/red] No authentication method found for auto-upload")
             console.print()
             console.print("To fix this, try one of the following:")
-            console.print(
-                "  1. Set RECCE_API_TOKEN environment variable (works in any CI)"
-            )
-            console.print(
-                "  2. Run in GitHub Actions (GITHUB_TOKEN) or GitLab CI (CI_JOB_TOKEN)"
-            )
-            console.print(
-                "  3. Use --session-id or --session-name for explicit session targeting"
-            )
+            console.print("  1. Set RECCE_API_TOKEN environment variable (works in any CI)")
+            console.print("  2. Run in GitHub Actions (GITHUB_TOKEN) or GitLab CI (CI_JOB_TOKEN)")
+            console.print("  3. Use --session-id or --session-name for explicit session targeting")
             raise UploadError("No authentication method found")
 
 
@@ -998,9 +911,7 @@ def list_sessions_cmd(session_type, output_json):
     token = os.getenv("RECCE_API_TOKEN") or get_api_token()
     if not token:
         console.print("[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in")
-        console.print(
-            "Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first"
-        )
+        console.print("Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first")
         sys.exit(2)
 
     # 2. Resolve org/project configuration
@@ -1022,9 +933,7 @@ def list_sessions_cmd(session_type, output_json):
 
         org_info = client.get_organization(org)
         if not org_info:
-            console.print(
-                f"[red]Error:[/red] Organization '{org}' not found or you don't have access"
-            )
+            console.print(f"[red]Error:[/red] Organization '{org}' not found or you don't have access")
             sys.exit(2)
         org_id = org_info.get("id")
         if not org_id:
@@ -1033,9 +942,7 @@ def list_sessions_cmd(session_type, output_json):
 
         project_info = client.get_project(org_id, project)
         if not project_info:
-            console.print(
-                f"[red]Error:[/red] Project '{project}' not found in organization '{org}'"
-            )
+            console.print(f"[red]Error:[/red] Project '{project}' not found in organization '{org}'")
             sys.exit(2)
         project_id = project_info.get("id")
         if not project_id:
@@ -1043,9 +950,7 @@ def list_sessions_cmd(session_type, output_json):
             sys.exit(2)
 
     except Exception as e:
-        logger.debug(
-            "Failed to initialize client for list_sessions: %s", e, exc_info=True
-        )
+        logger.debug("Failed to initialize client for list_sessions: %s", e, exc_info=True)
         console.print(f"[red]Error:[/red] Failed to initialize: {e}")
         console.print("  Check your authentication and network connection.")
         sys.exit(2)
@@ -1111,9 +1016,7 @@ def list_sessions_cmd(session_type, output_json):
                 pass
         adapter = session.get("adapter_type", "-")
 
-        table.add_row(
-            name or "(unnamed)", session_id, s_type, created_at, adapter or "-"
-        )
+        table.add_row(name or "(unnamed)", session_id, s_type, created_at, adapter or "-")
 
     console.print(table)
     sys.exit(0)
@@ -1178,17 +1081,18 @@ def download(target_path, session_id, prod, dry_run, force):
     console = Console()
 
     # Track download-specific properties
-    track("cli_download_started", {
-        "has_session_id": session_id is not None,
-        "prod": prod,
-        "dry_run": dry_run,
-    })
+    track(
+        "cli_download_started",
+        {
+            "has_session_id": session_id is not None,
+            "prod": prod,
+            "dry_run": dry_run,
+        },
+    )
 
     # Validate flag combinations
     if session_id and prod:
-        console.print(
-            "[yellow]Warning:[/yellow] --prod is ignored when --session-id is provided"
-        )
+        console.print("[yellow]Warning:[/yellow] --prod is ignored when --session-id is provided")
 
     # Determine session type from --prod flag
     session_type = "prod" if prod else None
@@ -1241,9 +1145,7 @@ def download(target_path, session_id, prod, dry_run, force):
     # 2. Handle dry-run mode (before authentication or API calls)
     if dry_run:
         console.rule("Dry Run Summary", style="yellow")
-        console.print(
-            "[yellow]Dry run mode enabled - no actual download will be performed[/yellow]"
-        )
+        console.print("[yellow]Dry run mode enabled - no actual download will be performed[/yellow]")
         console.print()
 
         # Display platform information if detected
@@ -1272,9 +1174,7 @@ def download(target_path, session_id, prod, dry_run, force):
             if ci_info and ci_info.platform in ["github-actions", "gitlab-ci"]:
                 console.print("  • Platform-specific APIs will be used")
             else:
-                console.print(
-                    "  • [yellow]Warning: Platform not supported for auto-session discovery[/yellow]"
-                )
+                console.print("  • [yellow]Warning: Platform not supported for auto-session discovery[/yellow]")
 
         console.print()
         console.print("[cyan]Download destination:[/cyan]")
@@ -1283,9 +1183,7 @@ def download(target_path, session_id, prod, dry_run, force):
         if force:
             console.print("  • Will overwrite existing files")
         elif os.path.exists(target_path):
-            console.print(
-                "  • [yellow]Warning: Target path exists (use --force to overwrite)[/yellow]"
-            )
+            console.print("  • [yellow]Warning: Target path exists (use --force to overwrite)[/yellow]")
 
         console.print()
         console.print("[green]✓[/green] Dry run completed successfully")
@@ -1299,12 +1197,8 @@ def download(target_path, session_id, prod, dry_run, force):
 
         token = os.getenv("RECCE_API_TOKEN") or get_api_token()
         if not token:
-            console.print(
-                "[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in"
-            )
-            console.print(
-                "Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first"
-            )
+            console.print("[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in")
+            console.print("Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first")
             sys.exit(2)
 
         download_from_existing_session(console, token, session_id, target_path, force)
@@ -1312,23 +1206,15 @@ def download(target_path, session_id, prod, dry_run, force):
         # Platform-specific workflow: Use platform APIs to find session and download
         # This workflow MUST use CI job tokens (CI_JOB_TOKEN or GITHUB_TOKEN)
         if not ci_info or not ci_info.access_token:
-            console.print(
-                "[red]Error:[/red] Platform-specific download requires CI environment"
-            )
-            console.print(
-                "Either run in GitHub Actions/GitLab CI or provide --session-id for generic download"
-            )
+            console.print("[red]Error:[/red] Platform-specific download requires CI environment")
+            console.print("Either run in GitHub Actions/GitLab CI or provide --session-id for generic download")
             sys.exit(2)
 
         token = ci_info.access_token
         if ci_info.platform == "github-actions":
-            console.print(
-                "[cyan]Info:[/cyan] Using GITHUB_TOKEN for platform-specific authentication"
-            )
+            console.print("[cyan]Info:[/cyan] Using GITHUB_TOKEN for platform-specific authentication")
         elif ci_info.platform == "gitlab-ci":
-            console.print(
-                "[cyan]Info:[/cyan] Using CI_JOB_TOKEN for platform-specific authentication"
-            )
+            console.print("[cyan]Info:[/cyan] Using CI_JOB_TOKEN for platform-specific authentication")
 
         download_with_platform_apis(console, token, ci_info, target_path, force)
 
@@ -1394,24 +1280,16 @@ def delete(session_id, dry_run, force):
             # Only show session type and CR info for platform workflow
             if not session_id:
                 if ci_info.session_type:
-                    info_table.append(
-                        f"[cyan]Session Type:[/cyan] {ci_info.session_type}"
-                    )
+                    info_table.append(f"[cyan]Session Type:[/cyan] {ci_info.session_type}")
 
                 # Only show CR number and URL for CR sessions (not for prod)
                 if ci_info.session_type == "pr" and ci_info.pr_number is not None:
                     if ci_info.platform == "github-actions":
-                        info_table.append(
-                            f"[cyan]PR Number:[/cyan] {ci_info.pr_number}"
-                        )
+                        info_table.append(f"[cyan]PR Number:[/cyan] {ci_info.pr_number}")
                     elif ci_info.platform == "gitlab-ci":
-                        info_table.append(
-                            f"[cyan]MR Number:[/cyan] {ci_info.pr_number}"
-                        )
+                        info_table.append(f"[cyan]MR Number:[/cyan] {ci_info.pr_number}")
                     else:
-                        info_table.append(
-                            f"[cyan]PR Number:[/cyan] {ci_info.pr_number}"
-                        )
+                        info_table.append(f"[cyan]PR Number:[/cyan] {ci_info.pr_number}")
 
                 # Only show PR URL for CR sessions
                 if ci_info.session_type == "pr" and ci_info.pr_url:
@@ -1434,9 +1312,7 @@ def delete(session_id, dry_run, force):
     # 2. Handle dry-run mode (before authentication or API calls)
     if dry_run:
         console.rule("Dry Run Summary", style="yellow")
-        console.print(
-            "[yellow]Dry run mode enabled - no actual deletion will be performed[/yellow]"
-        )
+        console.print("[yellow]Dry run mode enabled - no actual deletion will be performed[/yellow]")
         console.print()
 
         # Display platform information if detected
@@ -1462,9 +1338,7 @@ def delete(session_id, dry_run, force):
             if ci_info and ci_info.platform in ["github-actions", "gitlab-ci"]:
                 console.print("  • Platform-specific APIs will be used")
             else:
-                console.print(
-                    "  • [yellow]Warning: Platform not supported for auto-session discovery[/yellow]"
-                )
+                console.print("  • [yellow]Warning: Platform not supported for auto-session discovery[/yellow]")
 
         console.print()
         console.print("[green]✓[/green] Dry run completed successfully")
@@ -1490,12 +1364,8 @@ def delete(session_id, dry_run, force):
 
         token = os.getenv("RECCE_API_TOKEN") or get_api_token()
         if not token:
-            console.print(
-                "[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in"
-            )
-            console.print(
-                "Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first"
-            )
+            console.print("[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in")
+            console.print("Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first")
             sys.exit(2)
 
         delete_existing_session(console, token, session_id)
@@ -1503,23 +1373,15 @@ def delete(session_id, dry_run, force):
         # Platform-specific workflow: Use platform APIs to find and delete session
         # This workflow MUST use CI job tokens (CI_JOB_TOKEN or GITHUB_TOKEN)
         if not ci_info or not ci_info.access_token:
-            console.print(
-                "[red]Error:[/red] Platform-specific delete requires CI environment"
-            )
-            console.print(
-                "Either run in GitHub Actions/GitLab CI or provide --session-id for generic delete"
-            )
+            console.print("[red]Error:[/red] Platform-specific delete requires CI environment")
+            console.print("Either run in GitHub Actions/GitLab CI or provide --session-id for generic delete")
             sys.exit(2)
 
         token = ci_info.access_token
         if ci_info.platform == "github-actions":
-            console.print(
-                "[cyan]Info:[/cyan] Using GITHUB_TOKEN for platform-specific authentication"
-            )
+            console.print("[cyan]Info:[/cyan] Using GITHUB_TOKEN for platform-specific authentication")
         elif ci_info.platform == "gitlab-ci":
-            console.print(
-                "[cyan]Info:[/cyan] Using CI_JOB_TOKEN for platform-specific authentication"
-            )
+            console.print("[cyan]Info:[/cyan] Using CI_JOB_TOKEN for platform-specific authentication")
 
         delete_with_platform_apis(console, token, ci_info, prod=False)
 
@@ -1598,9 +1460,7 @@ def report(repo, since, until, base_branch, merged_only, output):
     token = os.getenv("RECCE_API_TOKEN") or get_api_token()
     if not token:
         console.print("[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in")
-        console.print(
-            "Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first"
-        )
+        console.print("Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first")
         sys.exit(2)
 
     # Auto-detect repo from git remote if not provided
@@ -1636,9 +1496,7 @@ def report(repo, since, until, base_branch, merged_only, output):
             logger.debug("Failed to auto-detect repository from git remote: %s", e)
 
     if not repo:
-        console.print(
-            "[red]Error:[/red] Could not detect repository. Please provide --repo option."
-        )
+        console.print("[red]Error:[/red] Could not detect repository. Please provide --repo option.")
         sys.exit(1)
 
     # Generate report
@@ -1665,8 +1523,7 @@ def report(repo, since, until, base_branch, merged_only, output):
 )
 @click.option(
     "--session-name",
-    help="Name of the session to generate data review for. "
-    "Mutually exclusive with --session-id.",
+    help="Name of the session to generate data review for. " "Mutually exclusive with --session-id.",
 )
 @click.option(
     "--org",
@@ -1736,12 +1593,15 @@ def review(session_id, session_name, org, project, regenerate, timeout, json_out
     console = Console()
 
     # Track review-specific properties
-    track("cli_review_started", {
-        "has_session_id": session_id is not None,
-        "has_session_name": session_name is not None,
-        "regenerate": regenerate,
-        "json_output": json_output,
-    })
+    track(
+        "cli_review_started",
+        {
+            "has_session_id": session_id is not None,
+            "has_session_name": session_name is not None,
+            "regenerate": regenerate,
+            "json_output": json_output,
+        },
+    )
 
     # Validate that at least one of session_id or session_name is provided
     if not session_id and not session_name:
@@ -1755,17 +1615,14 @@ def review(session_id, session_name, org, project, regenerate, timeout, json_out
                 )
             )
         else:
-            console.print(
-                "[red]Error:[/red] Either --session-id or --session-name must be provided"
-            )
+            console.print("[red]Error:[/red] Either --session-id or --session-name must be provided")
         sys.exit(1)
 
     # Warn if both are provided (session-id takes precedence)
     if session_id and session_name:
         if not json_output:
             console.print(
-                "[yellow]Warning:[/yellow] Both --session-id and --session-name provided. "
-                "Using --session-id."
+                "[yellow]Warning:[/yellow] Both --session-id and --session-name provided. " "Using --session-id."
             )
         session_name = None  # Clear session_name to use session_id
 
@@ -1784,12 +1641,8 @@ def review(session_id, session_name, org, project, regenerate, timeout, json_out
                 )
             )
         else:
-            console.print(
-                "[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in"
-            )
-            console.print(
-                "Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first"
-            )
+            console.print("[red]Error:[/red] No RECCE_API_TOKEN provided and not logged in")
+            console.print("Either set RECCE_API_TOKEN environment variable or run 'recce-cloud login' first")
         sys.exit(2)
 
     # 2. Resolve org/project configuration
@@ -1812,9 +1665,7 @@ def review(session_id, session_name, org, project, regenerate, timeout, json_out
         else:
             console.print(f"[red]Error:[/red] {e}")
             console.print()
-            console.print(
-                "Provide --org and --project options, or run 'recce-cloud init' to bind to a project"
-            )
+            console.print("Provide --org and --project options, or run 'recce-cloud init' to bind to a project")
         sys.exit(1)
 
     if not json_output:
@@ -1822,9 +1673,7 @@ def review(session_id, session_name, org, project, regenerate, timeout, json_out
         console.print(f"[cyan]Organization:[/cyan] {org_id}")
         console.print(f"[cyan]Project:[/cyan] {project_id}")
         if session_id:
-            session_id_display = (
-                session_id[:8] + "..." if len(session_id) > 8 else session_id
-            )
+            session_id_display = session_id[:8] + "..." if len(session_id) > 8 else session_id
             console.print(f"[cyan]Session ID:[/cyan] {session_id_display}")
         else:
             console.print(f"[cyan]Session:[/cyan] {session_name}")

--- a/recce_cloud/tests/test_cli.py
+++ b/recce_cloud/tests/test_cli.py
@@ -1977,12 +1977,15 @@ class TestListProjects(unittest.TestCase):
     def test_no_org_available(self):
         """Exit with code 2 when no organization can be resolved."""
         with patch.dict(os.environ, {"RECCE_API_TOKEN": "test_token"}, clear=True):
+            # resolver.py binds get_project_binding at import time, so the patch
+            # must target the resolver module, not project_config.
             with patch(
-                "recce_cloud.config.project_config.get_project_binding",
+                "recce_cloud.config.resolver.get_project_binding",
                 return_value=None,
-            ):
+            ) as mock_binding:
                 result = self.runner.invoke(cloud_cli, ["list-projects"])
 
+        self.assertTrue(mock_binding.called, "get_project_binding was not patched in the code under test")
         self.assertEqual(result.exit_code, 2, f"Output: {result.output}")
         self.assertIn("recce-cloud list-orgs", result.output)
 

--- a/recce_cloud/tests/test_cli.py
+++ b/recce_cloud/tests/test_cli.py
@@ -323,9 +323,7 @@ class TestUploadDryRun(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, f"Command failed: {result.output}")
         self.assertIn("Dry run mode enabled", result.output)
         self.assertIn("Auto-create session and upload", result.output)
-        self.assertIn(
-            "Warning: Platform not supported for auto-session creation", result.output
-        )
+        self.assertIn("Warning: Platform not supported for auto-session creation", result.output)
 
     def test_dry_run_missing_artifacts(self):
         """Test dry-run with missing dbt artifacts."""
@@ -432,27 +430,19 @@ class TestUploadBlocksDevSession(unittest.TestCase):
         }
 
         with patch.dict(os.environ, env, clear=True):
-            with patch(
-                "recce_cloud.config.project_config.get_project_binding"
-            ) as mock_binding:
+            with patch("recce_cloud.config.project_config.get_project_binding") as mock_binding:
                 mock_binding.return_value = {
                     "org": "test-org",
                     "project": "test-project",
                 }
-                with patch(
-                    "recce_cloud.api.client.RecceCloudClient.get_organization"
-                ) as mock_org:
+                with patch("recce_cloud.api.client.RecceCloudClient.get_organization") as mock_org:
                     mock_org.return_value = {"id": "org-123", "slug": "test-org"}
-                    with patch(
-                        "recce_cloud.api.client.RecceCloudClient.get_project"
-                    ) as mock_proj:
+                    with patch("recce_cloud.api.client.RecceCloudClient.get_project") as mock_proj:
                         mock_proj.return_value = {
                             "id": "proj-456",
                             "slug": "test-project",
                         }
-                        with patch(
-                            "recce_cloud.api.client.RecceCloudClient.list_sessions"
-                        ) as mock_sessions:
+                        with patch("recce_cloud.api.client.RecceCloudClient.list_sessions") as mock_sessions:
                             mock_sessions.return_value = []  # No production session found
                             result = self.runner.invoke(
                                 cloud_cli,
@@ -485,9 +475,7 @@ class TestUploadBlocksDevSession(unittest.TestCase):
                 ["upload", "--target-path", self.temp_dir, "--dry-run"],
             )
 
-        self.assertEqual(
-            result.exit_code, 0, f"Dry run should succeed: {result.output}"
-        )
+        self.assertEqual(result.exit_code, 0, f"Dry run should succeed: {result.output}")
         self.assertIn("Blocked", result.output)
         self.assertIn("feature branch with no PR/MR detected", result.output)
 
@@ -710,9 +698,7 @@ class TestDownloadDryRun(unittest.TestCase):
 
         # Assertions
         self.assertEqual(result.exit_code, 0, f"Command failed: {result.output}")
-        self.assertIn(
-            "Warning: Target path exists (use --force to overwrite)", result.output
-        )
+        self.assertIn("Warning: Target path exists (use --force to overwrite)", result.output)
 
     def test_dry_run_session_id_with_prod_warning(self):
         """Test dry-run shows warning when both --session-id and --prod are provided."""
@@ -758,9 +744,7 @@ class TestDownloadDryRun(unittest.TestCase):
         # Assertions
         self.assertEqual(result.exit_code, 0, f"Command failed: {result.output}")
         self.assertIn("Dry run mode enabled", result.output)
-        self.assertIn(
-            "Warning: Platform not supported for auto-session discovery", result.output
-        )
+        self.assertIn("Warning: Platform not supported for auto-session discovery", result.output)
 
     def test_dry_run_gitlab_ci_self_hosted(self):
         """Test dry-run with self-hosted GitLab instance."""
@@ -820,9 +804,7 @@ class TestDownloadDryRun(unittest.TestCase):
         # Mock git command to return "main" branch
         # This simulates the fallback when GITHUB_REF_NAME is not available
         with patch.dict(os.environ, env, clear=True):
-            with patch(
-                "recce_cloud.ci_providers.base.BaseCIProvider.run_git_command"
-            ) as mock_git:
+            with patch("recce_cloud.ci_providers.base.BaseCIProvider.run_git_command") as mock_git:
                 mock_git.return_value = "main"
 
                 result = self.runner.invoke(
@@ -834,9 +816,7 @@ class TestDownloadDryRun(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, f"Command failed: {result.output}")
         self.assertIn("Platform: github-actions", result.output)
         self.assertIn("Repository: DataRecce/recce", result.output)
-        self.assertIn(
-            "Session Type: prod", result.output
-        )  # Auto-detected from main branch
+        self.assertIn("Session Type: prod", result.output)  # Auto-detected from main branch
 
         # Prod session should NOT show CR number or PR number
         self.assertNotIn("PR Number:", result.output)
@@ -997,9 +977,7 @@ class TestDeleteDryRun(unittest.TestCase):
         # Assertions
         self.assertEqual(result.exit_code, 0, f"Command failed: {result.output}")
         self.assertIn("Dry run mode enabled", result.output)
-        self.assertIn(
-            "Warning: Platform not supported for auto-session discovery", result.output
-        )
+        self.assertIn("Warning: Platform not supported for auto-session discovery", result.output)
 
     def test_dry_run_gitlab_ci_self_hosted(self):
         """Test dry-run with self-hosted GitLab instance."""
@@ -1068,9 +1046,7 @@ class TestDoctor(unittest.TestCase):
         env = {}
 
         with patch.dict(os.environ, env, clear=True):
-            with patch(
-                "recce_cloud.auth.profile.get_api_token", return_value="test_token"
-            ):
+            with patch("recce_cloud.auth.profile.get_api_token", return_value="test_token"):
                 with patch(
                     "recce_cloud.auth.login.check_login_status",
                     return_value=(True, "test@example.com"),
@@ -1099,9 +1075,7 @@ class TestDoctor(unittest.TestCase):
         }
 
         with patch.dict(os.environ, env, clear=True):
-            with patch(
-                "recce_cloud.auth.profile.get_api_token", return_value="test_token"
-            ):
+            with patch("recce_cloud.auth.profile.get_api_token", return_value="test_token"):
                 with patch(
                     "recce_cloud.auth.login.check_login_status",
                     return_value=(True, "test@example.com"),
@@ -1111,12 +1085,8 @@ class TestDoctor(unittest.TestCase):
                         return_value=None,
                     ):
                         # Mock API calls
-                        with patch(
-                            "recce_cloud.api.client.RecceCloudClient.get_organization"
-                        ) as mock_get_org:
-                            with patch(
-                                "recce_cloud.api.client.RecceCloudClient.get_project"
-                            ) as mock_get_project:
+                        with patch("recce_cloud.api.client.RecceCloudClient.get_organization") as mock_get_org:
+                            with patch("recce_cloud.api.client.RecceCloudClient.get_project") as mock_get_project:
                                 with patch(
                                     "recce_cloud.api.client.RecceCloudClient.list_sessions"
                                 ) as mock_list_sessions:
@@ -1142,9 +1112,7 @@ class TestDoctor(unittest.TestCase):
         env = {}
 
         with patch.dict(os.environ, env, clear=True):
-            with patch(
-                "recce_cloud.auth.profile.get_api_token", return_value="test_token"
-            ):
+            with patch("recce_cloud.auth.profile.get_api_token", return_value="test_token"):
                 with patch(
                     "recce_cloud.auth.login.check_login_status",
                     return_value=(True, "test@example.com"),
@@ -1154,12 +1122,8 @@ class TestDoctor(unittest.TestCase):
                         return_value={"org_id": "org-123", "project_id": "proj-456"},
                     ):
                         # Mock API calls
-                        with patch(
-                            "recce_cloud.api.client.RecceCloudClient.get_organization"
-                        ) as mock_get_org:
-                            with patch(
-                                "recce_cloud.api.client.RecceCloudClient.get_project"
-                            ) as mock_get_project:
+                        with patch("recce_cloud.api.client.RecceCloudClient.get_organization") as mock_get_org:
+                            with patch("recce_cloud.api.client.RecceCloudClient.get_project") as mock_get_project:
                                 with patch(
                                     "recce_cloud.api.client.RecceCloudClient.list_sessions"
                                 ) as mock_list_sessions:
@@ -1191,9 +1155,7 @@ class TestDoctor(unittest.TestCase):
                                     result = self.runner.invoke(cloud_cli, ["doctor"])
 
         # Assertions
-        self.assertEqual(
-            result.exit_code, 0, f"Should pass when all checks pass: {result.output}"
-        )
+        self.assertEqual(result.exit_code, 0, f"Should pass when all checks pass: {result.output}")
         self.assertIn("Recce Doctor", result.output)
         self.assertIn("Logged in as", result.output)
         self.assertIn("Bound to", result.output)
@@ -1209,9 +1171,7 @@ class TestDoctor(unittest.TestCase):
         env = {}
 
         with patch.dict(os.environ, env, clear=True):
-            with patch(
-                "recce_cloud.auth.profile.get_api_token", return_value="test_token"
-            ):
+            with patch("recce_cloud.auth.profile.get_api_token", return_value="test_token"):
                 with patch(
                     "recce_cloud.auth.login.check_login_status",
                     return_value=(True, "test@example.com"),
@@ -1221,12 +1181,8 @@ class TestDoctor(unittest.TestCase):
                         return_value={"org": "myorg", "project": "myproject"},
                     ):
                         # Mock API calls
-                        with patch(
-                            "recce_cloud.api.client.RecceCloudClient.get_organization"
-                        ) as mock_get_org:
-                            with patch(
-                                "recce_cloud.api.client.RecceCloudClient.get_project"
-                            ) as mock_get_project:
+                        with patch("recce_cloud.api.client.RecceCloudClient.get_organization") as mock_get_org:
+                            with patch("recce_cloud.api.client.RecceCloudClient.get_project") as mock_get_project:
                                 with patch(
                                     "recce_cloud.api.client.RecceCloudClient.list_sessions"
                                 ) as mock_list_sessions:
@@ -1243,9 +1199,7 @@ class TestDoctor(unittest.TestCase):
                                     result = self.runner.invoke(cloud_cli, ["doctor"])
 
         # Assertions
-        self.assertNotEqual(
-            result.exit_code, 0, "Should fail when no production session"
-        )
+        self.assertNotEqual(result.exit_code, 0, "Should fail when no production session")
         self.assertIn("No production artifacts found", result.output)
         self.assertIn("dbt docs generate --target prod", result.output)
         self.assertIn("recce-cloud upload --type prod", result.output)
@@ -1255,9 +1209,7 @@ class TestDoctor(unittest.TestCase):
         env = {}
 
         with patch.dict(os.environ, env, clear=True):
-            with patch(
-                "recce_cloud.auth.profile.get_api_token", return_value="test_token"
-            ):
+            with patch("recce_cloud.auth.profile.get_api_token", return_value="test_token"):
                 with patch(
                     "recce_cloud.auth.login.check_login_status",
                     return_value=(True, "test@example.com"),
@@ -1267,12 +1219,8 @@ class TestDoctor(unittest.TestCase):
                         return_value={"org": "myorg", "project": "myproject"},
                     ):
                         # Mock API calls
-                        with patch(
-                            "recce_cloud.api.client.RecceCloudClient.get_organization"
-                        ) as mock_get_org:
-                            with patch(
-                                "recce_cloud.api.client.RecceCloudClient.get_project"
-                            ) as mock_get_project:
+                        with patch("recce_cloud.api.client.RecceCloudClient.get_organization") as mock_get_org:
+                            with patch("recce_cloud.api.client.RecceCloudClient.get_project") as mock_get_project:
                                 with patch(
                                     "recce_cloud.api.client.RecceCloudClient.list_sessions"
                                 ) as mock_list_sessions:
@@ -1298,9 +1246,7 @@ class TestDoctor(unittest.TestCase):
                                     result = self.runner.invoke(cloud_cli, ["doctor"])
 
         # Assertions
-        self.assertNotEqual(
-            result.exit_code, 0, "Should fail when production session has no data"
-        )
+        self.assertNotEqual(result.exit_code, 0, "Should fail when production session has no data")
         self.assertIn("Production session exists but has no data", result.output)
         self.assertIn("dbt docs generate --target prod", result.output)
         self.assertIn("recce-cloud upload --type prod", result.output)
@@ -1312,9 +1258,7 @@ class TestDoctor(unittest.TestCase):
         env = {}
 
         with patch.dict(os.environ, env, clear=True):
-            with patch(
-                "recce_cloud.auth.profile.get_api_token", return_value="test_token"
-            ):
+            with patch("recce_cloud.auth.profile.get_api_token", return_value="test_token"):
                 with patch(
                     "recce_cloud.auth.login.check_login_status",
                     return_value=(True, "test@example.com"),
@@ -1324,12 +1268,8 @@ class TestDoctor(unittest.TestCase):
                         return_value={"org_id": "org-123", "project_id": "proj-456"},
                     ):
                         # Mock API calls
-                        with patch(
-                            "recce_cloud.api.client.RecceCloudClient.get_organization"
-                        ) as mock_get_org:
-                            with patch(
-                                "recce_cloud.api.client.RecceCloudClient.get_project"
-                            ) as mock_get_project:
+                        with patch("recce_cloud.api.client.RecceCloudClient.get_organization") as mock_get_org:
+                            with patch("recce_cloud.api.client.RecceCloudClient.get_project") as mock_get_project:
                                 with patch(
                                     "recce_cloud.api.client.RecceCloudClient.list_sessions"
                                 ) as mock_list_sessions:
@@ -1358,14 +1298,10 @@ class TestDoctor(unittest.TestCase):
                                         },
                                     ]
 
-                                    result = self.runner.invoke(
-                                        cloud_cli, ["doctor", "--json"]
-                                    )
+                                    result = self.runner.invoke(cloud_cli, ["doctor", "--json"])
 
         # Assertions
-        self.assertEqual(
-            result.exit_code, 0, f"Should pass with JSON output: {result.output}"
-        )
+        self.assertEqual(result.exit_code, 0, f"Should pass with JSON output: {result.output}")
 
         # Parse JSON output
         data = json.loads(result.output)
@@ -1409,9 +1345,7 @@ class TestDoctor(unittest.TestCase):
         env = {}
 
         with patch.dict(os.environ, env, clear=True):
-            with patch(
-                "recce_cloud.auth.profile.get_api_token", return_value="expired_token"
-            ):
+            with patch("recce_cloud.auth.profile.get_api_token", return_value="expired_token"):
                 with patch(
                     "recce_cloud.auth.login.check_login_status",
                     return_value=(False, None),
@@ -1709,9 +1643,7 @@ class TestDiagnosticServiceAPIErrors(unittest.TestCase):
         env = {}
 
         with patch.dict(os.environ, env, clear=True):
-            with patch(
-                "recce_cloud.auth.profile.get_api_token", return_value="test_token"
-            ):
+            with patch("recce_cloud.auth.profile.get_api_token", return_value="test_token"):
                 with patch(
                     "recce_cloud.auth.login.check_login_status",
                     return_value=(True, "test@example.com"),

--- a/recce_cloud/tests/test_cli.py
+++ b/recce_cloud/tests/test_cli.py
@@ -2,6 +2,7 @@
 Integration tests for recce-cloud CLI commands.
 """
 
+import json
 import os
 import tempfile
 import unittest
@@ -1893,6 +1894,198 @@ class TestUploadSessionBaseWithPlatformTokens(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, f"Failed: {result.output}")
         self.assertIn("Session base", result.output)
+
+
+class TestListOrgs(unittest.TestCase):
+    """Test cases for the list-orgs command."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_not_logged_in(self):
+        """Exit with code 2 and a login hint when no token is available."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("recce_cloud.auth.profile.get_api_token", return_value=None):
+                result = self.runner.invoke(cloud_cli, ["list-orgs"])
+
+        self.assertEqual(result.exit_code, 2, f"Output: {result.output}")
+        self.assertIn("recce-cloud login", result.output)
+
+    def test_table_output(self):
+        """Prefer display_name over name in the table."""
+        with patch.dict(os.environ, {"RECCE_API_TOKEN": "test_token"}, clear=True):
+            with patch(
+                "recce_cloud.api.client.RecceCloudClient.list_organizations",
+                return_value=[{"id": 42, "name": "acme", "display_name": "Acme Inc"}],
+            ):
+                result = self.runner.invoke(cloud_cli, ["list-orgs"])
+
+        self.assertEqual(result.exit_code, 0, f"Output: {result.output}")
+        self.assertIn("42", result.output)
+        self.assertIn("Acme Inc", result.output)
+        self.assertNotIn("acme", result.output)
+
+    def test_json_output(self):
+        """Emit parsable JSON, with a rich style tag in a value."""
+        orgs = [{"id": 42, "name": "acme", "display_name": "[dim] Acme"}]
+
+        with patch.dict(os.environ, {"RECCE_API_TOKEN": "test_token"}, clear=True):
+            with patch(
+                "recce_cloud.api.client.RecceCloudClient.list_organizations",
+                return_value=orgs,
+            ):
+                result = self.runner.invoke(cloud_cli, ["list-orgs", "--json"])
+
+        self.assertEqual(result.exit_code, 0, f"Output: {result.output}")
+        self.assertEqual(json.loads(result.output), orgs)
+
+    def test_no_organizations(self):
+        """Succeed with a hint when the user has no organizations."""
+        with patch.dict(os.environ, {"RECCE_API_TOKEN": "test_token"}, clear=True):
+            with patch(
+                "recce_cloud.api.client.RecceCloudClient.list_organizations",
+                return_value=[],
+            ):
+                result = self.runner.invoke(cloud_cli, ["list-orgs"])
+
+        self.assertEqual(result.exit_code, 0, f"Output: {result.output}")
+        self.assertIn("No organizations found", result.output)
+
+
+class TestListProjects(unittest.TestCase):
+    """Test cases for the list-projects command."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.org = {"id": 42, "name": "acme", "display_name": "Acme Inc"}
+        self.projects = [
+            {
+                "id": 1,
+                "name": "analytics",
+                "status": "active",
+                "repository": {"full_name": "acme/analytics-dbt"},
+            },
+            {"id": 3, "name": "no-repo", "status": "active", "repository": None},
+            {
+                "id": 2,
+                "name": "legacy",
+                "status": "archived",
+                "repository": {"full_name": "acme/old-dbt"},
+            },
+        ]
+
+    def test_no_org_available(self):
+        """Exit with code 2 when no organization can be resolved."""
+        with patch.dict(os.environ, {"RECCE_API_TOKEN": "test_token"}, clear=True):
+            with patch(
+                "recce_cloud.config.project_config.get_project_binding",
+                return_value=None,
+            ):
+                result = self.runner.invoke(cloud_cli, ["list-projects"])
+
+        self.assertEqual(result.exit_code, 2, f"Output: {result.output}")
+        self.assertIn("recce-cloud list-orgs", result.output)
+
+    def test_org_not_found(self):
+        """Exit with code 2 when the organization does not exist."""
+        with patch.dict(os.environ, {"RECCE_API_TOKEN": "test_token"}, clear=True):
+            with patch(
+                "recce_cloud.api.client.RecceCloudClient.list_organizations",
+                return_value=[],
+            ):
+                result = self.runner.invoke(cloud_cli, ["list-projects", "--org", "nope"])
+
+        self.assertEqual(result.exit_code, 2, f"Output: {result.output}")
+        self.assertIn("not found", result.output)
+
+    def test_table_output(self):
+        """Show the repository, fall back to a dash, and hide archived projects."""
+        with patch.dict(os.environ, {"RECCE_API_TOKEN": "test_token"}, clear=True):
+            with patch(
+                "recce_cloud.api.client.RecceCloudClient.list_organizations",
+                return_value=[self.org],
+            ):
+                with patch(
+                    "recce_cloud.api.client.RecceCloudClient.list_projects",
+                    return_value=self.projects,
+                ):
+                    result = self.runner.invoke(cloud_cli, ["list-projects", "--org", "acme"])
+
+        self.assertEqual(result.exit_code, 0, f"Output: {result.output}")
+        self.assertIn("acme/analytics-dbt", result.output)
+        self.assertIn("no-repo", result.output)
+        self.assertNotIn("legacy", result.output)
+        self.assertNotIn("acme/old-dbt", result.output)
+
+    def test_json_output_with_all(self):
+        """Include archived projects in JSON output when --all is passed."""
+        with patch.dict(os.environ, {"RECCE_API_TOKEN": "test_token"}, clear=True):
+            with patch(
+                "recce_cloud.api.client.RecceCloudClient.list_organizations",
+                return_value=[self.org],
+            ):
+                with patch(
+                    "recce_cloud.api.client.RecceCloudClient.list_projects",
+                    return_value=self.projects,
+                ):
+                    result = self.runner.invoke(cloud_cli, ["list-projects", "--org", "42", "--all", "--json"])
+
+        self.assertEqual(result.exit_code, 0, f"Output: {result.output}")
+        self.assertEqual(json.loads(result.output), self.projects)
+
+    def test_org_from_env(self):
+        """Fall back to RECCE_ORG when --org is not passed."""
+        env = {"RECCE_API_TOKEN": "test_token", "RECCE_ORG": "42"}
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch(
+                "recce_cloud.api.client.RecceCloudClient.list_organizations",
+                return_value=[self.org],
+            ):
+                with patch(
+                    "recce_cloud.api.client.RecceCloudClient.list_projects",
+                    return_value=self.projects,
+                ) as mock_list_projects:
+                    result = self.runner.invoke(cloud_cli, ["list-projects", "--json"])
+
+        self.assertEqual(result.exit_code, 0, f"Output: {result.output}")
+        mock_list_projects.assert_called_once_with(42)
+
+    def test_only_archived_projects(self):
+        """Suggest --all when the archived filter removes every project."""
+        archived = [p for p in self.projects if p["status"] == "archived"]
+
+        with patch.dict(os.environ, {"RECCE_API_TOKEN": "test_token"}, clear=True):
+            with patch(
+                "recce_cloud.api.client.RecceCloudClient.list_organizations",
+                return_value=[self.org],
+            ):
+                with patch(
+                    "recce_cloud.api.client.RecceCloudClient.list_projects",
+                    return_value=archived,
+                ):
+                    result = self.runner.invoke(cloud_cli, ["list-projects", "--org", "acme"])
+
+        self.assertEqual(result.exit_code, 0, f"Output: {result.output}")
+        self.assertIn("No active projects found", result.output)
+        self.assertIn("--all", result.output)
+        self.assertNotIn("create a project", result.output)
+
+    def test_no_projects(self):
+        """Succeed with a hint when the organization has no projects."""
+        with patch.dict(os.environ, {"RECCE_API_TOKEN": "test_token"}, clear=True):
+            with patch(
+                "recce_cloud.api.client.RecceCloudClient.list_organizations",
+                return_value=[self.org],
+            ):
+                with patch(
+                    "recce_cloud.api.client.RecceCloudClient.list_projects",
+                    return_value=[],
+                ):
+                    result = self.runner.invoke(cloud_cli, ["list-projects", "--org", "acme"])
+
+        self.assertEqual(result.exit_code, 0, f"Output: {result.output}")
+        self.assertIn("No projects found", result.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Feature.

**What this PR does / why we need it**:

`recce-cloud init --org X --project Y` already binds a directory without prompts. But nothing in the CLI lists the organizations and projects you can pass to it. Those names appear only inside the interactive picker in `init`, which needs a person to answer. An agent or a script therefore cannot finish the setup on its own.

This PR adds `recce-cloud list-orgs` and `recce-cloud list-projects`. Both print a table, or JSON with `--json`. There is no API change: the client already had `list_organizations` and `list_projects`, and until now only the interactive branch of `init` called them.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Read the second commit only. The first commit is black formatting of the same two files, with no logic change. They were written at 88 columns while the repository setting is 120, so any edit reformats them in full.

**Does this PR introduce a user-facing change?**:

Yes.

Add `recce-cloud list-orgs` and `recce-cloud list-projects`. You can now find the organization and project IDs that `recce-cloud init --org ... --project ...` needs without going through the interactive picker. Both commands support `--json` for scripts and agents.
