### PR TITLE
fix(lineage): show multi-select only when actionable

### DIFF
--- a/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.test.tsx
@@ -35,7 +35,12 @@ vi.mock("../nodes", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../nodes")>();
   return {
     ...actual,
-    LineageNode: (props: { runsAggregatedTag?: ReactNode }) => {
+    LineageNode: (props: {
+      interactive?: boolean;
+      onSelect?: (nodeId: string) => void;
+      runsAggregatedTag?: ReactNode;
+      selectMode?: string;
+    }) => {
       mockLineageNode(props);
       return <div data-testid="lineage-node">{props.runsAggregatedTag}</div>;
     },
@@ -166,6 +171,31 @@ describe("GraphNode", () => {
         showChangeAnalysis: false,
       }),
     );
+  });
+
+  it("keeps first-node selection wired in normal mode", () => {
+    const selectNode = vi.fn();
+    mockViewContext.current = createViewContext({
+      selectNode,
+    });
+
+    render(<GraphNode {...createNodeProps()} />);
+
+    const lineageNodeProps = mockLineageNode.mock.lastCall?.[0] as {
+      interactive?: boolean;
+      onSelect?: (nodeId: string) => void;
+      selectMode?: string;
+    };
+    expect(lineageNodeProps).toEqual(
+      expect.objectContaining({
+        interactive: true,
+        selectMode: "normal",
+      }),
+    );
+
+    lineageNodeProps.onSelect?.("model.test.orders");
+
+    expect(selectNode).toHaveBeenCalledWith("model.test.orders");
   });
 
   it.each([

--- a/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
@@ -310,7 +310,7 @@ describe("LineageNode", () => {
   // ==========================================================================
 
   describe("interactive mode", () => {
-    it("renders checkbox when interactive is true", () => {
+    it("does not render checkbox in normal mode even when interactive", () => {
       const props = createMockNodeProps(
         { interactive: true },
         { label: "test" },
@@ -318,7 +318,7 @@ describe("LineageNode", () => {
 
       render(<LineageNode {...props} />);
 
-      expect(screen.getByRole("checkbox")).toBeInTheDocument();
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
     });
 
     it("does not render checkbox when interactive is false", () => {

--- a/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
@@ -310,15 +310,49 @@ describe("LineageNode", () => {
   // ==========================================================================
 
   describe("interactive mode", () => {
-    it("does not render checkbox in normal mode even when interactive", () => {
+    it("hides checkbox until hover in normal interactive mode", () => {
+      const props = createMockNodeProps(
+        { interactive: true },
+        { label: "test" },
+      );
+
+      const { container } = render(<LineageNode {...props} />);
+      const checkbox = screen.getByRole("checkbox");
+      const checkboxRoot = checkbox.parentElement;
+
+      expect(checkboxRoot).toHaveStyle({ opacity: "0" });
+
+      fireEvent.mouseEnter(container.firstChild as HTMLElement);
+
+      expect(checkboxRoot).toHaveStyle({ opacity: "1" });
+    });
+
+    it("reveals the normal-mode checkbox when it receives keyboard focus", () => {
       const props = createMockNodeProps(
         { interactive: true },
         { label: "test" },
       );
 
       render(<LineageNode {...props} />);
+      const checkbox = screen.getByRole("checkbox");
 
-      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+      fireEvent.focus(checkbox);
+
+      expect(checkbox.parentElement).toHaveStyle({ opacity: "1" });
+    });
+
+    it("selects the first node from the hover checkbox in normal mode", () => {
+      const onSelect = vi.fn();
+      const props = createMockNodeProps(
+        { interactive: true, onSelect },
+        { label: "test" },
+      );
+
+      const { container } = render(<LineageNode {...props} />);
+      fireEvent.mouseEnter(container.firstChild as HTMLElement);
+      fireEvent.click(screen.getByRole("checkbox"));
+
+      expect(onSelect).toHaveBeenCalledWith("test-node-1");
     });
 
     it("does not render checkbox when interactive is false", () => {

--- a/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
@@ -927,6 +927,7 @@ describe("LineageNode", () => {
         {
           selected: true,
           interactive: true,
+          selectMode: "selecting",
           hasParents: true,
           hasChildren: true,
         },

--- a/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
@@ -317,7 +317,9 @@ describe("LineageNode", () => {
       );
 
       const { container } = render(<LineageNode {...props} />);
-      const checkbox = screen.getByRole("checkbox");
+      const checkbox = screen.getByRole("checkbox", {
+        name: "Select test",
+      });
       const checkboxRoot = checkbox.parentElement;
 
       expect(checkboxRoot).toHaveStyle({ opacity: "0" });

--- a/js/packages/ui/src/components/lineage/contextmenu/__tests__/LineageViewContextMenu.test.tsx
+++ b/js/packages/ui/src/components/lineage/contextmenu/__tests__/LineageViewContextMenu.test.tsx
@@ -63,6 +63,35 @@ describe("ModelNodeContextMenu — Show Impact Radius", () => {
   });
 });
 
+describe("ModelNodeContextMenu — lineage selection", () => {
+  it.each([
+    ["Select All Upstream Nodes", "parent"],
+    ["Select All Downstream Nodes", "child"],
+  ] as const)(
+    "keeps %s reachable without a node checkbox",
+    async (label, direction) => {
+      const selectParentNodes = vi.fn();
+      const selectChildNodes = vi.fn();
+      render(
+        <ModelNodeContextMenu
+          x={0}
+          y={0}
+          isOpen
+          onClose={vi.fn()}
+          node={modifiedNode()}
+          viewOptions={{ selectParentNodes, selectChildNodes }}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("menuitem", { name: label }));
+
+      const selectedDirection =
+        direction === "parent" ? selectParentNodes : selectChildNodes;
+      expect(selectedDirection).toHaveBeenCalledWith(NODE_ID);
+    },
+  );
+});
+
 describe("ColumnNodeContextMenu — Histogram launcher", () => {
   it("keeps lineage-column Histogram as a direct launch with its source", async () => {
     const runAction = vi.fn();

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -303,6 +303,7 @@ function LineageNodeComponent({
   onContextMenu,
 }: LineageNodeProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const [isSelectionFocused, setIsSelectionFocused] = useState(false);
 
   // Bridge the hover gap between the card and the floating toolbar:
   // the toolbar is portaled outside the card, so moving from card -> toolbar
@@ -342,7 +343,9 @@ function LineageNodeComponent({
   const isSelected = isNodeSelected || dataIsSelected || selected || false;
   const showColumns = columnCount > 0;
   const hasAction = selectMode === "action_result" && actionTag;
-  const showSelectionControl = interactive && selectMode !== "normal";
+  const isSelectionMode = selectMode !== "normal";
+  const isSelectionControlVisible =
+    isSelectionMode || isHovered || isSelectionFocused;
 
   // Structural presentation wins over impact when the node itself changed.
   // The MiniMap resolves the same neutral structural channel through this
@@ -540,24 +543,39 @@ function LineageNodeComponent({
             display: "flex",
             bgcolor: statusBlockColor,
             color: statusBlockText,
-            padding: showSelectionControl ? "8px" : "2px",
+            padding: isSelectionMode ? "8px" : "2px",
             borderRightWidth: borderWidth,
             borderRightStyle: "solid",
             borderColor,
             alignItems: "top",
+            position: "relative",
             visibility: showContent ? "inherit" : "hidden",
           }}
         >
-          {showSelectionControl && (
+          {interactive && (
             <Checkbox
               checked={
                 (selectMode === "selecting" && isSelected) ||
                 (selectMode === "action_result" && !!hasAction)
               }
               onClick={handleCheckboxClick}
+              onBlur={() => setIsSelectionFocused(false)}
+              onFocus={() => setIsSelectionFocused(true)}
               disabled={selectMode === "action_result"}
               size="small"
               sx={{
+                ...(selectMode === "normal" && {
+                  backgroundColor: statusBlockColor,
+                  borderRadius: 1,
+                  left: 2,
+                  opacity: isSelectionControlVisible ? 1 : 0,
+                  pointerEvents: isSelectionControlVisible ? "auto" : "none",
+                  position: "absolute",
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  transition: "opacity 0.15s ease-in-out",
+                  zIndex: 1,
+                }),
                 padding: 0,
                 color: "inherit",
                 "&.Mui-checked": { color: "inherit" },

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -10,7 +10,7 @@
  * Features:
  * - Change status visualization (added, removed, modified, unchanged)
  * - Selection modes (normal, selecting, action_result)
- * - Interactive checkbox for multi-select
+ * - Actionable checkbox for multi-select and action results
  * - Action tag display for run status
  * - Resource type and change status icons
  * - Hover menu with context actions
@@ -113,7 +113,7 @@ export interface LineageNodeProps {
   selected?: boolean;
 
   // === Interactive Mode Props ===
-  /** Enable interactive mode with checkbox */
+  /** Enable interactive selection controls */
   interactive?: boolean;
   /** Selection mode */
   selectMode?: SelectMode;
@@ -342,6 +342,7 @@ function LineageNodeComponent({
   const isSelected = isNodeSelected || dataIsSelected || selected || false;
   const showColumns = columnCount > 0;
   const hasAction = selectMode === "action_result" && actionTag;
+  const showSelectionControl = interactive && selectMode !== "normal";
 
   // Structural presentation wins over impact when the node itself changed.
   // The MiniMap resolves the same neutral structural channel through this
@@ -532,14 +533,14 @@ function LineageNodeComponent({
           position: "relative",
         }}
       >
-        {/* Left panel with checkbox */}
+        {/* Left status panel and mode-specific selection control */}
         <Box
           data-testid="lineage-node-status-block"
           sx={{
             display: "flex",
             bgcolor: statusBlockColor,
             color: statusBlockText,
-            padding: interactive ? "8px" : "2px",
+            padding: showSelectionControl ? "8px" : "2px",
             borderRightWidth: borderWidth,
             borderRightStyle: "solid",
             borderColor,
@@ -547,7 +548,7 @@ function LineageNodeComponent({
             visibility: showContent ? "inherit" : "hidden",
           }}
         >
-          {interactive && (
+          {showSelectionControl && (
             <Checkbox
               checked={
                 (selectMode === "selecting" && isSelected) ||

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -563,6 +563,9 @@ function LineageNodeComponent({
               onFocus={() => setIsSelectionFocused(true)}
               disabled={selectMode === "action_result"}
               size="small"
+              slotProps={{
+                input: { "aria-label": `Select ${label}` },
+              }}
               sx={{
                 ...(selectMode === "normal" && {
                   backgroundColor: statusBlockColor,


### PR DESCRIPTION
## Summary

- replace the persistent normal-state lineage checkbox with a compact control that appears on pointer hover or keyboard focus
- keep the checkbox visible during selection and action-result modes
- preserve first-node selection in single-environment mode and give every checkbox a node-specific accessible name
- retain upstream/downstream context-menu selection actions where those actions are supported

## Evidence

For the 90 days ending 2026-08-26 UTC, `multi_nodes_action` recorded 34 events: 4 multi (11.8%), 9 single (26.5%), and 21 none (61.8%). This supports removing persistent clutter while preserving an accessible low-frequency entry point.

## Stack

- Base: #1525 (DRC-3463 analysis tab)
- This PR: DRC-2854 OSS shared lineage node
- Companion cloud PR: DataRecce/recce-cloud-infra#1698

## Verification

- `corepack pnpm@11.1.1 --dir js lint:fix`
- `corepack pnpm@11.1.1 --dir js type:check`
- `corepack pnpm@11.1.1 --dir js test` — 205 files, 4,277 passed, 5 skipped
- `corepack pnpm@11.1.1 --dir js run build`
- adversarial review: pass, no remaining blockers

Linear: DRC-2854
