### PR TITLE
refactor(lineage): centralize CLL frontend state

### DIFF
--- a/docs/cll-state-and-fetching.md
+++ b/docs/cll-state-and-fetching.md
@@ -39,4 +39,80 @@ Measurements ran locally with Node.js. Raw bytes use compact `JSON.stringify`, g
 
 These results are directional, not a production browser benchmark: they use a warm local Node runtime, omit network latency, and reproduce the proprietary project's counts and captured object shapes rather than its source payload. They are sufficient for the transport choice because the browser cost is paid up front even when a user inspects only one column.
 
+### Reproduction
+
+The measurement used Node.js v26.7.0 and fixture commit `329a59989d94e83c74a021a6d2799e8e0bc4b2a1`. The fixture's SHA-256 is `ffd66a9ff511e51d6374df003a652e59345c0e5e45eeaef7faf59b09e38868f1`.
+
+```bash
+cll_fixture_path=$(mktemp)
+git show 329a59989d94e83c74a021a6d2799e8e0bc4b2a1:js/packages/ui/src/components/lineage/__tests__/fixtures/cll-full-map.json > "$cll_fixture_path"
+CLL_FIXTURE_PATH="$cll_fixture_path" node --expose-gc <<'NODE'
+const fs = require("node:fs");
+const zlib = require("node:zlib");
+
+const sourceJson = fs.readFileSync(process.env.CLL_FIXTURE_PATH, "utf8");
+const source = JSON.parse(sourceJson).current;
+
+function cycle(entries, count) {
+  return Object.fromEntries(
+    Array.from({ length: count }, (_, index) => {
+      const [key, value] = entries[index % entries.length];
+      const prefix = `synthetic_${index}_`;
+      const copy = structuredClone(value);
+      if (copy && typeof copy === "object" && "id" in copy) {
+        copy.id = prefix + copy.id;
+      }
+      return [prefix + key, copy];
+    }),
+  );
+}
+
+function cycleMap(entries, count) {
+  return Object.fromEntries(
+    Array.from({ length: count }, (_, index) => {
+      const [key, value] = entries[index % entries.length];
+      const prefix = `synthetic_${index}_`;
+      return [
+        prefix + key,
+        Array.isArray(value) ? value.map((item) => prefix + item) : value,
+      ];
+    }),
+  );
+}
+
+const payload = {
+  current: {
+    nodes: cycle(Object.entries(source.nodes), 1796),
+    columns: cycle(Object.entries(source.columns), 15520),
+    parent_map: cycleMap(Object.entries(source.parent_map), 17316),
+    child_map: cycleMap(Object.entries(source.child_map), 17316),
+  },
+};
+const json = JSON.stringify(payload);
+const parseTimes = [];
+for (let index = 0; index < 12; index++) {
+  const started = process.hrtime.bigint();
+  JSON.parse(json);
+  parseTimes.push(Number(process.hrtime.bigint() - started) / 1e6);
+}
+parseTimes.sort((left, right) => left - right);
+
+global.gc();
+const heapBefore = process.memoryUsage().heapUsed;
+global.parsedCllPayload = JSON.parse(json);
+global.gc();
+const heapAfter = process.memoryUsage().heapUsed;
+
+console.log({
+  sourceRawBytes: Buffer.byteLength(sourceJson),
+  sourceGzipBytes: zlib.gzipSync(sourceJson).length,
+  syntheticRawBytes: Buffer.byteLength(json),
+  syntheticGzipBytes: zlib.gzipSync(json).length,
+  parseMedianMs: parseTimes[Math.floor(parseTimes.length / 2)],
+  retainedHeapBytes: heapAfter - heapBefore,
+});
+NODE
+rm "$cll_fixture_path"
+```
+
 The complete-map option would trade cached slice requests for about 15.6 MB of JSON allocation and about 19.4 MB of retained heap at the measured large shape. Since complete-map computation is already cached server-side, that trade is not justified without evidence from production click-latency and browser-memory telemetry.

