### PR TITLE
chore(pnpm): upgrade to pnpm 12.4.1

### DIFF
--- a/.claude/agents/recce-pr-verifier.md
+++ b/.claude/agents/recce-pr-verifier.md
@@ -95,7 +95,7 @@ uv run pytest tests/test_foo.py --cov=recce.module --cov-report=term-missing
 
 ### Frontend (TypeScript) — only if `js/` changed
 
-For frontend tooling specifics (pnpm v11 quirks, Biome config, style conventions), see **[`js/CLAUDE.md`](../../js/CLAUDE.md)**.
+For frontend tooling specifics (pnpm v12 quirks, Biome config, style conventions), see **[`js/CLAUDE.md`](../../js/CLAUDE.md)**.
 
 ```bash
 cd js

--- a/.claude/skills/address-dependabot/skill.md
+++ b/.claude/skills/address-dependabot/skill.md
@@ -50,7 +50,7 @@ digraph address_dependabot {
 
 This repo contains `@datarecce/ui`, a **published npm package** consumed by external projects. Its `dependencies` field is a contract with consumers. This shapes how dependency updates are applied.
 
-For frontend tooling context (pnpm v11 `strictDepBuilds`/`allowBuilds`, Biome migration on bump, Node.js 26 via `nave`), reference **[`js/CLAUDE.md`](../../../js/CLAUDE.md)** before applying npm updates.
+For frontend tooling context (pnpm v12 `strictDepBuilds`/`allowBuilds`, Biome migration on bump, Node.js 26 via `nave`), reference **[`js/CLAUDE.md`](../../../js/CLAUDE.md)** before applying npm updates.
 
 ### The Three Zones
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Recce Copilot Instructions
 
-> Claude Code and other agents using `CLAUDE.md` should also consult **[`js/CLAUDE.md`](../js/CLAUDE.md)** for frontend tooling specifics (pnpm commands, Biome, Vitest, `@datarecce/ui` publishing, pnpm v11 `strictDepBuilds`/`allowBuilds`, style conventions). This file remains the canonical Copilot context.
+> Claude Code and other agents using `CLAUDE.md` should also consult **[`js/CLAUDE.md`](../js/CLAUDE.md)** for frontend tooling specifics (pnpm commands, Biome, Vitest, `@datarecce/ui` publishing, pnpm v12 `strictDepBuilds`/`allowBuilds`, style conventions). This file remains the canonical Copilot context.
 
 ## Project Overview
 
@@ -86,7 +86,7 @@ below:
 
 ```bash
 cd js
-pnpm install  # Uses pnpm 11, NOT npm or yarn
+pnpm install  # Uses pnpm 12, NOT npm or yarn
 ```
 
 **Development Server:**
@@ -218,7 +218,7 @@ recce/
 
 ```
 js/
-├── package.json        # pnpm 11, Node >=26.5.0, React 19, Next.js 16
+├── package.json        # pnpm 12, Node >=26.5.0, React 19, Next.js 16
 ├── tsconfig.json       # TypeScript config
 ├── next.config.js      # Next.js config (output: 'export')
 ├── app/                # OSS Next.js App Router shell (routes/layout only)

--- a/.github/instructions/frontend-instructions.md
+++ b/.github/instructions/frontend-instructions.md
@@ -4,7 +4,7 @@ applyTo: "js/**/*.ts,js/**/*.tsx,js/**/*.js,js/**/*.jsx,js/**/*.json,js/**/*.mjs
 
 # Frontend Build Instructions (js/ Directory)
 
-> This file is the **Copilot-targeted** frontend guide (scoped via `applyTo:` frontmatter). Claude Code and other agents using `CLAUDE.md` should consult **[`js/CLAUDE.md`](../../js/CLAUDE.md)** for the equivalent guidance — both should stay in sync on tooling specifics (pnpm v11, Biome, `@datarecce/ui` publishing, style conventions).
+> This file is the **Copilot-targeted** frontend guide (scoped via `applyTo:` frontmatter). Claude Code and other agents using `CLAUDE.md` should consult **[`js/CLAUDE.md`](../../js/CLAUDE.md)** for the equivalent guidance — both should stay in sync on tooling specifics (pnpm v12, Biome, `@datarecce/ui` publishing, style conventions).
 
 ## Critical Frontend Build Requirements
 
