### PR TITLE
fix(lineage): signal filtered CLL chain boundaries

### DIFF
--- a/docs/cll-chain-truncation.md
+++ b/docs/cll-chain-truncation.md
@@ -1,0 +1,35 @@
+# CLL chain truncation and expansion
+
+Status: accepted for [DRC-3218](https://linear.app/recce/issue/DRC-3218/cll-column-click-signal-and-resolve-truncation-when-the-impact-chain), 2026-08-26.
+
+## Decision
+
+Show a compact, non-interactive count at each visible column-lineage boundary, and do not add an expansion affordance for now.
+
+The upstream badge reads `← N`; the downstream badge reads `N →`. Its accessible label states the direction, exact number of ancestry columns hidden by the current graph view, and why they are absent. A full visible chain has no badge.
+
+## Options considered
+
+### Button on the annotation
+
+This is the most discoverable expansion option, but it adds a repeated control to already dense column rows. It also turns a diagnostic annotation into a graph-mutating action: one click could introduce many models, rerun layout, and destroy the scoped view the reviewer deliberately selected.
+
+### Context-menu entry
+
+This avoids permanent visual clutter, but makes a consequential expansion hard to discover and easy to invoke without a preview of its size. It would also add another selection/layout transition to the CLL context-menu state machine.
+
+### None for now
+
+This is the selected option. The indicator fixes the correctness problem—partial lineage is no longer presented as complete—without automatically widening the graph or adding another canvas mode. Reviewers can deliberately widen the existing lineage filter or switch to the full view when the count matters.
+
+## DRC-3273 alignment
+
+[DRC-3273](https://linear.app/recce/issue/DRC-3273/keep-cll-from-being-overwhleming) calls out CLL overwhelm as an unresolved product concern. Automatic expansion is therefore rejected. The annotation-button option is also deferred because it encourages incremental expansion without a size preview or collapse story. The compact count provides information without increasing graph density beyond the two boundary rows that already render.
+
+No follow-up implementation issue is filed because the decision is to build no expansion affordance. Revisit only when product research or telemetry establishes all three of the following:
+
+1. Reviewers frequently need to widen a truncated chain.
+2. The expansion can preview the number of models and columns before changing layout.
+3. The interaction has a clear collapse or restore-view path consistent with DRC-3273.
+
+At that point, file a scoped implementation issue related to both DRC-3218 and DRC-3273 rather than extending this correctness fix.

--- a/js/packages/ui/src/components/lineage/GraphColumnNodeOss.tsx
+++ b/js/packages/ui/src/components/lineage/GraphColumnNodeOss.tsx
@@ -38,7 +38,15 @@ export type GraphColumnNodeProps = NodeProps<LineageGraphColumnNode>;
 function GraphColumnNodeComponent(nodeProps: GraphColumnNodeProps) {
   const { id: columnNodeId, data } = nodeProps;
   const { id: nodeId } = data.node;
-  const { column, type, transformationType, changeStatus, isImpacted } = data;
+  const {
+    column,
+    type,
+    transformationType,
+    changeStatus,
+    isImpacted,
+    hiddenUpstreamColumnCount,
+    hiddenDownstreamColumnCount,
+  } = data;
 
   // Get zoom level for content visibility
   const showContent = useStore((s) => s.transform[2] > 0.3);
@@ -73,6 +81,8 @@ function GraphColumnNodeComponent(nodeProps: GraphColumnNodeProps) {
     isHighlighted,
     isFocused,
     isImpacted,
+    hiddenUpstreamColumnCount,
+    hiddenDownstreamColumnCount,
   };
 
   // Callbacks

--- a/js/packages/ui/src/components/lineage/__tests__/LineageColumnNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageColumnNode.test.tsx
@@ -115,14 +115,14 @@ describe("LineageColumnNode", () => {
       render(<LineageColumnNode {...props} />);
 
       expect(
-        screen.getByLabelText(
-          "2 upstream lineage columns hidden by the current view",
-        ),
+        screen.getByRole("img", {
+          name: "2 upstream lineage columns hidden by the current view",
+        }),
       ).toBeInTheDocument();
       expect(
-        screen.getByLabelText(
-          "3 downstream lineage columns hidden by the current view",
-        ),
+        screen.getByRole("img", {
+          name: "3 downstream lineage columns hidden by the current view",
+        }),
       ).toBeInTheDocument();
     });
   });

--- a/js/packages/ui/src/components/lineage/__tests__/LineageColumnNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageColumnNode.test.tsx
@@ -105,6 +105,26 @@ describe("LineageColumnNode", () => {
 
       expect(screen.queryByText("INTEGER")).not.toBeInTheDocument();
     });
+
+    it("renders accessible indicators for hidden lineage columns", () => {
+      const props = createMockColumnNodeProps({}, {
+        hiddenUpstreamColumnCount: 2,
+        hiddenDownstreamColumnCount: 3,
+      } as Partial<LineageColumnNodeData>);
+
+      render(<LineageColumnNode {...props} />);
+
+      expect(
+        screen.getByLabelText(
+          "2 upstream lineage columns hidden by the current view",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(
+          "3 downstream lineage columns hidden by the current view",
+        ),
+      ).toBeInTheDocument();
+    });
   });
 
   // ==========================================================================