--- a/docs/cll-state-and-fetching.md
+++ b/docs/cll-state-and-fetching.md
@@ -1,0 +1,42 @@
+# CLL frontend state and fetching
+
+Status: accepted for [DRC-3021](https://linear.app/recce/issue/DRC-3021/cll-frontend-refactor-centralize-cll-data-in-one-store-separated-from), 2026-08-26.
+
+## Decision
+
+The frontend keeps fetching column-level lineage (CLL) slices per interaction. It does not fetch and retain the complete CLL map.
+
+The backend still owns complete-map construction and caching. That removes repeated SQL parsing and manifest traversal from per-node requests without making every browser download the whole map. The frontend can revisit complete-map transport if production telemetry shows that cached slice latency is material and browser memory remains acceptable on large projects.
+
+## State boundary
+
+`useCllState` is the single frontend owner of:
+
+- the current `ColumnLineageData` result;
+- CLL request, cache-patch, and stale-response ownership;
+- the optional-input history stack;
+- CLL interaction generations;
+- published node, column, and whole-model impact snapshots.
+
+`LineageViewOss` continues to own presentation and layout state: view options, change-analysis presentation mode, model focus, model-focus history, selection, React Flow nodes and edges, and layout generations. It commits a fetched CLL result only after the existing layout-generation guard accepts it.
+
+[DRC-3315](https://linear.app/recce/issue/DRC-3315/split-lineageviewcontext-into-stable-dynamic-slices-or-migrate-to) owns state-library selection and `LineageViewContext` slicing. DRC-3021 deliberately introduces neither a state library nor context-value restructuring.
+
+## Release-flag gate
+
+The April release-flag blocker is obsolete for this data refactor. The remaining single-environment onboarding flag controls lineage affordances and messaging in the controls; it does not choose the CLL request, cache-patch, history, or result-storage path. Extracting those mechanics therefore does not require removing the flag.
+
+## Payload measurement
+
+The source fixture is `cll-full-map.json` from closed draft [DataRecce/recce PR #1244](https://github.com/DataRecce/recce/pull/1244). The large measurement cycles the captured fixture's real node, column, and map objects, prefixes their identifiers, and matches the anonymized project shape reported in that PR: 1,796 total nodes, 15,520 columns, and 17,316 map entries (including 1,207 models).
+
+Measurements ran locally with Node.js. Raw bytes use compact `JSON.stringify`, gzip bytes use Node's default `zlib.gzipSync`, parse time is the median of 12 warm `JSON.parse` runs, and retained heap is measured after parsing and forced garbage collection.
+
+| Fixture | Nodes | Columns | Map entries | Raw JSON | gzip | Parse median | Retained heap |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Captured jaffle full map | 99 | 804 | 903 | 885,797 B | 57,315 B | — | — |
+| Count-matched synthetic large map | 1,796 | 15,520 | 17,316 | 15,639,943 B | 1,379,393 B | 33.36 ms | 19,391,736 B |
+
+These results are directional, not a production browser benchmark: they use a warm local Node runtime, omit network latency, and reproduce the proprietary project's counts and captured object shapes rather than its source payload. They are sufficient for the transport choice because the browser cost is paid up front even when a user inspects only one column.
+
+The complete-map option would trade cached slice requests for about 15.6 MB of JSON allocation and about 19.4 MB of retained heap at the measured large shape. Since complete-map computation is already cached server-side, that trade is not justified without evidence from production click-latency and browser-memory telemetry.

--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -846,14 +846,9 @@ export function PrivateLineageView(
 
   const resetColumnLevelLineage = async (previous?: boolean) => {
     if (previous) {
-      const previousEntry = cllStateHistory.peek();
-      if (!previousEntry) {
-        return;
-      }
-      const applied = await applyColumnLevelLineage(previousEntry.input, true);
-      if (applied) {
-        cllStateHistory.pop();
-      }
+      await cllStateHistory.restore((input) =>
+        applyColumnLevelLineage(input, true),
+      );
     } else {
       // In the new CLL experience, reset returns to Layer 2 (global impact)
       // instead of clearing CLL entirely.

--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -7,7 +7,6 @@ import {
   cacheKeys,
   createLineageDiffCheck,
   createSchemaDiffCheck,
-  getCll,
   type LineageDiffViewOptions,
   select,
 } from "../../api";
@@ -50,7 +49,7 @@ import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   Background,
   BackgroundVariant,
@@ -91,7 +90,6 @@ import {
   nextChangeAnalysisMode,
   resolveResetCllInput,
 } from "./changeAnalysisState";
-import { createCllCachePatchLifecycle } from "./cllCachePatchLifecycle";
 import { computeColumnLineage } from "./computeColumnLineage";
 import { computeImpactedColumns } from "./computeImpactedColumns";
 import { computeIsImpacted } from "./computeIsImpacted";
@@ -108,7 +106,6 @@ import {
 import {
   useLineageCopyToClipboard,
   useNavToCheck,
-  usePublishedImpactSets,
   useResizeObserver,
   useTrackLineageRender,
 } from "./hooks";
@@ -132,6 +129,7 @@ import {
   LineageViewNoChanges,
 } from "./states";
 import { LineageViewTopBarOss as LineageViewTopBar } from "./topbar/LineageViewTopBarOss";
+import { useCllState } from "./useCllState";
 
 /** Hide MiniMap when node count exceeds this threshold to reduce DOM pressure */
 export const MINIMAP_NODE_THRESHOLD = 500;
@@ -259,26 +257,28 @@ export function PrivateLineageView(
   });
 
   const trackLineageRender = useTrackLineageRender();
-
-  const cllHistory = useRef<(CllInput | undefined)[]>([]).current;
-
-  const [cll, setCll] = useState<ColumnLineageData | undefined>(undefined);
+  const {
+    cll,
+    action: cllAction,
+    commit: commitCll,
+    resolveForLayout: resolveCllForLayout,
+    refresh: refreshCll,
+    invalidate: invalidateCll,
+    supersedeInteraction: supersedeCllInteraction,
+    isInteractionCurrent: isCllInteractionCurrent,
+    history: cllStateHistory,
+    impactedNodeIds,
+    impactedColumnIds,
+    wholeModelImpactedNodeIds,
+    wholeModelChangedNodeIds,
+    publishImpactSets,
+  } = useCllState({ apiClient, queryClient });
   const [changeAnalysisMode, setChangeAnalysisMode] = useState(false);
   // Ref mirror of changeAnalysisMode for reading inside useLayoutEffect
   // without adding it as a dependency (avoids re-running layout on toggle).
   const changeAnalysisModeRef = useRef(false);
   changeAnalysisModeRef.current = changeAnalysisMode;
-  const actionGetCll = useMutation({
-    mutationFn: (input: CllInput) => getCll(input, apiClient),
-  });
-  // Owns the CLL fetch / cache-patch / re-entry lifecycle. When setQueryData
-  // patches the lineage query, queryServerInfo.data changes, lineageGraph
-  // recomputes via useMemo, and the layout effect re-fires — the lifecycle is
-  // what tells the effect to reuse the previous CLL result instead of calling
-  // the API and patching again (which would loop forever).
-  const cllCachePatch = useRef(createCllCachePatchLifecycle()).current;
   const layoutGenerationRef = useRef(0);
-  const cllInteractionGenerationRef = useRef(0);
   const runFocusIntentRef = useRef<string | undefined>(undefined);
   const pendingRunFocusIntentRef = useRef<
     | {
@@ -287,10 +287,6 @@ export function PrivateLineageView(
       }
     | undefined
   >(undefined);
-  const supersedeCllInteraction = useCallback(
-    () => ++cllInteractionGenerationRef.current,
-    [],
-  );
   // Bumped when a layout owner gives up without producing a layout, so the
   // layout effect runs again. Without it the view can be left with `nodes` still
   // at its initial identity, which the render guard below turns into an empty
@@ -308,10 +304,9 @@ export function PrivateLineageView(
       // A user-triggered refresh may own a newer one, so unmount must
       // unconditionally supersede every component-owned async continuation.
       ++layoutGenerationRef.current;
-      supersedeCllInteraction();
-      cllCachePatch.invalidate();
+      invalidateCll();
     };
-  }, [cllCachePatch, supersedeCllInteraction]);
+  }, [invalidateCll]);
 
   const findNodeByName = useCallback(
     (name: string) => {
@@ -501,14 +496,6 @@ export function PrivateLineageView(
 
   // Guard: auto-trigger impact analysis only once per mount
   const impactAtStartupFired = useRef(false);
-  const {
-    impactedNodeIds,
-    impactedColumnIds,
-    wholeModelImpactedNodeIds,
-    wholeModelChangedNodeIds,
-    publish: publishImpactSets,
-  } = usePublishedImpactSets();
-
   // MiniMap node coloring. Mirror the canvas: in the new CLL experience,
   // impacted-but-unchanged nodes are amber, so thread the impacted set through
   // instead of coloring by change status alone (DRC-3250).
@@ -539,11 +526,9 @@ export function PrivateLineageView(
       let filteredNodeIds: string[] | undefined = undefined;
 
       if (!lineageGraph) {
-        void cllCachePatch.resolveCllForLayout({
+        void resolveCllForLayout({
           cllInput: undefined,
           changeAnalysis: changeAnalysisModeRef.current,
-          actionGetCll,
-          queryClient,
         });
         return;
       }
@@ -627,11 +612,9 @@ export function PrivateLineageView(
       try {
         // Fetch + patch for a genuine input, reuse the pending result when this
         // effect re-fired because of our own patch, disarm when CLL is off.
-        const resolution = await cllCachePatch.resolveCllForLayout({
+        const resolution = await resolveCllForLayout({
           cllInput,
           changeAnalysis: changeAnalysisModeRef.current,
-          actionGetCll,
-          queryClient,
         });
         if (!isCurrentGeneration() || !resolution.isCurrent()) {
           return;
@@ -686,7 +669,7 @@ export function PrivateLineageView(
       setNodes(nodes);
       setEdges(edges);
       setNodeColumSetMap(nodeColumnSetMap);
-      setCll(cll);
+      commitCll(cll);
 
       // Snapshot impacted sets during impact analysis so they stay stable
       // when the user clicks a column (which returns column-scoped CLL data).
@@ -714,7 +697,7 @@ export function PrivateLineageView(
     // impact_at_startup flag arrives (may load after lineageGraph), or when a
     // layout owner abandoned its turn without laying anything out.
     // viewOptions changes are handled separately by handleViewOptionsChanged.
-    // Other dependencies (setNodes, setEdges, actionGetCll) are stable.
+    // Other dependencies (setNodes, setEdges, resolveCllForLayout) are stable.
     // changeAnalysisModeRef is a ref to avoid stale closure issues.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lineageGraph, serverFlags?.impact_at_startup, layoutRetryNonce]);
@@ -841,12 +824,12 @@ export function PrivateLineageView(
       interactionGeneration,
     );
 
-    if (cllInteractionGenerationRef.current !== interactionGeneration) {
+    if (!isCllInteractionCurrent(interactionGeneration)) {
       return false;
     }
 
     if (!previous) {
-      cllHistory.push(previousColumnLevelLineage);
+      cllStateHistory.push(previousColumnLevelLineage);
     }
     if (columnLevelLineage?.node_id) {
       setFocusedNodeId(columnLevelLineage.node_id);
@@ -863,13 +846,13 @@ export function PrivateLineageView(
 
   const resetColumnLevelLineage = async (previous?: boolean) => {
     if (previous) {
-      if (cllHistory.length === 0) {
+      const previousEntry = cllStateHistory.peek();
+      if (!previousEntry) {
         return;
       }
-      const previousCll = cllHistory[cllHistory.length - 1];
-      const applied = await applyColumnLevelLineage(previousCll, true);
+      const applied = await applyColumnLevelLineage(previousEntry.input, true);
       if (applied) {
-        cllHistory.pop();
+        cllStateHistory.pop();
       }
     } else {
       // In the new CLL experience, reset returns to Layer 2 (global impact)
@@ -967,11 +950,9 @@ export function PrivateLineageView(
       // Nothing can be armed yet in that state — the layout effect disarms on
       // every lineageGraph transition — so this is defence in depth for a future
       // caller that reaches refreshLayout without owning that transition.
-      void cllCachePatch.refreshCll({
+      void refreshCll({
         cllInput: undefined,
         changeAnalysis: changeAnalysisMode,
-        actionGetCll,
-        queryClient,
       });
       return;
     }
@@ -1025,11 +1006,9 @@ export function PrivateLineageView(
     // re-run the layout effect, so this is the only place a cleared CLL is
     // guaranteed to drop whatever the last patch left pending.
     try {
-      const resolution = await cllCachePatch.refreshCll({
+      const resolution = await refreshCll({
         cllInput: newViewOptions.column_level_lineage,
         changeAnalysis: changeAnalysisMode,
-        actionGetCll,
-        queryClient,
       });
       if (!isCurrentGeneration() || !resolution.isCurrent()) {
         return;
@@ -1101,7 +1080,7 @@ export function PrivateLineageView(
     setNodes(newNodes);
     setEdges(newEdges);
     setNodeColumSetMap(newNodeColumnSetMap);
-    setCll(cll);
+    commitCll(cll);
 
     // Snapshot impacted node and column IDs during impact analysis (see layout effect).
     if (impacted && !cllInput2?.column) {
@@ -1206,8 +1185,7 @@ export function PrivateLineageView(
     const pendingIntent = pendingRunFocusIntentRef.current;
     const isCurrentPendingIntent =
       pendingIntent?.key === intentKey &&
-      pendingIntent.interactionGeneration ===
-        cllInteractionGenerationRef.current;
+      isCllInteractionCurrent(pendingIntent.interactionGeneration);
 
     if (!isNewIntent && !isCurrentPendingIntent) {
       pendingRunFocusIntentRef.current = undefined;
@@ -1713,7 +1691,7 @@ export function PrivateLineageView(
             </Panel>
             <Panel position="top-left">
               <Stack spacing="5px">
-                <ColumnLevelLineageControlOss action={actionGetCll} />
+                <ColumnLevelLineageControlOss action={cllAction} />
                 {nodes.length == 0 && (
                   <Typography
                     sx={{ fontSize: "1.25rem", color: "grey", opacity: 0.5 }}

--- a/js/packages/ui/src/components/lineage/__tests__/useCllState.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/useCllState.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient } from "@tanstack/react-query";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ColumnLineageData } from "../../../api/cll";
+import type { CllInput, ColumnLineageData } from "../../../api/cll";
 import type { ApiClient } from "../../../lib/fetchClient";
 import { useCllState } from "../useCllState";
 
@@ -21,6 +21,14 @@ function createApiClient(): ApiClient {
     patch: vi.fn(),
     delete: vi.fn(),
   } as ApiClient;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 describe("useCllState", () => {
@@ -78,6 +86,45 @@ describe("useCllState", () => {
     expect(result.current.history.pop()).toBeUndefined();
   });
 
+  it("pops history only after the previous input is restored successfully", async () => {
+    const { result } = renderHook(() =>
+      useCllState({ apiClient, queryClient }),
+    );
+    result.current.history.push({ node_id: "model.orders" });
+
+    const failed = await result.current.history.restore(async () => false);
+
+    expect(failed).toBe(false);
+    expect(result.current.history.peek()).toEqual({
+      input: { node_id: "model.orders" },
+    });
+
+    const restored = await result.current.history.restore(async (input) => {
+      expect(input).toEqual({ node_id: "model.orders" });
+      return true;
+    });
+
+    expect(restored).toBe(true);
+    expect(result.current.history.peek()).toBeUndefined();
+  });
+
+  it("restores an undefined history input without mistaking it for an empty stack", async () => {
+    const { result } = renderHook(() =>
+      useCllState({ apiClient, queryClient }),
+    );
+    result.current.history.push(undefined);
+
+    let restoredInput: CllInput | undefined | "not-called" = "not-called";
+    const restored = await result.current.history.restore(async (input) => {
+      restoredInput = input;
+      return true;
+    });
+
+    expect(restored).toBe(true);
+    expect(restoredInput).toBeUndefined();
+    expect(result.current.history.peek()).toBeUndefined();
+  });
+
   it("resets current CLL, history, and impact snapshots", () => {
     const { result } = renderHook(() =>
       useCllState({ apiClient, queryClient }),
@@ -104,5 +151,49 @@ describe("useCllState", () => {
     expect(result.current.impactedColumnIds).toEqual(new Set());
     expect(result.current.wholeModelImpactedNodeIds).toEqual(new Set());
     expect(result.current.wholeModelChangedNodeIds).toEqual(new Set());
+  });
+
+  it("keeps mutation status idle after reset and stale request completion", async () => {
+    const request = deferred<{ data: ColumnLineageData }>();
+    apiClient.post = vi.fn().mockReturnValue(request.promise);
+    const { result } = renderHook(() =>
+      useCllState({ apiClient, queryClient }),
+    );
+
+    let pending!: Promise<unknown>;
+    act(() => {
+      pending = result.current.refresh({
+        cllInput: { node_id: "model.orders" },
+        changeAnalysis: false,
+      });
+    });
+    await waitFor(() => expect(result.current.action.isPending).toBe(true));
+
+    act(() => {
+      result.current.reset();
+    });
+    const statusImmediatelyAfterReset = result.current.action.status;
+
+    await act(async () => {
+      request.resolve({ data: CLL_RESULT });
+      await pending;
+    });
+
+    expect(statusImmediatelyAfterReset).toBe("idle");
+    expect(result.current.action.status).toBe("idle");
+  });
+
+  it("invalidates the current interaction generation on reset", () => {
+    const { result } = renderHook(() =>
+      useCllState({ apiClient, queryClient }),
+    );
+    const generation = result.current.supersedeInteraction();
+    expect(result.current.isInteractionCurrent(generation)).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.isInteractionCurrent(generation)).toBe(false);
   });
 });

--- a/js/packages/ui/src/components/lineage/__tests__/useCllState.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/useCllState.test.tsx
@@ -125,6 +125,28 @@ describe("useCllState", () => {
     expect(result.current.history.peek()).toBeUndefined();
   });
 
+  it("does not pop a newer entry pushed while restoration is in flight", async () => {
+    const { result } = renderHook(() =>
+      useCllState({ apiClient, queryClient }),
+    );
+    const applyResult = deferred<boolean>();
+    result.current.history.push({ node_id: "model.orders" });
+
+    const restoration = result.current.history.restore(
+      async () => await applyResult.promise,
+    );
+    result.current.history.push({ node_id: "model.customers" });
+    applyResult.resolve(true);
+
+    expect(await restoration).toBe(false);
+    expect(result.current.history.pop()).toEqual({
+      input: { node_id: "model.customers" },
+    });
+    expect(result.current.history.pop()).toEqual({
+      input: { node_id: "model.orders" },
+    });
+  });
+
   it("resets current CLL, history, and impact snapshots", () => {
     const { result } = renderHook(() =>
       useCllState({ apiClient, queryClient }),

--- a/js/packages/ui/src/components/lineage/__tests__/useCllState.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/useCllState.test.tsx
@@ -1,0 +1,108 @@
+import { QueryClient } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ColumnLineageData } from "../../../api/cll";
+import type { ApiClient } from "../../../lib/fetchClient";
+import { useCllState } from "../useCllState";
+
+const CLL_RESULT: ColumnLineageData = {
+  current: {
+    nodes: {},
+    columns: {},
+    parent_map: {},
+    child_map: {},
+  },
+};
+
+function createApiClient(): ApiClient {
+  return {
+    get: vi.fn(),
+    post: vi.fn().mockResolvedValue({ data: CLL_RESULT }),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  } as ApiClient;
+}
+
+describe("useCllState", () => {
+  let apiClient: ApiClient;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    apiClient = createApiClient();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  it("fetches CLL and commits the accepted result", async () => {
+    const { result } = renderHook(() =>
+      useCllState({ apiClient, queryClient }),
+    );
+
+    let resolution: Awaited<ReturnType<typeof result.current.refresh>>;
+    await act(async () => {
+      resolution = await result.current.refresh({
+        cllInput: { node_id: "model.orders" },
+        changeAnalysis: false,
+      });
+      result.current.commit(resolution.cll);
+    });
+
+    expect(resolution!.cll).toEqual(CLL_RESULT);
+    expect(result.current.cll).toEqual(CLL_RESULT);
+  });
+
+  it("preserves optional inputs in LIFO history", () => {
+    const { result } = renderHook(() =>
+      useCllState({ apiClient, queryClient }),
+    );
+
+    act(() => {
+      result.current.history.push(undefined);
+      result.current.history.push({
+        node_id: "model.orders",
+        column: "id",
+      });
+    });
+
+    expect(result.current.history.peek()).toEqual({
+      input: { node_id: "model.orders", column: "id" },
+    });
+    expect(result.current.history.pop()).toEqual({
+      input: { node_id: "model.orders", column: "id" },
+    });
+    expect(result.current.history.pop()).toEqual({ input: undefined });
+    expect(result.current.history.pop()).toBeUndefined();
+  });
+
+  it("resets current CLL, history, and impact snapshots", () => {
+    const { result } = renderHook(() =>
+      useCllState({ apiClient, queryClient }),
+    );
+
+    act(() => {
+      result.current.commit(CLL_RESULT);
+      result.current.history.push({ node_id: "model.orders" });
+      result.current.publishImpactSets({
+        nodeIds: new Set(["model.orders"]),
+        columnIds: new Set(["model.orders:id"]),
+        wholeModelImpactedNodeIds: new Set(["model.orders"]),
+        wholeModelChangedNodeIds: new Set(),
+      });
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.cll).toBeUndefined();
+    expect(result.current.history.peek()).toBeUndefined();
+    expect(result.current.impactedNodeIds).toEqual(new Set());
+    expect(result.current.impactedColumnIds).toEqual(new Set());
+    expect(result.current.wholeModelImpactedNodeIds).toEqual(new Set());
+    expect(result.current.wholeModelChangedNodeIds).toEqual(new Set());
+  });
+});

--- a/js/packages/ui/src/components/lineage/cllCachePatchLifecycle.ts
+++ b/js/packages/ui/src/components/lineage/cllCachePatchLifecycle.ts
@@ -47,7 +47,7 @@ export interface CllLifecycleRequest {
   queryClient: QueryClient;
 }
 
-interface CllLifecycleResolution {
+export interface CllLifecycleResolution {
   cll: ColumnLineageData | undefined;
   isCurrent: () => boolean;
 }

--- a/js/packages/ui/src/components/lineage/hooks/usePublishedImpactSets.ts
+++ b/js/packages/ui/src/components/lineage/hooks/usePublishedImpactSets.ts
@@ -13,6 +13,7 @@ export interface UsePublishedImpactSetsResult {
   wholeModelImpactedNodeIds: Set<string>;
   wholeModelChangedNodeIds: Set<string>;
   publish: (sets: ImpactSets) => void;
+  reset: () => void;
 }
 
 // Stable empty-set reference for the whole-model initial state (before the
@@ -44,11 +45,19 @@ export function usePublishedImpactSets(): UsePublishedImpactSetsResult {
     setWholeModelChangedNodeIds(sets.wholeModelChangedNodeIds);
   }, []);
 
+  const reset = useCallback(() => {
+    setImpactedNodeIds(new Set());
+    setImpactedColumnIds(new Set());
+    setWholeModelImpactedNodeIds(EMPTY_SET as Set<string>);
+    setWholeModelChangedNodeIds(EMPTY_SET as Set<string>);
+  }, []);
+
   return {
     impactedNodeIds,
     impactedColumnIds,
     wholeModelImpactedNodeIds,
     wholeModelChangedNodeIds,
     publish,
+    reset,
   };
 }

--- a/js/packages/ui/src/components/lineage/useCllState.ts
+++ b/js/packages/ui/src/components/lineage/useCllState.ts
@@ -77,6 +77,9 @@ function createCllHistory(): CllHistory {
       if (!entry || !(await apply(entry.input))) {
         return false;
       }
+      if (entries[entries.length - 1] !== entry) {
+        return false;
+      }
       entries.pop();
       return true;
     },

--- a/js/packages/ui/src/components/lineage/useCllState.ts
+++ b/js/packages/ui/src/components/lineage/useCllState.ts
@@ -1,9 +1,12 @@
-import type { QueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type QueryClient,
+  type UseMutationResult,
+  useMutation,
+} from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { type CllInput, type ColumnLineageData, getCll } from "../../api/cll";
 import type { ApiClient } from "../../lib/fetchClient";
 import {
-  type CllFetcher,
   type CllLifecycleRequest,
   type CllLifecycleResolution,
   createCllCachePatchLifecycle,
@@ -36,6 +39,7 @@ export interface UseCllStateOptions {
 
 export interface UseCllStateResult {
   cll: ColumnLineageData | undefined;
+  action: UseMutationResult<ColumnLineageData, Error, CllInput>;
   commit(cll: ColumnLineageData | undefined): void;
   resolveForLayout(request: CllStateRequest): Promise<CllLifecycleResolution>;
   refresh(request: CllStateRequest): Promise<CllLifecycleResolution>;
@@ -59,7 +63,7 @@ function createCllHistory(): CllHistory {
       entries.push({ input });
     },
     peek() {
-      return entries.at(-1);
+      return entries[entries.length - 1];
     },
     pop() {
       return entries.pop();
@@ -87,11 +91,11 @@ export function useCllState({
     reset: resetImpactSets,
   } = usePublishedImpactSets();
 
-  const actionGetCll = useMemo<CllFetcher>(
-    () => ({
-      mutateAsync: (input) => getCll(input, apiClient),
-    }),
-    [apiClient],
+  const actionGetCll = useMutation<ColumnLineageData, Error, CllInput>(
+    {
+      mutationFn: (input) => getCll(input, apiClient),
+    },
+    queryClient,
   );
 
   const bindRequest = useCallback(
@@ -151,6 +155,7 @@ export function useCllState({
 
   return {
     cll,
+    action: actionGetCll,
     commit,
     resolveForLayout,
     refresh,

--- a/js/packages/ui/src/components/lineage/useCllState.ts
+++ b/js/packages/ui/src/components/lineage/useCllState.ts
@@ -1,0 +1,168 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type CllInput, type ColumnLineageData, getCll } from "../../api/cll";
+import type { ApiClient } from "../../lib/fetchClient";
+import {
+  type CllFetcher,
+  type CllLifecycleRequest,
+  type CllLifecycleResolution,
+  createCllCachePatchLifecycle,
+} from "./cllCachePatchLifecycle";
+import {
+  type ImpactSets,
+  usePublishedImpactSets,
+} from "./hooks/usePublishedImpactSets";
+
+export type CllStateRequest = Pick<
+  CllLifecycleRequest,
+  "cllInput" | "changeAnalysis"
+>;
+
+export interface CllHistoryEntry {
+  input: CllInput | undefined;
+}
+
+export interface CllHistory {
+  push(input: CllInput | undefined): void;
+  peek(): CllHistoryEntry | undefined;
+  pop(): CllHistoryEntry | undefined;
+  reset(): void;
+}
+
+export interface UseCllStateOptions {
+  apiClient: ApiClient;
+  queryClient: QueryClient;
+}
+
+export interface UseCllStateResult {
+  cll: ColumnLineageData | undefined;
+  commit(cll: ColumnLineageData | undefined): void;
+  resolveForLayout(request: CllStateRequest): Promise<CllLifecycleResolution>;
+  refresh(request: CllStateRequest): Promise<CllLifecycleResolution>;
+  invalidate(): void;
+  supersedeInteraction(): number;
+  isInteractionCurrent(generation: number): boolean;
+  history: CllHistory;
+  impactedNodeIds: Set<string>;
+  impactedColumnIds: Set<string>;
+  wholeModelImpactedNodeIds: Set<string>;
+  wholeModelChangedNodeIds: Set<string>;
+  publishImpactSets(sets: ImpactSets): void;
+  reset(): void;
+}
+
+function createCllHistory(): CllHistory {
+  const entries: CllHistoryEntry[] = [];
+
+  return {
+    push(input) {
+      entries.push({ input });
+    },
+    peek() {
+      return entries.at(-1);
+    },
+    pop() {
+      return entries.pop();
+    },
+    reset() {
+      entries.length = 0;
+    },
+  };
+}
+
+export function useCllState({
+  apiClient,
+  queryClient,
+}: UseCllStateOptions): UseCllStateResult {
+  const [cll, setCll] = useState<ColumnLineageData>();
+  const history = useRef(createCllHistory()).current;
+  const lifecycle = useRef(createCllCachePatchLifecycle()).current;
+  const interactionGeneration = useRef(0);
+  const {
+    impactedNodeIds,
+    impactedColumnIds,
+    wholeModelImpactedNodeIds,
+    wholeModelChangedNodeIds,
+    publish: publishImpactSets,
+    reset: resetImpactSets,
+  } = usePublishedImpactSets();
+
+  const actionGetCll = useMemo<CllFetcher>(
+    () => ({
+      mutateAsync: (input) => getCll(input, apiClient),
+    }),
+    [apiClient],
+  );
+
+  const bindRequest = useCallback(
+    (request: CllStateRequest): CllLifecycleRequest => ({
+      ...request,
+      actionGetCll,
+      queryClient,
+    }),
+    [actionGetCll, queryClient],
+  );
+
+  const resolveForLayout = useCallback(
+    (request: CllStateRequest) =>
+      lifecycle.resolveCllForLayout(bindRequest(request)),
+    [bindRequest, lifecycle],
+  );
+
+  const refresh = useCallback(
+    (request: CllStateRequest) => lifecycle.refreshCll(bindRequest(request)),
+    [bindRequest, lifecycle],
+  );
+
+  const commit = useCallback((nextCll: ColumnLineageData | undefined) => {
+    setCll(nextCll);
+  }, []);
+
+  const supersedeInteraction = useCallback(
+    () => ++interactionGeneration.current,
+    [],
+  );
+
+  const isInteractionCurrent = useCallback(
+    (generation: number) => interactionGeneration.current === generation,
+    [],
+  );
+
+  const invalidate = useCallback(() => {
+    ++interactionGeneration.current;
+    lifecycle.invalidate();
+  }, [lifecycle]);
+
+  const reset = useCallback(() => {
+    invalidate();
+    history.reset();
+    setCll(undefined);
+    resetImpactSets();
+  }, [history, invalidate, resetImpactSets]);
+
+  useEffect(
+    () => () => {
+      ++interactionGeneration.current;
+      lifecycle.invalidate();
+      history.reset();
+    },
+    [history, lifecycle],
+  );
+
+  return {
+    cll,
+    commit,
+    resolveForLayout,
+    refresh,
+    invalidate,
+    supersedeInteraction,
+    isInteractionCurrent,
+    history,
+    impactedNodeIds,
+    impactedColumnIds,
+    wholeModelImpactedNodeIds,
+    wholeModelChangedNodeIds,
+    publishImpactSets,
+    reset,
+  };
+}

--- a/js/packages/ui/src/components/lineage/useCllState.ts
+++ b/js/packages/ui/src/components/lineage/useCllState.ts
@@ -3,10 +3,11 @@ import {
   type UseMutationResult,
   useMutation,
 } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type CllInput, type ColumnLineageData, getCll } from "../../api/cll";
 import type { ApiClient } from "../../lib/fetchClient";
 import {
+  type CllFetcher,
   type CllLifecycleRequest,
   type CllLifecycleResolution,
   createCllCachePatchLifecycle,
@@ -29,6 +30,9 @@ export interface CllHistory {
   push(input: CllInput | undefined): void;
   peek(): CllHistoryEntry | undefined;
   pop(): CllHistoryEntry | undefined;
+  restore(
+    apply: (input: CllInput | undefined) => Promise<boolean>,
+  ): Promise<boolean>;
   reset(): void;
 }
 
@@ -68,6 +72,14 @@ function createCllHistory(): CllHistory {
     pop() {
       return entries.pop();
     },
+    async restore(apply) {
+      const entry = entries[entries.length - 1];
+      if (!entry || !(await apply(entry.input))) {
+        return false;
+      }
+      entries.pop();
+      return true;
+    },
     reset() {
       entries.length = 0;
     },
@@ -79,8 +91,8 @@ export function useCllState({
   queryClient,
 }: UseCllStateOptions): UseCllStateResult {
   const [cll, setCll] = useState<ColumnLineageData>();
-  const history = useRef(createCllHistory()).current;
-  const lifecycle = useRef(createCllCachePatchLifecycle()).current;
+  const [history] = useState(createCllHistory);
+  const [lifecycle] = useState(createCllCachePatchLifecycle);
   const interactionGeneration = useRef(0);
   const {
     impactedNodeIds,
@@ -97,14 +109,20 @@ export function useCllState({
     },
     queryClient,
   );
+  const mutateCll = actionGetCll.mutateAsync;
+  const resetMutation = actionGetCll.reset;
+  const cllFetcher = useMemo<CllFetcher>(
+    () => ({ mutateAsync: mutateCll }),
+    [mutateCll],
+  );
 
   const bindRequest = useCallback(
     (request: CllStateRequest): CllLifecycleRequest => ({
       ...request,
-      actionGetCll,
+      actionGetCll: cllFetcher,
       queryClient,
     }),
-    [actionGetCll, queryClient],
+    [cllFetcher, queryClient],
   );
 
   const resolveForLayout = useCallback(
@@ -142,7 +160,8 @@ export function useCllState({
     history.reset();
     setCll(undefined);
     resetImpactSets();
-  }, [history, invalidate, resetImpactSets]);
+    resetMutation();
+  }, [history, invalidate, resetImpactSets, resetMutation]);
 
   useEffect(
     () => () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Refactor, tests, and documentation.

**What this PR does / why we need it**:

- Adds one internal `useCllState` controller for the current CLL result, fetch/cache-patch lifecycle, optional-input history, interaction generations, and published impact snapshots.
- Keeps lineage view options, focus, selection, presentation mode, and layout ownership in `LineageViewOss`, preserving the existing layout-generation commit guard.
- Makes async history restoration transactional: a previous entry is popped only after successful application and only if no newer entry replaced it while the layout was in flight.
- Resets TanStack mutation observer state with controller data, preventing stale pending/success/error status after a reset or late request completion.
- Records the per-node transport decision with reproducible payload measurements. The count-matched large map measured 15.64 MB raw JSON and about 19.4 MB retained heap; the backend already builds and caches the complete map.
- Confirms the single-environment release flag gates affordances rather than the CLL data path, and leaves state-library/context slicing to DRC-3315.

**Which issue(s) this PR fixes**:

Closes DRC-3021

**Special notes for your reviewer**:

- This is the base PR for Stack A. DRC-3218 will branch from and target this branch so its offscreen-chain UI change stays reviewable independently.
- Closed draft PR #1244 was used only as an immutable captured-fixture source and performance reference; none of its stale client-side full-map implementation or bulk fixtures were revived.
- Independent review found and drove tests for mutation reset and overlapping async history restoration.

Verification from final HEAD:

- `pnpm lint`: 696 files checked, no errors
- `pnpm type:check`: root, `@datarecce/ui`, and Storybook pass
- `pnpm test`: 206 files; 4,269 passed, 5 skipped
- `pnpm run build`: Next.js static build succeeds

**Does this PR introduce a user-facing change?**:

No visible behavior change.

```release-note
NONE
```
