### PR TITLE
fix(histogram): reject TIME and TIMETZ column types before datetime bucketing

### DIFF
--- a/js/packages/ui/src/components/histogram/__tests__/HistogramDiffForm.test.ts
+++ b/js/packages/ui/src/components/histogram/__tests__/HistogramDiffForm.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { supportsHistogramDiff } from "../HistogramDiffForm";
+
+describe("supportsHistogramDiff", () => {
+  it("should return true for supported numeric types", () => {
+    const supportedNumericTypes = [
+      "INT",
+      "INTEGER",
+      "BIGINT",
+      "SMALLINT",
+      "TINYINT",
+      "FLOAT",
+      "DOUBLE",
+      "DECIMAL",
+      "NUMERIC",
+      "REAL",
+    ];
+
+    for (const type of supportedNumericTypes) {
+      expect(supportsHistogramDiff(type)).toBe(true);
+      expect(supportsHistogramDiff(type.toLowerCase())).toBe(true);
+    }
+  });
+
+  it("should return false for string data types", () => {
+    const stringTypes = [
+      "CHAR",
+      "VARCHAR",
+      "VARCHAR(255)",
+      "NVARCHAR(50)",
+      "TEXT",
+      "LONGTEXT",
+      "CLOB",
+      "JSON",
+    ];
+
+    for (const type of stringTypes) {
+      expect(supportsHistogramDiff(type)).toBe(false);
+      expect(supportsHistogramDiff(type.toLowerCase())).toBe(false);
+    }
+  });
+
+  it("should return false for boolean data types", () => {
+    const booleanTypes = ["BOOLEAN", "BOOL", "BIT", "TINYINT(1)"];
+
+    for (const type of booleanTypes) {
+      expect(supportsHistogramDiff(type)).toBe(false);
+      expect(supportsHistogramDiff(type.toLowerCase())).toBe(false);
+    }
+  });
+
+  it("should return false for datetime and timestamp types", () => {
+    const datetimeTypes = [
+      "DATE",
+      "DATETIME",
+      "TIMESTAMP",
+      "TIMESTAMPTZ",
+      "TIMESTAMP WITH TIME ZONE",
+      "TIMESTAMP_NTZ",
+      "DATETIME2",
+    ];
+
+    for (const type of datetimeTypes) {
+      expect(supportsHistogramDiff(type)).toBe(false);
+      expect(supportsHistogramDiff(type.toLowerCase())).toBe(false);
+    }
+  });
+
+  it("should return false for TIME and TIMETZ types", () => {
+    const timeTypes = ["TIME", "TIMETZ", "time", "timetz"];
+
+    for (const type of timeTypes) {
+      expect(supportsHistogramDiff(type)).toBe(false);
+    }
+  });
+});