@@ -27,7 +27,7 @@ pnpm run build
 ## Package Manager - MUST use pnpm
 
 ```bash
-# CORRECT - Always use pnpm (version 11)
+# CORRECT - Always use pnpm (version 12)
 pnpm install
 pnpm dev
 pnpm run build
@@ -87,7 +87,7 @@ pnpm run clean
 ## Tech Stack
 
 - **Node.js >=26.5.0** - JavaScript runtime (required)
-- **pnpm 11** - Package manager (NOT npm or yarn)
+- **pnpm 12** - Package manager (NOT npm or yarn)
 - **Next.js 16** - React framework with App Router
 - **React 19.2** - UI library with new JSX transform
 - **React DOM 19.2** - React renderer
@@ -130,7 +130,7 @@ js/
 
 **package.json:**
 - Requires Node.js >=26.5.0
-- Uses pnpm@11.1.1 as package manager (pinned via Corepack)
+- Uses pnpm@12.0.0 as package manager (pinned via Corepack)
 - Key scripts:
   - `dev`: Start development server with Turbopack
   - `build`: Clean, build Next.js, move to ../recce/data
@@ -225,7 +225,7 @@ pnpm test  # Watch mode
 
 **What it checks:**
 1. Node.js 26.5.0 setup from `js/.nvmrc`
-2. pnpm 11 installation
+2. pnpm 12 installation
 3. Dependency install with frozen lockfile
 4. Biome linting (`pnpm lint`)
 5. Production build (`pnpm run build`)

--- a/.github/workflows/address-dependabot.yaml
+++ b/.github/workflows/address-dependabot.yaml
@@ -41,9 +41,21 @@ jobs:
         with:
           node-version-file: 'js/.nvmrc'
 
-      - uses: pnpm/action-setup@v6
+      - name: Set up pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          version: 11.1.1
+          package-json-file: js/package.json
+          install: false
+          cache: true
+          cache-dependency-path: js/pnpm-lock.yaml
+
+      - name: Verify pnpm version
+        working-directory: ./js
+        run: |
+          expected=$(node -p "require('./package.json').packageManager.match(/^pnpm@([^+]+)/)[1]")
+          actual=$(pnpm --version)
+          echo "pnpm version: $actual"
+          test "$actual" = "$expected"
 
       - name: Install frontend dependencies
         working-directory: ./js

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -40,9 +40,21 @@ jobs:
         with:
           node-version-file: 'js/.nvmrc'
 
-      - uses: pnpm/action-setup@v6
+      - name: Set up pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          version: 11.1.1
+          package-json-file: js/package.json
+          install: false
+          cache: true
+          cache-dependency-path: js/pnpm-lock.yaml
+
+      - name: Verify pnpm version
+        working-directory: ./js
+        run: |
+          expected=$(node -p "require('./package.json').packageManager.match(/^pnpm@([^+]+)/)[1]")
+          actual=$(pnpm --version)
+          echo "pnpm version: $actual"
+          test "$actual" = "$expected"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release-ui.yaml
+++ b/.github/workflows/release-ui.yaml
@@ -44,17 +44,27 @@ jobs:
           # For workflow_run, checkout the same ref that triggered the parent workflow
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 11.1.1
-
       - name: Setup Node.js 26
         uses: actions/setup-node@v7
         with:
           node-version-file: 'js/.nvmrc' # Node 26 includes npm 11+ with OIDC support
-          cache: 'pnpm'
-          cache-dependency-path: js/pnpm-lock.yaml
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Set up pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          package-json-file: js/package.json
+          install: false
+          cache: true
+          cache-dependency-path: js/pnpm-lock.yaml
+
+      - name: Verify pnpm version
+        working-directory: ./js
+        run: |
+          expected=$(node -p "require('./package.json').packageManager.match(/^pnpm@([^+]+)/)[1]")
+          actual=$(pnpm --version)
+          echo "pnpm version: $actual"
+          test "$actual" = "$expected"
 
       - name: Verify npm version
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,9 +27,21 @@ jobs:
         with:
           node-version-file: 'js/.nvmrc'
 
-      - uses: pnpm/action-setup@v6
+      - name: Set up pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          version: 11.1.1
+          package-json-file: js/package.json
+          install: false
+          cache: true
+          cache-dependency-path: js/pnpm-lock.yaml
+
+      - name: Verify pnpm version
+        working-directory: ./js
+        run: |
+          expected=$(node -p "require('./package.json').packageManager.match(/^pnpm@([^+]+)/)[1]")
+          actual=$(pnpm --version)
+          echo "pnpm version: $actual"
+          test "$actual" = "$expected"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests-js.yaml
+++ b/.github/workflows/tests-js.yaml
@@ -23,23 +23,21 @@ jobs:
         with:
           node-version-file: 'js/.nvmrc'
 
-      - uses: pnpm/action-setup@v6
+      - name: Set up pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          version: 11.1.1
-          run_install: false
+          package-json-file: js/package.json
+          install: false
+          cache: true
+          cache-dependency-path: js/pnpm-lock.yaml
 
-      - name: Get pnpm store directory
-        shell: bash
+      - name: Verify pnpm version
+        working-directory: ./js
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          expected=$(node -p "require('./package.json').packageManager.match(/^pnpm@([^+]+)/)[1]")
+          actual=$(pnpm --version)
+          echo "pnpm version: $actual"
+          test "$actual" = "$expected"
 
       - name: Install dependencies
         working-directory: ./js
@@ -60,23 +58,21 @@ jobs:
         with:
           node-version-file: 'js/.nvmrc'
 
-      - uses: pnpm/action-setup@v6
+      - name: Set up pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          version: 11.1.1
-          run_install: false
+          package-json-file: js/package.json
+          install: false
+          cache: true
+          cache-dependency-path: js/pnpm-lock.yaml
 
-      - name: Get pnpm store directory
-        shell: bash
+      - name: Verify pnpm version
+        working-directory: ./js
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          expected=$(node -p "require('./package.json').packageManager.match(/^pnpm@([^+]+)/)[1]")
+          actual=$(pnpm --version)
+          echo "pnpm version: $actual"
+          test "$actual" = "$expected"
 
       - name: Install dependencies
         working-directory: ./js

--- a/.github/workflows/tests-python.yaml
+++ b/.github/workflows/tests-python.yaml
@@ -74,10 +74,21 @@ jobs:
         with:
           node-version-file: 'js/.nvmrc'
 
-      - uses: pnpm/action-setup@v6
+      - name: Set up pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          version: 11.1.1
-          run_install: false
+          package-json-file: js/package.json
+          install: false
+          cache: true
+          cache-dependency-path: js/pnpm-lock.yaml
+
+      - name: Verify pnpm version
+        working-directory: ./js
+        run: |
+          expected=$(node -p "require('./package.json').packageManager.match(/^pnpm@([^+]+)/)[1]")
+          actual=$(pnpm --version)
+          echo "pnpm version: $actual"
+          test "$actual" = "$expected"
 
       - name: Build frontend assets
         run: make build-frontend
@@ -117,10 +128,21 @@ jobs:
         with:
           node-version-file: 'js/.nvmrc'
 
-      - uses: pnpm/action-setup@v6
+      - name: Set up pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          version: 11.1.1
-          run_install: false
+          package-json-file: js/package.json
+          install: false
+          cache: true
+          cache-dependency-path: js/pnpm-lock.yaml
+
+      - name: Verify pnpm version
+        working-directory: ./js
+        run: |
+          expected=$(node -p "require('./package.json').packageManager.match(/^pnpm@([^+]+)/)[1]")
+          actual=$(pnpm --version)
+          echo "pnpm version: $actual"
+          test "$actual" = "$expected"
 
       - name: Build frontend assets
         run: make build-frontend

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        # pnpm 12 lockfiles are valid multi-document YAML streams.
+        exclude: ^js/pnpm-lock\.yaml$
       - id: check-added-large-files
         exclude: ^uv\.lock$
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 ## Quick Reference
 
 → `docs/KNOWLEDGE_BASE.md` - Architecture, code patterns, frontend structure, testing, debugging
-→ `js/CLAUDE.md` - Frontend conventions and tooling (Node.js 26 via `nave`, Biome, Vitest, pnpm v11
+→ `js/CLAUDE.md` - Frontend conventions and tooling (Node.js 26 via `nave`, Biome, Vitest, pnpm v12
   quirks, Storybook imports, CSS color format, rem vs px, shell vs shared code)
 
 ## Working Preferences

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,10 @@ test-tox-python-versions:
 	@tox run-parallel -e 3.10,3.11,3.12,3.13
 
 install-frontend-requires:
-# Install pnpm if not installed
-	@command -v pnpm || npm install -g pnpm
+# Install Corepack if needed, then provision the pnpm version pinned by js/package.json
+	@command -v corepack >/dev/null || npm install -g corepack@latest
+	@corepack enable
+	@cd js && corepack install
 	@cd js && pnpm install
 
 dev: install-frontend-requires

--- a/docs/KNOWLEDGE_BASE.md
+++ b/docs/KNOWLEDGE_BASE.md
@@ -21,7 +21,7 @@ Separation of concerns across models, APIs, tasks, adapters, and state. Import r
 Monorepo with `@datarecce/ui` shared package. OSS app (`js/app/`) stays thin; shared components, hooks, and API clients live in `js/packages/ui/`.
 
 → `docs/frontend.md` (structure, import rules, build process)
-→ `js/CLAUDE.md` (tooling: pnpm, Biome, Vitest, @datarecce/ui publishing, style conventions, pnpm v11 quirks)
+→ `js/CLAUDE.md` (tooling: pnpm, Biome, Vitest, @datarecce/ui publishing, style conventions, pnpm v12 quirks)
 
 ## Testing
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,6 +1,6 @@
 # Frontend Structure
 
-> For frontend tooling specifics (pnpm commands, Biome, Vitest, `@datarecce/ui` publishing, pnpm v11 `strictDepBuilds`/`allowBuilds`, and style conventions), see **[`js/CLAUDE.md`](../js/CLAUDE.md)**. This document focuses on monorepo structure, package boundaries, and the build pipeline.
+> For frontend tooling specifics (pnpm commands, Biome, Vitest, `@datarecce/ui` publishing, pnpm v12 `strictDepBuilds`/`allowBuilds`, and style conventions), see **[`js/CLAUDE.md`](../js/CLAUDE.md)**. This document focuses on monorepo structure, package boundaries, and the build pipeline.
 
 ## Monorepo Layout
 

--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -46,17 +46,19 @@ When updating frontend deps:
 
 Packages requiring overrides (exist in multiple `package.json`): `@emotion/react`, `@mui/material`, `@tanstack/react-query`, `@xyflow/react`, `axios`, `date-fns`, `lodash`, `tailwindcss`, `typescript`, `vitest`.
 
-## pnpm v11 — strictDepBuilds + allowBuilds
+## pnpm v12 — strictDepBuilds + allowBuilds
 
-The repo runs on pnpm v11.1.1 (since DRC-3439, 2026-05-13). Four non-obvious behaviors:
+The repo runs on pnpm v12.0.0 (since 2026-08-27). Five non-obvious behaviors:
 
 1. **`strictDepBuilds: true` is on by default.** Any transitive package with a `postinstall` script that isn't explicitly listed in `pnpm-workspace.yaml#allowBuilds` will cause `pnpm install --frozen-lockfile` to hard-fail in CI with `ERR_PNPM_IGNORED_BUILDS`. When a new dep triggers this, add it to `allowBuilds` as `true` (run its postinstall) or `false` (acknowledge it exists, do NOT run postinstall).
 
 2. **Local repro requires CI parity.** Use `CI=true pnpm install --frozen-lockfile` to match CI exactly. The `--ignore-scripts` flag will MASK this failure — do not use it as a verification path.
 
