### PR TITLE
feat(profile): polish headers and add explicit delta modes

### DIFF
--- a/js/packages/ui/src/api/types/base.ts
+++ b/js/packages/ui/src/api/types/base.ts
@@ -68,9 +68,17 @@ export type ColumnType =
  * - raw: display value as-is
  * - percent: display as percentage
  * - delta: display as delta/change value
+ * - percent_delta: display percentage-point change for Profile Diff proportions
+ * - percent_change: display relative-percent change for Profile Diff numerics
  * - 2: display with 2 decimal places
  */
-export type ColumnRenderMode = "raw" | "percent" | "delta" | 2;
+export type ColumnRenderMode =
+  | "raw"
+  | "percent"
+  | "delta"
+  | "percent_delta"
+  | "percent_change"
+  | 2;
 
 // ============================================================================
 // DataFrame Types

--- a/js/packages/ui/src/components/ui/dataGrid/DataFrameColumnGroupHeader.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/DataFrameColumnGroupHeader.tsx
@@ -29,6 +29,10 @@ import { columnPrecisionSelectOptions } from "../../../utils/dataGrid/columnPrec
 export interface DataFrameColumnGroupHeaderProps {
   /** Column name to display */
   name: string;
+  /** Optional presentation-only name for the column */
+  displayName?: string;
+  /** Hides the primary-key indicator without changing primary-key behavior */
+  hidePrimaryKeyIcon?: boolean;
   /** Column diff status: 'added', 'removed', 'modified', or empty string */
   columnStatus: string;
   /** Column data type for determining available options */
@@ -86,6 +90,8 @@ export interface DataFrameColumnGroupHeaderProps {
  */
 export function DataFrameColumnGroupHeader({
   name,
+  displayName,
+  hidePrimaryKeyIcon = false,
   columnStatus,
   columnType,
   primaryKeys = [],
@@ -161,7 +167,7 @@ export function DataFrameColumnGroupHeader({
       className="grid-header"
     >
       {/* Primary key icon */}
-      {isPK && <VscKey />}
+      {isPK && !hidePrimaryKeyIcon && <VscKey data-testid="primary-key-icon" />}
 
       {/* Column name */}
       <Box
@@ -172,7 +178,7 @@ export function DataFrameColumnGroupHeader({
           whiteSpace: "nowrap",
         }}
       >
-        {name}
+        {displayName ?? name}
       </Box>
 
       {/* Primary key toggle (only when onPrimaryKeyChange is provided) */}

--- a/js/packages/ui/src/components/ui/dataGrid/DataFrameColumnGroupHeader.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/DataFrameColumnGroupHeader.tsx
@@ -47,6 +47,8 @@ export interface DataFrameColumnGroupHeaderProps {
   onPinnedColumnsChange?: (pinnedColumns: string[]) => void;
   /** Callback when column render mode changes */
   onColumnsRenderModeChanged?: (col: Record<string, ColumnRenderMode>) => void;
+  /** Optional list limiting which render modes appear in the precision menu */
+  allowedRenderModes?: readonly ColumnRenderMode[];
 }
 
 /**
@@ -99,6 +101,7 @@ export function DataFrameColumnGroupHeader({
   pinnedColumns = [],
   onPinnedColumnsChange,
   onColumnsRenderModeChanged,
+  allowedRenderModes,
 }: DataFrameColumnGroupHeaderProps) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const menuOpen = Boolean(anchorEl);
@@ -129,6 +132,7 @@ export function DataFrameColumnGroupHeader({
     selectOptions = columnPrecisionSelectOptions(
       name,
       onColumnsRenderModeChanged,
+      allowedRenderModes,
     );
   }
 
@@ -209,7 +213,11 @@ export function DataFrameColumnGroupHeader({
 
       {/* Precision menu for number columns (only for non-PK columns) */}
       {!isPK &&
-        (columnType === "number" || columnType === "float") &&
+        // Profile Diff can explicitly opt integer fields into its scoped menu.
+        // All other grids retain their historical number/float eligibility.
+        (columnType === "number" ||
+          columnType === "float" ||
+          allowedRenderModes !== undefined) &&
         selectOptions.length > 0 && (
           <>
             <IconButton

--- a/js/packages/ui/src/components/ui/dataGrid/DataFrameColumnHeader.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/DataFrameColumnHeader.tsx
@@ -33,6 +33,8 @@ export interface DataFrameColumnHeaderProps {
   onPinnedColumnsChange?: (pinnedColumns: string[]) => void;
   /** Callback when column render mode changes */
   onColumnsRenderModeChanged?: (col: Record<string, ColumnRenderMode>) => void;
+  /** Optional list limiting which render modes appear in the precision menu */
+  allowedRenderModes?: readonly ColumnRenderMode[];
 }
 
 /**
@@ -62,6 +64,7 @@ export function DataFrameColumnHeader({
   },
   columnType,
   onColumnsRenderModeChanged,
+  allowedRenderModes,
 }: DataFrameColumnHeaderProps) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const menuOpen = Boolean(anchorEl);
@@ -79,6 +82,7 @@ export function DataFrameColumnHeader({
     selectOptions = columnPrecisionSelectOptions(
       name,
       onColumnsRenderModeChanged,
+      allowedRenderModes,
     );
   }
 
@@ -110,7 +114,9 @@ export function DataFrameColumnHeader({
         }}
         onClick={isPinned ? handleUnpin : handlePin}
       />
-      {(columnType === "number" || columnType === "float") && (
+      {(columnType === "number" ||
+        columnType === "float" ||
+        (allowedRenderModes !== undefined && selectOptions.length > 0)) && (
         <>
           <IconButton
             aria-label="Options"

--- a/js/packages/ui/src/components/ui/dataGrid/DataFrameColumnHeader.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/DataFrameColumnHeader.tsx
@@ -114,8 +114,8 @@ export function DataFrameColumnHeader({
         }}
         onClick={isPinned ? handleUnpin : handlePin}
       />
-      {(columnType === "number" ||
-        columnType === "float" ||
+      {((allowedRenderModes === undefined &&
+        (columnType === "number" || columnType === "float")) ||
         (allowedRenderModes !== undefined && selectOptions.length > 0)) && (
         <>
           <IconButton

--- a/js/packages/ui/src/components/ui/dataGrid/DataFrameColumnHeader.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/DataFrameColumnHeader.tsx
@@ -23,6 +23,8 @@ import { columnPrecisionSelectOptions } from "../../../utils/dataGrid/columnPrec
 export interface DataFrameColumnHeaderProps {
   /** Column name to display */
   name: string;
+  /** Optional presentation-only name for the column */
+  displayName?: string;
   /** Column data type for determining available options */
   columnType: ColumnType;
   /** List of currently pinned column names */
@@ -53,6 +55,7 @@ export interface DataFrameColumnHeaderProps {
  */
 export function DataFrameColumnHeader({
   name,
+  displayName,
   pinnedColumns = [],
   onPinnedColumnsChange = () => {
     return void 0;
@@ -96,7 +99,7 @@ export function DataFrameColumnHeader({
       sx={{ display: "flex", alignItems: "center", width: "100%" }}
       className="grid-header"
     >
-      <Box sx={{ flex: 1 }}>{name}</Box>
+      <Box sx={{ flex: 1 }}>{displayName ?? name}</Box>
 
       <Box
         component={isPinned ? VscPinned : VscPin}

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/DataFrameColumnGroupHeader.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/DataFrameColumnGroupHeader.test.tsx
@@ -72,9 +72,26 @@ describe("DataFrameColumnGroupHeader - Primary Key", () => {
       />,
     );
 
-    // VscKey icon should be present
-    const keyIcons = document.querySelectorAll("svg");
-    expect(keyIcons.length).toBeGreaterThan(0);
+    expect(screen.getByTestId("primary-key-icon")).toBeInTheDocument();
+  });
+
+  test("hides only the primary key indicator when requested", () => {
+    const { container } = render(
+      <DataFrameColumnGroupHeader
+        name="column_name"
+        columnStatus=""
+        columnType="number"
+        primaryKeys={["column_name"]}
+        pinnedColumns={[]}
+        onPinnedColumnsChange={vi.fn()}
+        onColumnsRenderModeChanged={vi.fn()}
+        hidePrimaryKeyIcon
+      />,
+    );
+
+    expect(screen.queryByTestId("primary-key-icon")).not.toBeInTheDocument();
+    expect(container.querySelector(".pin-icon")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Options")).not.toBeInTheDocument();
   });
 
   test("shows close icon for PK column when onPrimaryKeyChange is provided", () => {

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/DataFrameColumnHeader.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/DataFrameColumnHeader.test.tsx
@@ -31,6 +31,28 @@ describe("DataFrameColumnHeader - Basic Rendering", () => {
 
     expect(container.querySelector(".grid-header")).toBeInTheDocument();
   });
+
+  test("shows displayName while precision callbacks keep the raw name", () => {
+    const onColumnsRenderModeChanged = vi.fn();
+    render(
+      <DataFrameColumnHeader
+        name="ROW_COUNT"
+        displayName="Row Count"
+        columnType="number"
+        onColumnsRenderModeChanged={onColumnsRenderModeChanged}
+      />,
+    );
+
+    expect(screen.getByText("Row Count")).toBeInTheDocument();
+    expect(screen.queryByText("ROW_COUNT")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Options"));
+    fireEvent.click(screen.getByText("Show raw value"));
+
+    expect(onColumnsRenderModeChanged).toHaveBeenCalledWith({
+      ROW_COUNT: "raw",
+    });
+  });
 });
 
 // ============================================================================

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/DataFrameColumnHeader.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/DataFrameColumnHeader.test.tsx
@@ -155,6 +155,19 @@ describe("DataFrameColumnHeader - Precision Menu", () => {
     expect(screen.queryByLabelText("Options")).not.toBeInTheDocument();
   });
 
+  test("does not show an empty menu for an explicit empty allow-list", () => {
+    render(
+      <DataFrameColumnHeader
+        name="price"
+        columnType="number"
+        allowedRenderModes={[]}
+        onColumnsRenderModeChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByLabelText("Options")).not.toBeInTheDocument();
+  });
+
   test("opens menu on button click", () => {
     render(
       <DataFrameColumnHeader

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/createDataGrid.profile.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/createDataGrid.profile.test.tsx
@@ -8,7 +8,7 @@
  * but buildDiffRows lowercases PK keys in diff rows.
  */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type {
   ColDef,
   ColGroupDef,
@@ -375,6 +375,139 @@ describe("createDataGrid - profile_diff (side_by_side) with UPPERCASE keys", () 
         (child) => (child as ColDef<RowObjectType>).field,
       ),
     ).toEqual(["base__ROW_COUNT", "current__ROW_COUNT"]);
+  });
+});
+
+// ============================================================================
+// DRC-2866: explicit percentage modes are limited to inline Profile Diff
+// ============================================================================
+
+describe("createDataGrid - profile_diff explicit percentage mode eligibility", () => {
+  const columns = [
+    { key: "column_name", name: "column_name", type: "text" },
+    { key: "data_type", name: "data_type", type: "text" },
+    { key: "row_count", name: "row_count", type: "integer" },
+    {
+      key: "not_null_proportion",
+      name: "not_null_proportion",
+      type: "float",
+    },
+  ] as const;
+  const run = makeProfileDiffRun({
+    base: makeDataFrame([...columns], [["id", "integer", 10, 0.98]]),
+    current: makeDataFrame([...columns], [["id", "integer", 12, 0.94]]),
+  });
+
+  function renderHeaderFor(
+    result: ReturnType<typeof createDataGrid>,
+    field: string,
+  ) {
+    const column = findColumn(result!.columns, field);
+    const Header = column?.headerComponent;
+    if (!Header) {
+      throw new Error(`Expected ${field} to have a header component`);
+    }
+    render(<Header />);
+    fireEvent.click(screen.getByRole("button", { name: "Options" }));
+  }
+
+  test("offers percentage-point delta only for inline proportion fields", () => {
+    const callback = vi.fn();
+    const result = createDataGrid(run, {
+      displayMode: "inline",
+      onColumnsRenderModeChanged: callback,
+    });
+
+    renderHeaderFor(result, "not_null_proportion");
+
+    expect(screen.getByText("Show percentage-point delta")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Show relative percentage change"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Show percentage-point delta"));
+    expect(callback).toHaveBeenCalledWith({
+      not_null_proportion: "percent_delta",
+    });
+  });
+
+  test("offers relative percentage change for other inline numeric fields", () => {
+    const callback = vi.fn();
+    const result = createDataGrid(run, {
+      displayMode: "inline",
+      onColumnsRenderModeChanged: callback,
+    });
+
+    renderHeaderFor(result, "row_count");
+
+    expect(
+      screen.getByText("Show relative percentage change"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Show percentage-point delta"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Show relative percentage change"));
+    expect(callback).toHaveBeenCalledWith({ row_count: "percent_change" });
+  });
+
+  test("keeps the new modes out of side-by-side Profile Diff headers", () => {
+    const result = createDataGrid(run, {
+      displayMode: "side_by_side",
+      onColumnsRenderModeChanged: vi.fn(),
+    })!;
+    const proportionGroup = result.columns.find(
+      (column) =>
+        "children" in column &&
+        column.headerName?.toLowerCase() === "not_null_proportion",
+    ) as ColGroupDef<RowObjectType>;
+
+    const Header = proportionGroup.headerGroupComponent;
+    if (!Header) {
+      throw new Error("Expected a side-by-side Profile Diff group header");
+    }
+    render(<Header />);
+    fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+    expect(
+      screen.queryByText("Show percentage-point delta"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Show relative percentage change"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("keeps the new modes out of single Profile headers", () => {
+    const singleProfileRun = makeProfileRun({
+      current: makeDataFrame([...columns], [["id", "integer", 12, 0.94]]),
+    });
+    const result = createDataGrid(singleProfileRun, {
+      onColumnsRenderModeChanged: vi.fn(),
+    });
+    const column = findColumn(result!.columns, "not_null_proportion");
+    const Header = column?.headerComponent;
+    if (!Header) {
+      throw new Error("Expected a single Profile header component");
+    }
+
+    render(<Header />);
+    fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+    expect(
+      screen.queryByText("Show percentage-point delta"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Show relative percentage change"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("passes profile presentation metadata through the factory to hide the key icon", () => {
+    const result = createDataGrid(run, { displayMode: "inline" })!;
+    const primaryKeyColumn = findColumn(result.columns, "column_name");
+
+    render(<>{primaryKeyColumn?.headerComponent?.()}</>);
+
+    expect(screen.queryByTestId("primary-key-icon")).not.toBeInTheDocument();
   });
 });
 

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/createDataGrid.profile.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/createDataGrid.profile.test.tsx
@@ -495,6 +495,25 @@ describe("createDataGrid - profile_diff explicit percentage mode eligibility", (
     expect(screen.queryByText("1,200%")).not.toBeInTheDocument();
   });
 
+  test("renders zero-to-zero percent_change through the actual factory cell", async () => {
+    const zeroRun = makeProfileDiffRun({
+      base: makeDataFrame([...columns], [["id", "integer", 0, 0.98]]),
+      current: makeDataFrame([...columns], [["id", "integer", 0, 0.94]]),
+    });
+    const result = createDataGrid(zeroRun, {
+      displayMode: "inline",
+      columnsRenderMode: { row_count: "percent_change" },
+    });
+
+    renderActualCellFor(result, "row_count");
+
+    expect(screen.getByText("0%")).toBeInTheDocument();
+    fireEvent.mouseOver(screen.getByText("0%"));
+    expect(await screen.findByText(/Base: 0/)).toBeInTheDocument();
+    expect(screen.getByText(/Current: 0/)).toBeInTheDocument();
+    expect(screen.getByText(/Change: 0/)).toBeInTheDocument();
+  });
+
   test.each([
     ["row_count", "percent_delta", "10", "12"],
     ["not_null_proportion", "percent_change", "0.98", "0.94"],

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/createDataGrid.profile.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/createDataGrid.profile.test.tsx
@@ -85,11 +85,16 @@ const LOWERCASE_COLUMNS = [
   { key: "data_type", name: "data_type", type: "text" },
   { key: "row_count", name: "row_count", type: "integer" },
   { key: "distinct_count", name: "distinct_count", type: "integer" },
+  {
+    key: "not_null_proportion",
+    name: "not_null_proportion",
+    type: "float",
+  },
 ] as const;
 
 const LOWERCASE_DATA: (string | number)[][] = [
-  ["customer_id", "integer", 500, 450],
-  ["name", "varchar", 500, 400],
+  ["customer_id", "integer", 500, 450, 0.9],
+  ["name", "varchar", 500, 400, 0.8],
 ];
 
 // ============================================================================
@@ -138,6 +143,26 @@ function findColumn(
   ) as ColDef<RowObjectType> | undefined;
 }
 
+function profileStatHeaderText(
+  column: ColDef<RowObjectType> | ColGroupDef<RowObjectType> | undefined,
+): string {
+  if (!column) {
+    throw new Error("Expected a profile stat column");
+  }
+
+  const Header =
+    (column as ColDef<RowObjectType>).headerComponent ??
+    (column as ColGroupDef<RowObjectType>).headerGroupComponent;
+  if (!Header) {
+    throw new Error("Expected a profile stat header component");
+  }
+
+  const { container, unmount } = render(<Header />);
+  const text = container.querySelector(".grid-header")?.textContent ?? "";
+  unmount();
+  return text;
+}
+
 // ============================================================================
 // 1. Profile (single env) with UPPERCASE keys
 // ============================================================================
@@ -177,6 +202,15 @@ describe("createDataGrid - profile (single env) with UPPERCASE keys", () => {
     // The row should have COLUMN_NAME accessible (original case or lowercase)
     const colNameValue = firstRow.COLUMN_NAME ?? firstRow.column_name;
     expect(colNameValue).toBe("CUSTOMER_ID");
+  });
+
+  test("humanizes profile statistic headers without changing raw fields", () => {
+    const result = createDataGrid(run, {})!;
+
+    expect(profileStatHeaderText(findColumn(result.columns, "row_count"))).toBe(
+      "Row Count",
+    );
+    expect(findColumn(result.columns, "row_count")?.field).toBe("ROW_COUNT");
   });
 });
 
@@ -246,6 +280,18 @@ describe("createDataGrid - profile_diff (inline) with UPPERCASE keys", () => {
     // Both base and current have the same 3 columns
     expect(result.rows.length).toBe(3);
   });
+
+  test("humanizes inline profile diff headers and retains the structural key", () => {
+    const result = createDataGrid(run, { displayMode: "inline" })!;
+    const primaryKeyColumn = findColumn(result.columns, "column_name");
+
+    expect(profileStatHeaderText(findColumn(result.columns, "row_count"))).toBe(
+      "Row Count",
+    );
+    expect(findColumn(result.columns, "row_count")?.field).toBe("ROW_COUNT");
+    expect(primaryKeyColumn?.field).toBe("COLUMN_NAME");
+    expect(primaryKeyColumn?.pinned).toBe("left");
+  });
 });
 
 // ============================================================================
@@ -314,6 +360,22 @@ describe("createDataGrid - profile_diff (side_by_side) with UPPERCASE keys", () 
       }
     }
   });
+
+  test("humanizes side-by-side profile diff group headers", () => {
+    const result = createDataGrid(run, { displayMode: "side_by_side" })!;
+    const rowCountGroup = result.columns.find(
+      (column) =>
+        "children" in column &&
+        column.headerName?.toLowerCase() === "row_count",
+    ) as ColGroupDef<RowObjectType> | undefined;
+
+    expect(profileStatHeaderText(rowCountGroup)).toBe("Row Count");
+    expect(
+      rowCountGroup?.children.map(
+        (child) => (child as ColDef<RowObjectType>).field,
+      ),
+    ).toEqual(["base__ROW_COUNT", "current__ROW_COUNT"]);
+  });
 });
 
 // ============================================================================
@@ -363,6 +425,18 @@ describe("createDataGrid - profile with lowercase keys (backwards compat)", () =
 
     render(<>{renderer(params)}</>);
     expect(screen.getByText("customer_id")).toBeInTheDocument();
+  });
+
+  test("humanizes lowercase profile statistic headers", () => {
+    const result = createDataGrid(run, {})!;
+
+    expect(profileStatHeaderText(findColumn(result.columns, "row_count"))).toBe(
+      "Row Count",
+    );
+    expect(findColumn(result.columns, "row_count")?.field).toBe("row_count");
+    expect(
+      profileStatHeaderText(findColumn(result.columns, "not_null_proportion")),
+    ).toBe("Not Null Proportion");
   });
 });
 

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/createDataGrid.profile.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/createDataGrid.profile.test.tsx
@@ -411,6 +411,18 @@ describe("createDataGrid - profile_diff explicit percentage mode eligibility", (
     fireEvent.click(screen.getByRole("button", { name: "Options" }));
   }
 
+  function renderActualCellFor(
+    result: ReturnType<typeof createDataGrid>,
+    field: string,
+  ) {
+    const column = findColumn(result!.columns, field)!;
+    const renderer = column.cellRenderer as (
+      params: ICellRendererParams<RowObjectType>,
+    ) => React.ReactNode;
+
+    render(<>{renderer(createRendererParams(result!.rows[0], column))}</>);
+  }
+
   test("offers percentage-point delta only for inline proportion fields", () => {
     const callback = vi.fn();
     const result = createDataGrid(run, {
@@ -450,6 +462,57 @@ describe("createDataGrid - profile_diff explicit percentage mode eligibility", (
     fireEvent.click(screen.getByText("Show relative percentage change"));
     expect(callback).toHaveBeenCalledWith({ row_count: "percent_change" });
   });
+
+  test("renders percent_delta through the actual modified Profile Diff row", () => {
+    const result = createDataGrid(run, {
+      displayMode: "inline",
+      columnsRenderMode: { not_null_proportion: "percent_delta" },
+    });
+
+    expect(result!.rows[0].__status).toBe("modified");
+    renderActualCellFor(result, "not_null_proportion");
+
+    expect(screen.getByText("94%")).toBeInTheDocument();
+    expect(screen.getByText("(-4pp)")).toHaveAttribute(
+      "data-direction",
+      "decrease",
+    );
+  });
+
+  test("renders percent_change with an ordinary current value through the factory", () => {
+    const result = createDataGrid(run, {
+      displayMode: "inline",
+      columnsRenderMode: { row_count: "percent_change" },
+    });
+
+    renderActualCellFor(result, "row_count");
+
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("(+20%)")).toHaveAttribute(
+      "data-direction",
+      "increase",
+    );
+    expect(screen.queryByText("1,200%")).not.toBeInTheDocument();
+  });
+
+  test.each([
+    ["row_count", "percent_delta", "10", "12"],
+    ["not_null_proportion", "percent_change", "0.98", "0.94"],
+  ] as const)(
+    "falls back for persisted %s on %s",
+    (field, mode, baseText, currentText) => {
+      const result = createDataGrid(run, {
+        displayMode: "inline",
+        columnsRenderMode: { [field]: mode },
+      });
+
+      renderActualCellFor(result, field);
+
+      expect(screen.getByText(baseText)).toBeInTheDocument();
+      expect(screen.getByText(currentText)).toBeInTheDocument();
+      expect(screen.queryByText(/pp\)|%\)/)).not.toBeInTheDocument();
+    },
+  );
 
   test("keeps the new modes out of side-by-side Profile Diff headers", () => {
     const result = createDataGrid(run, {
@@ -508,6 +571,79 @@ describe("createDataGrid - profile_diff explicit percentage mode eligibility", (
     render(<>{primaryKeyColumn?.headerComponent?.()}</>);
 
     expect(screen.queryByTestId("primary-key-icon")).not.toBeInTheDocument();
+  });
+});
+
+// ============================================================================
+// DRC-2866: generic grid factories never expose Profile Diff-only modes
+// ============================================================================
+
+describe("createDataGrid - generic percentage mode exclusion", () => {
+  const dataframe = makeDataFrame(
+    [
+      { key: "id", name: "id", type: "integer" },
+      { key: "value", name: "value", type: "number" },
+    ],
+    [[1, 10]],
+  );
+  const queryRun = {
+    type: "query",
+    run_id: "query-run",
+    run_at: "2026-01-01T00:00:00Z",
+    status: "Finished",
+    params: { sql_template: "select 1" },
+    result: dataframe,
+  } as Extract<Run, { type: "query" }>;
+  const queryDiffRun = {
+    type: "query_diff",
+    run_id: "query-diff-run",
+    run_at: "2026-01-01T00:00:00Z",
+    status: "Finished",
+    params: { sql_template: "select 1", primary_keys: ["id"] },
+    result: { base: dataframe, current: dataframe },
+  } as Extract<Run, { type: "query_diff" }>;
+  const valueDiffDetailDataframe = makeDataFrame(
+    [
+      { key: "id", name: "id", type: "integer" },
+      { key: "value", name: "value", type: "number" },
+      { key: "in_a", name: "in_a", type: "boolean" },
+      { key: "in_b", name: "in_b", type: "boolean" },
+    ],
+    [[1, 10, true, true]],
+  );
+  const valueDiffDetailRun = {
+    type: "value_diff_detail",
+    run_id: "value-diff-detail-run",
+    run_at: "2026-01-01T00:00:00Z",
+    status: "Finished",
+    params: { model: "model", primary_key: "id" },
+    result: valueDiffDetailDataframe,
+  } as Extract<Run, { type: "value_diff_detail" }>;
+
+  test.each([
+    ["Query", queryRun],
+    ["Query Diff", queryDiffRun],
+    ["Value Diff Detail", valueDiffDetailRun],
+  ] as const)("keeps Profile Diff-only modes out of %s", (_name, run) => {
+    const result = createDataGrid(run, {
+      displayMode: "inline",
+      onColumnsRenderModeChanged: vi.fn(),
+    })!;
+    const column = findColumn(result.columns, "value")!;
+    const Header = column.headerComponent;
+    if (!Header) {
+      throw new Error("Expected a numeric grid header");
+    }
+
+    render(<Header />);
+    fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+    expect(
+      screen.queryByText("Show percentage-point delta"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Show relative percentage change"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/createDataGrid.profile.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/createDataGrid.profile.test.tsx
@@ -414,13 +414,14 @@ describe("createDataGrid - profile_diff explicit percentage mode eligibility", (
   function renderActualCellFor(
     result: ReturnType<typeof createDataGrid>,
     field: string,
+    row: RowObjectType = result!.rows[0],
   ) {
     const column = findColumn(result!.columns, field)!;
     const renderer = column.cellRenderer as (
       params: ICellRendererParams<RowObjectType>,
     ) => React.ReactNode;
 
-    render(<>{renderer(createRendererParams(result!.rows[0], column))}</>);
+    render(<>{renderer(createRendererParams(row, column))}</>);
   }
 
   test("offers percentage-point delta only for inline proportion fields", () => {
@@ -479,6 +480,38 @@ describe("createDataGrid - profile_diff explicit percentage mode eligibility", (
     );
   });
 
+  test.each(["added", "removed"] as const)(
+    "renders an %s percent_delta row in the column's percentage unit",
+    (status) => {
+      const withExtraRow = makeDataFrame(
+        [...columns],
+        [
+          ["id", "integer", 10, 0.98],
+          ["email", "varchar", 12, 0.94],
+        ],
+      );
+      const withoutExtraRow = makeDataFrame(
+        [...columns],
+        [["id", "integer", 10, 0.98]],
+      );
+      const structuralRun = makeProfileDiffRun({
+        base: status === "added" ? withoutExtraRow : withExtraRow,
+        current: status === "added" ? withExtraRow : withoutExtraRow,
+      });
+      const result = createDataGrid(structuralRun, {
+        displayMode: "inline",
+        columnsRenderMode: { not_null_proportion: "percent_delta" },
+      });
+
+      const structuralRow = result!.rows.find((row) => row.__status === status);
+      expect(structuralRow).toBeDefined();
+      renderActualCellFor(result, "not_null_proportion", structuralRow);
+
+      expect(screen.getByText("94%")).toBeInTheDocument();
+      expect(screen.queryByText("0.94")).not.toBeInTheDocument();
+    },
+  );
+
   test("renders percent_change with an ordinary current value through the factory", () => {
     const result = createDataGrid(run, {
       displayMode: "inline",
@@ -507,11 +540,14 @@ describe("createDataGrid - profile_diff explicit percentage mode eligibility", (
 
     renderActualCellFor(result, "row_count");
 
+    expect(screen.getByText("0")).toBeInTheDocument();
     expect(screen.getByText("0%")).toBeInTheDocument();
+
+    // Exact text content, not a substring regex: a tooltip whose newlines are
+    // the two literal characters `\n` matches every substring regex too.
     fireEvent.mouseOver(screen.getByText("0%"));
-    expect(await screen.findByText(/Base: 0/)).toBeInTheDocument();
-    expect(screen.getByText(/Current: 0/)).toBeInTheDocument();
-    expect(screen.getByText(/Change: 0/)).toBeInTheDocument();
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toBe("Base: 0\nCurrent: 0\nChange: 0");
   });
 
   test.each([

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/inlineRenderCell.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/inlineRenderCell.test.tsx
@@ -29,7 +29,7 @@ import {
 interface RecceColumnContext {
   columnType?: string;
   columnRenderMode?: string | number;
-  enableProfileDiffPercentModes?: boolean;
+  profileDiffPercentMode?: "percent_delta" | "percent_change";
 }
 
 type ColDefWithMetadata = ColDef<RowObjectType> & {
@@ -264,13 +264,15 @@ describe("inlineRenderCell - DRC-2866 explicit percentage modes", () => {
   function renderExplicitMode(
     mode: "percent_delta" | "percent_change",
     data: Partial<RowObjectType>,
+    field = mode === "percent_delta" ? "proportion" : "row_count",
+    columnType = mode === "percent_delta" ? "float" : "integer",
   ) {
     const colDef: ColDefWithMetadata = {
-      field: "proportion",
+      field,
       context: {
-        columnType: "float",
+        columnType,
         columnRenderMode: mode,
-        enableProfileDiffPercentModes: true,
+        profileDiffPercentMode: mode,
       },
     };
 
@@ -296,14 +298,14 @@ describe("inlineRenderCell - DRC-2866 explicit percentage modes", () => {
   });
 
   test.each([
-    [0.5, 0.6, "60%", "(+20%)", "increase"],
-    [0.5, 0.4, "40%", "(-20%)", "decrease"],
+    [0.5, 0.6, "0.6", "(+20%)", "increase"],
+    [0.5, 0.4, "0.4", "(-20%)", "decrease"],
   ] as const)(
     "renders a %s to %s relative change as %s %s",
     (base, current, currentText, changeText, direction) => {
       renderExplicitMode("percent_change", {
-        base__proportion: base,
-        current__proportion: current,
+        base__row_count: base,
+        current__row_count: current,
       });
 
       expect(screen.getByText(currentText)).toBeInTheDocument();
@@ -316,11 +318,11 @@ describe("inlineRenderCell - DRC-2866 explicit percentage modes", () => {
 
   test("renders an unchanged zero relative value as a percentage", () => {
     renderExplicitMode("percent_change", {
-      base__proportion: 0,
-      current__proportion: 0,
+      base__row_count: 0,
+      current__row_count: 0,
     });
 
-    expect(screen.getByText("0%")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
     expect(screen.queryByText("N/A")).not.toBeInTheDocument();
   });
 
@@ -357,8 +359,8 @@ describe("inlineRenderCell - DRC-2866 explicit percentage modes", () => {
     [-0.1, -0.1],
   ])("renders %s to %s relative change as N/A", (base, current) => {
     renderExplicitMode("percent_change", {
-      base__proportion: base,
-      current__proportion: current,
+      base__row_count: base,
+      current__row_count: current,
     });
 
     expect(screen.getByText("N/A")).toHaveAttribute("data-direction", "equal");
@@ -375,8 +377,8 @@ describe("inlineRenderCell - DRC-2866 explicit percentage modes", () => {
     "keeps invalid %p to %p values in the existing inline presentation",
     (base, current) => {
       renderExplicitMode("percent_change", {
-        base__proportion: base,
-        current__proportion: current,
+        base__row_count: base,
+        current__row_count: current,
       });
 
       expect(screen.queryByText("N/A")).not.toBeInTheDocument();
@@ -389,12 +391,47 @@ describe("inlineRenderCell - DRC-2866 explicit percentage modes", () => {
     (status) => {
       renderExplicitMode("percent_change", {
         __status: status,
-        base__proportion: 0,
-        current__proportion: 0.94,
+        base__row_count: 0,
+        current__row_count: 0.94,
       });
 
       expect(screen.queryByText("N/A")).not.toBeInTheDocument();
       expect(document.querySelector("[data-comparison-role]")).not.toBeNull();
+    },
+  );
+
+  test("keeps the full computed percentage-point change in the tooltip", async () => {
+    renderExplicitMode("percent_delta", {
+      base__proportion: 0.9,
+      current__proportion: 0.941234,
+    });
+
+    expect(screen.getByText("(+4.12pp)")).toBeInTheDocument();
+    fireEvent.mouseOver(screen.getByText("94.12%"));
+    expect(
+      await screen.findByText(/Change: \+4\.123400000000004pp/),
+    ).toBeInTheDocument();
+  });
+
+  test.each([
+    ["percent_delta", "proportion", "float"],
+    ["percent_change", "row_count", "integer"],
+  ] as const)(
+    "falls back when %s arithmetic overflows",
+    (mode, field, columnType) => {
+      renderExplicitMode(
+        mode,
+        {
+          [`base__${field}`]: Number.MIN_VALUE,
+          [`current__${field}`]: Number.MAX_VALUE,
+        },
+        field,
+        columnType,
+      );
+
+      expect(document.querySelectorAll("[data-comparison-role]")).toHaveLength(
+        2,
+      );
     },
   );
 });

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/inlineRenderCell.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/inlineRenderCell.test.tsx
@@ -260,6 +260,19 @@ describe("inlineRenderCell - Delta Mode", () => {
 // DRC-2866: explicit percentage-point and relative-percent modes
 // ============================================================================
 
+/**
+ * Opens the tooltip anchored to `anchor` and returns its exact text content.
+ *
+ * Exact `textContent` rather than a substring regex: only an exact match tells
+ * a real three-line tooltip apart from a single line that contains the two
+ * literal characters `\n`.
+ */
+async function openTooltipText(anchor: HTMLElement): Promise<string> {
+  fireEvent.mouseOver(anchor);
+  const tooltip = await screen.findByRole("tooltip");
+  return tooltip.textContent ?? "";
+}
+
 describe("inlineRenderCell - DRC-2866 explicit percentage modes", () => {
   function renderExplicitMode(
     mode: "percent_delta" | "percent_change",
@@ -316,19 +329,19 @@ describe("inlineRenderCell - DRC-2866 explicit percentage modes", () => {
     },
   );
 
-  test("renders an unchanged zero relative value as an explicit percentage with a tooltip", async () => {
+  test("renders an unchanged zero relative value beside its own value with a tooltip", async () => {
     renderExplicitMode("percent_change", {
       base__row_count: 0,
       current__row_count: 0,
     });
 
+    expect(screen.getByText("0")).toBeInTheDocument();
     expect(screen.getByText("0%")).toBeInTheDocument();
     expect(screen.queryByText("N/A")).not.toBeInTheDocument();
 
-    fireEvent.mouseOver(screen.getByText("0%"));
-    expect(await screen.findByText(/Base: 0/)).toBeInTheDocument();
-    expect(screen.getByText(/Current: 0/)).toBeInTheDocument();
-    expect(screen.getByText(/Change: 0/)).toBeInTheDocument();
+    expect(await openTooltipText(screen.getByText("0%"))).toBe(
+      "Base: 0\nCurrent: 0\nChange: 0",
+    );
   });
 
   test.each([
@@ -359,17 +372,78 @@ describe("inlineRenderCell - DRC-2866 explicit percentage modes", () => {
   );
 
   test.each([
-    [0, 0.2],
-    [-0.1, 0.2],
-    [-0.1, -0.1],
-  ])("renders %s to %s relative change as N/A", (base, current) => {
+    [0, 0.2, ["0", "0.2"]],
+    [-0.1, 0.2, ["-0.1", "0.2"]],
+    [-0.1, -0.1, ["-0.1"]],
+  ] as const)(
+    "renders %s to %s relative change as N/A beside the cell values",
+    (base, current, visibleValues) => {
+      renderExplicitMode("percent_change", {
+        base__row_count: base,
+        current__row_count: current,
+      });
+
+      expect(screen.getByText("N/A")).toHaveAttribute(
+        "data-direction",
+        "equal",
+      );
+      for (const value of visibleValues) {
+        expect(screen.getByText(value)).toBeInTheDocument();
+      }
+    },
+  );
+
+  test("keeps the full-precision values in the undefined-change tooltip", async () => {
     renderExplicitMode("percent_change", {
-      base__row_count: base,
-      current__row_count: current,
+      base__row_count: 0,
+      current__row_count: 0.2,
     });
 
-    expect(screen.getByText("N/A")).toHaveAttribute("data-direction", "equal");
+    expect(await openTooltipText(screen.getByText("N/A"))).toBe(
+      "Base: 0\nCurrent: 0.2\nChange: N/A",
+    );
   });
+
+  test.each(["added", "removed"] as const)(
+    "renders a %s percent_delta row in the column's percentage unit",
+    (status) => {
+      renderExplicitMode("percent_delta", {
+        __status: status,
+        current__proportion: 0.94,
+      });
+
+      expect(screen.getByText("94%")).toBeInTheDocument();
+      expect(screen.queryByText("0.94")).not.toBeInTheDocument();
+    },
+  );
+
+  test.each(["added", "removed"] as const)(
+    "renders a %s percent_delta row with a placeholder base in the column's percentage unit",
+    (status) => {
+      renderExplicitMode("percent_delta", {
+        __status: status,
+        base__proportion: null,
+        current__proportion: 0.94,
+      });
+
+      expect(screen.getByText("-")).toBeInTheDocument();
+      expect(screen.getByText("94%")).toBeInTheDocument();
+      expect(screen.queryByText("0.94")).not.toBeInTheDocument();
+    },
+  );
+
+  test.each(["added", "removed"] as const)(
+    "renders a %s percent_change row without converting its value to a percentage",
+    (status) => {
+      renderExplicitMode("percent_change", {
+        __status: status,
+        current__row_count: 12,
+      });
+
+      expect(screen.getByText("12")).toBeInTheDocument();
+      expect(screen.queryByText("1,200%")).not.toBeInTheDocument();
+    },
+  );
 
   test.each([
     [null, 0.94],

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/inlineRenderCell.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/inlineRenderCell.test.tsx
@@ -316,14 +316,19 @@ describe("inlineRenderCell - DRC-2866 explicit percentage modes", () => {
     },
   );
 
-  test("renders an unchanged zero relative value as a percentage", () => {
+  test("renders an unchanged zero relative value as an explicit percentage with a tooltip", async () => {
     renderExplicitMode("percent_change", {
       base__row_count: 0,
       current__row_count: 0,
     });
 
-    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("0%")).toBeInTheDocument();
     expect(screen.queryByText("N/A")).not.toBeInTheDocument();
+
+    fireEvent.mouseOver(screen.getByText("0%"));
+    expect(await screen.findByText(/Base: 0/)).toBeInTheDocument();
+    expect(screen.getByText(/Current: 0/)).toBeInTheDocument();
+    expect(screen.getByText(/Change: 0/)).toBeInTheDocument();
   });
 
   test.each([

--- a/js/packages/ui/src/components/ui/dataGrid/__tests__/inlineRenderCell.test.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/__tests__/inlineRenderCell.test.tsx
@@ -10,7 +10,7 @@
  * - asNumber utility function
  */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ColDef, ICellRendererParams } from "ag-grid-community";
 import React from "react";
 import { vi } from "vitest";
@@ -19,6 +19,7 @@ import {
   asNumber,
   createInlineRenderCell,
   inlineRenderCell,
+  parseFiniteNumeric,
 } from "../inlineRenderCell";
 
 // ============================================================================
@@ -28,6 +29,7 @@ import {
 interface RecceColumnContext {
   columnType?: string;
   columnRenderMode?: string | number;
+  enableProfileDiffPercentModes?: boolean;
 }
 
 type ColDefWithMetadata = ColDef<RowObjectType> & {
@@ -92,6 +94,29 @@ describe("asNumber", () => {
   test("handles NaN input", () => {
     expect(asNumber(NaN)).toBe(NaN);
     expect(Number.isNaN(asNumber(NaN))).toBe(true);
+  });
+});
+
+// ============================================================================
+// DRC-2866: strict numeric parsing for explicit percentage modes
+// ============================================================================
+
+describe("parseFiniteNumeric", () => {
+  test.each([
+    [12.5, 12.5],
+    ["12.5", 12.5],
+    [" 12.5 ", 12.5],
+    ["12px", undefined],
+    ["", undefined],
+    ["   ", undefined],
+    [true, undefined],
+    [null, undefined],
+    [undefined, undefined],
+    [Number.NaN, undefined],
+    [Number.POSITIVE_INFINITY, undefined],
+    ["Infinity", undefined],
+  ])("parses %p as %p without partial coercion", (value, expected) => {
+    expect(parseFiniteNumeric(value)).toBe(expected);
   });
 });
 
@@ -229,6 +254,149 @@ describe("inlineRenderCell - Delta Mode", () => {
     expect(screen.getByText("100")).toBeInTheDocument();
     expect(screen.getByText("(+100)")).toBeInTheDocument();
   });
+});
+
+// ============================================================================
+// DRC-2866: explicit percentage-point and relative-percent modes
+// ============================================================================
+
+describe("inlineRenderCell - DRC-2866 explicit percentage modes", () => {
+  function renderExplicitMode(
+    mode: "percent_delta" | "percent_change",
+    data: Partial<RowObjectType>,
+  ) {
+    const colDef: ColDefWithMetadata = {
+      field: "proportion",
+      context: {
+        columnType: "float",
+        columnRenderMode: mode,
+        enableProfileDiffPercentModes: true,
+      },
+    };
+
+    render(<>{inlineRenderCell(createParams(data, colDef))}</>);
+  }
+
+  test("renders a percentage-point decrease with unrounded tooltip values", async () => {
+    renderExplicitMode("percent_delta", {
+      base__proportion: 0.98,
+      current__proportion: 0.94,
+    });
+
+    expect(screen.getByText("94%")).toBeInTheDocument();
+    expect(screen.getByText("(-4pp)")).toHaveAttribute(
+      "data-direction",
+      "decrease",
+    );
+
+    fireEvent.mouseOver(screen.getByText("94%"));
+    expect(await screen.findByText(/Base: 0\.98/)).toBeInTheDocument();
+    expect(screen.getByText(/Current: 0\.94/)).toBeInTheDocument();
+    expect(screen.getByText(/Change: -4pp/)).toBeInTheDocument();
+  });
+
+  test.each([
+    [0.5, 0.6, "60%", "(+20%)", "increase"],
+    [0.5, 0.4, "40%", "(-20%)", "decrease"],
+  ] as const)(
+    "renders a %s to %s relative change as %s %s",
+    (base, current, currentText, changeText, direction) => {
+      renderExplicitMode("percent_change", {
+        base__proportion: base,
+        current__proportion: current,
+      });
+
+      expect(screen.getByText(currentText)).toBeInTheDocument();
+      expect(screen.getByText(changeText)).toHaveAttribute(
+        "data-direction",
+        direction,
+      );
+    },
+  );
+
+  test("renders an unchanged zero relative value as a percentage", () => {
+    renderExplicitMode("percent_change", {
+      base__proportion: 0,
+      current__proportion: 0,
+    });
+
+    expect(screen.getByText("0%")).toBeInTheDocument();
+    expect(screen.queryByText("N/A")).not.toBeInTheDocument();
+  });
+
+  test.each([
+    ["raw", "0.98", "0.94"],
+    ["percent", "98%", "94%"],
+    [2, "0.98", "0.94"],
+  ] as const)(
+    "keeps the legacy %p mode rendering unchanged",
+    (mode, baseText, currentText) => {
+      const colDef: ColDefWithMetadata = {
+        field: "proportion",
+        context: { columnType: "float", columnRenderMode: mode },
+      };
+      render(
+        <>
+          {inlineRenderCell(
+            createParams(
+              { base__proportion: 0.98, current__proportion: 0.94 },
+              colDef,
+            ),
+          )}
+        </>,
+      );
+
+      expect(screen.getByText(baseText)).toBeInTheDocument();
+      expect(screen.getByText(currentText)).toBeInTheDocument();
+    },
+  );
+
+  test.each([
+    [0, 0.2],
+    [-0.1, 0.2],
+    [-0.1, -0.1],
+  ])("renders %s to %s relative change as N/A", (base, current) => {
+    renderExplicitMode("percent_change", {
+      base__proportion: base,
+      current__proportion: current,
+    });
+
+    expect(screen.getByText("N/A")).toHaveAttribute("data-direction", "equal");
+  });
+
+  test.each([
+    [null, 0.94],
+    [true, 0.94],
+    ["", 0.94],
+    ["12px", 0.94],
+    [Number.NaN, 0.94],
+    [Number.POSITIVE_INFINITY, 0.94],
+  ])(
+    "keeps invalid %p to %p values in the existing inline presentation",
+    (base, current) => {
+      renderExplicitMode("percent_change", {
+        base__proportion: base,
+        current__proportion: current,
+      });
+
+      expect(screen.queryByText("N/A")).not.toBeInTheDocument();
+      expect(document.querySelector("[data-comparison-role]")).not.toBeNull();
+    },
+  );
+
+  test.each(["added", "removed"] as const)(
+    "keeps %s rows in the existing inline structural presentation",
+    (status) => {
+      renderExplicitMode("percent_change", {
+        __status: status,
+        base__proportion: 0,
+        current__proportion: 0.94,
+      });
+
+      expect(screen.queryByText("N/A")).not.toBeInTheDocument();
+      expect(document.querySelector("[data-comparison-role]")).not.toBeNull();
+    },
+  );
 });
 
 // ============================================================================

--- a/js/packages/ui/src/components/ui/dataGrid/dataGridFactory.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/dataGridFactory.tsx
@@ -412,8 +412,24 @@ export function humanizeProfileStatLabel(name: string): string {
     .join(" ");
 }
 
+const profileDiffLegacyRenderModes: readonly ColumnRenderMode[] = [
+  "raw",
+  2,
+  "percent",
+  "delta",
+];
+
+function isNumericProfileColumn(column: DataFrame["columns"][number]): boolean {
+  return (
+    column.type === "number" ||
+    column.type === "float" ||
+    column.type === "integer"
+  );
+}
+
 function getProfileHeaderPresentation(
   result: ProfileDiffResult,
+  displayMode?: DiffGridOptions["displayMode"],
 ): Record<string, HeaderPresentation> {
   const columns = [
     ...(result.base?.columns ?? []),
@@ -426,9 +442,51 @@ function getProfileHeaderPresentation(
       {
         displayName: humanizeProfileStatLabel(column.key),
         hidePrimaryKeyIcon: column.key.toLowerCase() === "column_name",
+        allowedRenderModes:
+          displayMode === "inline" && isNumericProfileColumn(column)
+            ? [
+                ...profileDiffLegacyRenderModes,
+                ["distinct_proportion", "not_null_proportion"].includes(
+                  column.key.toLowerCase(),
+                )
+                  ? "percent_delta"
+                  : "percent_change",
+              ]
+            : undefined,
       },
     ]),
   );
+}
+
+function enableProfileDiffPercentModes(result: DataGridResult): DataGridResult {
+  const columns = result.columns.map((column) => {
+    if ("children" in column && column.children) {
+      return column;
+    }
+
+    const colDef = column as ColDef<RowObjectType>;
+    const columnType = (
+      colDef.context as { columnType?: ColumnType } | undefined
+    )?.columnType;
+    const isNumeric =
+      columnType === "number" ||
+      columnType === "float" ||
+      columnType === "integer";
+
+    if (!isNumeric) {
+      return column;
+    }
+
+    return {
+      ...colDef,
+      context: {
+        ...colDef.context,
+        enableProfileDiffPercentModes: true,
+      },
+    };
+  });
+
+  return { ...result, columns };
 }
 
 // ============================================================================
@@ -540,10 +598,15 @@ export function createDataGrid(
           displayMode: options.displayMode,
           columnsRenderMode: options.columnsRenderMode,
           onColumnsRenderModeChanged: options.onColumnsRenderModeChanged,
-          headerPresentation: getProfileHeaderPresentation(dataKind.result),
+          headerPresentation: getProfileHeaderPresentation(
+            dataKind.result,
+            options.displayMode ?? "inline",
+          ),
         },
       );
-      return injectProfileColumnNameRenderer(profileDiffResult);
+      return enableProfileDiffPercentModes(
+        injectProfileColumnNameRenderer(profileDiffResult),
+      );
     }
 
     case "row_count":

--- a/js/packages/ui/src/components/ui/dataGrid/dataGridFactory.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/dataGridFactory.tsx
@@ -56,6 +56,7 @@ import {
   toRowCountDiffDataGrid,
   toValueDiffGridConfigured as toValueDiffGrid,
 } from "../../../utils/dataGrid";
+import type { HeaderPresentation } from "../../../utils/dataGrid/renderTypes";
 import { hasOwn } from "../../../utils/hasOwn";
 import { getCaseInsensitive } from "../../../utils/transforms";
 import {
@@ -400,6 +401,36 @@ function getProfilePrimaryKey(result: ProfileDiffResult): string {
   return field?.name ?? "column_name";
 }
 
+export function humanizeProfileStatLabel(name: string): string {
+  return name
+    .trim()
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map(
+      (part) => `${part.charAt(0).toUpperCase()}${part.slice(1).toLowerCase()}`,
+    )
+    .join(" ");
+}
+
+function getProfileHeaderPresentation(
+  result: ProfileDiffResult,
+): Record<string, HeaderPresentation> {
+  const columns = [
+    ...(result.base?.columns ?? []),
+    ...(result.current?.columns ?? []),
+  ];
+
+  return Object.fromEntries(
+    columns.map((column) => [
+      column.key,
+      {
+        displayName: humanizeProfileStatLabel(column.key),
+        hidePrimaryKeyIcon: column.key.toLowerCase() === "column_name",
+      },
+    ]),
+  );
+}
+
 // ============================================================================
 // Factory Function
 // ============================================================================
@@ -492,6 +523,7 @@ export function createDataGrid(
         onPinnedColumnsChange: options.onPinnedColumnsChange,
         columnsRenderMode: options.columnsRenderMode,
         onColumnsRenderModeChanged: options.onColumnsRenderModeChanged,
+        headerPresentation: getProfileHeaderPresentation(dataKind.result),
       });
       return injectProfileColumnNameRenderer(profileResult);
     }
@@ -508,6 +540,7 @@ export function createDataGrid(
           displayMode: options.displayMode,
           columnsRenderMode: options.columnsRenderMode,
           onColumnsRenderModeChanged: options.onColumnsRenderModeChanged,
+          headerPresentation: getProfileHeaderPresentation(dataKind.result),
         },
       );
       return injectProfileColumnNameRenderer(profileDiffResult);

--- a/js/packages/ui/src/components/ui/dataGrid/dataGridFactory.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/dataGridFactory.tsx
@@ -427,6 +427,16 @@ function isNumericProfileColumn(column: DataFrame["columns"][number]): boolean {
   );
 }
 
+function profileDiffPercentMode(
+  field: string,
+): "percent_delta" | "percent_change" {
+  return ["distinct_proportion", "not_null_proportion"].includes(
+    field.toLowerCase(),
+  )
+    ? "percent_delta"
+    : "percent_change";
+}
+
 function getProfileHeaderPresentation(
   result: ProfileDiffResult,
   displayMode?: DiffGridOptions["displayMode"],
@@ -446,11 +456,7 @@ function getProfileHeaderPresentation(
           displayMode === "inline" && isNumericProfileColumn(column)
             ? [
                 ...profileDiffLegacyRenderModes,
-                ["distinct_proportion", "not_null_proportion"].includes(
-                  column.key.toLowerCase(),
-                )
-                  ? "percent_delta"
-                  : "percent_change",
+                profileDiffPercentMode(column.key),
               ]
             : undefined,
       },
@@ -481,7 +487,7 @@ function enableProfileDiffPercentModes(result: DataGridResult): DataGridResult {
       ...colDef,
       context: {
         ...colDef.context,
-        enableProfileDiffPercentModes: true,
+        profileDiffPercentMode: profileDiffPercentMode(colDef.field ?? ""),
       },
     };
   });

--- a/js/packages/ui/src/components/ui/dataGrid/inlineRenderCell.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/inlineRenderCell.tsx
@@ -34,6 +34,7 @@ interface RecceColumnContext {
   columnType?: ColumnType;
   columnRenderMode?: ColumnRenderMode;
   showStructuralIndicator?: boolean;
+  enableProfileDiffPercentModes?: boolean;
 }
 
 /**
@@ -61,6 +62,48 @@ export interface InlineRenderCellConfig {
    * (e.g., toast notifications on copy).
    */
   DiffTextComponent?: ComponentType<InlineDiffTextProps>;
+}
+
+/** Parses only finite numbers and complete numeric strings for explicit modes. */
+export function parseFiniteNumeric(value: RowDataTypes): number | undefined {
+  if (typeof value === "number")
+    return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== "string" || value.trim() === "") return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function formatPercent(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatSignedChange(value: number, suffix: string): string {
+  return `${value >= 0 ? "+" : ""}${formatSmartDecimal(value)}${suffix}`;
+}
+
+function renderUndefinedRelativeChange(base: number, current: number) {
+  const tooltipText = `Base: ${base}\nCurrent: ${current}\nChange: N/A`;
+
+  return (
+    <Tooltip
+      title={tooltipText}
+      slotProps={{
+        tooltip: { sx: { whiteSpace: "pre-line" } },
+      }}
+      enterDelay={300}
+      placement="top"
+    >
+      <Typography
+        data-direction="equal"
+        sx={{ color: "text.secondary", fontSize: "0.75rem" }}
+      >
+        N/A
+      </Typography>
+    </Tooltip>
+  );
 }
 
 /**
@@ -91,6 +134,8 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
     const colDef = params.colDef as ColDefWithMetadata;
     const columnType = colDef?.context?.columnType;
     const columnRenderMode = colDef?.context?.columnRenderMode;
+    const enableProfileDiffPercentModes =
+      colDef?.context?.enableProfileDiffPercentModes === true;
     const columnKey = colDef?.field ?? "";
 
     if (!params.data) {
@@ -123,6 +168,13 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
       columnRenderMode,
     );
 
+    const isExplicitPercentMode =
+      enableProfileDiffPercentModes &&
+      (columnRenderMode === "percent_delta" ||
+        columnRenderMode === "percent_change");
+    const baseNumericValue = parseFiniteNumeric(row[baseKey]);
+    const currentNumericValue = parseFiniteNumeric(row[currentKey]);
+
     // No change - render single value.
     // Must use the same type-dispatched comparison the row status and the
     // side-by-side cell classes use: a raw `===` here would render a
@@ -132,12 +184,27 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
     // query-diff views, so that mismatch was the whole reported symptom of
     // DRC-3025.
     if (!isCellChanged(row[baseKey], row[currentKey], columnType)) {
+      if (
+        isExplicitPercentMode &&
+        columnRenderMode === "percent_change" &&
+        baseNumericValue !== undefined &&
+        currentNumericValue !== undefined &&
+        baseNumericValue < 0
+      ) {
+        return renderUndefinedRelativeChange(
+          baseNumericValue,
+          currentNumericValue,
+        );
+      }
+
       return (
         <Typography
           component="span"
           style={{ color: currentGrayOut ? "gray" : "inherit" }}
         >
-          {currentValue}
+          {isExplicitPercentMode && currentNumericValue !== undefined
+            ? formatPercent(currentNumericValue)
+            : currentValue}
         </Typography>
       );
     }
@@ -210,6 +277,73 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
                 }}
               >
                 <span aria-hidden="true">{symbol}</span> {deltaText}
+              </Typography>
+            </Box>
+          </Tooltip>
+        );
+      }
+    }
+
+    if (
+      isExplicitPercentMode &&
+      (columnType === "number" ||
+        columnType === "float" ||
+        columnType === "integer") &&
+      hasBase &&
+      hasCurrent &&
+      row.__status === undefined
+    ) {
+      const baseNum = parseFiniteNumeric(row[baseKey]);
+      const currentNum = parseFiniteNumeric(row[currentKey]);
+
+      if (baseNum !== undefined && currentNum !== undefined) {
+        const isRelativeChange = columnRenderMode === "percent_change";
+        const relativeChangeIsUndefined = isRelativeChange && baseNum <= 0;
+
+        if (relativeChangeIsUndefined) {
+          return renderUndefinedRelativeChange(baseNum, currentNum);
+        }
+
+        const change = isRelativeChange
+          ? ((currentNum - baseNum) / baseNum) * 100
+          : currentNum * 100 - baseNum * 100;
+        const direction =
+          change > 0 ? "increase" : change < 0 ? "decrease" : "equal";
+        const suffix = isRelativeChange ? "%" : "pp";
+        const changeText = `(${formatSignedChange(change, suffix)})`;
+        const tooltipText = `Base: ${baseNum}\nCurrent: ${currentNum}\nChange: ${formatSignedChange(
+          change,
+          suffix,
+        )}`;
+
+        return (
+          <Tooltip
+            title={tooltipText}
+            slotProps={{
+              tooltip: { sx: { whiteSpace: "pre-line" } },
+            }}
+            enterDelay={300}
+            placement="top"
+          >
+            <Box
+              sx={{
+                gap: "5px",
+                display: "flex",
+                alignItems: "center",
+                lineHeight: "normal",
+                height: "100%",
+              }}
+            >
+              <DiffTextComp
+                value={formatPercent(currentNum)}
+                comparisonRole="current"
+                grayOut={currentGrayOut}
+              />
+              <Typography
+                data-direction={direction}
+                sx={{ color: "text.secondary", fontSize: "0.75rem" }}
+              >
+                {changeText}
               </Typography>
             </Box>
           </Tooltip>

--- a/js/packages/ui/src/components/ui/dataGrid/inlineRenderCell.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/inlineRenderCell.tsx
@@ -34,7 +34,7 @@ interface RecceColumnContext {
   columnType?: ColumnType;
   columnRenderMode?: ColumnRenderMode;
   showStructuralIndicator?: boolean;
-  enableProfileDiffPercentModes?: boolean;
+  profileDiffPercentMode?: "percent_delta" | "percent_change";
 }
 
 /**
@@ -84,6 +84,10 @@ function formatSignedChange(value: number, suffix: string): string {
   return `${value >= 0 ? "+" : ""}${formatSmartDecimal(value)}${suffix}`;
 }
 
+function formatUnroundedChange(value: number, suffix: string): string {
+  return `${value >= 0 ? "+" : ""}${value}${suffix}`;
+}
+
 function renderUndefinedRelativeChange(base: number, current: number) {
   const tooltipText = `Base: ${base}\nCurrent: ${current}\nChange: N/A`;
 
@@ -103,6 +107,43 @@ function renderUndefinedRelativeChange(base: number, current: number) {
         N/A
       </Typography>
     </Tooltip>
+  );
+}
+
+function renderInlineValues(
+  DiffTextComp: ComponentType<InlineDiffTextProps>,
+  hasBase: boolean,
+  hasCurrent: boolean,
+  baseValue: string,
+  currentValue: string,
+  baseGrayOut: boolean,
+  currentGrayOut: boolean,
+) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        gap: "5px",
+        alignItems: "center",
+        lineHeight: "normal",
+        height: "100%",
+      }}
+    >
+      {hasBase && (
+        <DiffTextComp
+          value={baseValue}
+          comparisonRole="base"
+          grayOut={baseGrayOut}
+        />
+      )}
+      {hasCurrent && (
+        <DiffTextComp
+          value={currentValue}
+          comparisonRole="current"
+          grayOut={currentGrayOut}
+        />
+      )}
+    </Box>
   );
 }
 
@@ -134,8 +175,7 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
     const colDef = params.colDef as ColDefWithMetadata;
     const columnType = colDef?.context?.columnType;
     const columnRenderMode = colDef?.context?.columnRenderMode;
-    const enableProfileDiffPercentModes =
-      colDef?.context?.enableProfileDiffPercentModes === true;
+    const profileDiffPercentMode = colDef?.context?.profileDiffPercentMode;
     const columnKey = colDef?.field ?? "";
 
     if (!params.data) {
@@ -169,9 +209,9 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
     );
 
     const isExplicitPercentMode =
-      enableProfileDiffPercentModes &&
       (columnRenderMode === "percent_delta" ||
-        columnRenderMode === "percent_change");
+        columnRenderMode === "percent_change") &&
+      columnRenderMode === profileDiffPercentMode;
     const baseNumericValue = parseFiniteNumeric(row[baseKey]);
     const currentNumericValue = parseFiniteNumeric(row[currentKey]);
 
@@ -187,6 +227,8 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
       if (
         isExplicitPercentMode &&
         columnRenderMode === "percent_change" &&
+        row.__status !== "added" &&
+        row.__status !== "removed" &&
         baseNumericValue !== undefined &&
         currentNumericValue !== undefined &&
         baseNumericValue < 0
@@ -203,7 +245,9 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
           style={{ color: currentGrayOut ? "gray" : "inherit" }}
         >
           {isExplicitPercentMode && currentNumericValue !== undefined
-            ? formatPercent(currentNumericValue)
+            ? columnRenderMode === "percent_delta"
+              ? formatPercent(currentNumericValue)
+              : currentValue
             : currentValue}
         </Typography>
       );
@@ -291,7 +335,8 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
         columnType === "integer") &&
       hasBase &&
       hasCurrent &&
-      row.__status === undefined
+      row.__status !== "added" &&
+      row.__status !== "removed"
     ) {
       const baseNum = parseFiniteNumeric(row[baseKey]);
       const currentNum = parseFiniteNumeric(row[currentKey]);
@@ -307,11 +352,24 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
         const change = isRelativeChange
           ? ((currentNum - baseNum) / baseNum) * 100
           : currentNum * 100 - baseNum * 100;
+
+        if (!Number.isFinite(change)) {
+          return renderInlineValues(
+            DiffTextComp,
+            hasBase,
+            hasCurrent,
+            baseValue,
+            currentValue,
+            baseGrayOut,
+            currentGrayOut,
+          );
+        }
+
         const direction =
           change > 0 ? "increase" : change < 0 ? "decrease" : "equal";
         const suffix = isRelativeChange ? "%" : "pp";
         const changeText = `(${formatSignedChange(change, suffix)})`;
-        const tooltipText = `Base: ${baseNum}\nCurrent: ${currentNum}\nChange: ${formatSignedChange(
+        const tooltipText = `Base: ${baseNum}\nCurrent: ${currentNum}\nChange: ${formatUnroundedChange(
           change,
           suffix,
         )}`;
@@ -335,7 +393,11 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
               }}
             >
               <DiffTextComp
-                value={formatPercent(currentNum)}
+                value={
+                  columnRenderMode === "percent_delta"
+                    ? formatPercent(currentNum)
+                    : currentValue
+                }
                 comparisonRole="current"
                 grayOut={currentGrayOut}
               />
@@ -352,31 +414,14 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
     }
 
     // Values differ - render inline diff with base (red) and current (green)
-    return (
-      <Box
-        sx={{
-          display: "flex",
-          gap: "5px",
-          alignItems: "center",
-          lineHeight: "normal",
-          height: "100%",
-        }}
-      >
-        {hasBase && (
-          <DiffTextComp
-            value={baseValue}
-            comparisonRole="base"
-            grayOut={baseGrayOut}
-          />
-        )}
-        {hasCurrent && (
-          <DiffTextComp
-            value={currentValue}
-            comparisonRole="current"
-            grayOut={currentGrayOut}
-          />
-        )}
-      </Box>
+    return renderInlineValues(
+      DiffTextComp,
+      hasBase,
+      hasCurrent,
+      baseValue,
+      currentValue,
+      baseGrayOut,
+      currentGrayOut,
     );
   };
 }

--- a/js/packages/ui/src/components/ui/dataGrid/inlineRenderCell.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/inlineRenderCell.tsx
@@ -110,6 +110,26 @@ function renderUndefinedRelativeChange(base: number, current: number) {
   );
 }
 
+function renderZeroRelativeChange() {
+  return (
+    <Tooltip
+      title="Base: 0\nCurrent: 0\nChange: 0"
+      slotProps={{
+        tooltip: { sx: { whiteSpace: "pre-line" } },
+      }}
+      enterDelay={300}
+      placement="top"
+    >
+      <Typography
+        data-direction="equal"
+        sx={{ color: "text.secondary", fontSize: "0.75rem" }}
+      >
+        0%
+      </Typography>
+    </Tooltip>
+  );
+}
+
 function renderInlineValues(
   DiffTextComp: ComponentType<InlineDiffTextProps>,
   hasBase: boolean,
@@ -224,6 +244,17 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
     // query-diff views, so that mismatch was the whole reported symptom of
     // DRC-3025.
     if (!isCellChanged(row[baseKey], row[currentKey], columnType)) {
+      if (
+        isExplicitPercentMode &&
+        columnRenderMode === "percent_change" &&
+        row.__status !== "added" &&
+        row.__status !== "removed" &&
+        baseNumericValue === 0 &&
+        currentNumericValue === 0
+      ) {
+        return renderZeroRelativeChange();
+      }
+
       if (
         isExplicitPercentMode &&
         columnRenderMode === "percent_change" &&

--- a/js/packages/ui/src/components/ui/dataGrid/inlineRenderCell.tsx
+++ b/js/packages/ui/src/components/ui/dataGrid/inlineRenderCell.tsx
@@ -10,7 +10,7 @@ import Box from "@mui/material/Box";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import type { ColDef, ICellRendererParams } from "ag-grid-community";
-import type { ComponentType } from "react";
+import type { ComponentType, ReactNode } from "react";
 import type {
   ColumnRenderMode,
   ColumnType,
@@ -88,9 +88,18 @@ function formatUnroundedChange(value: number, suffix: string): string {
   return `${value >= 0 ? "+" : ""}${value}${suffix}`;
 }
 
-function renderUndefinedRelativeChange(base: number, current: number) {
-  const tooltipText = `Base: ${base}\nCurrent: ${current}\nChange: N/A`;
-
+/**
+ * Renders a change indicator beside the cell's own values.
+ *
+ * The indicator never replaces the values: a row whose relative change cannot
+ * be expressed (`N/A`) or is exactly zero (`0%`) is still a row whose base and
+ * current numbers are the point of the cell.
+ */
+function renderChangeIndicator(
+  tooltipText: string,
+  changeText: string,
+  values: ReactNode,
+) {
   return (
     <Tooltip
       title={tooltipText}
@@ -100,34 +109,41 @@ function renderUndefinedRelativeChange(base: number, current: number) {
       enterDelay={300}
       placement="top"
     >
-      <Typography
-        data-direction="equal"
-        sx={{ color: "text.secondary", fontSize: "0.75rem" }}
+      <Box
+        sx={{
+          gap: "5px",
+          display: "flex",
+          alignItems: "center",
+          lineHeight: "normal",
+          height: "100%",
+        }}
       >
-        N/A
-      </Typography>
+        {values}
+        <Typography
+          data-direction="equal"
+          sx={{ color: "text.secondary", fontSize: "0.75rem" }}
+        >
+          {changeText}
+        </Typography>
+      </Box>
     </Tooltip>
   );
 }
 
-function renderZeroRelativeChange() {
-  return (
-    <Tooltip
-      title="Base: 0\nCurrent: 0\nChange: 0"
-      slotProps={{
-        tooltip: { sx: { whiteSpace: "pre-line" } },
-      }}
-      enterDelay={300}
-      placement="top"
-    >
-      <Typography
-        data-direction="equal"
-        sx={{ color: "text.secondary", fontSize: "0.75rem" }}
-      >
-        0%
-      </Typography>
-    </Tooltip>
+function renderUndefinedRelativeChange(
+  base: number,
+  current: number,
+  values: ReactNode,
+) {
+  return renderChangeIndicator(
+    `Base: ${base}\nCurrent: ${current}\nChange: N/A`,
+    "N/A",
+    values,
   );
+}
+
+function renderZeroRelativeChange(values: ReactNode) {
+  return renderChangeIndicator("Base: 0\nCurrent: 0\nChange: 0", "0%", values);
 }
 
 function renderInlineValues(
@@ -235,6 +251,20 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
     const baseNumericValue = parseFiniteNumeric(row[baseKey]);
     const currentNumericValue = parseFiniteNumeric(row[currentKey]);
 
+    // A percent_delta column holds proportions, so the unit has to be the same
+    // for every row status. Without this, an added or removed row skips the
+    // percentage block below and renders 0.94 in a column of 94% values.
+    const isExplicitPercentDeltaMode =
+      isExplicitPercentMode && columnRenderMode === "percent_delta";
+    const displayBaseValue =
+      isExplicitPercentDeltaMode && baseNumericValue !== undefined
+        ? formatPercent(baseNumericValue)
+        : baseValue;
+    const displayCurrentValue =
+      isExplicitPercentDeltaMode && currentNumericValue !== undefined
+        ? formatPercent(currentNumericValue)
+        : currentValue;
+
     // No change - render single value.
     // Must use the same type-dispatched comparison the row status and the
     // side-by-side cell classes use: a raw `===` here would render a
@@ -244,6 +274,15 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
     // query-diff views, so that mismatch was the whole reported symptom of
     // DRC-3025.
     if (!isCellChanged(row[baseKey], row[currentKey], columnType)) {
+      const unchangedValue = (
+        <Typography
+          component="span"
+          style={{ color: currentGrayOut ? "gray" : "inherit" }}
+        >
+          {displayCurrentValue}
+        </Typography>
+      );
+
       if (
         isExplicitPercentMode &&
         columnRenderMode === "percent_change" &&
@@ -252,7 +291,7 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
         baseNumericValue === 0 &&
         currentNumericValue === 0
       ) {
-        return renderZeroRelativeChange();
+        return renderZeroRelativeChange(unchangedValue);
       }
 
       if (
@@ -267,21 +306,11 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
         return renderUndefinedRelativeChange(
           baseNumericValue,
           currentNumericValue,
+          unchangedValue,
         );
       }
 
-      return (
-        <Typography
-          component="span"
-          style={{ color: currentGrayOut ? "gray" : "inherit" }}
-        >
-          {isExplicitPercentMode && currentNumericValue !== undefined
-            ? columnRenderMode === "percent_delta"
-              ? formatPercent(currentNumericValue)
-              : currentValue
-            : currentValue}
-        </Typography>
-      );
+      return unchangedValue;
     }
 
     // Check if we're using delta display mode
@@ -377,7 +406,19 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
         const relativeChangeIsUndefined = isRelativeChange && baseNum <= 0;
 
         if (relativeChangeIsUndefined) {
-          return renderUndefinedRelativeChange(baseNum, currentNum);
+          return renderUndefinedRelativeChange(
+            baseNum,
+            currentNum,
+            renderInlineValues(
+              DiffTextComp,
+              hasBase,
+              hasCurrent,
+              displayBaseValue,
+              displayCurrentValue,
+              baseGrayOut,
+              currentGrayOut,
+            ),
+          );
         }
 
         const change = isRelativeChange
@@ -389,8 +430,8 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
             DiffTextComp,
             hasBase,
             hasCurrent,
-            baseValue,
-            currentValue,
+            displayBaseValue,
+            displayCurrentValue,
             baseGrayOut,
             currentGrayOut,
           );
@@ -424,11 +465,7 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
               }}
             >
               <DiffTextComp
-                value={
-                  columnRenderMode === "percent_delta"
-                    ? formatPercent(currentNum)
-                    : currentValue
-                }
+                value={displayCurrentValue}
                 comparisonRole="current"
                 grayOut={currentGrayOut}
               />
@@ -449,8 +486,8 @@ export function createInlineRenderCell(config: InlineRenderCellConfig = {}) {
       DiffTextComp,
       hasBase,
       hasCurrent,
-      baseValue,
-      currentValue,
+      displayBaseValue,
+      displayCurrentValue,
       baseGrayOut,
       currentGrayOut,
     );

--- a/js/packages/ui/src/utils/dataGrid/__tests__/columnPrecisionOptions.test.ts
+++ b/js/packages/ui/src/utils/dataGrid/__tests__/columnPrecisionOptions.test.ts
@@ -96,4 +96,34 @@ describe("columnPrecisionSelectOptions", () => {
     expect(callback).toHaveBeenNthCalledWith(3, { price: "percent" });
     expect(callback).toHaveBeenNthCalledWith(4, { price: "delta" });
   });
+
+  test("limits a Profile field to its explicitly allowed render modes", () => {
+    const callback = vi.fn();
+    const options = columnPrecisionSelectOptions(
+      "not_null_proportion",
+      callback,
+      ["raw", "percent", "percent_delta"],
+    );
+
+    expect(options.map((option) => option.value)).toEqual([
+      "Show raw value",
+      "Show as percentage",
+      "Show percentage-point delta",
+    ]);
+  });
+
+  test.each([
+    ["percent_delta", "Show percentage-point delta"],
+    ["percent_change", "Show relative percentage change"],
+  ])("persists %s from the scoped option", (mode, label) => {
+    const callback = vi.fn();
+    const options = columnPrecisionSelectOptions("row_count", callback, [
+      "raw",
+      mode as "percent_delta" | "percent_change",
+    ]);
+
+    options.find((option) => option.value === label)?.onClick();
+
+    expect(callback).toHaveBeenCalledWith({ row_count: mode });
+  });
 });

--- a/js/packages/ui/src/utils/dataGrid/columnPrecisionOptions.ts
+++ b/js/packages/ui/src/utils/dataGrid/columnPrecisionOptions.ts
@@ -21,6 +21,48 @@ export interface ColumnPrecisionOption {
   onClick: () => void;
 }
 
+const defaultColumnRenderModes: readonly ColumnRenderMode[] = [
+  "raw",
+  2,
+  "percent",
+  "delta",
+];
+
+const columnPrecisionOptions: readonly (ColumnPrecisionOption & {
+  mode: ColumnRenderMode;
+})[] = [
+  {
+    mode: "raw",
+    value: "Show raw value",
+    onClick: () => undefined,
+  },
+  {
+    mode: 2,
+    value: "Show 2 decimal points",
+    onClick: () => undefined,
+  },
+  {
+    mode: "percent",
+    value: "Show as percentage",
+    onClick: () => undefined,
+  },
+  {
+    mode: "delta",
+    value: "Show with net change",
+    onClick: () => undefined,
+  },
+  {
+    mode: "percent_delta",
+    value: "Show percentage-point delta",
+    onClick: () => undefined,
+  },
+  {
+    mode: "percent_change",
+    value: "Show relative percentage change",
+    onClick: () => undefined,
+  },
+];
+
 /**
  * Generates precision select options for a numeric column
  *
@@ -30,6 +72,7 @@ export interface ColumnPrecisionOption {
  *
  * @param colName - The column name to apply the render mode to
  * @param onColumnsRenderModeChanged - Callback to update column render modes
+ * @param allowedModes - Optional list limiting which modes appear in this menu
  * @returns Array of menu options with value and onClick handler
  *
  * @example
@@ -50,31 +93,14 @@ export interface ColumnPrecisionOption {
 export function columnPrecisionSelectOptions(
   colName: string,
   onColumnsRenderModeChanged: (col: Record<string, ColumnRenderMode>) => void,
+  allowedModes: readonly ColumnRenderMode[] = defaultColumnRenderModes,
 ): ColumnPrecisionOption[] {
-  return [
-    {
-      value: "Show raw value",
+  return columnPrecisionOptions
+    .filter(({ mode }) => allowedModes.includes(mode))
+    .map(({ mode, value }) => ({
+      value,
       onClick: () => {
-        onColumnsRenderModeChanged({ [colName]: "raw" });
+        onColumnsRenderModeChanged({ [colName]: mode });
       },
-    },
-    {
-      value: "Show 2 decimal points",
-      onClick: () => {
-        onColumnsRenderModeChanged({ [colName]: 2 });
-      },
-    },
-    {
-      value: "Show as percentage",
-      onClick: () => {
-        onColumnsRenderModeChanged({ [colName]: "percent" });
-      },
-    },
-    {
-      value: "Show with net change",
-      onClick: () => {
-        onColumnsRenderModeChanged({ [colName]: "delta" });
-      },
-    },
-  ];
+    }));
 }

--- a/js/packages/ui/src/utils/dataGrid/diffColumnBuilder.tsx
+++ b/js/packages/ui/src/utils/dataGrid/diffColumnBuilder.tsx
@@ -16,6 +16,7 @@ import { getHeaderCellClass } from "./gridUtils";
 import type {
   DataFrameColumnGroupHeaderProps,
   DiffColumnRenderComponents,
+  HeaderPresentation,
 } from "./renderTypes";
 import type { RecceColumnContext } from "./toDiffColumn";
 import { toDiffColumn } from "./toDiffColumn";
@@ -52,7 +53,9 @@ export interface BuildDiffColumnDefinitionsConfig {
   /**
    * Props to pass to DataFrameColumnGroupHeader for all columns
    */
-  headerProps: Partial<DataFrameColumnGroupHeaderProps>;
+  headerProps: Partial<DataFrameColumnGroupHeaderProps> & {
+    headerPresentation?: Record<string, HeaderPresentation>;
+  };
 
   /**
    * Title for base column in side_by_side mode
@@ -143,12 +146,13 @@ function createIndexColumn(
  */
 function createPrimaryKeyColumn(
   config: ColumnConfig,
-  headerProps: Partial<DataFrameColumnGroupHeaderProps>,
+  headerProps: BuildDiffColumnDefinitionsConfig["headerProps"],
   renderComponents: DiffColumnRenderComponents,
   showStructuralIndicator: boolean,
 ): DiffColumnDefinition {
   const { key, name, columnType, columnStatus, columnRenderMode } = config;
   const { DataFrameColumnGroupHeader, defaultRenderCell } = renderComponents;
+  const { headerPresentation, ...headerComponentProps } = headerProps;
 
   return {
     field: key,
@@ -168,7 +172,8 @@ function createPrimaryKeyColumn(
           name={name}
           columnStatus={columnStatus ?? ""}
           columnType={columnType}
-          {...headerProps}
+          {...headerComponentProps}
+          {...headerPresentation?.[key]}
         />
       </Box>
     ),

--- a/js/packages/ui/src/utils/dataGrid/generators/toDataDiffGrid.ts
+++ b/js/packages/ui/src/utils/dataGrid/generators/toDataDiffGrid.ts
@@ -18,7 +18,10 @@ import {
   getPrimaryKeyValue,
   validatePrimaryKeys,
 } from "../gridUtils";
-import type { DiffColumnRenderComponents } from "../renderTypes";
+import type {
+  DiffColumnRenderComponents,
+  HeaderPresentation,
+} from "../renderTypes";
 import { buildDiffRows, type RowStats } from "../rowBuilders";
 import { validateToDataDiffGridInputs } from "../validation";
 
@@ -40,6 +43,7 @@ export interface QueryDataDiffGridOptions {
   baseTitle?: string;
   currentTitle?: string;
   displayMode?: "side_by_side" | "inline";
+  headerPresentation?: Record<string, HeaderPresentation>;
 }
 
 /**
@@ -177,6 +181,7 @@ export function toDataDiffGrid(
       onPrimaryKeyChange: options?.onPrimaryKeyChange,
       onPinnedColumnsChange: options?.onPinnedColumnsChange,
       onColumnsRenderModeChanged: options?.onColumnsRenderModeChanged,
+      headerPresentation: options?.headerPresentation,
     },
     renderComponents: config?.renderComponents ?? {
       // Default render components (for testing or when not specified)

--- a/js/packages/ui/src/utils/dataGrid/generators/toDataGrid.ts
+++ b/js/packages/ui/src/utils/dataGrid/generators/toDataGrid.ts
@@ -14,7 +14,10 @@ import type { ColumnRenderMode, DataFrame, RowObjectType } from "../../../api";
 import { dataFrameToRowObjects } from "../../transforms";
 import { getSimpleDisplayColumns } from "../columnBuilders";
 import { buildColumnMap } from "../gridUtils";
-import type { SimpleColumnRenderComponents } from "../renderTypes";
+import type {
+  HeaderPresentation,
+  SimpleColumnRenderComponents,
+} from "../renderTypes";
 import {
   buildSimpleColumnDefinitions,
   type SimpleColumnDefinition,
@@ -35,6 +38,7 @@ export interface QueryDataGridOptions {
   onPinnedColumnsChange?: (pinnedColumns: string[]) => void;
   columnsRenderMode?: Record<string, ColumnRenderMode>;
   onColumnsRenderModeChanged?: (col: Record<string, ColumnRenderMode>) => void;
+  headerPresentation?: Record<string, HeaderPresentation>;
 }
 
 /**
@@ -105,6 +109,7 @@ export function toDataGrid(
       pinnedColumns,
       onPinnedColumnsChange: options.onPinnedColumnsChange,
       onColumnsRenderModeChanged: options.onColumnsRenderModeChanged,
+      headerPresentation: options.headerPresentation,
     },
     allowIndexFallback: true,
     renderComponents: config.renderComponents,

--- a/js/packages/ui/src/utils/dataGrid/renderTypes.ts
+++ b/js/packages/ui/src/utils/dataGrid/renderTypes.ts
@@ -38,6 +38,8 @@ export interface DataFrameColumnGroupHeaderProps {
   onPinnedColumnsChange?: (pinnedColumns: string[]) => void;
   /** Callback when column render mode changes */
   onColumnsRenderModeChanged?: (col: Record<string, ColumnRenderMode>) => void;
+  /** Optional list limiting which render modes appear in the precision menu */
+  allowedRenderModes?: readonly ColumnRenderMode[];
 }
 
 /**
@@ -56,12 +58,14 @@ export interface DataFrameColumnHeaderProps {
   onPinnedColumnsChange?: (pinnedColumns: string[]) => void;
   /** Callback when column render mode changes */
   onColumnsRenderModeChanged?: (col: Record<string, ColumnRenderMode>) => void;
+  /** Optional list limiting which render modes appear in the precision menu */
+  allowedRenderModes?: readonly ColumnRenderMode[];
 }
 
 /** Presentation-only metadata applied to an individual column header. */
 export type HeaderPresentation = Pick<
   DataFrameColumnGroupHeaderProps,
-  "displayName" | "hidePrimaryKeyIcon"
+  "displayName" | "hidePrimaryKeyIcon" | "allowedRenderModes"
 >;
 
 // ============================================================================

--- a/js/packages/ui/src/utils/dataGrid/renderTypes.ts
+++ b/js/packages/ui/src/utils/dataGrid/renderTypes.ts
@@ -20,6 +20,10 @@ import type { ColumnRenderMode, ColumnType } from "../../api";
 export interface DataFrameColumnGroupHeaderProps {
   /** Column name to display */
   name: string;
+  /** Optional presentation-only name for the column */
+  displayName?: string;
+  /** Hides the primary-key indicator without changing primary-key behavior */
+  hidePrimaryKeyIcon?: boolean;
   /** Column diff status: 'added', 'removed', 'modified', or empty string */
   columnStatus: string;
   /** Column data type for determining available options */
@@ -42,6 +46,8 @@ export interface DataFrameColumnGroupHeaderProps {
 export interface DataFrameColumnHeaderProps {
   /** Column name to display */
   name: string;
+  /** Optional presentation-only name for the column */
+  displayName?: string;
   /** Column data type for determining available options */
   columnType: ColumnType;
   /** List of currently pinned column names */
@@ -51,6 +57,12 @@ export interface DataFrameColumnHeaderProps {
   /** Callback when column render mode changes */
   onColumnsRenderModeChanged?: (col: Record<string, ColumnRenderMode>) => void;
 }
+
+/** Presentation-only metadata applied to an individual column header. */
+export type HeaderPresentation = Pick<
+  DataFrameColumnGroupHeaderProps,
+  "displayName" | "hidePrimaryKeyIcon"
+>;
 
 // ============================================================================
 // Cell Renderer Types

--- a/js/packages/ui/src/utils/dataGrid/simpleColumnBuilder.tsx
+++ b/js/packages/ui/src/utils/dataGrid/simpleColumnBuilder.tsx
@@ -14,7 +14,10 @@
 import type { ColDef, ColGroupDef } from "ag-grid-community";
 import type { ColumnRenderMode, RowObjectType } from "../../api";
 import type { ColumnConfig } from "./columnBuilders";
-import type { SimpleColumnRenderComponents } from "./renderTypes";
+import type {
+  HeaderPresentation,
+  SimpleColumnRenderComponents,
+} from "./renderTypes";
 import type { RecceColumnContext } from "./toDiffColumn";
 
 // Re-export RecceColumnContext for convenience
@@ -51,6 +54,7 @@ export interface BuildSimpleColumnDefinitionsConfig {
     onColumnsRenderModeChanged?: (
       cols: Record<string, ColumnRenderMode>,
     ) => void;
+    headerPresentation?: Record<string, HeaderPresentation>;
   };
 
   /**
@@ -114,6 +118,7 @@ function createPrimaryKeyColumn(
 ): SimpleColumnDefinition {
   const { key, name, columnType, columnRenderMode } = config;
   const { DataFrameColumnGroupHeader, defaultRenderCell } = renderComponents;
+  const { headerPresentation, ...headerComponentProps } = headerProps;
 
   return {
     field: key,
@@ -121,11 +126,14 @@ function createPrimaryKeyColumn(
     headerComponent: () => (
       <DataFrameColumnGroupHeader
         name={name}
+        {...headerPresentation?.[key]}
         columnStatus=""
         columnType={columnType}
-        pinnedColumns={headerProps.pinnedColumns}
-        onPinnedColumnsChange={headerProps.onPinnedColumnsChange}
-        onColumnsRenderModeChanged={headerProps.onColumnsRenderModeChanged}
+        pinnedColumns={headerComponentProps.pinnedColumns}
+        onPinnedColumnsChange={headerComponentProps.onPinnedColumnsChange}
+        onColumnsRenderModeChanged={
+          headerComponentProps.onColumnsRenderModeChanged
+        }
       />
     ),
     pinned: "left",
@@ -146,6 +154,7 @@ function createRegularColumn(
 ): SimpleColumnDefinition {
   const { key, name, columnType, columnRenderMode } = config;
   const { DataFrameColumnHeader, defaultRenderCell } = renderComponents;
+  const { headerPresentation, ...headerComponentProps } = headerProps;
 
   return {
     field: key,
@@ -153,10 +162,13 @@ function createRegularColumn(
     headerComponent: () => (
       <DataFrameColumnHeader
         name={name}
+        {...headerPresentation?.[key]}
         columnType={columnType}
-        pinnedColumns={headerProps.pinnedColumns}
-        onPinnedColumnsChange={headerProps.onPinnedColumnsChange}
-        onColumnsRenderModeChanged={headerProps.onColumnsRenderModeChanged}
+        pinnedColumns={headerComponentProps.pinnedColumns}
+        onPinnedColumnsChange={headerComponentProps.onPinnedColumnsChange}
+        onColumnsRenderModeChanged={
+          headerComponentProps.onColumnsRenderModeChanged
+        }
       />
     ),
     cellRenderer: defaultRenderCell,

--- a/js/packages/ui/src/utils/dataGrid/toDiffColumn.tsx
+++ b/js/packages/ui/src/utils/dataGrid/toDiffColumn.tsx
@@ -15,6 +15,7 @@ import { getCellClass, getHeaderCellClass } from "./gridUtils";
 import type {
   DataFrameColumnGroupHeaderProps,
   DiffColumnRenderComponents,
+  HeaderPresentation,
 } from "./renderTypes";
 
 // ============================================================================
@@ -50,7 +51,9 @@ export interface DiffColumnConfig {
   /** Title for current column in side_by_side mode */
   currentTitle?: string;
   /** Props to pass to DataFrameColumnGroupHeader */
-  headerProps?: Partial<DataFrameColumnGroupHeaderProps>;
+  headerProps?: Partial<DataFrameColumnGroupHeaderProps> & {
+    headerPresentation?: Record<string, HeaderPresentation>;
+  };
   /** Render components for building the column */
   renderComponents: DiffColumnRenderComponents;
 }
@@ -186,6 +189,7 @@ export function toDiffColumn(config: DiffColumnConfig): DiffColumnResult {
 
   const { DataFrameColumnGroupHeader, defaultRenderCell, inlineRenderCell } =
     renderComponents;
+  const { headerPresentation, ...headerComponentProps } = headerProps;
 
   const headerCellClass = getHeaderCellClass(columnStatus);
 
@@ -204,7 +208,8 @@ export function toDiffColumn(config: DiffColumnConfig): DiffColumnResult {
         name={name}
         columnStatus={columnStatus}
         columnType={columnType}
-        {...headerProps}
+        {...headerComponentProps}
+        {...headerPresentation?.[name]}
       />
     </Box>
   );

--- a/js/src/components/profile/ProfileDiffResultView.test.tsx
+++ b/js/src/components/profile/ProfileDiffResultView.test.tsx
@@ -522,6 +522,35 @@ describe("ProfileDiffResultView", () => {
         }),
       );
     });
+
+    it("persists a Profile Diff percentage-point selection through the callback", () => {
+      const run = createProfileDiffRun();
+      const onViewOptionsChanged = vi.fn();
+
+      renderWithProviders(
+        <ProfileDiffResultView
+          run={run}
+          onViewOptionsChanged={onViewOptionsChanged}
+        />,
+      );
+
+      const gridOptions = mockCreateDataGrid.mock.calls[0]?.[1] as {
+        onColumnsRenderModeChanged: (columns: {
+          not_null_proportion: "percent_delta";
+        }) => void;
+      };
+      gridOptions.onColumnsRenderModeChanged({
+        not_null_proportion: "percent_delta",
+      });
+
+      expect(onViewOptionsChanged).toHaveBeenCalledWith(
+        expect.objectContaining({
+          columnsRenderMode: expect.objectContaining({
+            not_null_proportion: "percent_delta",
+          }),
+        }),
+      );
+    });
   });
 
   // ==========================================================================

--- a/js/src/components/profile/ProfileDiffResultView.test.tsx
+++ b/js/src/components/profile/ProfileDiffResultView.test.tsx
@@ -498,6 +498,30 @@ describe("ProfileDiffResultView", () => {
         }),
       );
     });
+
+    it("preserves an explicit percentage-point render mode in view options", () => {
+      const run = createProfileDiffRun();
+
+      renderWithProviders(
+        <ProfileDiffResultView
+          run={run}
+          viewOptions={{
+            columnsRenderMode: {
+              not_null_proportion: "percent_delta",
+            },
+          }}
+        />,
+      );
+
+      expect(mockCreateDataGrid).toHaveBeenCalledWith(
+        run,
+        expect.objectContaining({
+          columnsRenderMode: expect.objectContaining({
+            not_null_proportion: "percent_delta",
+          }),
+        }),
+      );
+    });
   });
 
   // ==========================================================================


### PR DESCRIPTION
## Stack

1. This PR: Profile readability and delta modes
2. #1518: Histogram readability and one-step launch

Merge this PR first. GitHub Stack #1519 tracks the dependency chain.

## Tickets

- [DRC-2833](https://linear.app/recce/issue/DRC-2833)
- [DRC-2866](https://linear.app/recce/issue/DRC-2866)

## Summary

- Humanizes Profile statistic headers while preserving raw field names and primary-key identity.
- Adds explicit percentage-point and percent-change modes.
- Keeps every legacy delta mode and persisted value backward compatible.
- Handles zero, negative, structural, modified, overflow, and tooltip cases explicitly.

## Verification

- Frontend lint passed.
- Root, UI package, and Storybook type checks passed.
- 198 frontend test files passed: 4,212 tests passed and 5 skipped.
- Production frontend build passed.
- Adversarial implementation and whole-layer reviews are clean.

## Compatibility

The new delta modes are additive. Existing saved checks and legacy mode values retain their prior semantics.