### PR TITLE
feat(lineage): move node analysis into dedicated tab

### DIFF
--- a/js/packages/storybook/stories/lineage/NodeView.stories.tsx
+++ b/js/packages/storybook/stories/lineage/NodeView.stories.tsx
@@ -13,6 +13,7 @@ import type {
   NodeViewActionCallbacks,
   NodeViewNodeData,
   NodeViewProps,
+  RecentAnalysisRun,
   RunTypeIconMap,
 } from "@datarecce/ui/advanced";
 import { NodeView, RowCountSummary } from "@datarecce/ui/advanced";
@@ -28,7 +29,7 @@ import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { expect, fn, waitFor, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import {
   mockRunResult,
   mockServerFlags,
@@ -207,7 +208,7 @@ const meta: Meta<typeof NodeView> = {
     docs: {
       description: {
         component:
-          "Node detail sidebar — header row (name, type tag, close), action buttons for diffs/queries, and tabbed Columns/Code content. Renders the real NodeView and real SchemaView. Story is wrapped in QueryClientProvider + MockLineageProvider so SchemaView's server-flag query and lineage lookups resolve against MSW fixtures.",
+          "Node detail sidebar — compact header (name, type tag, Row Count, close) and tabbed Columns/Code/Analysis content. Analysis keeps its four launchers visible above a flat model-scoped Recent list; Query lives with Code. Renders the real NodeView and real SchemaView. Story is wrapped in QueryClientProvider + MockLineageProvider so SchemaView's server-flag query and lineage lookups resolve against MSW fixtures.",
       },
     },
   },
@@ -272,6 +273,54 @@ export const Default: Story = {
         status: { name: "status", type: "varchar" },
       },
     }),
+  },
+};
+
+const recentAnalysisRuns: RecentAnalysisRun[] = [
+  {
+    id: "profile-finance-revenue",
+    type: "profile_diff",
+    runAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "histogram-status",
+    type: "histogram_diff",
+    columnName: "status",
+    runAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "top-k-order-date",
+    type: "top_k_diff",
+    columnName: "order_date",
+    runAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+  },
+];
+
+/** Settled DRC-3463 direction: launchers first, flat Recent history second. */
+export const AnalysisTab: Story = {
+  args: {
+    ...createStoryArgs({
+      name: "finance_revenue",
+      materialized: "table",
+      rowCountDiff: { base: 279991, curr: 280844 },
+    }),
+    recentAnalysisRuns,
+    onViewAnalysisRun: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("tab", { name: "Analysis" }));
+
+    await expect(canvas.getByRole("button", { name: "Profile" })).toBeVisible();
+    await expect(canvas.getByRole("button", { name: "Value" })).toBeVisible();
+    await expect(canvas.getByRole("button", { name: "Top-K" })).toBeVisible();
+    await expect(
+      canvas.getByRole("button", { name: "Histogram" }),
+    ).toBeVisible();
+    await expect(canvas.getByText("Histogram · status")).toBeVisible();
+    await expect(canvas.getAllByRole("button", { name: /view/i })).toHaveLength(
+      3,
+    );
   },
 };
 

--- a/js/packages/ui/src/advanced.ts
+++ b/js/packages/ui/src/advanced.ts
@@ -127,13 +127,15 @@ export {
   RowCountTag,
 } from "./components/lineage/NodeTag";
 /**
- * Node detail panel with Columns and Code tabs.
+ * Node detail panel with Columns, Code, Analysis, and optional Lineage tabs.
  */
 export {
+  type AnalysisRunType,
   NodeView,
   type NodeViewActionCallbacks,
   type NodeViewNodeData,
   type NodeViewProps,
+  type RecentAnalysisRun,
   type RunTypeIconMap,
   type SchemaViewProps,
 } from "./components/lineage/NodeView";

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -241,10 +241,12 @@ export interface NodeViewProps<
 // INTERNAL COMPONENTS
 // =============================================================================
 