-3. **pnpm 11 silently appends placeholder lines.** If you run `pnpm install` in a non-TTY context and it hits an ignored build, pnpm appends `<pkg>: set this to true or false` to `pnpm-workspace.yaml#allowBuilds`. Always `git status` after running install — never commit these placeholders.
+3. **Never accept generated `allowBuilds` placeholders.** If a non-TTY install discovers an ignored build, inspect `pnpm-workspace.yaml#allowBuilds` for `<pkg>: set this to true or false`. Always run `git status` after an install and replace any placeholder with a reviewed boolean decision before committing.
 
-4. **`packageManager` must be exact semver.** Corepack rejects ranges like `pnpm@11`. Pin the full `pnpm@11.x.y+sha512.<integrity>` via `corepack use pnpm@11.x.y` (note the `.` separator between `sha512` and the hash — not `:`).
+4. **`packageManager` must be exact semver.** Do not use ranges or dist-tags such as `pnpm@12`, `latest`, or `next-12`. Pin the full `pnpm@12.x.y+sha512.<integrity>` via `corepack use pnpm@12.x.y` (note the `.` separator between `sha512` and the hash — not `:`).
+
+5. **The lockfile pins pnpm's platform executables.** Changing `packageManager` requires regenerating `pnpm-lock.yaml` so its leading `packageManagerDependencies` document records pnpm and every supported platform package with integrity hashes. CI's frozen install rejects a mismatched pin. GitHub Actions must read the version from `js/package.json` through the SHA-pinned `pnpm/setup` action rather than duplicate the version in workflow YAML.
 
 Canonical `allowBuilds` examples live in recce-cloud-infra:
 - `recce-cloud-infra/recce-cloud/pnpm-workspace.yaml`

