### PR TITLE
fix(ui): normalize data type tooltips

### DIFF
--- a/js/packages/ui/src/components/index.ts
+++ b/js/packages/ui/src/components/index.ts
@@ -198,6 +198,7 @@ export {
   DiffDisplayModeSwitch,
   DiffText,
   HSplit,
+  normalizeTypeName,
   SquareIcon,
   ToggleSwitch,
   VSplit,

--- a/js/packages/ui/src/components/schema/ColumnNameCell.tsx
+++ b/js/packages/ui/src/components/schema/ColumnNameCell.tsx
@@ -37,7 +37,11 @@ import {
   useRecceInstanceContext,
 } from "../../contexts";
 import { supportsHistogramDiff } from "../histogram";
-import { buildColumnTooltip, DataTypeIcon } from "../ui/DataTypeIcon";
+import {
+  buildColumnTooltip,
+  DataTypeIcon,
+  normalizeTypeName,
+} from "../ui/DataTypeIcon";
 import { getColumnChangeStatus } from "./getColumnChangeStatus";
 import type { SchemaDiffRow } from "./types";
 
@@ -219,8 +223,8 @@ export function ColumnNameCell({
   const tooltipTitle = buildColumnTooltip({
     name,
     status: tooltipStatus,
-    baseType,
-    currentType,
+    baseType: baseType ? normalizeTypeName(baseType) : undefined,
+    currentType: currentType ? normalizeTypeName(currentType) : undefined,
     cllAvailable: !isCllDisabled,
     impacted: showImpactedTag,
   });

--- a/js/packages/ui/src/components/schema/__tests__/ColumnNameCell.test.tsx
+++ b/js/packages/ui/src/components/schema/__tests__/ColumnNameCell.test.tsx
@@ -14,16 +14,16 @@ import { theme } from "../../../theme";
 import { ColumnNameCell } from "../ColumnNameCell";
 import type { SchemaDiffRow } from "../types";
 
-// Mock DataTypeIcon and buildColumnTooltip
-vi.mock("../../ui/DataTypeIcon", () => ({
-  DataTypeIcon: ({ type, size }: { type: string; size?: number }) => (
-    <span data-testid="data-type-icon" data-type={type} data-size={size} />
-  ),
-  buildColumnTooltip: vi.fn(
-    ({ name, currentType }: { name: string; currentType?: string }) =>
-      `${name} ${currentType ?? ""}`,
-  ),
-}));
+// Keep tooltip behavior real; replace only the SVG-heavy icon rendering.
+vi.mock("../../ui/DataTypeIcon", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../ui/DataTypeIcon")>();
+  return {
+    ...actual,
+    DataTypeIcon: ({ type, size }: { type: string; size?: number }) => (
+      <span data-testid="data-type-icon" data-type={type} data-size={size} />
+    ),
+  };
+});
 
 // Mock dependencies with dynamic isActionAvailable and lineageViewContext
 const { mockIsActionAvailable, mockLineageViewContext } = vi.hoisted(() => ({
@@ -154,6 +154,25 @@ describe("ColumnNameCell", () => {
   });
 
   describe("column name display", () => {
+    test("normalizes the Schema type in the column tooltip", async () => {
+      const user = userEvent.setup();
+      renderWithMui(
+        <ColumnNameCell
+          model={createMockModel()}
+          row={createMockRow({
+            baseType: "character varying",
+            currentType: "character varying",
+          })}
+          showMenu={false}
+        />,
+      );
+
+      await user.hover(screen.getByText("user_id"));
+      expect(await screen.findByRole("tooltip")).toHaveTextContent(
+        "user_id VARCHAR",
+      );
+    });
+
     test("renders column name", () => {
       renderWithMui(
         <ColumnNameCell

--- a/js/packages/ui/src/components/ui/DataTypeIcon/__tests__/normalizeTypeName.test.ts
+++ b/js/packages/ui/src/components/ui/DataTypeIcon/__tests__/normalizeTypeName.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTypeName } from "..";
+
+describe("normalizeTypeName", () => {
+  it.each([
+    ["varchar", "VARCHAR"],
+    ["decimal(18, 3)", "DECIMAL(18, 3)"],
+    ["timestamp_s", "TIMESTAMP_S"],
+  ])("normalizes the DuckDB spelling %s", (rawType, expected) => {
+    expect(normalizeTypeName(rawType)).toBe(expected);
+  });
+
+  it.each([
+    ["character varying", "VARCHAR"],
+    ["character varying(255)", "VARCHAR(255)"],
+    ["double precision", "DOUBLE"],
+    ["numeric(12,4)[]", "NUMERIC(12,4)[]"],
+  ])("normalizes the PostgreSQL spelling %s", (rawType, expected) => {
+    expect(normalizeTypeName(rawType)).toBe(expected);
+  });
+
+  it.each([
+    ["number(38,0)", "NUMBER(38,0)"],
+    ["timestamp_ntz(9)", "TIMESTAMP_NTZ(9)"],
+  ])("normalizes the Snowflake spelling %s", (rawType, expected) => {
+    expect(normalizeTypeName(rawType)).toBe(expected);
+  });
+
+  it("preserves unknown type names exactly", () => {
+    expect(normalizeTypeName("MyDomain(12)")).toBe("MyDomain(12)");
+  });
+
+  it("preserves quoted parameter content", () => {
+    expect(normalizeTypeName("datetime64(3, 'UTC')")).toBe(
+      "DATETIME64(3, 'UTC')",
+    );
+  });
+
+  it.each(["", "   "])(
+    "normalizes an empty display value to empty",
+    (rawType) => {
+      expect(normalizeTypeName(rawType)).toBe("");
+    },
+  );
+});

--- a/js/packages/ui/src/components/ui/DataTypeIcon/__tests__/tooltipText.test.ts
+++ b/js/packages/ui/src/components/ui/DataTypeIcon/__tests__/tooltipText.test.ts
@@ -33,6 +33,17 @@ describe("buildColumnTooltip", () => {
     ).toBe("col, was VARCHAR(50) now VARCHAR(10)");
   });
 
+  it("does not describe a transition when normalized type names are equal", () => {
+    expect(
+      buildColumnTooltip({
+        name: "col",
+        status: "type_changed",
+        baseType: "VARCHAR",
+        currentType: "VARCHAR",
+      }),
+    ).toBe("col VARCHAR");
+  });
+
   it("returns changed definition for definition_changed", () => {
     expect(
       buildColumnTooltip({

--- a/js/packages/ui/src/components/ui/DataTypeIcon/index.tsx
+++ b/js/packages/ui/src/components/ui/DataTypeIcon/index.tsx
@@ -17,6 +17,7 @@ import {
   UnknownIcon,
 } from "./icons";
 
+export { normalizeTypeName } from "./normalizeTypeName";
 export type { ColumnTooltipInput } from "./tooltipText";
 export { buildColumnTooltip } from "./tooltipText";
 export type { TypeCategory };

--- a/js/packages/ui/src/components/ui/DataTypeIcon/normalizeTypeName.ts
+++ b/js/packages/ui/src/components/ui/DataTypeIcon/normalizeTypeName.ts
@@ -1,0 +1,28 @@
+import { classifyType } from "./classifyType";
+
+const TYPE_NAME_ALIASES: Readonly<Record<string, string>> = {
+  "CHARACTER VARYING": "VARCHAR",
+  "DOUBLE PRECISION": "DOUBLE",
+};
+
+/**
+ * Canonicalizes a known database type for tooltip display.
+ *
+ * Parameters and suffixes are preserved, while unknown or custom types are
+ * returned exactly as received.
+ */
+export function normalizeTypeName(rawType: string): string {
+  const trimmed = rawType.trim();
+  if (!trimmed) return "";
+
+  const suffixIndex = trimmed.search(/[([]/);
+  const rawBase = suffixIndex === -1 ? trimmed : trimmed.slice(0, suffixIndex);
+  const suffix = suffixIndex === -1 ? "" : trimmed.slice(suffixIndex);
+  const foldedBase = rawBase.trimEnd().toUpperCase();
+
+  if (classifyType(foldedBase) === "unknown") {
+    return rawType;
+  }
+
+  return `${TYPE_NAME_ALIASES[foldedBase] ?? foldedBase}${suffix}`;
+}

--- a/js/packages/ui/src/components/ui/DataTypeIcon/tooltipText.ts
+++ b/js/packages/ui/src/components/ui/DataTypeIcon/tooltipText.ts
@@ -29,7 +29,10 @@ export function buildColumnTooltip(input: ColumnTooltipInput): string {
       return `deleted ${name}`;
 
     case "type_changed":
-      text = `${name}, was ${baseType} now ${currentType}`;
+      text =
+        currentType && baseType === currentType
+          ? `${name} ${currentType}`
+          : `${name}, was ${baseType} now ${currentType}`;
       break;
 
     case "definition_changed":

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/profileColumnNameRenderer.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/profileColumnNameRenderer.test.tsx
@@ -9,6 +9,7 @@
  */
 
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ColDef, ICellRendererParams } from "ag-grid-community";
 import { describe, expect, test, vi } from "vitest";
 import type { RowObjectType } from "../../../../api";
@@ -54,6 +55,23 @@ function createParams(
 // ============================================================================
 
 describe("profileColumnNameRenderer", () => {
+  test("normalizes the Profile type in the column tooltip", async () => {
+    const user = userEvent.setup();
+    const colDef: ColDef<RowObjectType> = { field: "COLUMN_NAME" };
+    const params = createParams(
+      { COLUMN_NAME: "CUSTOMER_ID", data_type: "varchar" },
+      colDef,
+      "CUSTOMER_ID",
+    );
+
+    render(<>{profileColumnNameRenderer(params)}</>);
+
+    await user.hover(screen.getByText("CUSTOMER_ID"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "CUSTOMER_ID VARCHAR",
+    );
+  });
+
   test("renders column name from row data with UPPERCASE field (single profile)", () => {
     // Simulates: field="COLUMN_NAME", row has row["COLUMN_NAME"]="CUSTOMER_ID"
     // This is the non-diff case where dataFrameToRowObjects preserves original keys
@@ -114,6 +132,27 @@ describe("profileColumnNameRenderer", () => {
 // ============================================================================
 
 describe("profileDiffColumnNameRenderer", () => {
+  test("normalizes both Profile Diff types in the column tooltip", async () => {
+    const user = userEvent.setup();
+    const colDef: ColDef<RowObjectType> = { field: "COLUMN_NAME" };
+    const params = createParams(
+      {
+        column_name: "FIRST_NAME",
+        base__data_type: "character varying",
+        current__data_type: "varchar",
+      },
+      colDef,
+      "FIRST_NAME",
+    );
+
+    render(<>{profileDiffColumnNameRenderer(params)}</>);
+
+    await user.hover(screen.getByText("FIRST_NAME"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "FIRST_NAME VARCHAR",
+    );
+  });
+
   test("renders column name when row key is lowercase but field is UPPERCASE (inline diff)", () => {
     // This is the exact bug scenario: inline diff mode with UPPERCASE column keys
     const colDef: ColDef<RowObjectType> = { field: "COLUMN_NAME" };

--- a/js/packages/ui/src/components/ui/dataGrid/dataGridFactory.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/dataGridFactory.tsx
@@ -58,7 +58,11 @@ import {
 } from "../../../utils/dataGrid";
 import { hasOwn } from "../../../utils/hasOwn";
 import { getCaseInsensitive } from "../../../utils/transforms";
-import { buildColumnTooltip, DataTypeIcon } from "../DataTypeIcon";
+import {
+  buildColumnTooltip,
+  DataTypeIcon,
+  normalizeTypeName,
+} from "../DataTypeIcon";
 import { toValueDataGrid } from "./generators/toValueDataGrid";
 
 // ============================================================================
@@ -202,7 +206,10 @@ export function profileColumnNameRenderer(
   const name = String(getCaseInsensitive(row, fieldName) ?? params.value ?? "");
   const dataType =
     String(getCaseInsensitive(row, "data_type") ?? "") || undefined;
-  const tooltipText = buildColumnTooltip({ name, currentType: dataType });
+  const tooltipText = buildColumnTooltip({
+    name,
+    currentType: dataType ? normalizeTypeName(dataType) : undefined,
+  });
 
   return (
     <Tooltip title={tooltipText} placement="top">
@@ -253,7 +260,11 @@ export function profileDiffColumnNameRenderer(
   const isTypeChanged =
     baseType != null && currentType != null && baseType !== currentType;
   const displayType = currentType ?? baseType;
-  const tooltipText = buildColumnTooltip({ name, baseType, currentType });
+  const tooltipText = buildColumnTooltip({
+    name,
+    baseType: baseType ? normalizeTypeName(baseType) : undefined,
+    currentType: currentType ? normalizeTypeName(currentType) : undefined,
+  });
 
   return (
     <Tooltip title={tooltipText} placement="top">

--- a/js/packages/ui/src/components/ui/index.ts
+++ b/js/packages/ui/src/components/ui/index.ts
@@ -12,6 +12,7 @@ export {
   classifyType,
   DataTypeIcon,
   type DataTypeIconProps,
+  normalizeTypeName,
   type TypeCategory,
 } from "./DataTypeIcon";
 export {

--- a/js/packages/ui/src/index.ts
+++ b/js/packages/ui/src/index.ts
@@ -75,6 +75,7 @@ export {
   // Lineage
   LineageCanvas,
   LineageView,
+  normalizeTypeName,
   SquareIcon,
   StructuralChangeIndicator,
   VSplit,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix / UI polish

**What this PR does / why we need it**:

- adds a shared `normalizeTypeName` display helper for recognized database types
- canonicalizes Profile and Schema tooltip inputs without changing raw icon, action, or type-comparison data
- collapses canonical-equivalent tooltip transitions such as `character varying` → `varchar` to one `VARCHAR` label
- preserves unknown/custom types and parameter content

**Which issue(s) this PR fixes**:

Closes DRC-2840

**Special notes for your reviewer**:

The stale prototype branch `worktree-understand_type_change` was deleted after this replacement branch was pushed. Its former tip was `ee20a7f6`.

Verification:

- `pnpm lint`
- `pnpm type:check`
- `pnpm test` — 4,116 passed, 5 skipped
- `pnpm run build`
- push hooks — 1,828 related tests passed, 5 skipped

**Does this PR introduce a user-facing change?**:

Yes.

```release-note
Normalize data type names shown in Profile and Schema column tooltips.
```