--- a/recce/tasks/histogram.py
+++ b/recce/tasks/histogram.py
@@ -16,14 +16,12 @@ sql_datetime_types = [
     "DATE",
     "DATETIME",
     "TIMESTAMP",
-    "TIME",
     "YEAR",  # Specific to MySQL/MariaDB
     "DATETIME2",
     "SMALLDATETIME",
     "DATETIMEOFFSET",  # Specific to SQL Server
     "INTERVAL",  # Common in PostgreSQL and Oracle
     "TIMESTAMPTZ",
-    "TIMETZ",  # Specific to PostgreSQL
     "TIMESTAMP WITH TIME ZONE",
     "TIMESTAMP WITH LOCAL TIME ZONE",  # Oracle
     "TIMESTAMP_LTZ",
@@ -74,6 +72,8 @@ sql_not_supported_types = [
     "BIT",  # SQL Server and others use BIT to represent boolean values, where 1 is true and 0 is false
     "NUMBER(1)",  # Oracle uses NUMBER(1) where 1 is true and 0 is false, as it does not have a native BOOLEAN type
     "BOOL",  # Snowflake and PostgreSQL also support BOOL as an alias for BOOLEAN
+    "TIME",
+    "TIMETZ",
 ]
 
 sql_not_supported_types_pattern = [
@@ -428,6 +428,9 @@ class HistogramDiffCheckValidator(CheckValidator):
 
     def validate_check(self, check: Check):
         try:
-            HistogramDiffParams(**check.params)
+            params = HistogramDiffParams(**check.params)
         except Exception as e:
             raise ValueError(f"Invalid check: {str(e)}")
+
+        if _is_histogram_supported(params.column_type) is False:
+            raise ValueError(f"Column type {params.column_type} is not supported for histogram analysis")

--- a/tests/tasks/test_histogram.py
+++ b/tests/tasks/test_histogram.py
@@ -120,6 +120,24 @@ def test_validator():
     with pytest.raises(ValueError):
         validate({})
 
+    with pytest.raises(ValueError, match="not supported"):
+        validate(
+            {
+                "model": "customers",
+                "column_name": "time_col",
+                "column_type": "TIME",
+            }
+        )
+
+    with pytest.raises(ValueError, match="not supported"):
+        validate(
+            {
+                "model": "customers",
+                "column_name": "timetz_col",
+                "column_type": "TIMETZ",
+            }
+        )
+
 
 def test_is_column_type_supported_by_histogram():
     assert _is_histogram_supported("varchar") is False
@@ -127,3 +145,23 @@ def test_is_column_type_supported_by_histogram():
     assert _is_histogram_supported("varchar(256)") is False
     assert _is_histogram_supported("bool") is False
     assert _is_histogram_supported("int") is True
+    assert _is_histogram_supported("TIME") is False
+    assert _is_histogram_supported("time") is False
+    assert _is_histogram_supported("TIMETZ") is False
+    assert _is_histogram_supported("timetz") is False
+    assert _is_histogram_supported("DATE") is True
+    assert _is_histogram_supported("DATETIME") is True
+    assert _is_histogram_supported("TIMESTAMP") is True
+    assert _is_histogram_supported("TIMESTAMPTZ") is True
+
+
+def test_histogram_rejects_time_columns_before_sql(dbt_test_helper):
+    params_time = {"model": "customers", "column_name": "log_time", "column_type": "TIME"}
+    task = HistogramDiffTask(params_time)
+    with pytest.raises(ValueError, match="Column type TIME is not supported for histogram analysis"):
+        task.execute()
+
+    params_timetz = {"model": "customers", "column_name": "log_time_tz", "column_type": "TIMETZ"}
+    task_tz = HistogramDiffTask(params_timetz)
+    with pytest.raises(ValueError, match="Column type TIMETZ is not supported for histogram analysis"):
+        task_tz.execute()


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bugfix

**What this PR does / why we need it**:
Reject unsupported `TIME` and `TIMETZ` column types before executing datetime histogram queries or persisting checks. Previously, `TIME` and `TIMETZ` were listed in `sql_datetime_types` in `HistogramDiffTask`, which caused `query_datetime_histogram` to attempt date arithmetic (`(max_value - min_value).days`) on `datetime.time` objects, resulting in an unhandled `TypeError: unsupported operand type(s) for -: 'datetime.time' and 'datetime.time'`.

Changes made:
- Removed `"TIME"` and `"TIMETZ"` from `sql_datetime_types` in `recce/tasks/histogram.py`.
- Added `"TIME"` and `"TIMETZ"` to `sql_not_supported_types` in `recce/tasks/histogram.py`.
- Updated `HistogramDiffCheckValidator.validate_check` to validate `_is_histogram_supported(params.column_type)`.
- Added unit tests for validator rejection and task execution rejection in `tests/tasks/test_histogram.py`.
- Added unit tests for `supportsHistogramDiff` type predicate behavior in `js/packages/ui/src/components/histogram/__tests__/HistogramDiffForm.test.ts`.

**Which issue(s) this PR fixes**:
Closes DRC-4215

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
NONE
