### PR TITLE
feat(histogram): polish bin geometry and add one-step launch

### DIFF
--- a/js/packages/ui/src/components/data/HistogramChart.tsx
+++ b/js/packages/ui/src/components/data/HistogramChart.tsx
@@ -92,6 +92,8 @@ function formatBinRange(binEdges: number[], index: number): string {
   return `${formatAsAbbreviatedNumber(start)} - ${formatAsAbbreviatedNumber(end)}`;
 }
 
+const MAX_EDGE_TICK_LABELS = 8;
+
 /**
  * HistogramChart Component
  *
@@ -168,10 +170,6 @@ function HistogramChartComponent({
 
   // Build chart data
   const chartData = useMemo<ChartData<"bar">>(() => {
-    const labels = binEdges
-      .slice(0, -1)
-      .map((_, i) => formatBinRange(binEdges, i));
-
     const buildDataset = (
       data: HistogramDataset,
       label: string,
@@ -197,7 +195,8 @@ function HistogramChartComponent({
     };
 
     return {
-      labels,
+      // Labels represent bin edges; data remains one value per bin.
+      labels: binEdges,
       datasets: [
         buildDataset(
           currentData,
@@ -212,10 +211,10 @@ function HistogramChartComponent({
   // Build chart options
   const chartOptions = useMemo<ChartOptions<"bar">>(() => {
     const maxCount = Math.max(...currentData.counts, ...baseData.counts);
-
-    const labels = binEdges
-      .slice(0, -1)
-      .map((_, i) => formatBinRange(binEdges, i));
+    const edgeTickInterval = Math.max(
+      1,
+      Math.ceil((binEdges.length - 1) / (MAX_EDGE_TICK_LABELS - 1)),
+    );
     const dataTypeLabel = isDatetime
       ? "Date Range"
       : dataType === "string"
@@ -297,8 +296,15 @@ function HistogramChartComponent({
               type: "category",
               grid: { display: false },
               ticks: {
-                callback(_val, index) {
-                  return labels[index];
+                autoSkip: false,
+                callback(_value, index) {
+                  if (
+                    index % edgeTickInterval !== 0 &&
+                    index !== binEdges.length - 1
+                  ) {
+                    return undefined;
+                  }
+                  return formatAsAbbreviatedNumber(binEdges[index]);
                 },
                 color: themeColors.textColor,
               },

--- a/js/packages/ui/src/components/data/HistogramChart.tsx
+++ b/js/packages/ui/src/components/data/HistogramChart.tsx
@@ -244,6 +244,17 @@ function HistogramChartComponent({
       responsive: true,
       maintainAspectRatio: false,
       animation: animate ? undefined : false,
+      // Numeric bar widths come from their literal bin edges. Let Chart.js keep
+      // animating vertical properties, but do not create x/width animations
+      // that would later overwrite the edge geometry plugin's authoritative
+      // pixel values.
+      animations: isNumeric
+        ? {
+            numbers: {
+              properties: ["y", "base", "height"],
+            },
+          }
+        : undefined,
       plugins: {
         histogramBinGeometry: isNumeric ? { binEdges } : undefined,
         // The overlap painter reads its palette from here, not from a closure,

--- a/js/packages/ui/src/components/data/HistogramChart.tsx
+++ b/js/packages/ui/src/components/data/HistogramChart.tsx
@@ -19,6 +19,7 @@ import {
   formatAsAbbreviatedNumber,
   formatIntervalMinMax,
 } from "../../utils/formatters";
+import { histogramBinGeometryPlugin } from "./histogramBinGeometry";
 import {
   createHistogramLegendLabels,
   handleHistogramLegendClick,
@@ -244,6 +245,7 @@ function HistogramChartComponent({
       maintainAspectRatio: false,
       animation: animate ? undefined : false,
       plugins: {
+        histogramBinGeometry: isNumeric ? { binEdges } : undefined,
         // The overlap painter reads its palette from here, not from a closure,
         // so a light/dark switch repaints the crosshatch along with the bars.
         histogramOverlap: { palette: overlapPalette },
@@ -384,7 +386,7 @@ function HistogramChartComponent({
         role="img"
         aria-label={accessibleDescription}
         fallbackContent={accessibleDescription}
-        plugins={[histogramOverlapPlugin]}
+        plugins={[histogramOverlapPlugin, histogramBinGeometryPlugin]}
       />
     </div>
   );

--- a/js/packages/ui/src/components/data/HistogramChart.tsx
+++ b/js/packages/ui/src/components/data/HistogramChart.tsx
@@ -151,6 +151,7 @@ function HistogramChartComponent({
   const semanticColors = getSemanticColorTheme(isDark);
   const comparisonColors = semanticColors.comparison;
   const isDatetime = dataType === "datetime";
+  const isNumeric = dataType === "numeric";
   const accessibleDescription = `${title}. Histogram comparing Base and Current series. Overlap marks their shared distribution.`;
   const overlapPalette = useMemo(
     () => ({
@@ -170,6 +171,10 @@ function HistogramChartComponent({
 
   // Build chart data
   const chartData = useMemo<ChartData<"bar">>(() => {
+    const labels = binEdges
+      .slice(0, -1)
+      .map((_, i) => formatBinRange(binEdges, i));
+
     const buildDataset = (
       data: HistogramDataset,
       label: string,
@@ -178,7 +183,12 @@ function HistogramChartComponent({
       const counts = data.counts ?? [];
       const chartValues = isDatetime
         ? counts.map((v, i) => [binEdges[i], v] as [number, number])
-        : counts;
+        : isNumeric
+          ? counts.map((v, i) => ({
+              x: (binEdges[i] + binEdges[i + 1]) / 2,
+              y: v,
+            }))
+          : counts;
 
       return {
         label,
@@ -195,8 +205,7 @@ function HistogramChartComponent({
     };
 
     return {
-      // Labels represent bin edges; data remains one value per bin.
-      labels: binEdges,
+      labels: isNumeric ? [] : labels,
       datasets: [
         buildDataset(
           currentData,
@@ -206,7 +215,14 @@ function HistogramChartComponent({
         buildDataset(baseData, baseData.label ?? "Base", comparisonColors.base),
       ],
     };
-  }, [binEdges, baseData, comparisonColors, currentData, isDatetime]);
+  }, [
+    binEdges,
+    baseData,
+    comparisonColors,
+    currentData,
+    isDatetime,
+    isNumeric,
+  ]);
 
   // Build chart options
   const chartOptions = useMemo<ChartOptions<"bar">>(() => {
@@ -215,6 +231,8 @@ function HistogramChartComponent({
       1,
       Math.ceil((binEdges.length - 1) / (MAX_EDGE_TICK_LABELS - 1)),
     );
+    const firstEdge = binEdges[0] ?? 0;
+    const terminalEdge = binEdges[binEdges.length - 1] ?? firstEdge;
     const dataTypeLabel = isDatetime
       ? "Date Range"
       : dataType === "string"
@@ -291,24 +309,38 @@ function HistogramChartComponent({
                 color: themeColors.textColor,
               },
             }
-          : {
-              display: !hideAxis,
-              type: "category",
-              grid: { display: false },
-              ticks: {
-                autoSkip: false,
-                callback(_value, index) {
-                  if (
-                    index % edgeTickInterval !== 0 &&
-                    index !== binEdges.length - 1
-                  ) {
-                    return undefined;
-                  }
-                  return formatAsAbbreviatedNumber(binEdges[index]);
+          : isNumeric
+            ? {
+                display: !hideAxis,
+                type: "linear",
+                min: firstEdge,
+                max: terminalEdge,
+                grid: { display: false },
+                afterBuildTicks(axis) {
+                  axis.ticks = binEdges.map((value) => ({ value }));
                 },
-                color: themeColors.textColor,
+                ticks: {
+                  autoSkip: false,
+                  callback(value, index) {
+                    if (
+                      index % edgeTickInterval !== 0 &&
+                      index !== binEdges.length - 1
+                    ) {
+                      return undefined;
+                    }
+                    return formatAsAbbreviatedNumber(value as number);
+                  },
+                  color: themeColors.textColor,
+                },
+              }
+            : {
+                display: !hideAxis,
+                type: "category",
+                grid: { display: false },
+                ticks: {
+                  color: themeColors.textColor,
+                },
               },
-            },
         y: {
           display: !hideAxis,
           type: "linear",
@@ -330,6 +362,7 @@ function HistogramChartComponent({
     title,
     dataType,
     isDatetime,
+    isNumeric,
     samples,
     min,
     max,

--- a/js/packages/ui/src/components/data/HistogramChart.tsx
+++ b/js/packages/ui/src/components/data/HistogramChart.tsx
@@ -20,6 +20,7 @@ import {
   formatIntervalMinMax,
 } from "../../utils/formatters";
 import { histogramBinGeometryPlugin } from "./histogramBinGeometry";
+import { createHistogramEdgeFormatter } from "./histogramEdgeFormatter";
 import {
   createHistogramLegendLabels,
   handleHistogramLegendClick,
@@ -87,10 +88,15 @@ export interface HistogramChartProps {
 /**
  * Format bin range display
  */