--- a/js/packages/ui/src/components/lineage/__tests__/lineage.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/lineage.test.ts
@@ -215,10 +215,13 @@ describe("toReactFlow", () => {
       current: {
         nodes: {},
         columns: {
-          [`${modelA}_id`]: { name: "id" },
-          [`${modelB}_id`]: { name: "id" },
-          [`${modelB}_account_id`]: { name: "account_id" },
-          [`${modelC}_id`]: { name: "id" },
+          [`${modelA}_id`]: { name: "id", type: "integer" },
+          [`${modelB}_id`]: { name: "id", type: "integer" },
+          [`${modelB}_account_id`]: {
+            name: "account_id",
+            type: "integer",
+          },
+          [`${modelC}_id`]: { name: "id", type: "integer" },
         },
         parent_map: {
           [`${modelA}_id`]: [],
@@ -259,5 +262,18 @@ describe("toReactFlow", () => {
     expect(
       nodes.find((node) => node.id === `${modelC}_id`)?.data,
     ).toMatchObject({ hiddenUpstreamColumnCount: 2 });
+
+    const [fullChainNodes] = toReactFlow(lineageGraph, {
+      selectedNodes: [modelA, modelB, modelC],
+      cll,
+      newCllExperience: true,
+      columnAncestry,
+    });
+    expect(
+      fullChainNodes.find((node) => node.id === `${modelA}_id`)?.data,
+    ).toHaveProperty("hiddenDownstreamColumnCount", undefined);
+    expect(
+      fullChainNodes.find((node) => node.id === `${modelC}_id`)?.data,
+    ).toHaveProperty("hiddenUpstreamColumnCount", undefined);
   });
 });

--- a/js/packages/ui/src/components/lineage/__tests__/lineage.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/lineage.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ColumnLineageData } from "../../../api";
 import type { LineageGraph } from "../../../contexts/lineage/types";
 import { toReactFlow } from "../lineage";
 
@@ -203,5 +204,60 @@ describe("toReactFlow", () => {
     // Column nodes have relative positions within parent
     expect(columnNode?.position).toEqual({ x: 10, y: 70 });
     expect(columnNode?.parentId).toBe("node1");
+  });
+
+  it("signals the exact hidden-column count at both visible chain boundaries", () => {
+    const modelA = "model.test.a";
+    const modelB = "model.test.b";
+    const modelC = "model.test.c";
+    const lineageGraph = createMockLineageGraph([modelA, modelB, modelC]);
+    const cll: ColumnLineageData = {
+      current: {
+        nodes: {},
+        columns: {
+          [`${modelA}_id`]: { name: "id" },
+          [`${modelB}_id`]: { name: "id" },
+          [`${modelB}_account_id`]: { name: "account_id" },
+          [`${modelC}_id`]: { name: "id" },
+        },
+        parent_map: {
+          [`${modelA}_id`]: [],
+          [`${modelB}_id`]: [`${modelA}_id`],
+          [`${modelB}_account_id`]: [`${modelA}_id`],
+          [`${modelC}_id`]: [`${modelB}_id`, `${modelB}_account_id`],
+        },
+        child_map: {
+          [`${modelA}_id`]: [`${modelB}_id`, `${modelB}_account_id`],
+          [`${modelB}_id`]: [`${modelC}_id`],
+          [`${modelB}_account_id`]: [`${modelC}_id`],
+          [`${modelC}_id`]: [],
+        },
+      },
+    };
+    const columnAncestry = new Map([
+      [modelA, [{ column: "id", isImpacted: true }]],
+      [
+        modelB,
+        [
+          { column: "id", isImpacted: true },
+          { column: "account_id", isImpacted: true },
+        ],
+      ],
+      [modelC, [{ column: "id", isImpacted: true }]],
+    ]);
+
+    const [nodes] = toReactFlow(lineageGraph, {
+      selectedNodes: [modelA, modelC],
+      cll,
+      newCllExperience: true,
+      columnAncestry,
+    });
+
+    expect(
+      nodes.find((node) => node.id === `${modelA}_id`)?.data,
+    ).toMatchObject({ hiddenDownstreamColumnCount: 2 });
+    expect(
+      nodes.find((node) => node.id === `${modelC}_id`)?.data,
+    ).toMatchObject({ hiddenUpstreamColumnCount: 2 });
   });
 });