+type NodeViewTab = "columns" | "code" | "analysis" | "lineage";
+
 interface TabPanelProps {
   children?: ReactNode;
-  index: number;
-  value: number;
+  index: NodeViewTab;
+  value: NodeViewTab;
 }
 
 function TabPanel({ children, value, index }: TabPanelProps) {
@@ -599,6 +601,9 @@ function RecentAnalysisList({
               {formatTimeToNow(run.runAt)}
             </Typography>
             <Button
+              aria-label={`View ${analysisRunLabels[run.type]} result${
+                run.columnName ? ` for ${run.columnName}` : ""
+              }`}
               size="small"
               variant="text"
               onClick={() => onViewRun?.(run.id)}
@@ -683,7 +688,14 @@ export function NodeView<TNode extends NodeViewNodeData>({
     node.data.resourceType === "snapshot";
 
   const [isNotificationOpen, setIsNotificationOpen] = useState(true);
-  const [tabValue, setTabValue] = useState(0);
+  const [tabState, setTabState] = useState<{
+    nodeId: string;
+    value: NodeViewTab;
+  }>({ nodeId: node.id, value: "columns" });
+  const tabValue = tabState.nodeId === node.id ? tabState.value : "columns";
+  const setTabValue = (value: NodeViewTab) => {
+    setTabState({ nodeId: node.id, value });
+  };
 
   const { base, current } = modelDetail ?? {};
   const hasSchemaChanges =
@@ -702,7 +714,6 @@ export function NodeView<TNode extends NodeViewNodeData>({
     node.data.resourceType === "seed" ||
     node.data.resourceType === "snapshot";
   const showAnalysisTab = !isSingleEnv && isModelSeedOrSnapshot;
-  const lineageTabIndex = showAnalysisTab ? 3 : 2;
 
   const showAddSchemaDiff =
     !isSingleEnv &&
@@ -881,6 +892,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
             sx={{ borderBottom: 1, borderColor: "divider" }}
           >
             <Tab
+              value="columns"
               label={
                 <Box
                   component="span"
@@ -907,6 +919,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
               }
             />
             <Tab
+              value="code"
               label={
                 <Box
                   component="span"
@@ -932,13 +945,13 @@ export function NodeView<TNode extends NodeViewNodeData>({
                 </Box>
               }
             />
-            {showAnalysisTab && <Tab label="Analysis" />}
-            {lineageTabContent && <Tab label="Lineage" />}
+            {showAnalysisTab && <Tab label="Analysis" value="analysis" />}
+            {lineageTabContent && <Tab label="Lineage" value="lineage" />}
           </Tabs>
 
           {/* Tab panels mirror the conditional tab inventory above. */}
           <Box sx={{ overflow: "auto", height: "calc(100% - 48px)" }}>
-            <TabPanel value={tabValue} index={0}>
+            <TabPanel value={tabValue} index="columns">
               <Box sx={{ overflowY: "auto", height: "100%" }}>
                 {isSingleEnv
                   ? SingleEnvSchemaView && (
@@ -949,7 +962,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
                         base={base}
                         current={current}
                         columnChanges={node.data.change?.columns}
-                        onViewCode={() => setTabValue(1)}
+                        onViewCode={() => setTabValue("code")}
                         headerAction={
                           showAddSchemaDiff ? (
                             <AddSchemaDiffButton
@@ -962,7 +975,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
                     )}
               </Box>
             </TabPanel>
-            <TabPanel value={tabValue} index={1}>
+            <TabPanel value={tabValue} index="code">
               <Box
                 sx={{
                   height: "100%",
@@ -985,7 +998,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
               </Box>
             </TabPanel>
             {showAnalysisTab && (
-              <TabPanel value={tabValue} index={2}>
+              <TabPanel value={tabValue} index="analysis">
                 <Box sx={{ p: 2 }}>
                   <DiffActionButtons
                     node={node}
@@ -1003,7 +1016,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
               </TabPanel>
             )}
             {lineageTabContent && (
-              <TabPanel value={tabValue} index={lineageTabIndex}>
+              <TabPanel value={tabValue} index="lineage">
                 <Box sx={{ height: "100%" }}>{lineageTabContent}</Box>
               </TabPanel>
             )}

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -19,6 +19,7 @@ import { IoClose } from "react-icons/io5";
 import type { NodeData } from "../../api/info";
 import { DisableTooltipMessages } from "../../constants";
 import { useThemeColors } from "../../hooks";
+import { formatTimeToNow } from "../../utils";
 import { getChangeCategoryLabel } from "./changeCategory";
 import type { ChangeCategory } from "./nodes";
 import { TreatmentChip } from "./TreatmentChip";
@@ -132,6 +133,19 @@ export interface NodeViewActionCallbacks {
   onAddSchemaDiffClick?: () => void;
 }
 
+export type AnalysisRunType =
+  | "profile_diff"
+  | "value_diff"
+  | "top_k_diff"
+  | "histogram_diff";
+
+export interface RecentAnalysisRun {
+  id: string;
+  type: AnalysisRunType;
+  runAt: string;
+  columnName?: string;
+}
+
 /**
  * Props for NodeView component.
  *
@@ -192,6 +206,10 @@ export interface NodeViewProps<
    * no row-count data is available yet.
    */
   rowCountDisplay?: ReactNode;
+  /** Prior analysis runs for this focused model, newest first. */
+  recentAnalysisRuns?: RecentAnalysisRun[];
+  /** Reopen a prior analysis result in the consumer's result pane. */
+  onViewAnalysisRun?: (runId: string) => void;
 
   // =========================================================================
   // DEPENDENCY INJECTION: Icons
@@ -381,7 +399,6 @@ interface DiffActionButtonsProps {
     display: boolean;
     children: ReactNode;
   }>;
-  rowCountDisplay?: ReactNode;
 }
 
 function DiffActionButtons({
@@ -391,14 +408,11 @@ function DiffActionButtons({
   featureToggles,
   isActionAvailable,
   ConnectionPopoverWrapper,
-  rowCountDisplay,
 }: DiffActionButtonsProps) {
   const metadataOnly = featureToggles?.mode === "metadata only";
   const isAddedOrRemoved =
     node.data.changeStatus === "added" || node.data.changeStatus === "removed";
 
-  const QueryDiffIcon = runTypeIcons?.query_diff ?? DefaultIcon;
-  const RowCountDiffIcon = runTypeIcons?.row_count_diff ?? DefaultIcon;
   const ProfileDiffIcon = runTypeIcons?.profile_diff ?? DefaultIcon;
   const ValueDiffIcon = runTypeIcons?.value_diff ?? DefaultIcon;
   const TopKDiffIcon = runTypeIcons?.top_k_diff ?? DefaultIcon;
@@ -434,113 +448,167 @@ function DiffActionButtons({
   return (
     <Stack
       direction="row"
-      sx={{
-        alignItems: "center",
-        flexWrap: "wrap",
-        gap: 2,
-      }}
+      sx={{ alignItems: "center", flexWrap: "wrap", gap: 1 }}
     >
+      {wrapButton(
+        <Button
+          size="xsmall"
+          variant="outlined"
+          color="neutral"
+          startIcon={<ProfileDiffIcon fontSize="small" />}
+          onClick={actionCallbacks?.onProfileDiffClick}
+          disabled={isAddedOrRemoved || featureToggles?.disableDatabaseQuery}
+          sx={{ textTransform: "none" }}
+        >
+          Profile
+        </Button>,
+        "profile_diff",
+      )}
+      {wrapButton(
+        <Button
+          size="xsmall"
+          variant="outlined"
+          color="neutral"
+          startIcon={<ValueDiffIcon fontSize="small" />}
+          onClick={actionCallbacks?.onValueDiffClick}
+          disabled={isAddedOrRemoved || featureToggles?.disableDatabaseQuery}
+          sx={{ textTransform: "none" }}
+        >
+          Value
+        </Button>,
+        "value_diff",
+      )}
+      {wrapButton(
+        <Button
+          size="xsmall"
+          variant="outlined"
+          color="neutral"
+          startIcon={<TopKDiffIcon fontSize="small" />}
+          onClick={actionCallbacks?.onTopKDiffClick}
+          disabled={isAddedOrRemoved || featureToggles?.disableDatabaseQuery}
+          sx={{ textTransform: "none" }}
+        >
+          Top-K
+        </Button>,
+        "top_k_diff",
+      )}
+      {wrapButton(
+        <Button
+          size="xsmall"
+          variant="outlined"
+          color="neutral"
+          startIcon={<HistogramDiffIcon fontSize="small" />}
+          onClick={actionCallbacks?.onHistogramDiffClick}
+          disabled={isAddedOrRemoved || featureToggles?.disableDatabaseQuery}
+          sx={{ textTransform: "none" }}
+        >
+          Histogram
+        </Button>,
+        "histogram_diff",
+      )}
+    </Stack>
+  );
+}
+
+interface DiffUtilityButtonProps {
+  label: "Row Count" | "Query";
+  onClick?: () => void;
+  Icon: ComponentType<{ fontSize?: string }>;
+  featureToggles?: NodeViewProps["featureToggles"];
+  ConnectionPopoverWrapper: ComponentType<ConnectionPopoverWrapperProps>;
+  rowCountDisplay?: ReactNode;
+}
+
+function DiffUtilityButton({
+  label,
+  onClick,
+  Icon,
+  featureToggles,
+  ConnectionPopoverWrapper,
+  rowCountDisplay,
+}: DiffUtilityButtonProps) {
+  return (
+    <ConnectionPopoverWrapper
+      display={featureToggles?.mode === "metadata only"}
+    >
+      <Button
+        size="xsmall"
+        variant="outlined"
+        color="neutral"
+        startIcon={<Icon fontSize="small" />}
+        onClick={onClick}
+        disabled={featureToggles?.disableDatabaseQuery}
+        sx={{ textTransform: "none", flexShrink: 0 }}
+      >
+        {label}
+        {label === "Row Count" && rowCountDisplay != null && (
+          <>:&nbsp;{rowCountDisplay}</>
+        )}
+      </Button>
+    </ConnectionPopoverWrapper>
+  );
+}
+
+const analysisRunLabels: Record<AnalysisRunType, string> = {
+  profile_diff: "Profile",
+  value_diff: "Value",
+  top_k_diff: "Top-K",
+  histogram_diff: "Histogram",
+};
+
+function RecentAnalysisList({
+  runs,
+  onViewRun,
+}: {
+  runs: RecentAnalysisRun[];
+  onViewRun?: (runId: string) => void;
+}) {
+  return (
+    <Stack sx={{ gap: 0.5 }}>
       <Typography
-        variant="caption"
-        sx={{
-          fontWeight: "bold",
-        }}
+        variant="overline"
+        sx={{ color: "text.secondary", fontWeight: 700, mt: 2 }}
       >
-        Diff
+        Recent
       </Typography>
-      <Stack
-        direction="row"
-        sx={{
-          alignItems: "center",
-          flexWrap: "wrap",
-          gap: 1,
-          width: "93%",
-        }}
-      >
-        <ConnectionPopoverWrapper display={metadataOnly}>
-          <Button
-            size="xsmall"
-            variant="outlined"
-            color="neutral"
-            startIcon={<RowCountDiffIcon fontSize="small" />}
-            onClick={actionCallbacks?.onRowCountDiffClick}
-            disabled={featureToggles?.disableDatabaseQuery}
-            sx={{ textTransform: "none" }}
+      {runs.length === 0 ? (
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          No recent analysis runs
+        </Typography>
+      ) : (
+        runs.map((run) => (
+          <Stack
+            key={run.id}
+            direction="row"
+            sx={{
+              alignItems: "center",
+              gap: 1,
+              py: 0.75,
+              borderBottom: 1,
+              borderColor: "divider",
+            }}
           >
-            Row Count
-            {rowCountDisplay != null && <>:&nbsp;{rowCountDisplay}</>}
-          </Button>
-        </ConnectionPopoverWrapper>
-        {wrapButton(
-          <Button
-            size="xsmall"
-            variant="outlined"
-            color="neutral"
-            startIcon={<ProfileDiffIcon fontSize="small" />}
-            onClick={actionCallbacks?.onProfileDiffClick}
-            disabled={isAddedOrRemoved || featureToggles?.disableDatabaseQuery}
-            sx={{ textTransform: "none" }}
-          >
-            Profile
-          </Button>,
-          "profile_diff",
-        )}
-        {wrapButton(
-          <Button
-            size="xsmall"
-            variant="outlined"
-            color="neutral"
-            startIcon={<ValueDiffIcon fontSize="small" />}
-            onClick={actionCallbacks?.onValueDiffClick}
-            disabled={isAddedOrRemoved || featureToggles?.disableDatabaseQuery}
-            sx={{ textTransform: "none" }}
-          >
-            Value
-          </Button>,
-          "value_diff",
-        )}
-        {wrapButton(
-          <Button
-            size="xsmall"
-            variant="outlined"
-            color="neutral"
-            startIcon={<TopKDiffIcon fontSize="small" />}
-            onClick={actionCallbacks?.onTopKDiffClick}
-            disabled={isAddedOrRemoved || featureToggles?.disableDatabaseQuery}
-            sx={{ textTransform: "none" }}
-          >
-            Top-K
-          </Button>,
-          "top_k_diff",
-        )}
-        {wrapButton(
-          <Button
-            size="xsmall"
-            variant="outlined"
-            color="neutral"
-            startIcon={<HistogramDiffIcon fontSize="small" />}
-            onClick={actionCallbacks?.onHistogramDiffClick}
-            disabled={isAddedOrRemoved || featureToggles?.disableDatabaseQuery}
-            sx={{ textTransform: "none" }}
-          >
-            Histogram
-          </Button>,
-          "histogram_diff",
-        )}
-        <ConnectionPopoverWrapper display={metadataOnly}>
-          <Button
-            size="xsmall"
-            variant="outlined"
-            color="neutral"
-            startIcon={<QueryDiffIcon fontSize="small" />}
-            onClick={actionCallbacks?.onQueryDiffClick}
-            disabled={featureToggles?.disableDatabaseQuery}
-            sx={{ textTransform: "none" }}
-          >
-            Query
-          </Button>
-        </ConnectionPopoverWrapper>
-      </Stack>
+            <Typography variant="body2" sx={{ minWidth: 0 }}>
+              {analysisRunLabels[run.type]}
+              {run.columnName ? ` · ${run.columnName}` : ""}
+            </Typography>
+            <Typography
+              variant="caption"
+              sx={{ color: "text.secondary", mr: "auto" }}
+            >
+              {formatTimeToNow(run.runAt)}
+            </Typography>
+            <Button
+              size="small"
+              variant="text"
+              onClick={() => onViewRun?.(run.id)}
+              sx={{ minWidth: 0, textTransform: "none" }}
+            >
+              view ↗
+            </Button>
+          </Stack>
+        ))
+      )}
     </Stack>
   );
 }
@@ -554,8 +622,9 @@ function DiffActionButtons({
  *
  * Displays detailed information about a lineage node including:
  * - Node name and metadata
- * - Action buttons for various operations (Query, Profile, Diff, etc.)
- * - Tabs for Columns and Code views
+ * - A compact Row Count action in the header
+ * - Tabs for Columns, Code, Analysis, and optional Lineage views
+ * - Model-scoped recent analysis history
  *
  * Uses dependency injection for:
  * - Schema view components (different for OSS vs Cloud)
@@ -604,6 +673,8 @@ export function NodeView<TNode extends NodeViewNodeData>({
   newCllExperience = false,
   isImpacted = false,
   rowCountDisplay,
+  recentAnalysisRuns = [],
+  onViewAnalysisRun,
 }: NodeViewProps<TNode>) {
   const withColumns =
     node.data.resourceType === "model" ||
@@ -630,6 +701,8 @@ export function NodeView<TNode extends NodeViewNodeData>({
     node.data.resourceType === "model" ||
     node.data.resourceType === "seed" ||
     node.data.resourceType === "snapshot";
+  const showAnalysisTab = !isSingleEnv && isModelSeedOrSnapshot;
+  const lineageTabIndex = showAnalysisTab ? 3 : 2;
 
   const showAddSchemaDiff =
     !isSingleEnv &&
@@ -675,7 +748,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
         borderLeft: `3px solid ${titleChip ? titleChip.tokens.stripeAccent : "transparent"}`,
       }}
     >
-      {/* Header row: name, type tag, close button */}
+      {/* Header row: name, type tag, row count, close button */}
       <Stack
         direction="row"
         sx={{
@@ -745,35 +818,38 @@ export function NodeView<TNode extends NodeViewNodeData>({
             sx={{ flexShrink: 0 }}
           />
         )}
-        <IconButton size="small" onClick={onCloseNode} sx={{ flexShrink: 0 }}>
+        {showAnalysisTab && (
+          <DiffUtilityButton
+            label="Row Count"
+            Icon={runTypeIcons?.row_count_diff ?? DefaultIcon}
+            onClick={actionCallbacks?.onRowCountDiffClick}
+            featureToggles={featureToggles}
+            ConnectionPopoverWrapper={ConnectionPopoverWrapper}
+            rowCountDisplay={rowCountDisplay}
+          />
+        )}
+        <IconButton
+          aria-label="Close node details"
+          size="small"
+          onClick={onCloseNode}
+          sx={{ flexShrink: 0 }}
+        >
           <IoClose />
         </IconButton>
       </Stack>
-      {/* Action buttons row */}
-      {isModelSeedOrSnapshot && (
+      {/* Single-env redesign is explicitly outside DRC-3463. */}
+      {isModelSeedOrSnapshot && isSingleEnv && (
         <Box sx={{ pl: 2, py: 1 }}>
-          {isSingleEnv ? (
-            <SingleEnvActionButtons
-              node={node}
-              actionCallbacks={actionCallbacks}
-              runTypeIcons={runTypeIcons}
-              isActionAvailable={isActionAvailable}
-              rowCountDisplay={rowCountDisplay}
-            />
-          ) : (
-            <DiffActionButtons
-              node={node}
-              actionCallbacks={actionCallbacks}
-              runTypeIcons={runTypeIcons}
-              featureToggles={featureToggles}
-              isActionAvailable={isActionAvailable}
-              ConnectionPopoverWrapper={ConnectionPopoverWrapper}
-              rowCountDisplay={rowCountDisplay}
-            />
-          )}
+          <SingleEnvActionButtons
+            node={node}
+            actionCallbacks={actionCallbacks}
+            runTypeIcons={runTypeIcons}
+            isActionAvailable={isActionAvailable}
+            rowCountDisplay={rowCountDisplay}
+          />
         </Box>
       )}
-      {/* Content area: tabs for columns and code */}
+      {/* Content area: Columns stays the default landing tab. */}
       {withColumns && (
         <Box
           sx={{
@@ -798,7 +874,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
             </Box>
           )}
 
-          {/* Tabs — "Columns" is always index 0 (default landing tab) */}
+          {/* Stable order: Columns, Code, Analysis (diff), Lineage (optional). */}
           <Tabs
             value={tabValue}
             onChange={(_, newValue) => setTabValue(newValue)}
@@ -856,10 +932,11 @@ export function NodeView<TNode extends NodeViewNodeData>({
                 </Box>
               }
             />
+            {showAnalysisTab && <Tab label="Analysis" />}
             {lineageTabContent && <Tab label="Lineage" />}
           </Tabs>
 
-          {/* Tab panels — Columns=0, Code=1, Lineage=2 (when present) */}
+          {/* Tab panels mirror the conditional tab inventory above. */}
           <Box sx={{ overflow: "auto", height: "calc(100% - 48px)" }}>
             <TabPanel value={tabValue} index={0}>
               <Box sx={{ overflowY: "auto", height: "100%" }}>
@@ -886,12 +963,47 @@ export function NodeView<TNode extends NodeViewNodeData>({
               </Box>
             </TabPanel>
             <TabPanel value={tabValue} index={1}>
-              <Box sx={{ height: "100%" }}>
+              <Box
+                sx={{
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                {showAnalysisTab && (
+                  <Box sx={{ px: 2, pt: 1.5 }}>
+                    <DiffUtilityButton
+                      label="Query"
+                      Icon={runTypeIcons?.query_diff ?? DefaultIcon}
+                      onClick={actionCallbacks?.onQueryDiffClick}
+                      featureToggles={featureToggles}
+                      ConnectionPopoverWrapper={ConnectionPopoverWrapper}
+                    />
+                  </Box>
+                )}
                 {NodeSqlView && <NodeSqlView node={node} />}
               </Box>
             </TabPanel>
-            {lineageTabContent && (
+            {showAnalysisTab && (
               <TabPanel value={tabValue} index={2}>
+                <Box sx={{ p: 2 }}>
+                  <DiffActionButtons
+                    node={node}
+                    actionCallbacks={actionCallbacks}
+                    runTypeIcons={runTypeIcons}
+                    featureToggles={featureToggles}
+                    isActionAvailable={isActionAvailable}
+                    ConnectionPopoverWrapper={ConnectionPopoverWrapper}
+                  />
+                  <RecentAnalysisList
+                    runs={recentAnalysisRuns}
+                    onViewRun={onViewAnalysisRun}
+                  />
+                </Box>
+              </TabPanel>
+            )}
+            {lineageTabContent && (
+              <TabPanel value={tabValue} index={lineageTabIndex}>
                 <Box sx={{ height: "100%" }}>{lineageTabContent}</Box>
               </TabPanel>
             )}

--- a/js/packages/ui/src/components/lineage/NodeViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/NodeViewOss.tsx
@@ -14,12 +14,15 @@
 import Typography from "@mui/material/Typography";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { getModelInfo, type LineageGraphNode } from "../..";
 import {
+  cacheKeys,
   createSchemaDiffCheck,
+  listRuns,
   type RowCount,
   type RowCountDiff,
+  type Run,
 } from "../../api";
 import {
   useLineageGraphContext,
@@ -48,8 +51,10 @@ import { LineageTabContent } from "./LineageTabContent";
 import { NodeSqlViewOss } from "./NodeSqlViewOss";
 import { RowCountSummary } from "./NodeTag";
 import {
+  type AnalysisRunType,
   NodeView as BaseNodeView,
   type NodeViewActionCallbacks,
+  type RecentAnalysisRun,
   type RunTypeIconMap,
 } from "./NodeView";
 import { NodeTag } from "./tags";
@@ -82,6 +87,19 @@ const ResourceTypeTag = ({ node }: { node: LineageGraphNode }) => {
     />
   );
 };
+
+const ANALYSIS_RUN_TYPES = new Set<AnalysisRunType>([
+  "profile_diff",
+  "value_diff",
+  "top_k_diff",
+  "histogram_diff",
+]);
+
+function isAnalysisRun(
+  run: Run,
+): run is Extract<Run, { type: AnalysisRunType }> {
+  return ANALYSIS_RUN_TYPES.has(run.type as AnalysisRunType);
+}
 
 // =============================================================================
 // OSS-SPECIFIC WRAPPER COMPONENTS
@@ -126,7 +144,7 @@ export function NodeViewOss({
   onJumpToHistory,
 }: NodeViewProps) {
   const router = useRouter();
-  const { runAction } = useRecceActionContext();
+  const { runAction, showRunId } = useRecceActionContext();
   const { isActionAvailable, envInfo, lineageGraph } = useLineageGraphContext();
   // Optional: undefined in tests/Storybook that mount NodeView without LineageView.
   const lineageViewCtx = useLineageViewContext();
@@ -142,6 +160,11 @@ export function NodeViewOss({
   const { basePath } = useRouteConfig();
   const { runsAggregated } = useLineageGraphContext();
   const isSingleEnv = isSingleEnvOnboarding ?? false;
+  const supportsDiffAnalysis =
+    !isSingleEnv &&
+    (node.data.resourceType === "model" ||
+      node.data.resourceType === "seed" ||
+      node.data.resourceType === "snapshot");
 
   const rowCountDisplay = useMemo(() => {
     const aggregated = runsAggregated?.[node.id];
@@ -159,6 +182,44 @@ export function NodeViewOss({
     staleTime: 5 * 60 * 1000,
   });
   const modelDetail = modelDetailData?.model;
+
+  const { data: runs } = useQuery({
+    queryKey: cacheKeys.runs(),
+    queryFn: () => listRuns(apiClient),
+    enabled: supportsDiffAnalysis && !!apiClient,
+    retry: false,
+  });
+
+  const recentAnalysisRuns = useMemo<RecentAnalysisRun[]>(() => {
+    return (runs ?? [])
+      .filter(isAnalysisRun)
+      .filter(
+        (run) =>
+          run.status !== "Running" && run.params?.model === node.data.name,
+      )
+      .sort(
+        (a, b) => new Date(b.run_at).getTime() - new Date(a.run_at).getTime(),
+      )
+      .map((run) => {
+        const params = run.params;
+        return {
+          id: run.run_id,
+          type: run.type,
+          runAt: run.run_at,
+          columnName:
+            params != null &&
+            "column_name" in params &&
+            typeof params.column_name === "string"
+              ? params.column_name
+              : undefined,
+        };
+      });
+  }, [runs, node.data.name]);
+
+  const handleViewAnalysisRun = useCallback(
+    (runId: string) => showRunId(runId, false),
+    [showRunId],
+  );
 
   // Build run type icons map from OSS registry
   const runTypeIcons: RunTypeIconMap = useMemo(
@@ -382,6 +443,8 @@ export function NodeViewOss({
       ResourceTypeTag={ResourceTypeTag}
       // Row count text rendered inline on the Row Count button
       rowCountDisplay={rowCountDisplay}
+      recentAnalysisRuns={recentAnalysisRuns}
+      onViewAnalysisRun={handleViewAnalysisRun}
       // Notification for single env
       NotificationComponent={OssNotificationComponent}
       // Connection popover wrapper

--- a/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
@@ -9,7 +9,7 @@
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 import type { NodeColumnData } from "../../../api";
 import type { NodeViewNodeData } from "../NodeView";
 import { NodeView } from "../NodeView";
@@ -122,6 +122,145 @@ function renderNodeView(
 // ============================================================================
 
 describe("NodeView", () => {
+  describe("diff-mode information architecture", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-26T12:00:00Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("keeps only Row Count in the header and hides analysis launchers until the Analysis tab opens", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderNodeView(createNode("model", testColumns), testColumns, {
+        rowCountDisplay: <span>999 rows · No Change</span>,
+      });
+
+      expect(
+        screen.getByRole("button", { name: /row count.*999 rows/i }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /^profile$/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /^value$/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /^top-k$/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /^histogram$/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /^query$/i })).toBeNull();
+
+      await user.click(screen.getByRole("tab", { name: "Analysis" }));
+
+      expect(screen.getByRole("button", { name: /^profile$/i })).toBeVisible();
+      expect(screen.getByRole("button", { name: /^value$/i })).toBeVisible();
+      expect(screen.getByRole("button", { name: /^top-k$/i })).toBeVisible();
+      expect(
+        screen.getByRole("button", { name: /^histogram$/i }),
+      ).toBeVisible();
+      expect(screen.queryByRole("button", { name: /^query$/i })).toBeNull();
+    });
+
+    test("launches all four analysis actions from always-visible buttons", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const callbacks = {
+        onProfileDiffClick: vi.fn(),
+        onValueDiffClick: vi.fn(),
+        onTopKDiffClick: vi.fn(),
+        onHistogramDiffClick: vi.fn(),
+      };
+      renderNodeView(createNode("model", testColumns), testColumns, {
+        actionCallbacks: callbacks,
+      });
+
+      await user.click(screen.getByRole("tab", { name: "Analysis" }));
+      await user.click(screen.getByRole("button", { name: /^profile$/i }));
+      await user.click(screen.getByRole("button", { name: /^value$/i }));
+      await user.click(screen.getByRole("button", { name: /^top-k$/i }));
+      await user.click(screen.getByRole("button", { name: /^histogram$/i }));
+
+      expect(callbacks.onProfileDiffClick).toHaveBeenCalledOnce();
+      expect(callbacks.onValueDiffClick).toHaveBeenCalledOnce();
+      expect(callbacks.onTopKDiffClick).toHaveBeenCalledOnce();
+      expect(callbacks.onHistogramDiffClick).toHaveBeenCalledOnce();
+    });
+
+    test("renders a flat Recent list with column context and reopens a selected result", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const onViewAnalysisRun = vi.fn();
+      renderNodeView(createNode("model", testColumns), testColumns, {
+        recentAnalysisRuns: [
+          {
+            id: "profile-1",
+            type: "profile_diff",
+            runAt: "2026-08-23T12:00:00Z",
+          },
+          {
+            id: "histogram-1",
+            type: "histogram_diff",
+            columnName: "STATUS",
+            runAt: "2026-08-26T11:00:00Z",
+          },
+        ],
+        onViewAnalysisRun,
+      });
+
+      await user.click(screen.getByRole("tab", { name: "Analysis" }));
+
+      expect(screen.getByText("Recent")).toBeInTheDocument();
+      expect(screen.getByText("Profile")).toBeInTheDocument();
+      expect(screen.getByText(/Histogram.*STATUS/)).toBeInTheDocument();
+      expect(screen.getByText("3 days ago")).toBeInTheDocument();
+      expect(screen.getByText("about 1 hour ago")).toBeInTheDocument();
+
+      const viewButtons = screen.getAllByRole("button", { name: /view/i });
+      expect(viewButtons).toHaveLength(2);
+      await user.click(viewButtons[1]);
+      expect(onViewAnalysisRun).toHaveBeenCalledWith("histogram-1");
+    });
+
+    test("shows an explicit empty state when the focused model has no recent analysis", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderNodeView(createNode("model", testColumns), testColumns, {
+        recentAnalysisRuns: [],
+      });
+
+      await user.click(screen.getByRole("tab", { name: "Analysis" }));
+
+      expect(screen.getByText("No recent analysis runs")).toBeInTheDocument();
+    });
+
+    test("moves Query into the Code tab without changing its callback", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const onQueryDiffClick = vi.fn();
+      renderNodeView(createNode("model", testColumns), testColumns, {
+        actionCallbacks: { onQueryDiffClick },
+        NodeSqlView: () => <div>SQL diff</div>,
+      });
+
+      expect(screen.queryByRole("button", { name: /^query$/i })).toBeNull();
+      await user.click(screen.getByRole("tab", { name: "Code" }));
+      await user.click(screen.getByRole("button", { name: /^query$/i }));
+
+      expect(onQueryDiffClick).toHaveBeenCalledOnce();
+      expect(screen.getByText("SQL diff")).toBeInTheDocument();
+    });
+
+    test("keeps Columns first and appends Analysis before optional Lineage", () => {
+      renderNodeView(createNode("model", testColumns), testColumns, {
+        lineageTabContent: <div>lineage</div>,
+      });
+
+      expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+        "Columns",
+        "Code",
+        "Analysis",
+        "Lineage",
+      ]);
+      expect(screen.getByRole("tab", { name: "Columns" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+  });
+
   describe("change category", () => {
     test.each([
       ["breaking", "Model-Wide Change"], // wire-enum-ok
@@ -399,6 +538,7 @@ describe("NodeView", () => {
         node.data.changeStatus = changeStatus;
 
         renderNodeView(node, testColumns);
+        await userEvent.click(screen.getByRole("tab", { name: "Analysis" }));
 
         const { button } = await hoverDisabledReason(/^profile$/i);
 
@@ -431,6 +571,8 @@ describe("NodeView", () => {
         isActionAvailable: (runType) => runType !== "value_diff",
       });
 
+      await userEvent.click(screen.getByRole("tab", { name: "Analysis" }));
+
       await hoverDisabledReason(/^value$/i);
 
       expect(await screen.findByRole("tooltip")).toHaveTextContent(
@@ -445,6 +587,8 @@ describe("NodeView", () => {
         actionCallbacks: { onHistogramDiffClick },
       });
 
+      await userEvent.click(screen.getByRole("tab", { name: "Analysis" }));
+
       const histogram = screen.getByRole("button", { name: /histogram/i });
       expect(histogram).toBeDisabled();
       expect(onHistogramDiffClick).not.toHaveBeenCalled();
@@ -455,6 +599,8 @@ describe("NodeView", () => {
       node.data.changeStatus = "modified";
 
       renderNodeView(node, testColumns);
+
+      await userEvent.click(screen.getByRole("tab", { name: "Analysis" }));
 
       const { button } = await hoverDisabledReason(/^profile$/i);
 

--- a/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
@@ -7,7 +7,7 @@
  * row is conditionally absent.
  */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, vi } from "vitest";
 import type { NodeColumnData } from "../../../api";
@@ -133,7 +133,6 @@ describe("NodeView", () => {
     });
 
     test("keeps only Row Count in the header and hides analysis launchers until the Analysis tab opens", async () => {
-      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       renderNodeView(createNode("model", testColumns), testColumns, {
         rowCountDisplay: <span>999 rows · No Change</span>,
       });
@@ -147,7 +146,7 @@ describe("NodeView", () => {
       expect(screen.queryByRole("button", { name: /^histogram$/i })).toBeNull();
       expect(screen.queryByRole("button", { name: /^query$/i })).toBeNull();
 
-      await user.click(screen.getByRole("tab", { name: "Analysis" }));
+      fireEvent.click(screen.getByRole("tab", { name: "Analysis" }));
 
       expect(screen.getByRole("button", { name: /^profile$/i })).toBeVisible();
       expect(screen.getByRole("button", { name: /^value$/i })).toBeVisible();
@@ -159,7 +158,6 @@ describe("NodeView", () => {
     });
 
     test("launches all four analysis actions from always-visible buttons", async () => {
-      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       const callbacks = {
         onProfileDiffClick: vi.fn(),
         onValueDiffClick: vi.fn(),
@@ -170,11 +168,11 @@ describe("NodeView", () => {
         actionCallbacks: callbacks,
       });
 
-      await user.click(screen.getByRole("tab", { name: "Analysis" }));
-      await user.click(screen.getByRole("button", { name: /^profile$/i }));
-      await user.click(screen.getByRole("button", { name: /^value$/i }));
-      await user.click(screen.getByRole("button", { name: /^top-k$/i }));
-      await user.click(screen.getByRole("button", { name: /^histogram$/i }));
+      fireEvent.click(screen.getByRole("tab", { name: "Analysis" }));
+      fireEvent.click(screen.getByRole("button", { name: /^profile$/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^value$/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^top-k$/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^histogram$/i }));
 
       expect(callbacks.onProfileDiffClick).toHaveBeenCalledOnce();
       expect(callbacks.onValueDiffClick).toHaveBeenCalledOnce();
@@ -183,7 +181,6 @@ describe("NodeView", () => {
     });
 
     test("renders a flat Recent list with column context and reopens a selected result", async () => {
-      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       const onViewAnalysisRun = vi.fn();
       renderNodeView(createNode("model", testColumns), testColumns, {
         recentAnalysisRuns: [
@@ -202,33 +199,31 @@ describe("NodeView", () => {
         onViewAnalysisRun,
       });
 
-      await user.click(screen.getByRole("tab", { name: "Analysis" }));
+      fireEvent.click(screen.getByRole("tab", { name: "Analysis" }));
 
       expect(screen.getByText("Recent")).toBeInTheDocument();
-      expect(screen.getByText("Profile")).toBeInTheDocument();
+      expect(screen.getAllByText("Profile")).toHaveLength(2);
       expect(screen.getByText(/Histogram.*STATUS/)).toBeInTheDocument();
       expect(screen.getByText("3 days ago")).toBeInTheDocument();
       expect(screen.getByText("about 1 hour ago")).toBeInTheDocument();
 
       const viewButtons = screen.getAllByRole("button", { name: /view/i });
       expect(viewButtons).toHaveLength(2);
-      await user.click(viewButtons[1]);
+      fireEvent.click(viewButtons[1]);
       expect(onViewAnalysisRun).toHaveBeenCalledWith("histogram-1");
     });
 
     test("shows an explicit empty state when the focused model has no recent analysis", async () => {
-      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       renderNodeView(createNode("model", testColumns), testColumns, {
         recentAnalysisRuns: [],
       });
 
-      await user.click(screen.getByRole("tab", { name: "Analysis" }));
+      fireEvent.click(screen.getByRole("tab", { name: "Analysis" }));
 
       expect(screen.getByText("No recent analysis runs")).toBeInTheDocument();
     });
 
     test("moves Query into the Code tab without changing its callback", async () => {
-      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       const onQueryDiffClick = vi.fn();
       renderNodeView(createNode("model", testColumns), testColumns, {
         actionCallbacks: { onQueryDiffClick },
@@ -236,8 +231,8 @@ describe("NodeView", () => {
       });
 
       expect(screen.queryByRole("button", { name: /^query$/i })).toBeNull();
-      await user.click(screen.getByRole("tab", { name: "Code" }));
-      await user.click(screen.getByRole("button", { name: /^query$/i }));
+      fireEvent.click(screen.getByRole("tab", { name: "Code" }));
+      fireEvent.click(screen.getByRole("button", { name: /^query$/i }));
 
       expect(onQueryDiffClick).toHaveBeenCalledOnce();
       expect(screen.getByText("SQL diff")).toBeInTheDocument();

--- a/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
@@ -209,6 +209,10 @@ describe("NodeView", () => {
 
       const viewButtons = screen.getAllByRole("button", { name: /view/i });
       expect(viewButtons).toHaveLength(2);
+      expect(viewButtons[0]).toHaveAccessibleName("View Profile result");
+      expect(viewButtons[1]).toHaveAccessibleName(
+        "View Histogram result for STATUS",
+      );
       fireEvent.click(viewButtons[1]);
       expect(onViewAnalysisRun).toHaveBeenCalledWith("histogram-1");
     });
@@ -254,6 +258,44 @@ describe("NodeView", () => {
         "true",
       );
     });
+
+    test.each(["Analysis", "Lineage"])(
+      "resets to Columns when focus moves from the %s tab to a source node",
+      (selectedTab) => {
+        const sharedProps = {
+          onCloseNode: vi.fn(),
+          isSingleEnv: false,
+          SchemaView: MockSchemaView,
+          lineageTabContent: <div data-testid="lineage-content">lineage</div>,
+        };
+        const { rerender } = render(
+          <NodeView
+            {...sharedProps}
+            node={createNode("model", testColumns)}
+            modelDetail={createModelDetail(testColumns)}
+          />,
+        );
+        fireEvent.click(screen.getByRole("tab", { name: selectedTab }));
+
+        rerender(
+          <NodeView
+            {...sharedProps}
+            node={{
+              ...createNode("source", testColumns),
+              id: "source.test.next_node",
+            }}
+            modelDetail={createModelDetail(testColumns)}
+          />,
+        );
+
+        expect(screen.getByRole("tab", { name: "Columns" })).toHaveAttribute(
+          "aria-selected",
+          "true",
+        );
+        expect(screen.getByTestId("schema-view")).toBeInTheDocument();
+        expect(screen.queryByTestId("lineage-content")).toBeNull();
+      },
+    );
   });
 
   describe("change category", () => {

--- a/js/packages/ui/src/components/lineage/__tests__/NodeViewOss.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeViewOss.test.tsx
@@ -1,10 +1,21 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockPush, mockRunAction } = vi.hoisted(() => ({
+const {
+  mockPush,
+  mockRunAction,
+  mockShowRunId,
+  mockUseQuery,
+  capturedNodeViewProps,
+} = vi.hoisted(() => ({
   mockPush: vi.fn(),
   mockRunAction: vi.fn(),
+  mockShowRunId: vi.fn(),
+  mockUseQuery: vi.fn(() => ({ data: undefined })),
+  capturedNodeViewProps: {
+    current: undefined as Record<string, unknown> | undefined,
+  },
 }));
 
 vi.mock("next/navigation", () => ({
@@ -13,7 +24,7 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@tanstack/react-query", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-query")>();
-  return { ...actual, useQuery: () => ({ data: undefined }) };
+  return { ...actual, useQuery: mockUseQuery };
 });
 
 vi.mock("../../../contexts", async (importOriginal) => {
@@ -27,7 +38,10 @@ vi.mock("../../../contexts", async (importOriginal) => {
       runsAggregated: undefined,
     }),
     useLineageViewContext: () => undefined,
-    useRecceActionContext: () => ({ runAction: mockRunAction }),
+    useRecceActionContext: () => ({
+      runAction: mockRunAction,
+      showRunId: mockShowRunId,
+    }),
     useRecceInstanceContext: () => ({
       singleEnv: false,
       featureToggles: { disableDatabaseQuery: false },
@@ -56,15 +70,19 @@ vi.mock("../../../lib/api/track", async (importOriginal) => {
 });
 
 vi.mock("../NodeView", () => ({
-  NodeView: ({
-    actionCallbacks,
-  }: {
+  NodeView: (props: {
     actionCallbacks: { onHistogramDiffClick?: () => void };
-  }) => (
-    <button type="button" onClick={actionCallbacks.onHistogramDiffClick}>
-      Histogram
-    </button>
-  ),
+  }) => {
+    capturedNodeViewProps.current = props as unknown as Record<string, unknown>;
+    return (
+      <button
+        type="button"
+        onClick={props.actionCallbacks.onHistogramDiffClick}
+      >
+        Histogram
+      </button>
+    );
+  },
 }));
 
 import { NodeViewOss } from "../NodeViewOss";
@@ -72,6 +90,8 @@ import { NodeViewOss } from "../NodeViewOss";
 describe("NodeViewOss Histogram launcher", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseQuery.mockReturnValue({ data: undefined });
+    capturedNodeViewProps.current = undefined;
   });
 
   it("opts the model picker into one-step submission and model telemetry", async () => {
@@ -98,5 +118,112 @@ describe("NodeViewOss Histogram launcher", () => {
         trackProps: { source: "lineage_model_node" },
       },
     );
+  });
+
+  it("passes only prior analysis runs for the focused model, newest first", async () => {
+    mockUseQuery.mockImplementation(({ queryKey }: { queryKey: string[] }) => {
+      if (queryKey[0] !== "runs") return { data: undefined };
+      return {
+        data: [
+          {
+            run_id: "orders-profile-failed",
+            type: "profile_diff",
+            run_at: "2026-08-24T10:00:00Z",
+            status: "Failed",
+            params: { model: "orders" },
+          },
+          {
+            run_id: "customers-profile",
+            type: "profile_diff",
+            run_at: "2026-08-26T11:59:00Z",
+            status: "Finished",
+            params: { model: "customers" },
+          },
+          {
+            run_id: "orders-histogram",
+            type: "histogram_diff",
+            run_at: "2026-08-26T11:00:00Z",
+            status: "Finished",
+            params: { model: "orders", column_name: "status" },
+          },
+          {
+            run_id: "orders-running",
+            type: "top_k_diff",
+            run_at: "2026-08-26T12:00:00Z",
+            status: "Running",
+            params: { model: "orders", column_name: "state" },
+          },
+          {
+            run_id: "orders-row-count",
+            type: "row_count_diff",
+            run_at: "2026-08-26T10:00:00Z",
+            status: "Finished",
+            params: { node_names: ["orders"] },
+          },
+          {
+            run_id: "orders-value",
+            type: "value_diff",
+            run_at: "2026-08-25T10:00:00Z",
+            status: "Finished",
+            params: { model: "orders" },
+          },
+        ],
+      };
+    });
+
+    render(
+      <NodeViewOss
+        node={
+          {
+            id: "model.test.orders",
+            data: { name: "orders", resourceType: "model" },
+          } as never
+        }
+        onCloseNode={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(capturedNodeViewProps.current?.recentAnalysisRuns).toEqual([
+        {
+          id: "orders-histogram",
+          type: "histogram_diff",
+          runAt: "2026-08-26T11:00:00Z",
+          columnName: "status",
+        },
+        {
+          id: "orders-value",
+          type: "value_diff",
+          runAt: "2026-08-25T10:00:00Z",
+          columnName: undefined,
+        },
+        {
+          id: "orders-profile-failed",
+          type: "profile_diff",
+          runAt: "2026-08-24T10:00:00Z",
+          columnName: undefined,
+        },
+      ]);
+    });
+  });
+
+  it("reopens a recent analysis result in the existing bottom pane", () => {
+    render(
+      <NodeViewOss
+        node={
+          {
+            id: "model.test.orders",
+            data: { name: "orders", resourceType: "model" },
+          } as never
+        }
+        onCloseNode={vi.fn()}
+      />,
+    );
+
+    const onViewAnalysisRun = capturedNodeViewProps.current
+      ?.onViewAnalysisRun as ((runId: string) => void) | undefined;
+    onViewAnalysisRun?.("orders-histogram");
+
+    expect(mockShowRunId).toHaveBeenCalledWith("orders-histogram", false);
   });
 });

--- a/js/packages/ui/src/components/lineage/__tests__/NodeViewOss.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeViewOss.test.tsx
@@ -12,7 +12,9 @@ const {
   mockPush: vi.fn(),
   mockRunAction: vi.fn(),
   mockShowRunId: vi.fn(),
-  mockUseQuery: vi.fn(() => ({ data: undefined })),
+  mockUseQuery: vi.fn((_options?: { queryKey?: string[] }) => ({
+    data: undefined as unknown,
+  })),
   capturedNodeViewProps: {
     current: undefined as Record<string, unknown> | undefined,
   },
@@ -121,8 +123,8 @@ describe("NodeViewOss Histogram launcher", () => {
   });
 
   it("passes only prior analysis runs for the focused model, newest first", async () => {
-    mockUseQuery.mockImplementation(({ queryKey }: { queryKey: string[] }) => {
-      if (queryKey[0] !== "runs") return { data: undefined };
+    mockUseQuery.mockImplementation((options?: { queryKey?: string[] }) => {
+      if (options?.queryKey?.[0] !== "runs") return { data: undefined };
       return {
         data: [
           {

--- a/js/packages/ui/src/components/lineage/index.ts
+++ b/js/packages/ui/src/components/lineage/index.ts
@@ -56,10 +56,12 @@ export { NodeSqlViewOss } from "./NodeSqlViewOss";
 export * from "./NodeTag";
 // Node detail view component with dependency-injected components
 export {
+  type AnalysisRunType,
   NodeView,
   type NodeViewActionCallbacks,
   type NodeViewNodeData,
   type NodeViewProps,
+  type RecentAnalysisRun,
   type RunTypeIconMap,
 } from "./NodeView";
 export * from "./nodes";

--- a/js/packages/ui/src/hooks/__tests__/useRun.test.tsx
+++ b/js/packages/ui/src/hooks/__tests__/useRun.test.tsx
@@ -36,7 +36,10 @@ const mockWaitRun = vi.fn();
 const mockCancelRun = vi.fn();
 
 vi.mock("../../api", () => ({
-  cacheKeys: { run: (id: string) => ["run", id] },
+  cacheKeys: {
+    run: (id: string) => ["run", id],
+    runs: () => ["runs"],
+  },
   waitRun: (...args: unknown[]) => mockWaitRun(...args),
   cancelRun: (...args: unknown[]) => mockCancelRun(...args),
   runTypeHasRef: (type: string) =>
@@ -95,14 +98,16 @@ const createMockRun = (overrides: MockRunOverrides = {}): Run =>
 // Test Setup
 // ============================================================================
 
-const createWrapper = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
+const createWrapper = (providedQueryClient?: QueryClient) => {
+  const queryClient =
+    providedQueryClient ??
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
       },
-    },
-  });
+    });
   return ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
@@ -159,6 +164,30 @@ describe("useRun", () => {
   // ==========================================================================
 
   describe("polling lifecycle", () => {
+    it("invalidates run history once when a run completes", async () => {
+      const completedRun = createMockRun({
+        run_id: "analysis-run",
+        type: "histogram_diff",
+        result: { values: [] },
+        status: "Finished",
+      });
+      mockWaitRun.mockResolvedValue(completedRun);
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(() => useRun("analysis-run"), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isRunning).toBe(false);
+      });
+      expect(invalidateQueries).toHaveBeenCalledTimes(1);
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["runs"] });
+    });
+
     it("stops polling when run.result is received", async () => {
       const completedRun = createMockRun({
         result: { total: 100 },

--- a/js/packages/ui/src/hooks/__tests__/useRun.test.tsx
+++ b/js/packages/ui/src/hooks/__tests__/useRun.test.tsx
@@ -37,7 +37,7 @@ const mockCancelRun = vi.fn();
 
 vi.mock("../../api", () => ({
   cacheKeys: {
-    run: (id: string) => ["run", id],
+    run: (id: string) => ["runs", id],
     runs: () => ["runs"],
   },
   waitRun: (...args: unknown[]) => mockWaitRun(...args),
@@ -185,7 +185,10 @@ describe("useRun", () => {
         expect(result.current.isRunning).toBe(false);
       });
       expect(invalidateQueries).toHaveBeenCalledTimes(1);
-      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["runs"] });
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["runs"],
+        exact: true,
+      });
     });
 
     it("stops polling when run.result is received", async () => {

--- a/js/packages/ui/src/hooks/useRun.tsx
+++ b/js/packages/ui/src/hooks/useRun.tsx
@@ -54,12 +54,13 @@ export const useRun = (runId?: string): UseRunResult => {
       if (completedRunIdRef.current !== run.run_id) {
         completedRunIdRef.current = run.run_id;
         setIsRunning(false);
+        void queryClient.invalidateQueries({ queryKey: cacheKeys.runs() });
       }
     } else if (normalizedStatus === "running" && !userCanceled) {
       completedRunIdRef.current = null;
       setIsRunning(true);
     }
-  }, [run, error, userCanceled]);
+  }, [run, error, userCanceled, queryClient]);
 
   useEffect(() => {
     if (

--- a/js/packages/ui/src/hooks/useRun.tsx
+++ b/js/packages/ui/src/hooks/useRun.tsx
@@ -54,7 +54,10 @@ export const useRun = (runId?: string): UseRunResult => {
       if (completedRunIdRef.current !== run.run_id) {
         completedRunIdRef.current = run.run_id;
         setIsRunning(false);
-        void queryClient.invalidateQueries({ queryKey: cacheKeys.runs() });
+        void queryClient.invalidateQueries({
+          queryKey: cacheKeys.runs(),
+          exact: true,
+        });
       }
     } else if (normalizedStatus === "running" && !userCanceled) {
       completedRunIdRef.current = null;


### PR DESCRIPTION
## Summary

- replace the permanent six-button diff toolbar with a compact header Row Count action and a dedicated Analysis tab
- keep Profile, Value, Top-K, and Histogram launchers always visible; preserve the existing column-picker flows for Top-K and Histogram
- move Query into Code without changing the prefilled SQL or primary-key behavior
- add a flat, model-scoped Recent list with relative timestamps and an accessible View action that reopens the existing bottom result pane
- refresh only the exact run-list cache when a viewed run completes, without refetching the active run detail
- add a production Storybook scenario and regression coverage for tab inventory, focus changes, filtering, result reopen, and cache behavior

## Stack

This is the base PR for Stack B in the M4 Lineage & CLL burndown. DRC-2854 will target this branch so its NodeView cleanup builds on the settled tab structure.

## Cloud consumer

Cloud launch renders the shared `LineagePageOss -> LineageViewOss -> NodeViewOss` chain, so no Cloud-only component fork is required. The tab reaches Cloud when the next `@datarecce/ui` release containing this PR is adopted; that package-version adoption remains the deployment boundary.

## Test plan

- `pnpm lint` — 694 files clean
- `pnpm type:check` — root, `@datarecce/ui`, and Storybook clean
- `pnpm test` — 205 files; 4,272 passed, 5 skipped
- `pnpm run build` — production Next.js static build succeeds
- `pnpm --filter @datarecce/storybook run build` — production Storybook build succeeds
- pre-push — 88 related files; 1,804 passed, 5 skipped

## Deviations

- “Past runs” excludes only runs still in `Running`. Finished, Failed, and Cancelled analysis attempts remain in Recent because the existing bottom pane is the diagnostic surface for both results and errors.

Linear: https://linear.app/recce/issue/DRC-3463/nodeview-sidebar-move-the-diff-analysis-buttons-into-an-analysis-tab