-function formatBinRange(binEdges: number[], index: number): string {
+function formatBinRange(
+  binEdges: number[],
+  index: number,
+  formatEdge: (value: number) => string = (value) =>
+    String(formatAsAbbreviatedNumber(value)),
+): string {
   const start = binEdges[index];
   const end = binEdges[index + 1];
-  return `${formatAsAbbreviatedNumber(start)} - ${formatAsAbbreviatedNumber(end)}`;
+  return `${formatEdge(start)} - ${formatEdge(end)}`;
 }
 
 const MAX_EDGE_TICK_LABELS = 8;
@@ -153,6 +159,10 @@ function HistogramChartComponent({
   const comparisonColors = semanticColors.comparison;
   const isDatetime = dataType === "datetime";
   const isNumeric = dataType === "numeric";
+  const formatNumericEdge = useMemo(
+    () => createHistogramEdgeFormatter(binEdges),
+    [binEdges],
+  );
   const accessibleDescription = `${title}. Histogram comparing Base and Current series. Overlap marks their shared distribution.`;
   const overlapPalette = useMemo(
     () => ({
@@ -174,7 +184,9 @@ function HistogramChartComponent({
   const chartData = useMemo<ChartData<"bar">>(() => {
     const labels = binEdges
       .slice(0, -1)
-      .map((_, i) => formatBinRange(binEdges, i));
+      .map((_, i) =>
+        formatBinRange(binEdges, i, isNumeric ? formatNumericEdge : undefined),
+      );
 
     const buildDataset = (
       data: HistogramDataset,
@@ -221,6 +233,7 @@ function HistogramChartComponent({
     baseData,
     comparisonColors,
     currentData,
+    formatNumericEdge,
     isDatetime,
     isNumeric,
   ]);
@@ -282,7 +295,7 @@ function HistogramChartComponent({
           color: themeColors.textColor,
         },
         tooltip: {
-          mode: "index",
+          mode: isNumeric ? "x" : "index",
           intersect: false,
           backgroundColor: themeColors.tooltipBackgroundColor,
           titleColor: themeColors.tooltipTextColor,
@@ -291,7 +304,11 @@ function HistogramChartComponent({
           borderWidth: 1,
           callbacks: {
             title([{ dataIndex }]) {
-              const range = formatBinRange(binEdges, dataIndex);
+              const range = formatBinRange(
+                binEdges,
+                dataIndex,
+                isNumeric ? formatNumericEdge : undefined,
+              );
               return `${dataTypeLabel}\n${range}`;
             },
             label({ datasetIndex, dataIndex, dataset }) {
@@ -341,7 +358,7 @@ function HistogramChartComponent({
                     ) {
                       return undefined;
                     }
-                    return formatAsAbbreviatedNumber(value as number);
+                    return formatNumericEdge(value as number);
                   },
                   color: themeColors.textColor,
                 },
@@ -386,6 +403,7 @@ function HistogramChartComponent({
     animate,
     themeColors,
     overlapPalette,
+    formatNumericEdge,
   ]);
 
   return (

--- a/js/packages/ui/src/components/data/__tests__/HistogramChart.geometry.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/HistogramChart.geometry.test.tsx
@@ -200,6 +200,93 @@ describe("HistogramChart numeric geometry", () => {
     }
   });
 
+  it.each([
+    {
+      binEdges: [0, 1, 10],
+      pointerValues: [1.1],
+    },
+    {
+      binEdges: [0, 0, 10],
+      pointerValues: [0, 0.1],
+    },
+  ])(
+    "resolves numeric pointer hits by the literal intervals in $binEdges",
+    ({ binEdges, pointerValues }) => {
+      const counts = [3, 7];
+      render(
+        <HistogramChart
+          title="Pointer histogram"
+          binEdges={binEdges}
+          baseData={{ counts }}
+          currentData={{ counts }}
+        />,
+      );
+
+      const { data, options, plugins } = getLastChartProps();
+      const chart = new ChartJS(createCanvas() as never, {
+        type: "bar",
+        data,
+        options: {
+          ...options,
+          animation: false,
+          plugins: {
+            ...options.plugins,
+            legend: { display: false },
+            title: { ...options.plugins?.title, display: false },
+          },
+          responsive: false,
+        },
+        plugins: plugins?.filter(({ id }) => id === "histogramBinGeometry"),
+        platform: BasicPlatform,
+      });
+
+      try {
+        const tooltipOptions = chart.tooltip?.options;
+        expect(tooltipOptions).toBeDefined();
+
+        for (const pointerValue of pointerValues) {
+          const eventPosition = {
+            x: chart.scales.x.getPixelForValue(pointerValue),
+            y: (chart.chartArea.top + chart.chartArea.bottom) / 2,
+          };
+          const active = chart.getElementsAtEventForMode(
+            {
+              native: {} as Event,
+              ...eventPosition,
+            } as unknown as Event,
+            tooltipOptions?.mode ?? "index",
+            tooltipOptions ?? {},
+            false,
+          );
+
+          expect(
+            active.map(({ datasetIndex, index }) => ({ datasetIndex, index })),
+          ).toEqual([
+            { datasetIndex: 0, index: 1 },
+            { datasetIndex: 1, index: 1 },
+          ]);
+
+          chart.tooltip?.setActiveElements(active, eventPosition);
+          expect(
+            chart.tooltip?.dataPoints.map(({ datasetIndex, dataIndex }) => ({
+              datasetIndex,
+              dataIndex,
+            })),
+          ).toEqual([
+            { datasetIndex: 0, dataIndex: 1 },
+            { datasetIndex: 1, dataIndex: 1 },
+          ]);
+          expect(chart.tooltip?.title).toEqual([
+            "Value Range",
+            `${binEdges[1]} - ${binEdges[2]}`,
+          ]);
+        }
+      } finally {
+        chart.destroy();
+      }
+    },
+  );
+
   it("preserves non-uniform edges after the supported animation completes", async () => {
     const binEdges = [0, 1, 10];
     const counts = [3, 7];

--- a/js/packages/ui/src/components/data/__tests__/HistogramChart.geometry.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/HistogramChart.geometry.test.tsx
@@ -219,7 +219,7 @@ describe("HistogramChart numeric geometry", () => {
       numbers: { properties: ["y", "base", "height"] },
     });
 
-    let completeAnimation = () => undefined;
+    let completeAnimation: () => void = () => undefined;
     const animationComplete = new Promise<void>((resolve) => {
       completeAnimation = resolve;
     });
@@ -287,7 +287,7 @@ describe("HistogramChart numeric geometry", () => {
     );
 
     const { data, options, plugins } = getLastChartProps();
-    let completeAnimation = () => undefined;
+    let completeAnimation: () => void = () => undefined;
     const animationComplete = new Promise<void>((resolve) => {
       completeAnimation = resolve;
     });

--- a/js/packages/ui/src/components/data/__tests__/HistogramChart.geometry.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/HistogramChart.geometry.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@testing-library/react";
 import {
   BarController,
+  BasePlatform,
   BasicPlatform,
   type ChartData,
   Chart as ChartJS,
@@ -17,6 +18,13 @@ interface CapturedChartProps {
 }
 
 interface RenderedBar {
+  $animations?: {
+    base?: { active(): boolean };
+    height?: { active(): boolean };
+    width?: { active(): boolean };
+    x?: { active(): boolean };
+    y?: { active(): boolean };
+  };
   hidden: boolean;
   width: number;
   x: number;
@@ -24,6 +32,15 @@ interface RenderedBar {
 }
 
 const { chartSpy } = vi.hoisted(() => ({ chartSpy: vi.fn() }));
+
+class AnimationPlatform extends BasePlatform {
+  acquireContext(
+    canvas: HTMLCanvasElement,
+    _options?: CanvasRenderingContext2DSettings,
+  ): CanvasRenderingContext2D | null {
+    return canvas.getContext("2d");
+  }
+}
 
 vi.mock("react-chartjs-2", () => ({
   Chart: (props: CapturedChartProps) => {
@@ -178,6 +195,127 @@ describe("HistogramChart numeric geometry", () => {
       expect(baseBars[0]).toMatchObject({ hidden: true, width: 0 });
       expect(currentBars[1].hidden).toBe(false);
       expect(baseBars[1].hidden).toBe(false);
+    } finally {
+      chart.destroy();
+    }
+  });
+
+  it("preserves non-uniform edges after the supported animation completes", async () => {
+    const binEdges = [0, 1, 10];
+    const counts = [3, 7];
+    render(
+      <HistogramChart
+        title="Animated histogram"
+        animate={true}
+        binEdges={binEdges}
+        baseData={{ counts }}
+        currentData={{ counts }}
+      />,
+    );
+
+    const { data, options, plugins } = getLastChartProps();
+    expect(options.animation).toBeUndefined();
+    expect(options.animations).toEqual({
+      numbers: { properties: ["y", "base", "height"] },
+    });
+
+    let completeAnimation = () => undefined;
+    const animationComplete = new Promise<void>((resolve) => {
+      completeAnimation = resolve;
+    });
+    const chart = new ChartJS(createCanvas() as never, {
+      type: "bar",
+      data,
+      options: {
+        ...options,
+        animation: { duration: 20, onComplete: completeAnimation },
+        plugins: {
+          ...options.plugins,
+          legend: { display: false },
+          title: { ...options.plugins?.title, display: false },
+        },
+        responsive: false,
+      },
+      plugins: plugins?.filter(({ id }) => id === "histogramBinGeometry"),
+      platform: AnimationPlatform,
+    });
+
+    try {
+      const initialBars = chart.getDatasetMeta(0)
+        .data as unknown as RenderedBar[];
+      expect(initialBars.some((bar) => bar.$animations?.y?.active())).toBe(
+        true,
+      );
+      for (const bar of initialBars) {
+        expect(bar.$animations?.x).toBeUndefined();
+        expect(bar.$animations?.width).toBeUndefined();
+      }
+
+      await animationComplete;
+      const xScale = chart.scales.x;
+
+      for (const datasetIndex of [0, 1]) {
+        const bars = chart.getDatasetMeta(datasetIndex)
+          .data as unknown as RenderedBar[];
+        for (const [index, bar] of bars.entries()) {
+          expect(bar.x - bar.width / 2).toBeCloseTo(
+            xScale.getPixelForValue(binEdges[index]),
+            6,
+          );
+          expect(bar.x + bar.width / 2).toBeCloseTo(
+            xScale.getPixelForValue(binEdges[index + 1]),
+            6,
+          );
+        }
+      }
+    } finally {
+      chart.destroy();
+    }
+  });
+
+  it("keeps degenerate intervals hidden after animations complete", async () => {
+    const binEdges = [0, 0, 10];
+    const counts = [3, 7];
+    render(
+      <HistogramChart
+        title="Animated degenerate histogram"
+        animate={true}
+        binEdges={binEdges}
+        baseData={{ counts }}
+        currentData={{ counts }}
+      />,
+    );
+
+    const { data, options, plugins } = getLastChartProps();
+    let completeAnimation = () => undefined;
+    const animationComplete = new Promise<void>((resolve) => {
+      completeAnimation = resolve;
+    });
+    const chart = new ChartJS(createCanvas() as never, {
+      type: "bar",
+      data,
+      options: {
+        ...options,
+        animation: { duration: 20, onComplete: completeAnimation },
+        plugins: {
+          ...options.plugins,
+          legend: { display: false },
+          title: { ...options.plugins?.title, display: false },
+        },
+        responsive: false,
+      },
+      plugins: plugins?.filter(({ id }) => id === "histogramBinGeometry"),
+      platform: AnimationPlatform,
+    });
+
+    try {
+      await animationComplete;
+      for (const datasetIndex of [0, 1]) {
+        const bars = chart.getDatasetMeta(datasetIndex)
+          .data as unknown as RenderedBar[];
+        expect(bars[0]).toMatchObject({ hidden: true, width: 0 });
+        expect(bars[1].hidden).toBe(false);
+      }
     } finally {
       chart.destroy();
     }

--- a/js/packages/ui/src/components/data/__tests__/HistogramChart.geometry.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/HistogramChart.geometry.test.tsx
@@ -1,0 +1,136 @@
+import { render } from "@testing-library/react";
+import {
+  BarController,
+  BasicPlatform,
+  type ChartData,
+  Chart as ChartJS,
+  type ChartOptions,
+} from "chart.js";
+import { vi } from "vitest";
+import { HistogramChart } from "../HistogramChart";
+
+interface CapturedChartProps {
+  data: ChartData<"bar">;
+  options: ChartOptions<"bar">;
+}
+
+interface RenderedBar {
+  width: number;
+  x: number;
+  y: number;
+}
+
+const { chartSpy } = vi.hoisted(() => ({ chartSpy: vi.fn() }));
+
+vi.mock("react-chartjs-2", () => ({
+  Chart: (props: CapturedChartProps) => {
+    chartSpy(props);
+    return <div data-testid="captured-chart" />;
+  },
+}));
+
+ChartJS.register(BarController);
+
+function getLastChartProps(): CapturedChartProps {
+  const props = chartSpy.mock.lastCall?.[0] as CapturedChartProps | undefined;
+  if (!props) throw new Error("HistogramChart was not rendered");
+  return props;
+}
+
+function createCanvas() {
+  const canvas = { height: 300, width: 600 };
+  const context = new Proxy(
+    {
+      canvas,
+      measureText: () => ({ width: 0 }),
+    },
+    {
+      get(target, property) {
+        if (property in target) return target[property as keyof typeof target];
+        return () => undefined;
+      },
+      set(target, property, value) {
+        Object.assign(target, { [property]: value });
+        return true;
+      },
+    },
+  );
+
+  return {
+    ...canvas,
+    getContext: () => context,
+  };
+}
+
+describe("HistogramChart numeric geometry", () => {
+  it.each([
+    { binEdges: [0, 20], counts: [5] },
+    { binEdges: [0, 20, 40, 60, 80, 100], counts: [1, 2, 3, 4, 5] },
+  ])(
+    "spans each $binEdges.length-edge numeric bin without a trailing category",
+    ({ binEdges, counts }) => {
+      render(
+        <HistogramChart
+          title="Numeric histogram"
+          binEdges={binEdges}
+          baseData={{ counts }}
+          currentData={{ counts }}
+        />,
+      );
+
+      const { data, options } = getLastChartProps();
+      const chart = new ChartJS(createCanvas() as never, {
+        type: "bar",
+        data,
+        options: {
+          ...options,
+          animation: false,
+          plugins: {
+            ...options.plugins,
+            legend: { display: false },
+            title: { ...options.plugins?.title, display: false },
+          },
+          responsive: false,
+        },
+        platform: BasicPlatform,
+      });
+
+      try {
+        const xScale = chart.scales.x;
+        const bars = chart.getDatasetMeta(0).data as unknown as RenderedBar[];
+        const lastIndex = counts.length - 1;
+        const lastBar = bars[lastIndex];
+
+        expect(xScale.type).toBe("linear");
+        expect(xScale.ticks.map(({ value }) => value)).toEqual(binEdges);
+        expect(bars).toHaveLength(counts.length);
+        expect(chart.getDatasetMeta(1).data).toHaveLength(counts.length);
+
+        for (const [index, bar] of bars.entries()) {
+          expect(bar.x - bar.width / 2).toBeCloseTo(
+            xScale.getPixelForValue(binEdges[index]),
+            6,
+          );
+          expect(bar.x + bar.width / 2).toBeCloseTo(
+            xScale.getPixelForValue(binEdges[index + 1]),
+            6,
+          );
+        }
+
+        chart.tooltip?.setActiveElements(
+          [{ datasetIndex: 0, index: lastIndex }],
+          { x: lastBar.x, y: lastBar.y },
+        );
+        expect(
+          chart.tooltip?.dataPoints.map(({ dataIndex }) => dataIndex),
+        ).toEqual([lastIndex]);
+        expect(chart.tooltip?.title).toEqual([
+          "Value Range",
+          `${binEdges.at(-2)} - ${binEdges.at(-1)}`,
+        ]);
+      } finally {
+        chart.destroy();
+      }
+    },
+  );
+});

--- a/js/packages/ui/src/components/data/__tests__/HistogramChart.geometry.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/HistogramChart.geometry.test.tsx
@@ -5,6 +5,7 @@ import {
   type ChartData,
   Chart as ChartJS,
   type ChartOptions,
+  type Plugin,
 } from "chart.js";
 import { vi } from "vitest";
 import { HistogramChart } from "../HistogramChart";
@@ -12,9 +13,11 @@ import { HistogramChart } from "../HistogramChart";
 interface CapturedChartProps {
   data: ChartData<"bar">;
   options: ChartOptions<"bar">;
+  plugins?: Plugin<"bar">[];
 }
 
 interface RenderedBar {
+  hidden: boolean;
   width: number;
   x: number;
   y: number;
@@ -66,6 +69,7 @@ describe("HistogramChart numeric geometry", () => {
   it.each([
     { binEdges: [0, 20], counts: [5] },
     { binEdges: [0, 20, 40, 60, 80, 100], counts: [1, 2, 3, 4, 5] },
+    { binEdges: [0, 1, 10], counts: [3, 7] },
   ])(
     "spans each $binEdges.length-edge numeric bin without a trailing category",
     ({ binEdges, counts }) => {
@@ -78,7 +82,7 @@ describe("HistogramChart numeric geometry", () => {
         />,
       );
 
-      const { data, options } = getLastChartProps();
+      const { data, options, plugins } = getLastChartProps();
       const chart = new ChartJS(createCanvas() as never, {
         type: "bar",
         data,
@@ -92,6 +96,7 @@ describe("HistogramChart numeric geometry", () => {
           },
           responsive: false,
         },
+        plugins: plugins?.filter(({ id }) => id === "histogramBinGeometry"),
         platform: BasicPlatform,
       });
 
@@ -133,4 +138,48 @@ describe("HistogramChart numeric geometry", () => {
       }
     },
   );
+
+  it("hides a degenerate interval instead of drawing a positive-width bar", () => {
+    const binEdges = [0, 0, 10];
+    const counts = [3, 7];
+    render(
+      <HistogramChart
+        title="Degenerate histogram"
+        binEdges={binEdges}
+        baseData={{ counts }}
+        currentData={{ counts }}
+      />,
+    );
+
+    const { data, options, plugins } = getLastChartProps();
+    const chart = new ChartJS(createCanvas() as never, {
+      type: "bar",
+      data,
+      options: {
+        ...options,
+        animation: false,
+        plugins: {
+          ...options.plugins,
+          legend: { display: false },
+          title: { ...options.plugins?.title, display: false },
+        },
+        responsive: false,
+      },
+      plugins: plugins?.filter(({ id }) => id === "histogramBinGeometry"),
+      platform: BasicPlatform,
+    });
+
+    try {
+      const currentBars = chart.getDatasetMeta(0)
+        .data as unknown as RenderedBar[];
+      const baseBars = chart.getDatasetMeta(1).data as unknown as RenderedBar[];
+
+      expect(currentBars[0]).toMatchObject({ hidden: true, width: 0 });
+      expect(baseBars[0]).toMatchObject({ hidden: true, width: 0 });
+      expect(currentBars[1].hidden).toBe(false);
+      expect(baseBars[1].hidden).toBe(false);
+    } finally {
+      chart.destroy();
+    }
+  });
 });

--- a/js/packages/ui/src/components/data/__tests__/HistogramChart.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/HistogramChart.test.tsx
@@ -429,11 +429,12 @@ describe("HistogramChart", () => {
       },
     );
 
-    it("registers one explicit histogram overlap painter", () => {
+    it("registers overlap and bin-geometry painters", () => {
       render(<HistogramChart {...defaultProps} />);
 
       expect(getLastChartProps().plugins?.map(({ id }) => id)).toEqual([
         "histogramOverlap",
+        "histogramBinGeometry",
       ]);
     });
 

--- a/js/packages/ui/src/components/data/__tests__/HistogramChart.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/HistogramChart.test.tsx
@@ -23,6 +23,7 @@ import type { HistogramOverlapPalette } from "../histogramOverlap";
 
 interface MockChartProps {
   data: {
+    labels?: number[];
     datasets: Record<string, unknown>[];
   };
   fallbackContent?: React.ReactNode;
@@ -34,10 +35,27 @@ interface MockChartProps {
           generateLabels?: (chart: Chart<"bar">) => LegendItem[];
         };
       };
+      tooltip?: {
+        callbacks?: {
+          title?: (items: { dataIndex: number }[]) => string;
+          label?: (item: {
+            dataIndex: number;
+            datasetIndex: number;
+            dataset: { label?: string };
+          }) => string;
+        };
+      };
     };
     scales?: {
       x?: {
         type?: string;
+        ticks?: {
+          callback?: (
+            value: number | string,
+            index: number,
+            ticks: unknown[],
+          ) => string | undefined;
+        };
       };
     };
   };
@@ -219,14 +237,48 @@ describe("HistogramChart", () => {
       expect(data.datasets).toHaveLength(2);
     });
 
-    it("generates correct bin labels", () => {
-      const { getByTestId } = render(<HistogramChart {...defaultProps} />);
+    it("labels numeric bins with single edges while keeping full tooltip ranges", () => {
+      render(<HistogramChart {...defaultProps} />);
 
-      const chart = getByTestId("mock-chart");
-      const data = JSON.parse(chart.getAttribute("data-data") || "{}");
+      const { data, options } = getLastChartProps();
+      const tickCallback = options?.scales?.x?.ticks?.callback;
+      const tooltipCallbacks = options?.plugins?.tooltip?.callbacks;
 
-      // Should have binEdges.length - 1 labels
-      expect(data.labels).toHaveLength(5);
+      expect(data.labels).toEqual(mockBinEdges);
+      expect(data.datasets[0].data).toHaveLength(mockCurrentData.counts.length);
+      expect(tickCallback?.(0, 0, [])).toBe("0");
+      expect(tickCallback?.(100, 5, [])).toBe("100");
+      expect(tooltipCallbacks?.title?.([{ dataIndex: 4 }])).toBe(
+        "Value Range\n80 - 100",
+      );
+      expect(
+        tooltipCallbacks?.label?.({
+          dataIndex: 4,
+          datasetIndex: 0,
+          dataset: { label: "Current" },
+        }),
+      ).toBe("Current: 55");
+    });
+
+    it("thins numeric edge ticks while retaining the first and terminal edges", () => {
+      const binEdges = Array.from({ length: 13 }, (_, index) => index * 10);
+      const counts = Array.from({ length: 12 }, () => 1);
+      render(
+        <HistogramChart
+          title="Many bins"
+          binEdges={binEdges}
+          baseData={{ counts }}
+          currentData={{ counts }}
+        />,
+      );
+
+      const tickCallback =
+        getLastChartProps().options?.scales?.x?.ticks?.callback;
+      const labels = binEdges
+        .map((edge, index) => tickCallback?.(edge, index, []))
+        .filter((label): label is string => label !== undefined);
+
+      expect(labels).toEqual(["0", "20", "40", "60", "80", "100", "120"]);
     });
 
     it("creates datasets with correct labels", () => {

--- a/js/packages/ui/src/components/data/__tests__/HistogramChart.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/HistogramChart.test.tsx
@@ -297,6 +297,70 @@ describe("HistogramChart", () => {
       expect(labels).toEqual(["0", "20", "40", "60", "80", "100", "120"]);
     });
 
+    it.each([
+      {
+        name: "positive",
+        binEdges: Array.from(
+          { length: 51 },
+          (_, index) => 1_000_000 + index * 0.01,
+        ),
+      },
+      {
+        name: "negative",
+        binEdges: Array.from(
+          { length: 51 },
+          (_, index) => -1_000_000.5 + index * 0.01,
+        ),
+      },
+    ])(
+      "keeps selected ticks and tooltip endpoints distinct in a narrow $name high-offset domain",
+      ({ binEdges }) => {
+        const counts = Array.from({ length: binEdges.length - 1 }, () => 1);
+        render(
+          <HistogramChart
+            title="High-offset bins"
+            binEdges={binEdges}
+            baseData={{ counts }}
+            currentData={{ counts }}
+          />,
+        );
+
+        const { options } = getLastChartProps();
+        const tickCallback = options?.scales?.x?.ticks?.callback;
+        const selectedLabels = binEdges
+          .map((edge, index) => tickCallback?.(edge, index, []))
+          .filter((label): label is string => label !== undefined);
+        expect(new Set(selectedLabels).size).toBe(selectedLabels.length);
+
+        const title = options?.plugins?.tooltip?.callbacks?.title?.([
+          { dataIndex: 0 },
+        ]);
+        const [start, end] = title?.split("\n")[1]?.split(" - ") ?? [];
+        expect(start).toBeTruthy();
+        expect(end).toBeTruthy();
+        expect(start).not.toBe(end);
+      },
+    );
+
+    it("retains compact abbreviated labels when they are already distinct", () => {
+      const binEdges = [1_000_000, 1_200_000, 1_400_000];
+      const counts = [1, 1];
+      render(
+        <HistogramChart
+          title="Readable million bins"
+          binEdges={binEdges}
+          baseData={{ counts }}
+          currentData={{ counts }}
+        />,
+      );
+
+      const tickCallback =
+        getLastChartProps().options?.scales?.x?.ticks?.callback;
+      expect(
+        binEdges.map((edge, index) => tickCallback?.(edge, index, [])),
+      ).toEqual(["1M", "1.2M", "1.4M"]);
+    });
+
     it("keeps string labels and values on the pre-existing category path", () => {
       render(<HistogramChart {...defaultProps} dataType="string" />);
 

--- a/js/packages/ui/src/components/data/__tests__/HistogramChart.test.tsx
+++ b/js/packages/ui/src/components/data/__tests__/HistogramChart.test.tsx
@@ -48,6 +48,9 @@ interface MockChartProps {
     };
     scales?: {
       x?: {
+        display?: boolean;
+        max?: number;
+        min?: number;
         type?: string;
         ticks?: {
           callback?: (
@@ -237,15 +240,28 @@ describe("HistogramChart", () => {
       expect(data.datasets).toHaveLength(2);
     });
 
-    it("labels numeric bins with single edges while keeping full tooltip ranges", () => {
+    it("positions numeric bars at bin midpoints while keeping full tooltip ranges", () => {
       render(<HistogramChart {...defaultProps} />);
 
       const { data, options } = getLastChartProps();
       const tickCallback = options?.scales?.x?.ticks?.callback;
       const tooltipCallbacks = options?.plugins?.tooltip?.callbacks;
 
-      expect(data.labels).toEqual(mockBinEdges);
+      expect(data.labels).toEqual([]);
+      expect(options?.scales?.x).toMatchObject({
+        max: 100,
+        min: 0,
+        type: "linear",
+      });
       expect(data.datasets[0].data).toHaveLength(mockCurrentData.counts.length);
+      expect(data.datasets[1].data).toHaveLength(mockBaseData.counts.length);
+      expect(data.datasets[0].data).toEqual([
+        { x: 10, y: 15 },
+        { x: 30, y: 25 },
+        { x: 50, y: 35 },
+        { x: 70, y: 45 },
+        { x: 90, y: 55 },
+      ]);
       expect(tickCallback?.(0, 0, [])).toBe("0");
       expect(tickCallback?.(100, 5, [])).toBe("100");
       expect(tooltipCallbacks?.title?.([{ dataIndex: 4 }])).toBe(
@@ -279,6 +295,59 @@ describe("HistogramChart", () => {
         .filter((label): label is string => label !== undefined);
 
       expect(labels).toEqual(["0", "20", "40", "60", "80", "100", "120"]);
+    });
+
+    it("keeps string labels and values on the pre-existing category path", () => {
+      render(<HistogramChart {...defaultProps} dataType="string" />);
+
+      const { data, options } = getLastChartProps();
+      expect(data.labels).toEqual([
+        "0 - 20",
+        "20 - 40",
+        "40 - 60",
+        "60 - 80",
+        "80 - 100",
+      ]);
+      expect(data.datasets[0].data).toEqual(mockCurrentData.counts);
+      expect(data.datasets[1].data).toEqual(mockBaseData.counts);
+      expect(options?.scales?.x?.type).toBe("category");
+    });
+
+    it("keeps datetime labels, tuples, scale, and hidden axis unchanged", () => {
+      render(
+        <HistogramChart
+          {...defaultProps}
+          dataType="datetime"
+          hideAxis={true}
+        />,
+      );
+
+      const { data, options } = getLastChartProps();
+      expect(data.labels).toEqual([
+        "0 - 20",
+        "20 - 40",
+        "40 - 60",
+        "60 - 80",
+        "80 - 100",
+      ]);
+      expect(data.datasets[0].data).toEqual([
+        [0, 15],
+        [20, 25],
+        [40, 35],
+        [60, 45],
+        [80, 55],
+      ]);
+      expect(data.datasets[1].data).toEqual([
+        [0, 10],
+        [20, 20],
+        [40, 30],
+        [60, 40],
+        [80, 50],
+      ]);
+      expect(options?.scales?.x).toMatchObject({
+        display: false,
+        type: "timeseries",
+      });
     });
 
     it("creates datasets with correct labels", () => {
@@ -315,7 +384,11 @@ describe("HistogramChart", () => {
           data.datasets.every((dataset) => dataset.grouped === false),
         ).toBe(true);
         expect(options?.scales?.x?.type).toBe(
-          dataType === "datetime" ? "timeseries" : "category",
+          dataType === "datetime"
+            ? "timeseries"
+            : dataType === "numeric"
+              ? "linear"
+              : "category",
         );
       },
     );
@@ -572,7 +645,7 @@ describe("HistogramChart", () => {
       expect(currentData[0]).toHaveLength(2);
     });
 
-    it("uses plain count values for numeric type", () => {
+    it("uses midpoint coordinate objects for numeric type", () => {
       const { getByTestId } = render(
         <HistogramChart {...defaultProps} dataType="numeric" />,
       );
@@ -580,9 +653,9 @@ describe("HistogramChart", () => {
       const chart = getByTestId("mock-chart");
       const data = JSON.parse(chart.getAttribute("data-data") || "{}");
 
-      // For numeric, data should be plain numbers
+      // Numeric bars use explicit x coordinates on the linear edge scale.
       const currentData = data.datasets[0].data;
-      expect(typeof currentData[0]).toBe("number");
+      expect(currentData[0]).toEqual({ x: 10, y: 15 });
     });
   });
 

--- a/js/packages/ui/src/components/data/histogramBinGeometry.ts
+++ b/js/packages/ui/src/components/data/histogramBinGeometry.ts
@@ -1,0 +1,57 @@
+import type { ChartType, Element, Plugin } from "chart.js";
+
+export interface HistogramBinGeometryPluginOptions {
+  binEdges: number[];
+}
+
+declare module "chart.js" {
+  interface PluginOptionsByType<TType extends ChartType> {
+    histogramBinGeometry?: HistogramBinGeometryPluginOptions;
+  }
+}
+
+interface BarGeometry {
+  hidden: boolean;
+  width: number;
+  x: number;
+}
+
+function setBarGeometry(bar: Element, left: number, right: number): void {
+  const geometry = bar as unknown as BarGeometry;
+  if (!Number.isFinite(left) || !Number.isFinite(right) || right <= left) {
+    geometry.hidden = true;
+    geometry.width = 0;
+    return;
+  }
+
+  geometry.hidden = false;
+  geometry.x = (left + right) / 2;
+  geometry.width = right - left;
+}
+
+/**
+ * Aligns each numeric histogram bar with the literal edge pair that defines it.
+ * Chart.js normally gives every ungrouped bar a shared minimum width, which is
+ * incorrect when valid histogram bins have different widths.
+ */
+export const histogramBinGeometryPlugin: Plugin<
+  "bar",
+  HistogramBinGeometryPluginOptions
+> = {
+  id: "histogramBinGeometry",
+  afterDatasetUpdate(_chart, { meta }, options) {
+    const binEdges = options?.binEdges;
+    const xScale = meta.xScale;
+    if (!binEdges || !xScale || xScale.axis !== "x") return;
+
+    for (const [index, bar] of meta.data.entries()) {
+      const lower = binEdges[index];
+      const upper = binEdges[index + 1];
+      setBarGeometry(
+        bar,
+        xScale.getPixelForValue(lower),
+        xScale.getPixelForValue(upper),
+      );
+    }
+  },
+};

--- a/js/packages/ui/src/components/data/histogramBinGeometry.ts
+++ b/js/packages/ui/src/components/data/histogramBinGeometry.ts
@@ -12,19 +12,31 @@ declare module "chart.js" {
 
 interface BarGeometry {
   hidden: boolean;
+  inXRange(mouseX: number): boolean;
+  skip: boolean;
   width: number;
   x: number;
 }
 
-function setBarGeometry(bar: Element, left: number, right: number): void {
+function setBarGeometry(
+  bar: Element,
+  left: number,
+  right: number,
+  includeRightEdge: boolean,
+): void {
   const geometry = bar as unknown as BarGeometry;
   if (!Number.isFinite(left) || !Number.isFinite(right) || right <= left) {
     geometry.hidden = true;
+    geometry.inXRange = () => false;
+    geometry.skip = true;
     geometry.width = 0;
     return;
   }
 
   geometry.hidden = false;
+  geometry.inXRange = (mouseX) =>
+    mouseX >= left && (includeRightEdge ? mouseX <= right : mouseX < right);
+  geometry.skip = false;
   geometry.x = (left + right) / 2;
   geometry.width = right - left;
 }
@@ -51,6 +63,7 @@ export const histogramBinGeometryPlugin: Plugin<
         bar,
         xScale.getPixelForValue(lower),
         xScale.getPixelForValue(upper),
+        index === meta.data.length - 1,
       );
     }
   },

--- a/js/packages/ui/src/components/data/histogramEdgeFormatter.ts
+++ b/js/packages/ui/src/components/data/histogramEdgeFormatter.ts
@@ -1,0 +1,56 @@
+import { formatAsAbbreviatedNumber } from "../../utils/formatters";
+
+interface EdgeUnit {
+  divisor: number;
+  suffix: string;
+}
+
+const EDGE_UNITS: EdgeUnit[] = [
+  { divisor: 1e12, suffix: "T" },
+  { divisor: 1e9, suffix: "B" },
+  { divisor: 1e6, suffix: "M" },
+  { divisor: 1e3, suffix: "K" },
+];
+
+function labelsAreDistinct(
+  values: number[],
+  format: (value: number) => string,
+): boolean {
+  return new Set(values.map(format)).size === values.length;
+}
+
+/**
+ * Creates one shared formatter for a histogram domain. Compact labels remain
+ * unchanged when they identify every edge. For narrow, high-offset domains,
+ * the formatter adds only as much precision as is needed to keep every tick
+ * and tooltip endpoint distinguishable.
+ */
+export function createHistogramEdgeFormatter(
+  binEdges: number[],
+): (value: number) => string {
+  const distinctEdges = [...new Set(binEdges.filter(Number.isFinite))];
+  const abbreviated = (value: number) =>
+    String(formatAsAbbreviatedNumber(value));
+
+  if (labelsAreDistinct(distinctEdges, abbreviated)) return abbreviated;
+
+  const maxMagnitude = Math.max(0, ...distinctEdges.map(Math.abs));
+  const unit = EDGE_UNITS.find(({ divisor }) => maxMagnitude >= divisor) ?? {
+    divisor: 1,
+    suffix: "",
+  };
+
+  for (let fractionDigits = 0; fractionDigits <= 20; fractionDigits += 1) {
+    const numberFormat = new Intl.NumberFormat("en-US", {
+      maximumFractionDigits: fractionDigits,
+      useGrouping: unit.divisor === 1,
+    });
+    const candidate = (value: number) =>
+      `${numberFormat.format(value / unit.divisor)}${unit.suffix}`;
+    if (labelsAreDistinct(distinctEdges, candidate)) return candidate;
+  }
+
+  // Number#toString is the exact shortest round-trippable representation, so
+  // distinct finite JavaScript numbers cannot collapse here.
+  return (value: number) => value.toString();
+}

--- a/js/packages/ui/src/components/histogram/HistogramDiffForm.tsx
+++ b/js/packages/ui/src/components/histogram/HistogramDiffForm.tsx
@@ -129,6 +129,7 @@ export function HistogramDiffForm({
 }: HistogramDiffEditProps) {
   const {
     columns: allColumns,
+    columnAvailability,
     isLoading,
     error,
   } = useModelColumns(params.model);
@@ -137,6 +138,13 @@ export function HistogramDiffForm({
       !isStringDataType(c.type) &&
       !isBooleanDataType(c.type) &&
       !isDateTimeType(c.type),
+  );
+  const isAvailableInBothEnvironments = (columnName: string) => {
+    const availability = columnAvailability[columnName];
+    return availability?.base === true && availability.current === true;
+  };
+  const eligibleColumns = columns.filter((column) =>
+    isAvailableInBothEnvironments(column.name),
   );
 
   if (isLoading) {
@@ -154,7 +162,7 @@ export function HistogramDiffForm({
 
   return (
     <Box sx={{ m: "16px" }}>
-      <FormControl fullWidth disabled={columns.length === 0}>
+      <FormControl fullWidth disabled={eligibleColumns.length === 0}>
         <FormLabel sx={{ mb: 1 }}>
           Pick a column to show Histogram Diff
         </FormLabel>
@@ -162,16 +170,19 @@ export function HistogramDiffForm({
           value={params.column_name}
           onChange={(e) => {
             const columnName = e.target.value;
-            setIsReadyToExecute(!!columnName);
-            const columnType =
-              columns.find((c) => c.name === columnName)?.type ?? "";
+            const selectedColumn = columns.find((c) => c.name === columnName);
+            const isEligible =
+              selectedColumn !== undefined &&
+              isAvailableInBothEnvironments(columnName);
+            setIsReadyToExecute(isEligible);
+            const columnType = selectedColumn?.type ?? "";
             const nextParams = {
               ...params,
               column_name: columnName,
               column_type: columnType,
             };
             onParamsChanged(nextParams);
-            if (columnName && columnType) {
+            if (isEligible && columnType) {
               onSubmitRequested?.(nextParams as HistogramDiffParams);
             }
           }}
@@ -182,7 +193,12 @@ export function HistogramDiffForm({
               : "No numeric column is available"}
           </option>
           {columns.map((c) => (
-            <option key={c.name} value={c.name} className="no-track-pii-safe">
+            <option
+              key={c.name}
+              value={c.name}
+              className="no-track-pii-safe"
+              disabled={!isAvailableInBothEnvironments(c.name)}
+            >
               {c.name} : {c.type}
             </option>
           ))}

--- a/js/packages/ui/src/components/histogram/HistogramDiffForm.tsx
+++ b/js/packages/ui/src/components/histogram/HistogramDiffForm.tsx
@@ -188,9 +188,9 @@ export function HistogramDiffForm({
           }}
         >
           <option value="">
-            {columns.length !== 0
+            {eligibleColumns.length !== 0
               ? "Select column"
-              : "No numeric column is available"}
+              : "No numeric column is available in both environments"}
           </option>
           {columns.map((c) => (
             <option

--- a/js/packages/ui/src/components/histogram/HistogramDiffForm.tsx
+++ b/js/packages/ui/src/components/histogram/HistogramDiffForm.tsx
@@ -125,6 +125,7 @@ export function HistogramDiffForm({
   params,
   onParamsChanged,
   setIsReadyToExecute,
+  onSubmitRequested,
 }: HistogramDiffEditProps) {
   const {
     columns: allColumns,
@@ -164,11 +165,15 @@ export function HistogramDiffForm({
             setIsReadyToExecute(!!columnName);
             const columnType =
               columns.find((c) => c.name === columnName)?.type ?? "";
-            onParamsChanged({
+            const nextParams = {
               ...params,
               column_name: columnName,
               column_type: columnType,
-            });
+            };
+            onParamsChanged(nextParams);
+            if (columnName && columnType) {
+              onSubmitRequested?.(nextParams as HistogramDiffParams);
+            }
           }}
         >
           <option value="">

--- a/js/packages/ui/src/components/histogram/__tests__/HistogramDiffForm.test.tsx
+++ b/js/packages/ui/src/components/histogram/__tests__/HistogramDiffForm.test.tsx
@@ -16,17 +16,28 @@ vi.mock("../../../hooks", async (importOriginal) => {
   };
 });
 
-const eligibleColumns: NodeColumnData[] = [
+const catalogColumns: NodeColumnData[] = [
   { name: "amount", type: "DECIMAL(12, 2)" },
   { name: "quantity", type: "INTEGER" },
+  { name: "added_only", type: "BIGINT" },
+  { name: "removed_only", type: "DOUBLE" },
   { name: "description", type: "VARCHAR" },
 ];
+
+const columnAvailability = {
+  amount: { base: true, current: true },
+  quantity: { base: true, current: true },
+  added_only: { base: false, current: true },
+  removed_only: { base: true, current: false },
+  description: { base: true, current: true },
+};
 
 function modelColumns(
   overrides: Partial<UseModelColumnsReturn> = {},
 ): UseModelColumnsReturn {
   return {
-    columns: eligibleColumns,
+    columns: catalogColumns,
+    columnAvailability,
     primaryKey: undefined,
     isLoading: false,
     error: null,
@@ -107,4 +118,32 @@ describe("HistogramDiffForm one-step selection", () => {
       column_type: "INTEGER",
     });
   });
+
+  it.each(["added_only", "removed_only"])(
+    "keeps %s visible but ineligible for submission",
+    (columnName) => {
+      const onSubmitRequested = vi.fn();
+      const setIsReadyToExecute = vi.fn();
+
+      render(
+        <HistogramDiffForm
+          params={{ model: "orders", column_name: "", column_type: "" }}
+          onParamsChanged={vi.fn()}
+          setIsReadyToExecute={setIsReadyToExecute}
+          onSubmitRequested={onSubmitRequested}
+        />,
+      );
+
+      expect(
+        screen.getByRole("option", { name: new RegExp(columnName) }),
+      ).toBeDisabled();
+
+      fireEvent.change(screen.getByRole("combobox"), {
+        target: { value: columnName },
+      });
+
+      expect(setIsReadyToExecute).toHaveBeenLastCalledWith(false);
+      expect(onSubmitRequested).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/js/packages/ui/src/components/histogram/__tests__/HistogramDiffForm.test.tsx
+++ b/js/packages/ui/src/components/histogram/__tests__/HistogramDiffForm.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HistogramDiffParams, NodeColumnData } from "../../../api";
+import type { UseModelColumnsReturn } from "../../../hooks/useModelColumns";
+import { HistogramDiffForm } from "../HistogramDiffForm";
+
+const mockUseModelColumns =
+  vi.fn<(model: string | undefined) => UseModelColumnsReturn>();
+
+vi.mock("../../../hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../hooks")>();
+  return {
+    ...actual,
+    useModelColumns: (model: string | undefined) => mockUseModelColumns(model),
+  };
+});
+
+const eligibleColumns: NodeColumnData[] = [
+  { name: "amount", type: "DECIMAL(12, 2)" },
+  { name: "quantity", type: "INTEGER" },
+  { name: "description", type: "VARCHAR" },
+];
+
+function modelColumns(
+  overrides: Partial<UseModelColumnsReturn> = {},
+): UseModelColumnsReturn {
+  return {
+    columns: eligibleColumns,
+    primaryKey: undefined,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function ControlledForm({
+  onSubmitRequested,
+}: {
+  onSubmitRequested: (params: HistogramDiffParams) => void;
+}) {
+  const [params, setParams] = useState<Partial<HistogramDiffParams>>({
+    model: "orders",
+    column_name: "",
+    column_type: "",
+  });
+
+  return (
+    <HistogramDiffForm
+      params={params}
+      onParamsChanged={setParams}
+      setIsReadyToExecute={vi.fn()}
+      onSubmitRequested={onSubmitRequested}
+    />
+  );
+}
+
+describe("HistogramDiffForm one-step selection", () => {
+  beforeEach(() => {
+    mockUseModelColumns.mockReset();
+    mockUseModelColumns.mockReturnValue(modelColumns());
+  });
+
+  it.each([
+    ["loading", modelColumns({ isLoading: true })],
+    ["catalog error", modelColumns({ error: new Error("catalog failed") })],
+    [
+      "no eligible columns",
+      modelColumns({ columns: [{ name: "description", type: "VARCHAR" }] }),
+    ],
+  ])("does not request submission while %s", (_state, columnsState) => {
+    const onSubmitRequested = vi.fn();
+    mockUseModelColumns.mockReturnValue(columnsState);
+
+    render(<ControlledForm onSubmitRequested={onSubmitRequested} />);
+
+    expect(onSubmitRequested).not.toHaveBeenCalled();
+  });
+
+  it("requests complete parameters once per explicit eligible selection", () => {
+    const onSubmitRequested = vi.fn();
+    const { rerender } = render(
+      <ControlledForm onSubmitRequested={onSubmitRequested} />,
+    );
+    const picker = screen.getByRole("combobox");
+
+    fireEvent.change(picker, { target: { value: "amount" } });
+
+    expect(onSubmitRequested).toHaveBeenCalledTimes(1);
+    expect(onSubmitRequested).toHaveBeenLastCalledWith({
+      model: "orders",
+      column_name: "amount",
+      column_type: "DECIMAL(12, 2)",
+    });
+
+    rerender(<ControlledForm onSubmitRequested={onSubmitRequested} />);
+    expect(onSubmitRequested).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "quantity" },
+    });
+
+    expect(onSubmitRequested).toHaveBeenCalledTimes(2);
+    expect(onSubmitRequested).toHaveBeenLastCalledWith({
+      model: "orders",
+      column_name: "quantity",
+      column_type: "INTEGER",
+    });
+  });
+});

--- a/js/packages/ui/src/components/histogram/__tests__/HistogramDiffForm.test.tsx
+++ b/js/packages/ui/src/components/histogram/__tests__/HistogramDiffForm.test.tsx
@@ -146,4 +146,32 @@ describe("HistogramDiffForm one-step selection", () => {
       expect(onSubmitRequested).not.toHaveBeenCalled();
     },
   );
+
+  it("explains why the picker is dead when every numeric column is one-sided", () => {
+    mockUseModelColumns.mockReturnValue(
+      modelColumns({
+        columnAvailability: {
+          ...columnAvailability,
+          amount: { base: false, current: true },
+          quantity: { base: true, current: false },
+        },
+      }),
+    );
+
+    render(
+      <HistogramDiffForm
+        params={{ model: "orders", column_name: "", column_type: "" }}
+        onParamsChanged={vi.fn()}
+        setIsReadyToExecute={vi.fn()}
+        onSubmitRequested={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("combobox")).toBeDisabled();
+    expect(
+      screen.getByRole("option", {
+        name: "No numeric column is available in both environments",
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/js/packages/ui/src/components/histogram/__tests__/HistogramResultView.test.tsx
+++ b/js/packages/ui/src/components/histogram/__tests__/HistogramResultView.test.tsx
@@ -1,0 +1,99 @@
+import { ThemeProvider } from "@mui/material/styles";
+import { render } from "@testing-library/react";
+import { vi } from "vitest";
+import { theme } from "../../../theme";
+import type { HistogramDiffRun } from "../HistogramResultView";
+import { HistogramDiffResultView } from "../HistogramResultView";
+
+interface MockChartProps {
+  data: { labels?: number[]; datasets: { data: number[] }[] };
+  options?: {
+    scales?: {
+      x?: {
+        ticks?: {
+          callback?: (
+            value: number | string,
+            index: number,
+            ticks: unknown[],
+          ) => string | undefined;
+        };
+      };
+    };
+  };
+}
+
+const { chartSpy } = vi.hoisted(() => ({ chartSpy: vi.fn() }));
+
+vi.mock("react-chartjs-2", () => ({
+  Chart: (props: MockChartProps) => {
+    chartSpy(props);
+    return <div data-testid="histogram-chart" />;
+  },
+}));
+
+vi.mock("chart.js", () => ({
+  Chart: { register: vi.fn() },
+  BarElement: {},
+  CategoryScale: {},
+  Legend: {},
+  LinearScale: {},
+  TimeSeriesScale: {},
+  Title: {},
+  Tooltip: {},
+}));
+
+vi.mock("../../../hooks", () => ({
+  useIsDark: () => false,
+}));
+
+vi.mock("../../data/ScreenshotDataGrid", () => ({
+  EmptyRowsRenderer: () => null,
+  ScreenshotDataGrid: () => null,
+}));
+
+vi.mock("../../ui/ScreenshotBox", () => ({
+  ScreenshotBox: ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+function getLastChartProps(): MockChartProps {
+  const props = chartSpy.mock.lastCall?.[0] as MockChartProps | undefined;
+  if (!props) throw new Error("HistogramChart was not rendered");
+  return props;
+}
+
+describe("HistogramDiffResultView", () => {
+  it("passes numeric edges through to terminal-aware chart ticks", () => {
+    const run: HistogramDiffRun = {
+      type: "histogram_diff",
+      run_id: "histogram-run",
+      run_at: "2026-08-25T00:00:00Z",
+      status: "Finished",
+      params: {
+        model: "orders",
+        column_name: "amount",
+        column_type: "numeric",
+      },
+      result: {
+        base: { counts: [4, 3, 2, 1, 0], total: 10 },
+        current: { counts: [0, 1, 2, 3, 4], total: 10 },
+        min: 0,
+        max: 100,
+        bin_edges: [0, 20, 40, 60, 80, 100],
+      },
+    };
+
+    render(
+      <ThemeProvider theme={theme}>
+        <HistogramDiffResultView run={run} />
+      </ThemeProvider>,
+    );
+
+    const { data, options } = getLastChartProps();
+    const tickCallback = options?.scales?.x?.ticks?.callback;
+    expect(data.labels).toEqual(run.result?.bin_edges);
+    expect(data.datasets[0].data).toHaveLength(5);
+    expect(tickCallback?.(100, 5, [])).toBe("100");
+  });
+});

--- a/js/packages/ui/src/components/histogram/__tests__/HistogramResultView.test.tsx
+++ b/js/packages/ui/src/components/histogram/__tests__/HistogramResultView.test.tsx
@@ -10,6 +10,9 @@ interface MockChartProps {
   options?: {
     scales?: {
       x?: {
+        max?: number;
+        min?: number;
+        type?: string;
         ticks?: {
           callback?: (
             value: number | string,
@@ -92,8 +95,14 @@ describe("HistogramDiffResultView", () => {
 
     const { data, options } = getLastChartProps();
     const tickCallback = options?.scales?.x?.ticks?.callback;
-    expect(data.labels).toEqual(run.result?.bin_edges);
+    expect(data.labels).toEqual([]);
     expect(data.datasets[0].data).toHaveLength(5);
+    expect(data.datasets[1].data).toHaveLength(5);
+    expect(options?.scales?.x).toMatchObject({
+      max: 100,
+      min: 0,
+      type: "linear",
+    });
     expect(tickCallback?.(100, 5, [])).toBe("100");
   });
 });

--- a/js/packages/ui/src/components/lineage/NodeViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/NodeViewOss.tsx
@@ -299,7 +299,11 @@ export function NodeViewOss({
         runAction(
           "histogram_diff",
           { model: node.data.name, column_name: "", column_type: "" },
-          { showForm: true },
+          {
+            showForm: true,
+            submitOnSelection: true,
+            trackProps: { source: "lineage_model_node" },
+          },
         );
       },
 

--- a/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
@@ -438,6 +438,18 @@ describe("NodeView", () => {
       );
     });
 
+    test("does not launch Histogram while database queries are disabled", async () => {
+      const onHistogramDiffClick = vi.fn();
+      renderNodeView(createNode("model", testColumns), testColumns, {
+        featureToggles: { disableDatabaseQuery: true },
+        actionCallbacks: { onHistogramDiffClick },
+      });
+
+      const histogram = screen.getByRole("button", { name: /histogram/i });
+      expect(histogram).toBeDisabled();
+      expect(onHistogramDiffClick).not.toHaveBeenCalled();
+    });
+
     test("shows no reason on an action that is available", async () => {
       const node = createNode("model", testColumns);
       node.data.changeStatus = "modified";

--- a/js/packages/ui/src/components/lineage/__tests__/NodeViewOss.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeViewOss.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPush, mockRunAction } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockRunAction: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return { ...actual, useQuery: () => ({ data: undefined }) };
+});
+
+vi.mock("../../../contexts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../contexts")>();
+  return {
+    ...actual,
+    useLineageGraphContext: () => ({
+      isActionAvailable: () => true,
+      envInfo: { adapterType: "dbt" },
+      lineageGraph: { nodes: [] },
+      runsAggregated: undefined,
+    }),
+    useLineageViewContext: () => undefined,
+    useRecceActionContext: () => ({ runAction: mockRunAction }),
+    useRecceInstanceContext: () => ({
+      singleEnv: false,
+      featureToggles: { disableDatabaseQuery: false },
+    }),
+    useRouteConfig: () => ({ basePath: "" }),
+  };
+});
+
+vi.mock("../../../hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../hooks")>();
+  return {
+    ...actual,
+    useApiConfig: () => ({ apiClient: {} }),
+    useModelColumns: () => ({ primaryKey: undefined }),
+    useRecceQueryContext: () => ({
+      setSqlQuery: vi.fn(),
+      setPrimaryKeys: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("../../../lib/api/track", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../lib/api/track")>();
+  return { ...actual, trackExploreAction: vi.fn() };
+});
+
+vi.mock("../NodeView", () => ({
+  NodeView: ({
+    actionCallbacks,
+  }: {
+    actionCallbacks: { onHistogramDiffClick?: () => void };
+  }) => (
+    <button type="button" onClick={actionCallbacks.onHistogramDiffClick}>
+      Histogram
+    </button>
+  ),
+}));
+
+import { NodeViewOss } from "../NodeViewOss";
+
+describe("NodeViewOss Histogram launcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opts the model picker into one-step submission and model telemetry", async () => {
+    render(
+      <NodeViewOss
+        node={
+          {
+            id: "model.test.orders",
+            data: { name: "orders", resourceType: "model" },
+          } as never
+        }
+        onCloseNode={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Histogram" }));
+
+    expect(mockRunAction).toHaveBeenCalledWith(
+      "histogram_diff",
+      { model: "orders", column_name: "", column_type: "" },
+      {
+        showForm: true,
+        submitOnSelection: true,
+        trackProps: { source: "lineage_model_node" },
+      },
+    );
+  });
+});

--- a/js/packages/ui/src/components/lineage/contextmenu/__tests__/LineageViewContextMenu.test.tsx
+++ b/js/packages/ui/src/components/lineage/contextmenu/__tests__/LineageViewContextMenu.test.tsx
@@ -13,7 +13,10 @@ import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
 import type { LineageGraphNode } from "../../../../contexts/lineage/types";
-import { ModelNodeContextMenu } from "../LineageViewContextMenu";
+import {
+  ColumnNodeContextMenu,
+  ModelNodeContextMenu,
+} from "../LineageViewContextMenu";
 
 const NODE_ID = "model.test.orders";
 
@@ -57,5 +60,56 @@ describe("ModelNodeContextMenu — Show Impact Radius", () => {
       change_analysis: true,
       no_upstream: true,
     });
+  });
+});
+
+describe("ColumnNodeContextMenu — Histogram launcher", () => {
+  it("keeps lineage-column Histogram as a direct launch with its source", async () => {
+    const runAction = vi.fn();
+    const Icon = () => <span />;
+    render(
+      <ColumnNodeContextMenu
+        x={0}
+        y={0}
+        isOpen
+        onClose={vi.fn()}
+        node={
+          {
+            id: "model.test.orders.column.amount",
+            data: {
+              node: { name: "orders" },
+              column: "amount",
+              type: "DECIMAL(12, 2)",
+              changeStatus: "modified",
+            },
+          } as never
+        }
+        deps={{
+          runAction,
+          findByRunType: (type) => ({
+            title: type === "histogram_diff" ? "Histogram Diff" : type,
+            icon: Icon,
+          }),
+          supportsHistogramDiff: () => true,
+        }}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "Histogram Diff" }),
+    );
+
+    expect(runAction).toHaveBeenCalledWith(
+      "histogram_diff",
+      {
+        model: "orders",
+        column_name: "amount",
+        column_type: "DECIMAL(12, 2)",
+      },
+      {
+        showForm: false,
+        trackProps: { source: "lineage_column_node" },
+      },
+    );
   });
 });

--- a/js/packages/ui/src/components/run/RunModal.tsx
+++ b/js/packages/ui/src/components/run/RunModal.tsx
@@ -59,6 +59,9 @@ export interface RunModalProps<PT = unknown> {
   /** The form component to render for configuring run parameters */
   RunForm?: ComponentType<RunFormProps<PT>>;
 
+  /** Submit complete form params from an explicit selection event. */
+  submitOnSelection?: boolean;
+
   /**
    * Optional callback when the modal is cancelled (X button clicked without executing).
    * Use this for analytics/tracking of form cancellations.
@@ -150,6 +153,7 @@ export function RunModal<PT = unknown>({
   title,
   params: defaultParams,
   RunForm,
+  submitOnSelection = false,
   onCancel,
   onExecuteClick,
   documentationUrl,
@@ -171,12 +175,14 @@ export function RunModal<PT = unknown>({
     onClose();
   };
 
-  const handleExecuteClick = () => {
+  const executeWithParams = (executeParams: PT) => {
     executeClicked.current = true;
     // Track execute click if callback provided
     onExecuteClick?.();
-    onExecute(type, params as PT);
+    onExecute(type, executeParams);
   };
+
+  const handleExecuteClick = () => executeWithParams(params as PT);
 
   return (
     <MuiDialog
@@ -268,6 +274,9 @@ export function RunModal<PT = unknown>({
               params={params}
               onParamsChanged={setParams}
               setIsReadyToExecute={setIsReadyToExecute}
+              onSubmitRequested={
+                submitOnSelection ? executeWithParams : undefined
+              }
             />
           )}
         </Box>

--- a/js/packages/ui/src/components/run/RunModalOss.tsx
+++ b/js/packages/ui/src/components/run/RunModalOss.tsx
@@ -51,6 +51,9 @@ export interface RunModalProps {
 
   /** The form component to render for configuring run parameters */
   RunForm?: ComponentType<RunFormProps<RunFormParamTypes>>;
+
+  /** Submit complete form params from an explicit selection event. */
+  submitOnSelection?: boolean;
 }
 
 // ============================================================================
@@ -105,6 +108,7 @@ export function RunModalOss({
   params,
   initialRun,
   RunForm,
+  submitOnSelection,
 }: RunModalProps) {
   // Track form cancellation for explore actions
   const handleCancel = () => {
@@ -136,6 +140,7 @@ export function RunModalOss({
       params={params}
       initialRun={initialRun}
       RunForm={RunForm as UIRunModalProps<RunFormParamTypes>["RunForm"]}
+      submitOnSelection={submitOnSelection}
       onCancel={handleCancel}
       onExecuteClick={handleExecuteClick}
       documentationUrl={getDocumentationUrl(type)}

--- a/js/packages/ui/src/components/run/__tests__/RunModal.test.tsx
+++ b/js/packages/ui/src/components/run/__tests__/RunModal.test.tsx
@@ -23,7 +23,13 @@ describe("RunModal selection submission boundary", () => {
       columns: [
         { name: "amount", type: "DECIMAL(12, 2)" },
         { name: "quantity", type: "INTEGER" },
+        { name: "added_only", type: "BIGINT" },
       ],
+      columnAvailability: {
+        amount: { base: true, current: true },
+        quantity: { base: true, current: true },
+        added_only: { base: false, current: true },
+      },
       primaryKey: undefined,
       isLoading: false,
       error: null,
@@ -78,5 +84,27 @@ describe("RunModal selection submission boundary", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Execute" }));
     expect(onExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not execute a one-sided catalog column", () => {
+    const onExecute = vi.fn();
+    render(
+      <RunModal<HistogramDiffParams>
+        isOpen
+        onClose={vi.fn()}
+        onExecute={onExecute}
+        title="Histogram Diff"
+        type="histogram_diff"
+        params={{ model: "orders", column_name: "", column_type: "" }}
+        RunForm={HistogramDiffForm}
+        submitOnSelection
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "added_only" },
+    });
+
+    expect(onExecute).not.toHaveBeenCalled();
   });
 });

--- a/js/packages/ui/src/components/run/__tests__/RunModal.test.tsx
+++ b/js/packages/ui/src/components/run/__tests__/RunModal.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HistogramDiffParams } from "../../../api";
+import type { UseModelColumnsReturn } from "../../../hooks/useModelColumns";
+import { HistogramDiffForm } from "../../histogram/HistogramDiffForm";
+import { RunModal } from "../RunModal";
+
+const mockUseModelColumns =
+  vi.fn<(model: string | undefined) => UseModelColumnsReturn>();
+
+vi.mock("../../../hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../hooks")>();
+  return {
+    ...actual,
+    useModelColumns: (model: string | undefined) => mockUseModelColumns(model),
+  };
+});
+
+describe("RunModal selection submission boundary", () => {
+  beforeEach(() => {
+    mockUseModelColumns.mockReset();
+    mockUseModelColumns.mockReturnValue({
+      columns: [
+        { name: "amount", type: "DECIMAL(12, 2)" },
+        { name: "quantity", type: "INTEGER" },
+      ],
+      primaryKey: undefined,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it("executes exactly once from one explicit selection when opted in", () => {
+    const onExecute = vi.fn();
+    render(
+      <RunModal<HistogramDiffParams>
+        isOpen
+        onClose={vi.fn()}
+        onExecute={onExecute}
+        title="Histogram Diff"
+        type="histogram_diff"
+        params={{ model: "orders", column_name: "", column_type: "" }}
+        RunForm={HistogramDiffForm}
+        submitOnSelection
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "amount" },
+    });
+
+    expect(onExecute).toHaveBeenCalledTimes(1);
+    expect(onExecute).toHaveBeenCalledWith("histogram_diff", {
+      model: "orders",
+      column_name: "amount",
+      column_type: "DECIMAL(12, 2)",
+    });
+  });
+
+  it("keeps Execute-button behavior when selection submission is not opted in", () => {
+    const onExecute = vi.fn();
+    render(
+      <RunModal<HistogramDiffParams>
+        isOpen
+        onClose={vi.fn()}
+        onExecute={onExecute}
+        title="Histogram Diff"
+        type="histogram_diff"
+        params={{ model: "orders", column_name: "", column_type: "" }}
+        RunForm={HistogramDiffForm}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "amount" },
+    });
+    expect(onExecute).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Execute" }));
+    expect(onExecute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/js/packages/ui/src/components/run/types.ts
+++ b/js/packages/ui/src/components/run/types.ts
@@ -47,6 +47,12 @@ export interface RunFormProps<PT = unknown> {
   onParamsChanged: (params: Partial<PT>) => void;
   /** Callback to set whether the form is valid and ready to execute */
   setIsReadyToExecute: (isReadyToExecute: boolean) => void;
+  /**
+   * Optional explicit-event submission request supplied by launchers that opt
+   * into one-step form behavior. Forms must call this from a user event with
+   * complete parameters, never from an effect reacting to controlled values.
+   */
+  onSubmitRequested?: (params: PT) => void;
 }
 
 // ============================================================================

--- a/js/packages/ui/src/components/schema/__tests__/ColumnNameCell.test.tsx
+++ b/js/packages/ui/src/components/schema/__tests__/ColumnNameCell.test.tsx
@@ -26,12 +26,14 @@ vi.mock("../../ui/DataTypeIcon", async (importOriginal) => {
 });
 
 // Mock dependencies with dynamic isActionAvailable and lineageViewContext
-const { mockIsActionAvailable, mockLineageViewContext } = vi.hoisted(() => ({
-  mockIsActionAvailable: vi.fn(() => true),
-  mockLineageViewContext: { current: undefined as unknown },
-}));
+const { mockIsActionAvailable, mockLineageViewContext, mockRunAction } =
+  vi.hoisted(() => ({
+    mockIsActionAvailable: vi.fn(() => true),
+    mockLineageViewContext: { current: undefined as unknown },
+    mockRunAction: vi.fn(),
+  }));
 vi.mock("../../../contexts", () => ({
-  useRecceActionContext: () => ({ runAction: vi.fn() }),
+  useRecceActionContext: () => ({ runAction: mockRunAction }),
   useRecceInstanceContext: () => ({
     featureToggles: { disableDatabaseQuery: false },
   }),
@@ -87,6 +89,10 @@ function renderWithMui(ui: React.ReactElement) {
 // ============================================================================
 
 describe("ColumnNameCell", () => {
+  beforeEach(() => {
+    mockRunAction.mockClear();
+  });
+
   describe("showMenu prop", () => {
     test("renders menu button when showMenu is true (default)", () => {
       renderWithMui(
@@ -151,6 +157,33 @@ describe("ColumnNameCell", () => {
       const menuButton = screen.queryByRole("button");
       expect(menuButton).not.toBeInTheDocument();
     });
+  });
+
+  test("keeps schema-column Histogram as a direct launch with its source", async () => {
+    const user = userEvent.setup();
+    renderWithMui(
+      <ColumnNameCell model={createMockModel()} row={createMockRow()} />,
+    );
+
+    await user.click(screen.getByRole("button"));
+    await user.click(await screen.findByText("Histogram Diff"));
+
+    expect(mockRunAction).toHaveBeenCalledWith(
+      "histogram_diff",
+      {
+        model: "users",
+        column_name: "user_id",
+        column_type: "INT",
+      },
+      {
+        showForm: false,
+        trackProps: {
+          action: "histogram_diff",
+          source: "schema_column_menu",
+          node_count: 1,
+        },
+      },
+    );
   });
 
   describe("column name display", () => {

--- a/js/packages/ui/src/contexts/action/types.ts
+++ b/js/packages/ui/src/contexts/action/types.ts
@@ -62,6 +62,8 @@ export interface SubmitRunTrackProps {
 export interface RecceActionOptions {
   /** Whether to show a form before executing */
   showForm: boolean;
+  /** Submit a complete form value from an explicit selection event. */
+  submitOnSelection?: boolean;
   /** Whether to show the last run with matching params */
   showLast?: boolean;
   /** Tracking properties for analytics */

--- a/js/packages/ui/src/hooks/RecceActionAdapter.tsx
+++ b/js/packages/ui/src/hooks/RecceActionAdapter.tsx
@@ -41,6 +41,7 @@ import { useApiConfig } from "./useApiConfig";
  */
 export interface RecceActionOptions {
   showForm: boolean;
+  submitOnSelection?: boolean;
   showLast?: boolean;
   trackProps?: SubmitRunTrackProps;
 }
@@ -289,6 +290,7 @@ export function RecceActionAdapter({ children }: RecceActionAdapterProps) {
               ? action.RunForm
               : undefined
           }
+          submitOnSelection={action.options?.submitOnSelection}
         />
       )}
     </RecceActionProvider>

--- a/js/packages/ui/src/hooks/__tests__/RecceActionAdapter.test.tsx
+++ b/js/packages/ui/src/hooks/__tests__/RecceActionAdapter.test.tsx
@@ -1,0 +1,175 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../../lib/fetchClient";
+
+const { mockGetModelInfo, mockPush, mockSearchRuns, mockSubmitRun } =
+  vi.hoisted(() => ({
+    mockGetModelInfo: vi.fn(),
+    mockPush: vi.fn(),
+    mockSearchRuns: vi.fn(),
+    mockSubmitRun: vi.fn(),
+  }));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/lineage",
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("../../api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api")>();
+  return {
+    ...actual,
+    getModelInfo: (...args: unknown[]) => mockGetModelInfo(...args),
+    searchRuns: (...args: unknown[]) => mockSearchRuns(...args),
+    submitRun: (...args: unknown[]) => mockSubmitRun(...args),
+  };
+});
+
+import { Toaster } from "../../components/ui/Toaster";
+import {
+  LineageGraphProvider,
+  RouteConfigProvider,
+  useRecceActionContext,
+} from "../../contexts";
+import { ApiProvider } from "../../providers";
+import { RecceActionAdapter } from "../RecceActionAdapter";
+
+const apiClient = {
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+} as unknown as ApiClient;
+
+const modelInfo = {
+  model: {
+    base: {
+      columns: {
+        amount: { name: "amount", type: "DECIMAL(12, 2)" },
+        quantity: { name: "quantity", type: "INTEGER" },
+      },
+    },
+    current: {
+      columns: {
+        amount: { name: "amount", type: "DECIMAL(12, 2)" },
+        quantity: { name: "quantity", type: "INTEGER" },
+      },
+    },
+  },
+};
+
+function ModelHistogramLauncher() {
+  const { runAction, runId } = useRecceActionContext();
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          runAction(
+            "histogram_diff",
+            { model: "orders", column_name: "", column_type: "" },
+            {
+              showForm: true,
+              submitOnSelection: true,
+              trackProps: { source: "lineage_model_node" },
+            },
+          )
+        }
+      >
+        Launch model histogram
+      </button>
+      {runId && <output>{runId}</output>}
+    </>
+  );
+}
+
+function TestProviders({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ApiProvider config={{ client: apiClient }}>
+        <RouteConfigProvider>
+          <LineageGraphProvider
+            lineageGraph={
+              {
+                nodes: [
+                  {
+                    id: "model.test.orders",
+                    data: { name: "orders", resourceType: "model" },
+                  },
+                ],
+                edges: [],
+              } as never
+            }
+          >
+            {children}
+          </LineageGraphProvider>
+        </RouteConfigProvider>
+      </ApiProvider>
+    </QueryClientProvider>
+  );
+}
+
+function renderLauncher() {
+  return render(
+    <TestProviders>
+      <RecceActionAdapter>
+        <ModelHistogramLauncher />
+        <Toaster />
+      </RecceActionAdapter>
+    </TestProviders>,
+  );
+}
+
+describe("RecceActionAdapter model histogram selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetModelInfo.mockResolvedValue(modelInfo);
+    mockSearchRuns.mockResolvedValue([]);
+    mockSubmitRun.mockResolvedValue({ run_id: "run-123" });
+  });
+
+  it("submits once, opens the result, and preserves model launcher telemetry", async () => {
+    const user = userEvent.setup();
+    renderLauncher();
+
+    await user.click(screen.getByRole("button", { name: /launch model/i }));
+    await user.selectOptions(await screen.findByRole("combobox"), "amount");
+
+    await waitFor(() => expect(mockSubmitRun).toHaveBeenCalledTimes(1));
+    expect(mockSubmitRun).toHaveBeenCalledWith(
+      "histogram_diff",
+      {
+        model: "orders",
+        column_name: "amount",
+        column_type: "DECIMAL(12, 2)",
+      },
+      {
+        nowait: true,
+        trackProps: { source: "lineage_model_node" },
+      },
+      apiClient,
+    );
+    expect(await screen.findByText("run-123")).toBeInTheDocument();
+  });
+
+  it("keeps the submission failure toast visible", async () => {
+    const user = userEvent.setup();
+    mockSubmitRun.mockRejectedValue(new Error("warehouse unavailable"));
+    renderLauncher();
+
+    await user.click(screen.getByRole("button", { name: /launch model/i }));
+    await user.selectOptions(await screen.findByRole("combobox"), "amount");
+
+    expect(
+      await screen.findByText("Failed to submit a run"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("warehouse unavailable")).toBeInTheDocument();
+    expect(mockSubmitRun).toHaveBeenCalledTimes(1);
+  });
+});

--- a/js/packages/ui/src/hooks/__tests__/useModelColumns.test.tsx
+++ b/js/packages/ui/src/hooks/__tests__/useModelColumns.test.tsx
@@ -116,6 +116,10 @@ describe("useModelColumns", () => {
     expect(mockGetModelInfo).toHaveBeenCalledTimes(1);
     expect(mockGetModelInfo).toHaveBeenCalledWith(NODE_ID, mockApiClient);
     expect(result.current.columns.map((c) => c.name)).toEqual(["id", "name"]);
+    expect(result.current.columnAvailability).toEqual({
+      id: { base: true, current: true },
+      name: { base: false, current: true },
+    });
     expect(result.current.primaryKey).toBe("id");
     expect(result.current.error).toBe(null);
   });
@@ -170,6 +174,39 @@ describe("useModelColumns", () => {
     expect(result.current.error).toBe(null);
   });
 
+  it("reports two-sided availability from distinct base/current catalogs", async () => {
+    mockGetModelInfo.mockResolvedValue({
+      model: {
+        base: {
+          columns: {
+            shared: { name: "shared", type: "INT" },
+            removed_only: { name: "removed_only", type: "DOUBLE" },
+          },
+        },
+        current: {
+          columns: {
+            shared: { name: "shared", type: "BIGINT" },
+            added_only: { name: "added_only", type: "DECIMAL(12, 2)" },
+          },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useModelColumns(MODEL_NAME), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.columnAvailability).toEqual({
+      shared: { base: true, current: true },
+      removed_only: { base: true, current: false },
+      added_only: { base: false, current: true },
+    });
+  });
+
   it("dedupes the /api/models/{id} fetch when a sibling useQuery shares the cache key (DRC-3343)", async () => {
     mockGetModelInfo.mockResolvedValue(fakeModelInfo);
 
@@ -210,6 +247,7 @@ describe("useModelColumns", () => {
 
     expect(result.current.isLoading).toBe(false);
     expect(result.current.columns).toEqual([]);
+    expect(result.current.columnAvailability).toEqual({});
     expect(result.current.primaryKey).toBeUndefined();
     expect(mockGetModelInfo).not.toHaveBeenCalled();
   });

--- a/js/packages/ui/src/hooks/index.ts
+++ b/js/packages/ui/src/hooks/index.ts
@@ -44,6 +44,7 @@ export { useFeedbackCollectionToast } from "./useFeedbackCollectionToast";
 export { useGuideToast } from "./useGuideToast";
 export { useIsDark } from "./useIsDark";
 export {
+  type ModelColumnAvailability,
   type UseModelColumnsReturn,
   unionColumns,
   useModelColumns,

--- a/js/packages/ui/src/hooks/useModelColumns.tsx
+++ b/js/packages/ui/src/hooks/useModelColumns.tsx
@@ -40,9 +40,16 @@ export function unionColumns(
  */
 export interface UseModelColumnsReturn {
   columns: NodeColumnData[];
+  columnAvailability: Record<string, ModelColumnAvailability>;
   primaryKey: string | undefined;
   isLoading: boolean;
   error: Error | null;
+}
+
+/** Per-environment presence used by diff launchers to reject one-sided columns. */
+export interface ModelColumnAvailability {
+  base: boolean;
+  current: boolean;
 }
 
 /**
@@ -108,7 +115,7 @@ export function useModelColumns(
     staleTime: 5 * 60 * 1000,
   });
 
-  const { columns, primaryKey } = useMemo(() => {
+  const { columns, columnAvailability, primaryKey } = useMemo(() => {
     // added nodes have no base, removed nodes have no current
     const modelInfo = data?.model;
     const baseColumns = modelInfo?.base?.columns
@@ -117,8 +124,22 @@ export function useModelColumns(
     const currentColumns = modelInfo?.current?.columns
       ? Object.values(modelInfo.current.columns)
       : [];
+    const columns = unionColumns(baseColumns, currentColumns);
+    const baseColumnNames = new Set(baseColumns.map((column) => column.name));
+    const currentColumnNames = new Set(
+      currentColumns.map((column) => column.name),
+    );
     return {
-      columns: unionColumns(baseColumns, currentColumns),
+      columns,
+      columnAvailability: Object.fromEntries(
+        columns.map((column) => [
+          column.name,
+          {
+            base: baseColumnNames.has(column.name),
+            current: currentColumnNames.has(column.name),
+          },
+        ]),
+      ),
       primaryKey:
         modelInfo?.current?.primary_key ?? modelInfo?.base?.primary_key,
     };
@@ -135,7 +156,7 @@ export function useModelColumns(
       : new Error(String(queryError))
     : null;
 
-  return { columns, primaryKey, isLoading, error };
+  return { columns, columnAvailability, primaryKey, isLoading, error };
 }
 
 export default useModelColumns;

--- a/js/packages/ui/src/index.ts
+++ b/js/packages/ui/src/index.ts
@@ -164,6 +164,7 @@ export {
 } from "./contexts";
 // Hooks - utility hooks for theming and data
 export type {
+  ModelColumnAvailability,
   MultiNodesActionCallbacks,
   MultiNodesActionTracking,
   MultiNodesActionTrackProps,

--- a/recce/tasks/histogram.py
+++ b/recce/tasks/histogram.py
@@ -139,6 +139,24 @@ def _decimal_result_value(value):
     return int(decimal_value) if decimal_value == decimal_value.to_integral_value() else result
 
 
+def _decimal_display_value(value):
+    """Convert a display-only extremum, keeping magnitude instead of failing the run.
+
+    Bin edges must survive JSON unchanged because they define bucket boundaries, so they
+    go through _decimal_result_value. The reported minimum and maximum are labels: a
+    BIGINT id past 2**53 or a DECIMAL(38, 18) amount cannot round-trip through a double,
+    and refusing them would fail a histogram that computed correctly.
+    """
+    decimal_value = _decimal_value(value)
+    try:
+        result = float(decimal_value)
+    except (OverflowError, ValueError) as error:
+        raise ValueError(f"Histogram Decimal {decimal_value} cannot be represented as a finite JSON number") from error
+    if not math.isfinite(result) or (result == 0 and decimal_value != 0):
+        raise ValueError(f"Histogram Decimal {decimal_value} cannot be represented as a finite JSON number")
+    return int(decimal_value) if decimal_value == decimal_value.to_integral_value() else result
+
+
 def nice_histogram_width(raw_width):
     """Round a positive Decimal width up to the approved nice-width series."""
     raw_width = _decimal_value(raw_width)
@@ -184,19 +202,6 @@ def numeric_histogram_geometry(min_value, max_value, num_bins=50, *, is_integer=
         num_edges = max(1, int(edge_count.to_integral_value(rounding=ROUND_CEILING)))
         bin_edges = [lower_edge + width * i for i in range(num_edges + 1)]
     return NumericHistogramGeometry(width=width, bin_edges=bin_edges)
-
-
-def histogram_bucket_index(value, geometry):
-    """Return the single bin that owns a value, including the terminal edge."""
-    decimal_value = _decimal_value(value)
-    first_edge = geometry.bin_edges[0]
-    last_edge = geometry.bin_edges[-1]
-    if decimal_value == last_edge:
-        return geometry.num_bins - 1
-    index = int(((decimal_value - first_edge) / geometry.width).to_integral_value(rounding=ROUND_FLOOR))
-    if index < 0 or index >= geometry.num_bins:
-        raise ValueError(f"Histogram value {decimal_value} is outside the computed edge domain")
-    return index
 
 
 def _generate_histogram_sql(node, column, min_value, max_value, num_bins, bin_size):
@@ -509,8 +514,8 @@ class HistogramDiffTask(Task, QueryMixin):
                 result["min"] = min_value
                 result["max"] = max_value
             else:
-                result["min"] = _decimal_result_value(min_value)
-                result["max"] = _decimal_result_value(max_value)
+                result["min"] = _decimal_display_value(min_value)
+                result["max"] = _decimal_display_value(max_value)
             result["bin_edges"] = bin_edges
             result["labels"] = labels
         return result

--- a/recce/tasks/histogram.py
+++ b/recce/tasks/histogram.py
@@ -44,8 +44,6 @@ sql_integer_types = [
     "INT4",
     "INT8",  # PostgreSQL specific aliases
     "UNSIGNED BIG INT",  # SQLite specific
-    "NUMBER",  # Oracle, can be used as an integer with precision and scale
-    "NUMERIC",  # Generally available in many SQL databases, used with precision and scale
     "SMALLSERIAL",
     "SERIAL",
     "BIGSERIAL",  # PostgreSQL auto-increment types
@@ -53,6 +51,7 @@ sql_integer_types = [
     "SMALLIDENTITY",
     "BIGIDENTITY",  # SQL Server specific auto-increment types
     "BYTEINT",  # Specific to Snowflake, for storing very small integers
+    "INT64",  # BigQuery
 ]
 
 sql_not_supported_types = [
@@ -93,6 +92,16 @@ def _is_histogram_supported(column_type):
     return True
 
 
+def is_integral_histogram_type(column_type):
+    """Return whether an adapter-reported type can only contain integral values."""
+    normalized_type = column_type.strip().upper()
+    if normalized_type in sql_integer_types:
+        return True
+
+    numeric_match = re.fullmatch(r"(?:DECIMAL|NUMERIC|NUMBER)\(\s*\d+\s*(?:,\s*(\d+)\s*)?\)", normalized_type)
+    return numeric_match is not None and (numeric_match.group(1) is None or numeric_match.group(1) == "0")
+
+
 @dataclass(frozen=True)
 class NumericHistogramGeometry:
     width: Decimal
@@ -117,9 +126,17 @@ def _decimal_sql_literal(value):
 
 def _decimal_result_value(value):
     decimal_value = _decimal_value(value)
-    if decimal_value == decimal_value.to_integral_value():
-        return int(decimal_value)
-    return float(decimal_value)
+    try:
+        result = float(decimal_value)
+    except (OverflowError, ValueError) as error:
+        raise ValueError(
+            f"Histogram Decimal {decimal_value} cannot be represented as a finite JSON number without value change"
+        ) from error
+    if not math.isfinite(result) or _decimal_value(result) != decimal_value:
+        raise ValueError(
+            f"Histogram Decimal {decimal_value} cannot be represented as a finite JSON number without value change"
+        )
+    return int(decimal_value) if decimal_value == decimal_value.to_integral_value() else result
 
 
 def nice_histogram_width(raw_width):
@@ -186,6 +203,12 @@ def _generate_histogram_sql(node, column, min_value, max_value, num_bins, bin_si
     min_literal = _decimal_sql_literal(min_value)
     max_literal = _decimal_sql_literal(max_value)
     bin_size_literal = _decimal_sql_literal(bin_size)
+    decimal_min = _decimal_value(min_value)
+    decimal_bin_size = _decimal_value(bin_size)
+    internal_boundary_cases = "\n".join(
+        f"                WHEN {column} < {_decimal_sql_literal(decimal_min + decimal_bin_size * index)} THEN {index - 1}"
+        for index in range(1, num_bins)
+    )
 
     sql = f"""
     WITH value_ranges AS (
@@ -204,8 +227,13 @@ def _generate_histogram_sql(node, column, min_value, max_value, num_bins, bin_si
         SELECT
             {column} as column_value,
             CASE
+                WHEN {column} IS NULL THEN NULL
+                WHEN {column} < (SELECT min_value FROM bin_parameters)
+                    OR {column} > (SELECT max_value FROM bin_parameters)
+                    THEN FLOOR(({column} - (SELECT min_value FROM bin_parameters)) / (SELECT bin_size FROM bin_parameters))
                 WHEN {column} = (SELECT max_value FROM bin_parameters) THEN {num_bins - 1}
-                ELSE FLOOR(({column} - (SELECT min_value FROM bin_parameters)) / (SELECT bin_size FROM bin_parameters))
+{internal_boundary_cases}
+                ELSE {num_bins - 1}
             END AS bin
         FROM {{{{ ref("{node}") }}}},
         bin_parameters
@@ -244,7 +272,7 @@ class HistogramDiffParams(BaseModel):
 
 
 def query_numeric_histogram(task, node, column, column_type, min_value, max_value, num_bins=50):
-    is_integer = column_type.upper() in sql_integer_types
+    is_integer = is_integral_histogram_type(column_type)
     geometry = numeric_histogram_geometry(min_value, max_value, num_bins, is_integer=is_integer)
     min_edge = geometry.bin_edges[0]
     max_edge = geometry.bin_edges[-1]
@@ -272,8 +300,10 @@ def query_numeric_histogram(task, node, column, column_type, min_value, max_valu
 
     base_result = {}
     curr_result = {}
+    labels = [
+        f"{_decimal_sql_literal(edge)}-{_decimal_sql_literal(edge + geometry.width)}" for edge in geometry.bin_edges
+    ]
     bin_edges = [_decimal_result_value(edge) for edge in geometry.bin_edges]
-    labels = [f"{_decimal_sql_literal(edge)}-{_decimal_sql_literal(edge + geometry.width)}" for edge in bin_edges]
 
     if base is not None:
         counts = [0] * num_bins
@@ -475,8 +505,12 @@ class HistogramDiffTask(Task, QueryMixin):
                 current_result["total"] = curr_total
             result["base"] = base_result
             result["current"] = current_result
-            result["min"] = min_value
-            result["max"] = max_value
+            if column_type.upper() in sql_datetime_types or min_value is None:
+                result["min"] = min_value
+                result["max"] = max_value
+            else:
+                result["min"] = _decimal_result_value(min_value)
+                result["max"] = _decimal_result_value(max_value)
             result["bin_edges"] = bin_edges
             result["labels"] = labels
         return result

--- a/recce/tasks/histogram.py
+++ b/recce/tasks/histogram.py
@@ -1,6 +1,8 @@
 import math
 import re
+from dataclasses import dataclass
 from datetime import date, datetime
+from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal, localcontext
 from typing import Optional
 
 from dateutil.relativedelta import relativedelta
@@ -91,26 +93,120 @@ def _is_histogram_supported(column_type):
     return True
 
 
-def generate_histogram_sql_integer(node, column, min_value, max_value, num_bins=50):
-    bin_size = math.ceil((max_value - min_value) / num_bins) or 1
+@dataclass(frozen=True)
+class NumericHistogramGeometry:
+    width: Decimal
+    bin_edges: list[Decimal]
+
+    @property
+    def num_bins(self):
+        return len(self.bin_edges) - 1
+
+
+def _decimal_value(value):
+    return Decimal(str(value))
+
+
+def _decimal_sql_literal(value):
+    decimal_value = _decimal_value(value)
+    if decimal_value == 0:
+        return "0"
+    literal = format(decimal_value, "f")
+    return literal.rstrip("0").rstrip(".") if "." in literal else literal
+
+
+def _decimal_result_value(value):
+    decimal_value = _decimal_value(value)
+    if decimal_value == decimal_value.to_integral_value():
+        return int(decimal_value)
+    return float(decimal_value)
+
+
+def nice_histogram_width(raw_width):
+    """Round a positive Decimal width up to the approved nice-width series."""
+    raw_width = _decimal_value(raw_width)
+    if raw_width <= 0:
+        return Decimal("1")
+
+    with localcontext() as context:
+        context.prec = max(context.prec, len(raw_width.as_tuple().digits) + 5)
+        scale = Decimal("1").scaleb(raw_width.adjusted())
+        mantissa = raw_width / scale
+        for candidate in (Decimal("1"), Decimal("2"), Decimal("2.5"), Decimal("5"), Decimal("10")):
+            if mantissa <= candidate:
+                return candidate * scale
+    raise AssertionError("nice histogram width candidates must include an upper bound")
+
+
+def numeric_histogram_geometry(min_value, max_value, num_bins=50, *, is_integer=False):
+    """Build Decimal bin geometry that covers the complete numeric domain."""
+    minimum = _decimal_value(min_value)
+    maximum = _decimal_value(max_value)
+    requested_bins = max(int(num_bins), 1)
+    precision = (
+        max(
+            len(minimum.as_tuple().digits),
+            len(maximum.as_tuple().digits),
+            len(str(requested_bins)),
+        )
+        + 8
+    )
+    with localcontext() as context:
+        context.prec = max(context.prec, precision)
+        raw_width = (maximum - minimum) / requested_bins
+        width = nice_histogram_width(raw_width)
+        if is_integer and width < 1:
+            width = Decimal("1")
+
+        lower_bin = (minimum / width).to_integral_value(rounding=ROUND_FLOOR)
+        lower_edge = lower_bin * width
+        if minimum >= 0 and (minimum / width).to_integral_value(rounding=ROUND_CEILING) <= 1:
+            lower_edge = Decimal("0")
+
+        edge_count = (maximum - lower_edge) / width
+        num_edges = max(1, int(edge_count.to_integral_value(rounding=ROUND_CEILING)))
+        bin_edges = [lower_edge + width * i for i in range(num_edges + 1)]
+    return NumericHistogramGeometry(width=width, bin_edges=bin_edges)
+
+
+def histogram_bucket_index(value, geometry):
+    """Return the single bin that owns a value, including the terminal edge."""
+    decimal_value = _decimal_value(value)
+    first_edge = geometry.bin_edges[0]
+    last_edge = geometry.bin_edges[-1]
+    if decimal_value == last_edge:
+        return geometry.num_bins - 1
+    index = int(((decimal_value - first_edge) / geometry.width).to_integral_value(rounding=ROUND_FLOOR))
+    if index < 0 or index >= geometry.num_bins:
+        raise ValueError(f"Histogram value {decimal_value} is outside the computed edge domain")
+    return index
+
+
+def _generate_histogram_sql(node, column, min_value, max_value, num_bins, bin_size):
+    min_literal = _decimal_sql_literal(min_value)
+    max_literal = _decimal_sql_literal(max_value)
+    bin_size_literal = _decimal_sql_literal(bin_size)
 
     sql = f"""
     WITH value_ranges AS (
         SELECT
-            {min_value} as min_value,
-            {max_value} as max_value
+            {min_literal} as min_value,
+            {max_literal} as max_value
     ),
     bin_parameters AS (
         SELECT
             min_value,
             max_value,
-            {bin_size} AS bin_size
+            {bin_size_literal} AS bin_size
         FROM value_ranges
     ),
     binned_values AS (
         SELECT
             {column} as column_value,
-            FLOOR(({column} - (SELECT min_value FROM bin_parameters)) / (SELECT bin_size FROM bin_parameters)) AS bin
+            CASE
+                WHEN {column} = (SELECT max_value FROM bin_parameters) THEN {num_bins - 1}
+                ELSE FLOOR(({column} - (SELECT min_value FROM bin_parameters)) / (SELECT bin_size FROM bin_parameters))
+            END AS bin
         FROM {{{{ ref("{node}") }}}},
         bin_parameters
     ),
@@ -128,40 +224,16 @@ def generate_histogram_sql_integer(node, column, min_value, max_value, num_bins=
     return sql, bin_size
 
 
-def generate_histogram_sql_numeric(node, column, min_value, max_value, num_bins=50):
-    bin_size = (max_value - min_value) / num_bins
-    sql = f"""
-        WITH value_ranges AS (
-            SELECT
-                {min_value} as min_value,
-                {max_value} as max_value
-        ),
-        bin_parameters AS (
-            SELECT
-                min_value,
-                max_value,
-                {bin_size} AS bin_size
-            FROM value_ranges
-        ),
-        binned_values AS (
-            SELECT
-                {column} as column_value,
-                FLOOR(({column} - (SELECT min_value FROM bin_parameters)) / (SELECT bin_size FROM bin_parameters)) AS bin
-            FROM {{{{ ref("{node}") }}}},
-            bin_parameters
-        ),
-        bin_edges AS (
-            SELECT
-                bin,
-                COUNT(*) AS count
-            FROM binned_values, bin_parameters
-            GROUP BY bin
-            ORDER BY bin
-        )
+def generate_histogram_sql_integer(node, column, min_value, max_value, num_bins=50, bin_size=None):
+    if bin_size is None:
+        bin_size = Decimal(max(math.ceil((max_value - min_value) / num_bins), 1))
+    return _generate_histogram_sql(node, column, min_value, max_value, num_bins, bin_size)
 
-        SELECT bin, count FROM bin_edges
-        """
-    return sql, bin_size
+
+def generate_histogram_sql_numeric(node, column, min_value, max_value, num_bins=50, bin_size=None):
+    if bin_size is None:
+        bin_size = (_decimal_value(max_value) - _decimal_value(min_value)) / max(int(num_bins), 1)
+    return _generate_histogram_sql(node, column, min_value, max_value, num_bins, bin_size)
 
 
 class HistogramDiffParams(BaseModel):
@@ -172,12 +244,15 @@ class HistogramDiffParams(BaseModel):
 
 
 def query_numeric_histogram(task, node, column, column_type, min_value, max_value, num_bins=50):
-    if column_type.upper() in sql_integer_types:
-        if max_value - min_value < num_bins:
-            num_bins = int(max_value - min_value + 1)
-        histogram_sql, bin_size = generate_histogram_sql_integer(node, column, min_value, max_value, num_bins)
+    is_integer = column_type.upper() in sql_integer_types
+    geometry = numeric_histogram_geometry(min_value, max_value, num_bins, is_integer=is_integer)
+    min_edge = geometry.bin_edges[0]
+    max_edge = geometry.bin_edges[-1]
+    num_bins = geometry.num_bins
+    if is_integer:
+        histogram_sql, _ = generate_histogram_sql_integer(node, column, min_edge, max_edge, num_bins, geometry.width)
     else:
-        histogram_sql, bin_size = generate_histogram_sql_numeric(node, column, min_value, max_value, num_bins)
+        histogram_sql, _ = generate_histogram_sql_numeric(node, column, min_edge, max_edge, num_bins, geometry.width)
 
     base = None
     try:
@@ -195,15 +270,10 @@ def query_numeric_histogram(task, node, column, column_type, min_value, max_valu
     finally:
         task.check_cancel()
 
-    bin_edges = [None] * (num_bins + 1)
-    labels = [""] * (num_bins + 1)
-
     base_result = {}
     curr_result = {}
-    for i in range(num_bins + 1):
-        val = int(min_value) + i * bin_size
-        bin_edges[i] = val
-        labels[i] = f"{val}-{val + bin_size}"
+    bin_edges = [_decimal_result_value(edge) for edge in geometry.bin_edges]
+    labels = [f"{_decimal_sql_literal(edge)}-{_decimal_sql_literal(edge + geometry.width)}" for edge in bin_edges]
 
     if base is not None:
         counts = [0] * num_bins
@@ -212,10 +282,9 @@ def query_numeric_histogram(task, node, column, column_type, min_value, max_valu
             count = row[1]
             if bin is not None:
                 i = int(bin)
-                if i < num_bins:
-                    counts[i] = count
-                else:
-                    counts[num_bins - 1] += count
+                if i < 0 or i >= num_bins:
+                    raise ValueError(f"Histogram bucket {i} is outside the computed edge domain")
+                counts[i] = count
         base_result = {
             "counts": counts,
         }
@@ -226,10 +295,9 @@ def query_numeric_histogram(task, node, column, column_type, min_value, max_valu
             count = row[1]
             if bin is not None:
                 i = int(bin)
-                if i < num_bins:
-                    counts[i] = count
-                else:
-                    counts[num_bins - 1] += count
+                if i < 0 or i >= num_bins:
+                    raise ValueError(f"Histogram bucket {i} is outside the computed edge domain")
+                counts[i] = count
         curr_result = {
             "counts": counts,
         }

--- a/tests/tasks/test_histogram.py
+++ b/tests/tasks/test_histogram.py
@@ -78,25 +78,6 @@ def test_numeric_histogram_geometry_covers_literal_domains(
         assert geometry.width >= Decimal("1")
 
 
-@pytest.mark.parametrize(
-    ("values", "expected_counts"),
-    [
-        ([Decimal("0"), Decimal("0.5"), Decimal("2")], [1, 1, 0, 1]),
-        ([Decimal("0"), Decimal("1"), Decimal("3")], [1, 1, 1]),
-    ],
-)
-def test_histogram_bucket_index_counts_internal_and_terminal_edges_once(values, expected_counts):
-    """Catch terminal escape or internal-boundary double counting."""
-    geometry = histogram.numeric_histogram_geometry(values[0], values[-1], len(expected_counts))
-    counts = [0] * geometry.num_bins
-
-    for value in values:
-        counts[histogram.histogram_bucket_index(value, geometry)] += 1
-
-    assert counts == expected_counts
-    assert sum(counts) == len(values)
-
-
 def test_histogram_sql_uses_plain_decimal_literals_and_terminal_rule():
     """Catch SQL that leaks exponent literals or lets a terminal maximum escape."""
     sql, _ = histogram.generate_histogram_sql_numeric(
@@ -131,8 +112,8 @@ class NumericHistogramQueryTask:
 
 
 class DecimalExtremaHistogramTask(HistogramDiffTask):
-    def __init__(self, minimum, maximum):
-        super().__init__({"model": "numbers", "column_name": "amount", "column_type": "NUMERIC", "num_bins": 1})
+    def __init__(self, minimum, maximum, column_type="NUMERIC"):
+        super().__init__({"model": "numbers", "column_name": "amount", "column_type": column_type, "num_bins": 1})
         self.minimum = minimum
         self.maximum = maximum
 
@@ -287,13 +268,38 @@ def test_numeric_histogram_query_rejects_decimal_edges_that_cannot_round_trip(mi
         histogram.query_numeric_histogram(task, "numbers", "amount", "NUMERIC", minimum, maximum, 2)
 
 
-def test_histogram_task_rejects_non_round_trippable_decimal_extrema(dbt_test_helper):
-    """Catch task results that expose an unrepresentable Decimal minimum or maximum as JSON numbers."""
-    minimum = Decimal("1" + "0" * 400 + ".1")
-    maximum = Decimal("1" + "0" * 400 + ".9")
-
-    with pytest.raises(ValueError, match="cannot be represented as a finite JSON number without value change"):
+@pytest.mark.parametrize(
+    ("minimum", "maximum"),
+    [
+        (Decimal("1" + "0" * 400 + ".1"), Decimal("1" + "0" * 400 + ".9")),
+        (Decimal("1E-400"), Decimal("3E-400")),
+    ],
+)
+def test_histogram_task_rejects_decimal_extrema_outside_float_range(dbt_test_helper, minimum, maximum):
+    """Catch task results that expose an overflowing or underflowing extremum as a JSON number."""
+    with pytest.raises(ValueError, match="cannot be represented as a finite JSON number"):
         DecimalExtremaHistogramTask(minimum, maximum).execute()
+
+
+@pytest.mark.parametrize(
+    ("column_type", "minimum", "maximum"),
+    [
+        ("BIGINT", Decimal("9007199254740993"), Decimal("9007199254741993")),
+        ("INT64", Decimal("1724544000123456789"), Decimal("1724544999123456789")),
+        ("NUMERIC(38, 18)", Decimal("1.234567890123456789"), Decimal("9.876543210987654321")),
+    ],
+)
+def test_histogram_task_reports_extrema_beyond_double_precision(dbt_test_helper, column_type, minimum, maximum):
+    """Catch a histogram that computed correctly being failed by its own min/max echo."""
+    task = DecimalExtremaHistogramTask(minimum, maximum, column_type=column_type)
+
+    result = task.execute()
+
+    assert result["bin_edges"][0] <= minimum
+    assert result["bin_edges"][-1] >= maximum
+    assert result["min"] == pytest.approx(float(minimum))
+    assert result["max"] == pytest.approx(float(maximum))
+    json.dumps(result)
 
 
 def test_histogram(dbt_test_helper):

--- a/tests/tasks/test_histogram.py
+++ b/tests/tasks/test_histogram.py
@@ -113,6 +113,189 @@ def test_histogram_sql_uses_plain_decimal_literals_and_terminal_rule():
     assert "WHEN amount = (SELECT max_value FROM bin_parameters) THEN 1" in sql
 
 
+class HistogramRows:
+    def __init__(self, rows):
+        self.rows = rows
+
+
+class NumericHistogramQueryTask:
+    def __init__(self, base_rows, current_rows):
+        self.base_rows = HistogramRows(base_rows)
+        self.current_rows = HistogramRows(current_rows)
+
+    def execute_sql(self, _sql, *, base):
+        return self.base_rows if base else self.current_rows
+
+    def check_cancel(self):
+        return None
+
+
+class DecimalExtremaHistogramTask(HistogramDiffTask):
+    def __init__(self, minimum, maximum):
+        super().__init__({"model": "numbers", "column_name": "amount", "column_type": "NUMERIC", "num_bins": 1})
+        self.minimum = minimum
+        self.maximum = maximum
+
+    def execute_sql(self, sql, *, base):
+        if "MIN(" in sql:
+            return [(self.minimum, self.maximum, 1)]
+        return HistogramRows([(0, 1)])
+
+
+@pytest.mark.parametrize(
+    ("column_type", "expected"),
+    [
+        ("INTEGER", True),
+        ("INT64", True),
+        ("NUMERIC", False),
+        ("NUMBER", False),
+        ("NUMERIC(20, 4)", False),
+        ("NUMBER(20, 4)", False),
+        ("NUMERIC(20, 0)", True),
+        ("NUMBER(20)", True),
+        ("DECIMAL(20, 0)", True),
+    ],
+)
+def test_histogram_integral_type_detection_respects_precision_and_scale(column_type, expected):
+    """Catch fractional adapter types being routed through the integer width safeguard."""
+    assert histogram.is_integral_histogram_type(column_type) is expected
+
+
+def test_fractional_histogram_uses_decimal_edges_for_labels_and_real_sql_boundaries(dbt_test_helper):
+    """Catch fractional label failures and floating internal/terminal misbucketing."""
+    base_csv = """
+        id,amount
+        1,0.0
+        2,0.2
+        3,0.4
+        4,0.6
+        5,0.8
+    """
+    current_csv = """
+        id,amount
+        1,0.0
+        2,0.2
+        3,0.4
+        4,0.6
+        5,0.8
+        6,1.0
+    """
+    dbt_test_helper.create_model("fractional_boundaries", base_csv, current_csv)
+
+    result = HistogramDiffTask(
+        {
+            "model": "fractional_boundaries",
+            "column_name": "amount",
+            "column_type": "NUMERIC",
+            "num_bins": 5,
+        }
+    ).execute()
+
+    assert result["min"] == 0.0
+    assert result["max"] == 1.0
+    assert result["bin_edges"] == [0, 0.2, 0.4, 0.6, 0.8, 1]
+    assert result["labels"] == ["0-0.2", "0.2-0.4", "0.4-0.6", "0.6-0.8", "0.8-1", "1-1.2"]
+    assert result["base"] == {"counts": [1, 1, 1, 1, 1], "total": 5}
+    assert result["current"] == {"counts": [1, 1, 1, 1, 2], "total": 6}
+    assert len(result["base"]["counts"]) == len(result["bin_edges"]) - 1
+    assert len(result["current"]["counts"]) == len(result["bin_edges"]) - 1
+    json.dumps(result)
+
+
+@pytest.mark.parametrize(
+    "model_name,base_csv,current_csv,first_edge,last_edge,base_nonzero,current_nonzero",
+    [
+        (
+            "sparse_histogram",
+            """id,amount\n1,0\n2,100""",
+            """id,amount\n1,5\n2,95""",
+            0,
+            100,
+            {0: 1, 49: 1},
+            {2: 1, 47: 1},
+        ),
+        (
+            "constant_histogram",
+            """id,amount\n1,4""",
+            """id,amount\n1,4""",
+            4,
+            5,
+            {0: 1},
+            {0: 1},
+        ),
+        (
+            "negative_histogram",
+            """id,amount\n1,-23\n2,-3""",
+            """id,amount\n1,-20\n2,-10""",
+            -23,
+            -3,
+            {0: 1, 19: 1},
+            {3: 1, 13: 1},
+        ),
+        (
+            "mixed_histogram",
+            """id,amount\n1,-2\n2,12""",
+            """id,amount\n1,-1\n2,10""",
+            -2,
+            12,
+            {0: 1, 13: 1},
+            {1: 1, 12: 1},
+        ),
+        (
+            "disjoint_histogram",
+            """id,amount\n1,-2\n2,-1""",
+            """id,amount\n1,10\n2,12""",
+            -2,
+            12,
+            {0: 1, 1: 1},
+            {12: 1, 13: 1},
+        ),
+    ],
+)
+def test_integer_histogram_result_preserves_union_domain_and_each_side(
+    dbt_test_helper, model_name, base_csv, current_csv, first_edge, last_edge, base_nonzero, current_nonzero
+):
+    """Catch result paths that omit a side, union endpoint, or expected bucket count."""
+    dbt_test_helper.create_model(model_name, base_csv, current_csv)
+
+    result = HistogramDiffTask({"model": model_name, "column_name": "amount", "column_type": "INTEGER"}).execute()
+
+    assert result["bin_edges"][0] == first_edge
+    assert result["bin_edges"][-1] == last_edge
+    assert result["labels"]
+    for side, expected_nonzero in (("base", base_nonzero), ("current", current_nonzero)):
+        counts = result[side]["counts"]
+        assert len(counts) == len(result["bin_edges"]) - 1
+        assert sum(counts) == result[side]["total"] == sum(expected_nonzero.values())
+        assert {index: count for index, count in enumerate(counts) if count} == expected_nonzero
+    json.dumps(result)
+
+
+@pytest.mark.parametrize(
+    ("minimum", "maximum"),
+    [
+        (Decimal("1E-400"), Decimal("3E-400")),
+        (Decimal("1E400"), Decimal("3E400")),
+        (Decimal("1" + "0" * 400 + ".1"), Decimal("1" + "0" * 400 + ".9")),
+    ],
+)
+def test_numeric_histogram_query_rejects_decimal_edges_that_cannot_round_trip(minimum, maximum):
+    """Catch JSON edge conversion that underflows, overflows, or changes the Decimal domain."""
+    task = NumericHistogramQueryTask([(0, 1)], [(0, 1)])
+
+    with pytest.raises(ValueError, match="cannot be represented as a finite JSON number without value change"):
+        histogram.query_numeric_histogram(task, "numbers", "amount", "NUMERIC", minimum, maximum, 2)
+
+
+def test_histogram_task_rejects_non_round_trippable_decimal_extrema(dbt_test_helper):
+    """Catch task results that expose an unrepresentable Decimal minimum or maximum as JSON numbers."""
+    minimum = Decimal("1" + "0" * 400 + ".1")
+    maximum = Decimal("1" + "0" * 400 + ".9")
+
+    with pytest.raises(ValueError, match="cannot be represented as a finite JSON number without value change"):
+        DecimalExtremaHistogramTask(minimum, maximum).execute()
+
+
 def test_histogram(dbt_test_helper):
     csv_data = """
         customer_id,name,age
@@ -176,6 +359,8 @@ def test_histogram_emtpy(dbt_test_helper):
     assert run_result["min"] is None
     assert run_result["max"] is None
     assert len(run_result["bin_edges"]) == 0
+    assert run_result["labels"] == []
+    json.dumps(run_result)
 
     params = {"model": "customers2", "column_name": "age", "column_type": "int"}
 
@@ -191,6 +376,10 @@ def test_histogram_emtpy(dbt_test_helper):
     assert run_result["max"] == 50
     assert run_result["bin_edges"][0] == 25
     assert run_result["bin_edges"][-1] == 50
+    assert len(run_result["base"]["counts"]) == len(run_result["bin_edges"]) - 1
+    assert len(run_result["current"]["counts"]) == len(run_result["bin_edges"]) - 1
+    assert run_result["labels"]
+    json.dumps(run_result)
 
     params = {"model": "customers3", "column_name": "age", "column_type": "int"}
 
@@ -206,6 +395,10 @@ def test_histogram_emtpy(dbt_test_helper):
     assert run_result["max"] == 50
     assert run_result["bin_edges"][0] == 25
     assert run_result["bin_edges"][-1] == 50
+    assert len(run_result["base"]["counts"]) == len(run_result["bin_edges"]) - 1
+    assert len(run_result["current"]["counts"]) == len(run_result["bin_edges"]) - 1
+    assert run_result["labels"]
+    json.dumps(run_result)
 
 
 def test_validator():

--- a/tests/tasks/test_histogram.py
+++ b/tests/tasks/test_histogram.py
@@ -1,10 +1,116 @@
+import json
+from decimal import Decimal
+
 import pytest
 
+import recce.tasks.histogram as histogram
 from recce.tasks.histogram import (
     HistogramDiffCheckValidator,
     HistogramDiffTask,
     _is_histogram_supported,
 )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (Decimal("0.11"), Decimal("0.2")),
+        (Decimal("2.1"), Decimal("2.5")),
+        (Decimal("26"), Decimal("50")),
+    ],
+)
+def test_nice_histogram_width(raw, expected):
+    """Catch widths that do not round up to the specified nice series."""
+    assert histogram.nice_histogram_width(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (Decimal("0.001"), Decimal("0.001")),
+        (Decimal("0.01"), Decimal("0.01")),
+        (Decimal("0.0100001"), Decimal("0.02")),
+        (Decimal("0.025"), Decimal("0.025")),
+        (Decimal("0.0250001"), Decimal("0.05")),
+        (Decimal("0.05"), Decimal("0.05")),
+        (Decimal("0.0500001"), Decimal("0.1")),
+        (Decimal("1"), Decimal("1")),
+        (Decimal("1.000001"), Decimal("2")),
+    ],
+)
+def test_nice_histogram_width_ceilings_are_decimal_exact(raw, expected):
+    """Catch boundary rounding that selects a smaller or non-series width."""
+    assert histogram.nice_histogram_width(raw) == expected
+
+
+def test_numeric_histogram_geometry_anchors_only_the_first_zero_width():
+    """Catch zero anchoring after the first width above the minimum."""
+    first = histogram.numeric_histogram_geometry(Decimal("0.2"), Decimal("1.0"), 4)
+    second = histogram.numeric_histogram_geometry(Decimal("0.21"), Decimal("1.0"), 4)
+
+    assert first.bin_edges[0] == Decimal("0")
+    assert second.bin_edges[0] == Decimal("0.2")
+
+
+@pytest.mark.parametrize(
+    ("minimum", "maximum", "num_bins", "is_integer", "first_edge", "last_edge"),
+    [
+        (Decimal("0"), Decimal("100"), 50, True, Decimal("0"), Decimal("100")),
+        (Decimal("4"), Decimal("4"), 50, True, Decimal("4"), Decimal("5")),
+        (Decimal("-23"), Decimal("-3"), 50, True, Decimal("-23"), Decimal("-3")),
+        (Decimal("-1.1"), Decimal("1.1"), 50, False, Decimal("-1.1"), Decimal("1.1")),
+        (Decimal("0.11"), Decimal("0.89"), 4, False, Decimal("0"), Decimal("1.0")),
+        (Decimal("-2"), Decimal("12"), 50, True, Decimal("-2"), Decimal("12")),
+    ],
+)
+def test_numeric_histogram_geometry_covers_literal_domains(
+    minimum, maximum, num_bins, is_integer, first_edge, last_edge
+):
+    """Catch geometry that starts at observations or excludes a union endpoint."""
+    geometry = histogram.numeric_histogram_geometry(minimum, maximum, num_bins, is_integer=is_integer)
+
+    assert geometry.bin_edges[0] == first_edge
+    assert geometry.bin_edges[-1] == last_edge
+    assert geometry.bin_edges[0] <= minimum <= geometry.bin_edges[-1]
+    assert geometry.bin_edges[0] <= maximum <= geometry.bin_edges[-1]
+    assert len(geometry.bin_edges) == geometry.num_bins + 1
+    if is_integer:
+        assert geometry.width >= Decimal("1")
+
+
+@pytest.mark.parametrize(
+    ("values", "expected_counts"),
+    [
+        ([Decimal("0"), Decimal("0.5"), Decimal("2")], [1, 1, 0, 1]),
+        ([Decimal("0"), Decimal("1"), Decimal("3")], [1, 1, 1]),
+    ],
+)
+def test_histogram_bucket_index_counts_internal_and_terminal_edges_once(values, expected_counts):
+    """Catch terminal escape or internal-boundary double counting."""
+    geometry = histogram.numeric_histogram_geometry(values[0], values[-1], len(expected_counts))
+    counts = [0] * geometry.num_bins
+
+    for value in values:
+        counts[histogram.histogram_bucket_index(value, geometry)] += 1
+
+    assert counts == expected_counts
+    assert sum(counts) == len(values)
+
+
+def test_histogram_sql_uses_plain_decimal_literals_and_terminal_rule():
+    """Catch SQL that leaks exponent literals or lets a terminal maximum escape."""
+    sql, _ = histogram.generate_histogram_sql_numeric(
+        "customers",
+        "amount",
+        Decimal("0.000001"),
+        Decimal("0.000003"),
+        2,
+    )
+
+    assert "0.000001" in sql
+    assert "0.000003" in sql
+    assert "E-" not in sql.upper()
+    assert "WHEN amount = (SELECT max_value FROM bin_parameters) THEN 1" in sql
 
 
 def test_histogram(dbt_test_helper):
@@ -27,8 +133,8 @@ def test_histogram(dbt_test_helper):
     #     'base': {'counts': [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], 'total': 4},
     #     'current': {'counts': [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], 'total': 4},
     #     'min': 25, 'max': 50,
-    #     'bin_edges': [25, 26, ..., 51],
-    #     'labels': ['25-26', ..., '51-52']
+    #     'bin_edges': [25, 26, ..., 50],
+    #     'labels': ['25-26', ..., '50-51']
     # }
     assert run_result["current"]["counts"][0] == 1
     assert run_result["current"]["counts"][-1] == 1
@@ -36,7 +142,11 @@ def test_histogram(dbt_test_helper):
     assert run_result["min"] == 25
     assert run_result["max"] == 50
     assert run_result["bin_edges"][0] == 25
-    assert run_result["bin_edges"][-1] == 51
+    assert run_result["bin_edges"][-1] == 50
+    assert len(run_result["current"]["counts"]) == len(run_result["bin_edges"]) - 1
+    assert sum(run_result["current"]["counts"]) == run_result["current"]["total"]
+    assert run_result["labels"]
+    json.dumps(run_result)
 
 
 def test_histogram_emtpy(dbt_test_helper):
@@ -80,7 +190,7 @@ def test_histogram_emtpy(dbt_test_helper):
     assert run_result["min"] == 25
     assert run_result["max"] == 50
     assert run_result["bin_edges"][0] == 25
-    assert run_result["bin_edges"][-1] == 51
+    assert run_result["bin_edges"][-1] == 50
 
     params = {"model": "customers3", "column_name": "age", "column_type": "int"}
 
@@ -95,7 +205,7 @@ def test_histogram_emtpy(dbt_test_helper):
     assert run_result["min"] == 25
     assert run_result["max"] == 50
     assert run_result["bin_edges"][0] == 25
-    assert run_result["bin_edges"][-1] == 51
+    assert run_result["bin_edges"][-1] == 50
 
 
 def test_validator():


### PR DESCRIPTION
## Stack

1. #1517: Profile readability and delta modes
2. This PR: Histogram readability and one-step launch

This PR is based on #1517. Merge the stack bottom-up. GitHub Stack #1519 tracks the dependency chain.

## Tickets

- [DRC-2838](https://linear.app/recce/issue/DRC-2838)
- [DRC-2848](https://linear.app/recce/issue/DRC-2848)

## Summary

- Adds Decimal-safe nice numeric bins, exact zero anchoring, full-domain coverage, and exact internal and terminal boundary ownership.
- Renders literal edge ticks, variable-width bars, domain-aware labels, accurate tooltip hit testing, and stable animated geometry.
- Launches a model-level Histogram run exactly once after an explicit eligible column selection.
- Preserves the generic Execute path and the existing schema-column and lineage-column direct launch paths.
- Requires columns to exist in both environments before one-step submission and records distinct launcher telemetry sources.

## Verification

- Frontend lint-fix passed across 692 files with no changes.
- Root, UI package, and Storybook type checks passed.
- 204 frontend test files passed: 4,243 tests passed and 5 skipped.
- Production frontend build passed with no tracked generated changes.
- Python suite passed: 1,630 tests passed and 5 skipped.
- Focused backend Histogram suite passed: 45 tests.
- Final adversarial whole-layer review: Ready to merge.

## Compatibility and follow-up

Existing Histogram wire fields and direct launch behavior remain compatible. Large num_bins SQL growth is tracked in [DRC-4232](https://linear.app/recce/issue/DRC-4232); this stack intentionally avoids an incompatible hard cap until adapter-specific exact bucketing is proven.