--- a/js/README.md
+++ b/js/README.md
@@ -5,7 +5,7 @@
    nave install "$(cat .nvmrc)"
    nave use "$(cat .nvmrc)"
    ```
-2. pnpm
+2. pnpm 12 (the exact version is pinned in `package.json`)
 
    ```
    npm install -g corepack@latest

--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "node": ">=26.5.0"
   },
-  "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a",
+  "packageManager": "pnpm@12.0.0+sha512.9e2e3dc3911995868dc94b8175c217c27e95408fa03b4a22749778f2b34f773b77cdd3b39ede8171b22fcd53be6a35342e9fac9948a68ef58df6488ce89a7e67",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build && cp -R out/. ../recce/data/ && rm -rf out",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0
+        version: 12.0.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    resolution: {integrity: sha512-sqeoPfVMIfQhbwzDrKraXY2ynyuWClFqzvfImzAS/yczEru1m5SGvQ9kgFPDvQzJZ9AetedgJeDZC6qYvH8/tQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    resolution: {integrity: sha512-Quc3J6c9cGTy+LDgz1cLVgCNOU9IERuyAlDoEj0DCilKqvo50Jx1GV8k74iwn4J9fFSKkm8JrwNvtTDj3uWnUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    resolution: {integrity: sha512-EVWd3OTmgsMFhXx69b5JxIzoabG9Ma7m4OeTaf0ZKBzMnfYi8u21NDQo92ToMrdYL5dYDDCHsyYIjXzk+d0HhA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    resolution: {integrity: sha512-cXHHW8M4rAPsYNkKZO9WVcpLLK55i9EaIsZPfIqUuY2eopd5LqnFyBge54HCh1GC0yCX8ySn0hYIi+4OyAEoDg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    resolution: {integrity: sha512-UcXwMdFjly0mpddkGigHKTxe27IMv2fUK4IWW/MHmJ3yMguxXmkwNlEI4aE+G1HO2TLo20uNEUWD4ymLe/DaCQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    resolution: {integrity: sha512-6Rsl+zEWMOmus7v7/9J3OE8EMvHyNAfxYmDfmhQG4J0985OuT3G3Ho9NSGHjkBn4aU4bgklWifRhe1HX8dUSyw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    resolution: {integrity: sha512-O5F76A4oVFrpDGdFxEszRIThOSBfjHdH5c006gR+7UTCfiXrukr1XfqPungUI1DXcSR5gb9jBsPQqQZOAoOOxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    resolution: {integrity: sha512-5dKFajIEWJ1ai+KHXFJvskY6vchbunmLwSUV2ywbLymcmJjfY5XJVpgzPCyIoVCMVG0zHorr66+hM8h8b3aRfQ==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0:
+    resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    optional: true
+
+  pnpm@12.0.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

chore

**What this PR does / why we need it**:

Upgrades the repository from pnpm 11.1.1 to pnpm 12.4.1 with an exact, integrity-pinned release for local development and CI.

- Pins `pnpm@12.4.1+sha512.<integrity>` in `js/package.json` and records pnpm plus all 14 platform executables in the lockfile. Their versions, platform constraints, and SHA-512 integrity values match fresh npm registry metadata.
- Uses the native `pnpm/setup` GitHub Action at an exact commit. Every pnpm CI setup reads `js/package.json` and checks that the installed version matches it.
- Makes the local bootstrap provision the exact Corepack pin, updates developer documentation, and accommodates pnpm 12's two-document YAML lockfile in pre-commit.
- Preserves the application dependency lock document, including all 1,031 package records, unchanged from current `main`.

**Release notes reviewed**:

- [12.1](https://pnpm.io/blog/releases/12.1): workspace task scheduling, install/linking changes, and side-effects cache configuration.
- [12.2–12.3](https://pnpm.io/blog/releases/12.2-12.3): workspace linking fixes, credential redaction, registry routing, and stricter handling of explicitly configured minimum release ages.
- [12.4](https://pnpm.io/blog/releases/12.4): six additional executable platforms and registry metadata cache keys that include the full registry URL. The first install refetches metadata; the package store remains reusable. Python/Cargo support and pipeline caching are opt-in; this repository continues using uv and its existing scripts.
- [12.4.1](https://github.com/pnpm/pnpm/releases/tag/v12.4.1): filesystem copy fallbacks, symlink-target overwrite protection, workspace dependency links, and lifecycle scripts with effects outside the package directory.

No additional application or workspace configuration changes were needed for these releases.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Updated on top of `main` at `621a1bd5`, including the merged dependency consolidation in #1550.

Validation completed locally with Node 26.5.0 and pnpm 12.4.1:

- `CI=true pnpm install --frozen-lockfile` with all three workspace `node_modules` directories removed (existing package store reused), then repeated successfully. The fresh install ran lifecycle scripts and installed the Husky hooks.
- `pnpm lint:fix` — 705 files checked; no fixes needed.
- `pnpm type:check` — root, UI, and Storybook passed.
- `pnpm test` — 4,444 passed, 5 skipped across 211 passing files.
- `pnpm --filter @datarecce/ui build` and `pnpm run build`.
- `make install-frontend-requires` — installed the pinned release without lockfile drift.
- `actionlint -shellcheck=` — workflow syntax passed.
- Parsed both lockfile YAML documents and compared the application document with the prior lockfile; verified registry integrity values for pnpm and every platform executable.
- Repository commit hooks passed with `core.hooksPath=js/.husky/_` and Python pre-commit enabled.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