--- a/js/packages/ui/src/components/lineage/columns/LineageColumnNode.tsx
+++ b/js/packages/ui/src/components/lineage/columns/LineageColumnNode.tsx
@@ -219,6 +219,7 @@ function HiddenLineageIndicator({
   return (
     <Box
       component="span"
+      role="img"
       aria-label={label}
       title={label}
       sx={{

--- a/js/packages/ui/src/components/lineage/columns/LineageColumnNode.tsx
+++ b/js/packages/ui/src/components/lineage/columns/LineageColumnNode.tsx
@@ -46,6 +46,10 @@ export interface LineageColumnNodeData extends Record<string, unknown> {
   isFocused?: boolean;
   /** Whether this column is impacted (new CLL experience) */
   isImpacted?: boolean;
+  /** Number of upstream ancestry columns omitted by the current graph filter */
+  hiddenUpstreamColumnCount?: number;
+  /** Number of downstream ancestry columns omitted by the current graph filter */
+  hiddenDownstreamColumnCount?: number;
   /** Whether to use the new CLL experience palette (muted bg + left accent) */
   newCllExperience?: boolean;
 }
@@ -200,6 +204,44 @@ function TransformationIndicator({
   );
 }
 
+function HiddenLineageIndicator({
+  count,
+  direction,
+}: {
+  count?: number;
+  direction: "upstream" | "downstream";
+}) {
+  if (!count) {
+    return null;
+  }
+
+  const label = `${count} ${direction} lineage column${count === 1 ? "" : "s"} hidden by the current view`;
+  return (
+    <Box
+      component="span"
+      aria-label={label}
+      title={label}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        flexShrink: 0,
+        height: 18,
+        px: 0.5,
+        border: "1px solid",
+        borderColor: "warning.main",
+        borderRadius: "4px",
+        color: "warning.dark",
+        backgroundColor: "action.hover",
+        fontSize: "0.625rem",
+        fontWeight: 600,
+        lineHeight: 1,
+      }}
+    >
+      {direction === "upstream" ? `← ${count}` : `${count} →`}
+    </Box>
+  );
+}
+
 /**
  * LineageColumnNode Component
  *
@@ -267,6 +309,8 @@ function LineageColumnNodeComponent({
     isHighlighted = true,
     isFocused = false,
     isImpacted = false,
+    hiddenUpstreamColumnCount,
+    hiddenDownstreamColumnCount,
   } = data;
   const newCllExperience =
     newCllExperienceProp ?? data.newCllExperience ?? false;
@@ -345,6 +389,11 @@ function LineageColumnNodeComponent({
           height: `${COLUMN_NODE_HEIGHT - 1}px`,
         }}
       >
+        <HiddenLineageIndicator
+          count={hiddenUpstreamColumnCount}
+          direction="upstream"
+        />
+
         {/* Structural status and transformation are independent meanings. */}
         {changeStatus && <ChangeStatusIndicator changeStatus={changeStatus} />}
         {(!showChangeAnalysis || !changeStatus) && (
@@ -364,6 +413,11 @@ function LineageColumnNodeComponent({
         >
           {column}
         </Box>
+
+        <HiddenLineageIndicator
+          count={hiddenDownstreamColumnCount}
+          direction="downstream"
+        />
 
         {/* Column type or kebab menu */}
         {isHovered && onContextMenu ? (

--- a/js/packages/ui/src/components/lineage/lineage.ts
+++ b/js/packages/ui/src/components/lineage/lineage.ts
@@ -255,6 +255,11 @@ function addColumnAncestryNodes(
   cll: ColumnLineageData,
   filterSet: Set<string> | undefined,
 ) {
+  const truncationByModel = computeColumnAncestryTruncation(
+    columnAncestry,
+    cll,
+    filterSet,
+  );
   // Build columnId -> annotation lookup and set of ancestry column IDs
   const ancestryColumnIds = new Set<string>();
   const columnIdToAnnotation = new Map<
@@ -265,6 +270,7 @@ function addColumnAncestryNodes(
     // Skip columns whose model isn't in the current graph view
     if (filterSet && !filterSet.has(modelId)) continue;
 
+    const truncation = truncationByModel.get(modelId);
     for (let i = 0; i < annotations.length; i++) {
       const annotation = annotations[i];
       const columnKey = `${modelId}_${annotation.column}`;
@@ -290,6 +296,12 @@ function addColumnAncestryNodes(
           isHighlighted: true,
           isFocused: false,
           isImpacted: annotation.isImpacted,
+          hiddenUpstreamColumnCount:
+            i === 0 ? truncation?.upstreamColumnCount : undefined,
+          hiddenDownstreamColumnCount:
+            i === annotations.length - 1
+              ? truncation?.downstreamColumnCount
+              : undefined,
         },
         style: {
           zIndex: 9999,
@@ -334,6 +346,84 @@ function addColumnAncestryNodes(
       }
     }
   }
+}
+
+interface ColumnAncestryTruncation {
+  upstreamColumnCount?: number;
+  downstreamColumnCount?: number;
+}
+
+function computeColumnAncestryTruncation(
+  columnAncestry: Map<string, ColumnAnnotation[]>,
+  cll: ColumnLineageData,
+  filterSet: Set<string> | undefined,
+): Map<string, ColumnAncestryTruncation> {
+  if (!filterSet) {
+    return new Map();
+  }
+  const visibleModelIds = filterSet;
+
+  const columnToModel = new Map<string, string>();
+  for (const [modelId, annotations] of columnAncestry) {
+    for (const annotation of annotations) {
+      columnToModel.set(`${modelId}_${annotation.column}`, modelId);
+    }
+  }
+
+  function collectHiddenColumns(
+    startColumnIds: string[],
+    adjacency: Record<string, string[]>,
+    hiddenColumnIds: Set<string>,
+  ) {
+    const pending = [...startColumnIds];
+    while (pending.length > 0) {
+      const columnId = pending.pop();
+      if (!columnId || hiddenColumnIds.has(columnId)) {
+        continue;
+      }
+      const modelId = columnToModel.get(columnId);
+      if (!modelId || visibleModelIds.has(modelId)) {
+        continue;
+      }
+      hiddenColumnIds.add(columnId);
+      pending.push(...(adjacency[columnId] ?? []));
+    }
+  }
+
+  const result = new Map<string, ColumnAncestryTruncation>();
+  for (const [modelId, annotations] of columnAncestry) {
+    if (!visibleModelIds.has(modelId)) {
+      continue;
+    }
+
+    const hiddenUpstreamColumnIds = new Set<string>();
+    const hiddenDownstreamColumnIds = new Set<string>();
+    for (const annotation of annotations) {
+      const columnId = `${modelId}_${annotation.column}`;
+      collectHiddenColumns(
+        cll.current.parent_map[columnId] ?? [],
+        cll.current.parent_map,
+        hiddenUpstreamColumnIds,
+      );
+      collectHiddenColumns(
+        cll.current.child_map[columnId] ?? [],
+        cll.current.child_map,
+        hiddenDownstreamColumnIds,
+      );
+    }
+
+    if (
+      hiddenUpstreamColumnIds.size > 0 ||
+      hiddenDownstreamColumnIds.size > 0
+    ) {
+      result.set(modelId, {
+        upstreamColumnCount: hiddenUpstreamColumnIds.size || undefined,
+        downstreamColumnCount: hiddenDownstreamColumnIds.size || undefined,
+      });
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/js/packages/ui/src/contexts/lineage/types.ts
+++ b/js/packages/ui/src/contexts/lineage/types.ts
@@ -68,6 +68,8 @@ export type LineageGraphColumnNode = Node<
     transformationType?: string;
     changeStatus?: "added" | "removed" | "modified";
     isImpacted?: boolean;
+    hiddenUpstreamColumnCount?: number;
+    hiddenDownstreamColumnCount?: number;
   },
   "lineageGraphColumnNode"
 >;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix, tests, and documentation.

**What this PR does / why we need it**:

- Detects ancestry columns omitted when the new CLL column chain crosses models outside the current graph filter.
- Traverses only hidden parent/child components, stops at visible re-entry, and deduplicates counts per visible boundary model and direction.
- Renders compact `← N` / `N →` badges on the first/last visible annotation rows, with semantic image roles and descriptive accessible names.
- Emits no count or badge when the complete chain is visible; classic CLL and the global ancestry walk are unchanged.
- Records the expansion decision: no automatic/button/context-menu expansion for now, consistent with DRC-3273's overwhelm concern. Existing lineage filters remain the deliberate way to widen the graph.

**Which issue(s) this PR fixes**:

Closes DRC-3218

**Special notes for your reviewer**:

- This PR is stacked on #1523 and intentionally targets its branch. Review this PR's four commits/diff only; after #1523 merges, GitHub can retarget this PR to `main` without code changes.
- Commit `5708b7e` is the RED checkpoint: visible A → hidden two-column B → visible C renders without either required boundary count.
- Root cause: `addColumnAncestryNodes` applied `filterSet` before retaining offscreen annotations or their relationships, making natural chain ends indistinguishable from filtered truncation.
- No deviations from the root-cause hypothesis. The only test correction changed “property absent” to the behaviorally relevant “optional count is undefined.”
- Independent review verified branch/cycle termination, deduplication, direction semantics, visible re-entry, unrelated-entry exclusion, classic-path isolation, and DRC-3273 alignment; it also drove the semantic accessibility assertion.

Verification from final HEAD:

- `pnpm lint`: 696 files checked, no errors
- `pnpm type:check`: root, `@datarecce/ui`, and Storybook pass
- `pnpm test`: 206 files; 4,271 passed, 5 skipped
- `pnpm run build`: Next.js static build succeeds
- Pre-push related tests: 106 files; 2,064 passed, 5 skipped

**Does this PR introduce a user-facing change?**:

Yes. When a selected column's lineage continues through models hidden by the current graph filter, the visible boundary rows now show exact upstream/downstream hidden-column counts.

```release-note
Lineage now signals when a selected column's upstream or downstream chain continues beyond the models visible in the current graph filter.
```
