### PR TITLE
fix(artifact): make comparability side-aware

### DIFF
--- a/integration_tests/dbt/smoke_test.sh
+++ b/integration_tests/dbt/smoke_test.sh
@@ -94,7 +94,7 @@ grep -q '^## Manifest Information$' ./recce_summary.md
 lineage_section=$(awk '/^## Lineage Graph$/,/^## Checks Summary$/' ./recce_summary.md)
 grep -q 'model.jaffle_shop.customers' <<< "$lineage_section"
 
-checks_summary_row=$(grep -A 2 '^|Checks Run|Data Mismatch Detected|$' ./recce_summary.md | tail -1)
+checks_summary_row=$(grep -A 2 '^|Checks Run|Data Mismatch Detected|Incomplete Schema Comparisons|$' ./recce_summary.md | tail -1)
 checks_run=$(awk -F'|' '{gsub(/ /,"",$2); print $2}' <<< "$checks_summary_row")
 mismatch_count=$(awk -F'|' '{gsub(/ /,"",$3); print $3}' <<< "$checks_summary_row")
 # recce.yml defines two preset checks; only the row count one mismatches.

--- a/js/packages/ui/src/api/index.ts
+++ b/js/packages/ui/src/api/index.ts
@@ -62,6 +62,8 @@ export type { RecceServerFlags } from "./flag";
 export { getServerFlag, markRelaunchHintCompleted } from "./flag";
 // Server info API (lineage, environment, dbt metadata)
 export type {
+  ArtifactHealth,
+  ArtifactHealthPair,
   CatalogCoverage,
   CatalogMetadata,
   GitInfo,
@@ -78,6 +80,7 @@ export type {
   NodeColumnData,
   NodeData,
   PullRequestInfo,
+  SchemaCoverage,
   ServerInfoResult,
   SessionStaleness,
   SQLMeshInfo,

--- a/js/packages/ui/src/api/info.test.ts
+++ b/js/packages/ui/src/api/info.test.ts
@@ -91,5 +91,11 @@ describe("ServerInfoResult schema evidence contract", () => {
     expectTypeOf<MergedNodeData["schema_comparison_status"]>().toEqualTypeOf<
       "complete" | "unchecked" | "not_applicable" | undefined
     >();
+    expectTypeOf<MergedNodeData["base_catalog_status"]>().toEqualTypeOf<
+      "covered" | "unchecked" | "not_applicable" | undefined
+    >();
+    expectTypeOf<MergedNodeData["current_catalog_status"]>().toEqualTypeOf<
+      "covered" | "unchecked" | "not_applicable" | undefined
+    >();
   });
 });

--- a/js/packages/ui/src/api/info.test.ts
+++ b/js/packages/ui/src/api/info.test.ts
@@ -1,6 +1,13 @@
 import { describe, expectTypeOf, it } from "vitest";
 
-import type { CatalogCoverage, ServerInfoResult } from "./index";
+import type {
+  ArtifactHealth,
+  CatalogCoverage,
+  MergedLineageResponse,
+  MergedNodeData,
+  SchemaCoverage,
+  ServerInfoResult,
+} from "./index";
 
 type CatalogStatus =
   | "complete"
@@ -23,6 +30,66 @@ describe("ServerInfoResult catalog coverage contract", () => {
 
     expectTypeOf<ServerInfoResult["catalog_coverage"]>().toEqualTypeOf<
       CatalogCoverage | null | undefined
+    >();
+  });
+});
+
+describe("ServerInfoResult schema evidence contract", () => {
+  it("exports the bounded artifact health payload", () => {
+    expectTypeOf<ArtifactHealth>().toEqualTypeOf<{
+      status:
+        | "complete"
+        | "partial"
+        | "empty"
+        | "absent"
+        | "not_applicable"
+        | "unknown";
+      expected_count: number;
+      covered_count: number;
+      catalog_entry_count: number;
+      missing_node_count: number;
+      missing_nodes: string[];
+      missing_more: boolean;
+      orphan_node_count: number;
+      orphan_nodes: string[];
+      orphan_more: boolean;
+    }>();
+  });
+
+  it("exports optional nullable lineage evidence without rejecting legacy payloads", () => {
+    expectTypeOf<SchemaCoverage>().toEqualTypeOf<{
+      status: "complete" | "partial" | "unknown";
+      unchecked_nodes: string[];
+      unchecked_node_count: number;
+      more: boolean;
+    }>();
+    expectTypeOf<MergedLineageResponse["artifact_health"]>().toEqualTypeOf<
+      | {
+          base?: ArtifactHealth | null;
+          current?: ArtifactHealth | null;
+        }
+      | null
+      | undefined
+    >();
+    expectTypeOf<MergedLineageResponse["schema_coverage"]>().toEqualTypeOf<
+      SchemaCoverage | null | undefined
+    >();
+    expectTypeOf<ServerInfoResult["artifact_health"]>().toEqualTypeOf<
+      | {
+          base?: ArtifactHealth | null;
+          current?: ArtifactHealth | null;
+        }
+      | null
+      | undefined
+    >();
+    expectTypeOf<ServerInfoResult["schema_coverage"]>().toEqualTypeOf<
+      SchemaCoverage | null | undefined
+    >();
+  });
+
+  it("exports the optional per-node comparison status", () => {
+    expectTypeOf<MergedNodeData["schema_comparison_status"]>().toEqualTypeOf<
+      "complete" | "unchecked" | "not_applicable" | undefined
     >();
   });
 });

--- a/js/packages/ui/src/api/info.test.ts
+++ b/js/packages/ui/src/api/info.test.ts
@@ -74,17 +74,10 @@ describe("ServerInfoResult schema evidence contract", () => {
     expectTypeOf<MergedLineageResponse["schema_coverage"]>().toEqualTypeOf<
       SchemaCoverage | null | undefined
     >();
-    expectTypeOf<ServerInfoResult["artifact_health"]>().toEqualTypeOf<
-      | {
-          base?: ArtifactHealth | null;
-          current?: ArtifactHealth | null;
-        }
-      | null
-      | undefined
-    >();
-    expectTypeOf<ServerInfoResult["schema_coverage"]>().toEqualTypeOf<
-      SchemaCoverage | null | undefined
-    >();
+    // The server nests both under `lineage` and nowhere else, so
+    // ServerInfoResult must not declare top-level copies of them.
+    expectTypeOf<ServerInfoResult>().not.toHaveProperty("artifact_health");
+    expectTypeOf<ServerInfoResult>().not.toHaveProperty("schema_coverage");
   });
 
   it("exports the optional per-node comparison status", () => {

--- a/js/packages/ui/src/api/info.ts
+++ b/js/packages/ui/src/api/info.ts
@@ -89,6 +89,7 @@ export interface MergedNodeData {
     category: "breaking" | "non_breaking" | "partial_breaking" | "unknown";
     columns?: Record<string, "added" | "removed" | "modified" | "unknown">;
   };
+  schema_comparison_status?: "complete" | "unchecked" | "not_applicable";
 }
 
 /**
@@ -108,6 +109,37 @@ export interface MergedLineageEnvMetadata {
   catalog_metadata?: CatalogMetadata;
 }
 
+export interface ArtifactHealth {
+  status:
+    | "complete"
+    | "partial"
+    | "empty"
+    | "absent"
+    | "not_applicable"
+    | "unknown";
+  expected_count: number;
+  covered_count: number;
+  catalog_entry_count: number;
+  missing_node_count: number;
+  missing_nodes: string[];
+  missing_more: boolean;
+  orphan_node_count: number;
+  orphan_nodes: string[];
+  orphan_more: boolean;
+}
+
+export interface ArtifactHealthPair {
+  base?: ArtifactHealth | null;
+  current?: ArtifactHealth | null;
+}
+
+export interface SchemaCoverage {
+  status: "complete" | "partial" | "unknown";
+  unchecked_nodes: string[];
+  unchecked_node_count: number;
+  more: boolean;
+}
+
 /**
  * Server-side merged lineage response from /api/info.
  * Replaces the old {base, current, diff} triple.
@@ -119,6 +151,8 @@ export interface MergedLineageResponse {
     base: MergedLineageEnvMetadata;
     current: MergedLineageEnvMetadata;
   };
+  artifact_health?: ArtifactHealthPair | null;
+  schema_coverage?: SchemaCoverage | null;
 }
 
 /**
@@ -251,6 +285,8 @@ export interface ServerInfoResult {
    * null when the cloud session has not produced a conclusive classification.
    */
   catalog_coverage?: CatalogCoverage | null;
+  artifact_health?: ArtifactHealthPair | null;
+  schema_coverage?: SchemaCoverage | null;
 }
 
 /**

--- a/js/packages/ui/src/api/info.ts
+++ b/js/packages/ui/src/api/info.ts
@@ -289,8 +289,6 @@ export interface ServerInfoResult {
    * null when the cloud session has not produced a conclusive classification.
    */
   catalog_coverage?: CatalogCoverage | null;
-  artifact_health?: ArtifactHealthPair | null;
-  schema_coverage?: SchemaCoverage | null;
 }
 
 /**

--- a/js/packages/ui/src/api/info.ts
+++ b/js/packages/ui/src/api/info.ts
@@ -66,6 +66,8 @@ export interface SQLMeshInfo {
 
 export type CatalogMetadata = ArtifactMetadata;
 
+export type NodeCatalogStatus = "covered" | "unchecked" | "not_applicable";
+
 /**
  * Merged node from server-side lineage merge (DRC-3258).
  * Contains unified metadata from base+current with baked-in diff.
@@ -90,6 +92,8 @@ export interface MergedNodeData {
     columns?: Record<string, "added" | "removed" | "modified" | "unknown">;
   };
   schema_comparison_status?: "complete" | "unchecked" | "not_applicable";
+  base_catalog_status?: NodeCatalogStatus;
+  current_catalog_status?: NodeCatalogStatus;
 }
 
 /**

--- a/js/packages/ui/src/components/schema/SchemaView.tsx
+++ b/js/packages/ui/src/components/schema/SchemaView.tsx
@@ -18,7 +18,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import type { ArtifactHealthPair, NodeData, SchemaCoverage } from "../../api";
+import type { ArtifactHealthPair, NodeData } from "../../api";
 import {
   useLineageGraphContext,
   useLineageViewContext,
@@ -38,6 +38,7 @@ import {
 import { ProfileDistributionUnsupportedBanner } from "../data/ProfileDistributionUnsupportedBanner";
 import { createDataGridFromData } from "../ui/dataGrid";
 import type { SchemaDistributionData } from "../ui/dataGrid/schemaCells";
+import { formatUncheckedNodeText } from "./formatSchemaCoverage";
 import { getColumnChangeStatus } from "./getColumnChangeStatus";
 import { selectInlineProfileScope } from "./selectInlineProfileScope";
 
@@ -101,25 +102,7 @@ function affectedEnvironment(
   if (baseAffected) return "base environment";
   if (currentAffected) return "current environment";
 
-  const baseIncomplete =
-    artifactHealth?.base != null &&
-    !["complete", "not_applicable"].includes(artifactHealth.base.status);
-  const currentIncomplete =
-    artifactHealth?.current != null &&
-    !["complete", "not_applicable"].includes(artifactHealth.current.status);
-  if (baseIncomplete && currentIncomplete)
-    return "base and current environments";
-  if (baseIncomplete) return "base environment";
-  if (currentIncomplete) return "current environment";
   return "base/current environments";
-}
-
-function uncheckedNodeText(coverage: SchemaCoverage): string {
-  if (coverage.status === "unknown" && coverage.unchecked_node_count === 0) {
-    return "The number of unchecked nodes is unknown.";
-  }
-  const noun = coverage.unchecked_node_count === 1 ? "node was" : "nodes were";
-  return `${coverage.unchecked_node_count} ${noun} not checked.`;
 }
 
 function PrivateSingleEnvSchemaView(
@@ -572,7 +555,7 @@ export function PrivateSchemaView(
           sx={{ fontSize: "0.75rem", p: 1 }}
         >
           Schema comparison incomplete for the {affectedEnvironmentText}.{" "}
-          {uncheckedNodeText(schemaCoverage)} Regenerate the{" "}
+          {formatUncheckedNodeText(schemaCoverage)} Regenerate the{" "}
           {affectedCatalogText} with <code>dbt docs generate</code>, then rerun
           the comparison.
         </MuiAlert>

--- a/js/packages/ui/src/components/schema/SchemaView.tsx
+++ b/js/packages/ui/src/components/schema/SchemaView.tsx
@@ -38,7 +38,6 @@ import {
 import { ProfileDistributionUnsupportedBanner } from "../data/ProfileDistributionUnsupportedBanner";
 import { createDataGridFromData } from "../ui/dataGrid";
 import type { SchemaDistributionData } from "../ui/dataGrid/schemaCells";
-import { formatUncheckedNodeText } from "./formatSchemaCoverage";
 import { getColumnChangeStatus } from "./getColumnChangeStatus";
 import { selectInlineProfileScope } from "./selectInlineProfileScope";
 
@@ -281,17 +280,16 @@ export function PrivateSchemaView(
       : undefined;
   }, [current, base]);
   const nodeId = current?.id ?? base?.id;
-  const { lineageGraph, isActionAvailable } = useLineageGraphContext();
+  const { lineageGraph, isActionAvailable, envInfo } = useLineageGraphContext();
   const lineageNode = nodeId ? lineageGraph?.nodes[nodeId]?.data : undefined;
   const schemaComparisonStatus = nodeId
     ? (lineageNode?.schemaComparisonStatus ?? "unknown")
     : "not_applicable";
-  const schemaCoverage = lineageGraph?.schemaCoverage ?? {
-    status: "unknown",
-    unchecked_nodes: [],
-    unchecked_node_count: 0,
-    more: false,
-  };
+  // No project-wide coverage numbers here. `lineageGraph.schemaCoverage` counts
+  // every node in the lineage and samples the first 50 by id, so on any real
+  // project the node being viewed is usually absent from its own banner. The
+  // node-scoped claim is `schemaComparisonStatus` plus the affected side below;
+  // the project-wide count belongs to SchemaSummary.
   const comparisonIncomplete =
     schemaComparisonStatus === "unchecked" ||
     schemaComparisonStatus === "unknown";
@@ -307,6 +305,11 @@ export function PrivateSchemaView(
         : affectedEnvironmentText === "base and current environments"
           ? "base and current catalogs"
           : "base/current catalogs";
+  // `dbt docs generate` and catalog.json are dbt concepts. SQLMesh has neither
+  // — a snapshot's `columns_to_types` is its schema — so telling a SQLMesh user
+  // to regenerate a catalog is an instruction they cannot follow. Anything we
+  // cannot identify keeps the dbt wording, which is the common case.
+  const usesDbtCatalog = envInfo?.adapterType !== "sqlmesh";
 
   // This node's own column names (base ∪ current), used to attribute impacted
   // ids to this node by exact `<nodeId>_<column>` membership in the scoping
@@ -554,9 +557,17 @@ export function PrivateSchemaView(
           sx={{ fontSize: "0.75rem", p: 1 }}
         >
           Schema comparison incomplete for the {affectedEnvironmentText}.{" "}
-          {formatUncheckedNodeText(schemaCoverage)} Regenerate the{" "}
-          {affectedCatalogText} with <code>dbt docs generate</code>, then rerun
-          the comparison.
+          {usesDbtCatalog ? (
+            <>
+              Regenerate the {affectedCatalogText} with{" "}
+              <code>dbt docs generate</code>, then rerun the comparison.
+            </>
+          ) : (
+            <>
+              Refresh the {affectedEnvironmentText} so this model&apos;s columns
+              are resolved, then rerun the comparison.
+            </>
+          )}
         </MuiAlert>
       ) : catalogMissingMessage ? (
         <MuiAlert severity="warning" sx={{ fontSize: "0.75rem", p: 1 }}>

--- a/js/packages/ui/src/components/schema/SchemaView.tsx
+++ b/js/packages/ui/src/components/schema/SchemaView.tsx
@@ -18,7 +18,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import type { ArtifactHealthPair, NodeData } from "../../api";
+import type { MergedNodeData, NodeData } from "../../api";
 import {
   useLineageGraphContext,
   useLineageViewContext,
@@ -91,13 +91,11 @@ interface SchemaViewProps {
 }
 
 function affectedEnvironment(
-  artifactHealth: ArtifactHealthPair | null | undefined,
-  nodeId: string | undefined,
+  baseCatalogStatus: MergedNodeData["base_catalog_status"],
+  currentCatalogStatus: MergedNodeData["current_catalog_status"],
 ): string {
-  const baseAffected =
-    artifactHealth?.base?.missing_nodes.includes(nodeId ?? "") ?? false;
-  const currentAffected =
-    artifactHealth?.current?.missing_nodes.includes(nodeId ?? "") ?? false;
+  const baseAffected = baseCatalogStatus === "unchecked";
+  const currentAffected = currentCatalogStatus === "unchecked";
   if (baseAffected && currentAffected) return "base and current environments";
   if (baseAffected) return "base environment";
   if (currentAffected) return "current environment";
@@ -284,8 +282,9 @@ export function PrivateSchemaView(
   }, [current, base]);
   const nodeId = current?.id ?? base?.id;
   const { lineageGraph, isActionAvailable } = useLineageGraphContext();
+  const lineageNode = nodeId ? lineageGraph?.nodes[nodeId]?.data : undefined;
   const schemaComparisonStatus = nodeId
-    ? (lineageGraph?.nodes[nodeId]?.data.schemaComparisonStatus ?? "unknown")
+    ? (lineageNode?.schemaComparisonStatus ?? "unknown")
     : "not_applicable";
   const schemaCoverage = lineageGraph?.schemaCoverage ?? {
     status: "unknown",
@@ -297,8 +296,8 @@ export function PrivateSchemaView(
     schemaComparisonStatus === "unchecked" ||
     schemaComparisonStatus === "unknown";
   const affectedEnvironmentText = affectedEnvironment(
-    lineageGraph?.artifactHealth,
-    nodeId,
+    lineageNode?.baseCatalogStatus,
+    lineageNode?.currentCatalogStatus,
   );
   const affectedCatalogText =
     affectedEnvironmentText === "base environment"

--- a/js/packages/ui/src/components/schema/SchemaView.tsx
+++ b/js/packages/ui/src/components/schema/SchemaView.tsx
@@ -18,7 +18,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import type { NodeData } from "../../api";
+import type { ArtifactHealthPair, NodeData, SchemaCoverage } from "../../api";
 import {
   useLineageGraphContext,
   useLineageViewContext,
@@ -87,6 +87,39 @@ interface SchemaViewProps {
   onViewCode?: () => void;
   /** Optional action element rendered next to the legend (e.g. add-to-checklist button) */
   headerAction?: ReactNode;
+}
+
+function affectedEnvironment(
+  artifactHealth: ArtifactHealthPair | null | undefined,
+  nodeId: string | undefined,
+): string {
+  const baseAffected =
+    artifactHealth?.base?.missing_nodes.includes(nodeId ?? "") ?? false;
+  const currentAffected =
+    artifactHealth?.current?.missing_nodes.includes(nodeId ?? "") ?? false;
+  if (baseAffected && currentAffected) return "base and current environments";
+  if (baseAffected) return "base environment";
+  if (currentAffected) return "current environment";
+
+  const baseIncomplete =
+    artifactHealth?.base != null &&
+    !["complete", "not_applicable"].includes(artifactHealth.base.status);
+  const currentIncomplete =
+    artifactHealth?.current != null &&
+    !["complete", "not_applicable"].includes(artifactHealth.current.status);
+  if (baseIncomplete && currentIncomplete)
+    return "base and current environments";
+  if (baseIncomplete) return "base environment";
+  if (currentIncomplete) return "current environment";
+  return "base/current environments";
+}
+
+function uncheckedNodeText(coverage: SchemaCoverage): string {
+  if (coverage.status === "unknown" && coverage.unchecked_node_count === 0) {
+    return "The number of unchecked nodes is unknown.";
+  }
+  const noun = coverage.unchecked_node_count === 1 ? "node was" : "nodes were";
+  return `${coverage.unchecked_node_count} ${noun} not checked.`;
 }
 
 function PrivateSingleEnvSchemaView(
@@ -184,11 +217,11 @@ function PrivateSingleEnvSchemaView(
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
       {catalogMissingMessage ? (
-        <MuiAlert severity="warning" sx={{ fontSize: "12px", p: 1 }}>
+        <MuiAlert severity="warning" sx={{ fontSize: "0.75rem", p: 1 }}>
           {catalogMissingMessage}
         </MuiAlert>
       ) : schemaMissingMessage ? (
-        <MuiAlert severity="warning" sx={{ fontSize: "12px", p: 1 }}>
+        <MuiAlert severity="warning" sx={{ fontSize: "0.75rem", p: 1 }}>
           {schemaMissingMessage}
         </MuiAlert>
       ) : (
@@ -201,7 +234,7 @@ function PrivateSingleEnvSchemaView(
             blockSize: "auto",
             maxHeight: "100%",
             overflow: "auto",
-            fontSize: "10pt",
+            fontSize: "0.833rem",
             borderWidth: 1,
           }}
           columns={columns}
@@ -267,6 +300,31 @@ export function PrivateSchemaView(
       : undefined;
   }, [current, base]);
   const nodeId = current?.id ?? base?.id;
+  const { lineageGraph, isActionAvailable } = useLineageGraphContext();
+  const schemaComparisonStatus = nodeId
+    ? (lineageGraph?.nodes[nodeId]?.data.schemaComparisonStatus ?? "unknown")
+    : "not_applicable";
+  const schemaCoverage = lineageGraph?.schemaCoverage ?? {
+    status: "unknown",
+    unchecked_nodes: [],
+    unchecked_node_count: 0,
+    more: false,
+  };
+  const comparisonIncomplete =
+    schemaComparisonStatus === "unchecked" ||
+    schemaComparisonStatus === "unknown";
+  const affectedEnvironmentText = affectedEnvironment(
+    lineageGraph?.artifactHealth,
+    nodeId,
+  );
+  const affectedCatalogText =
+    affectedEnvironmentText === "base environment"
+      ? "base catalog"
+      : affectedEnvironmentText === "current environment"
+        ? "current catalog"
+        : affectedEnvironmentText === "base and current environments"
+          ? "base and current catalogs"
+          : "base/current catalogs";
 
   // This node's own column names (base ∪ current), used to attribute impacted
   // ids to this node by exact `<nodeId>_<column>` membership in the scoping
@@ -370,6 +428,7 @@ export function PrivateSchemaView(
         impactedColumns,
         nodeId,
         distribution: distributionData,
+        schemaComparisonStatus,
       },
     );
   }, [
@@ -383,9 +442,9 @@ export function PrivateSchemaView(
     onViewCode,
     impactedColumns,
     distributionData,
+    schemaComparisonStatus,
   ]);
 
-  const { lineageGraph, isActionAvailable } = useLineageGraphContext();
   const changeAnalysisAvailable = isActionAvailable("change_analysis");
   const noCatalogBase = !lineageGraph?.catalogMetadata.base;
   const noCatalogCurrent = !lineageGraph?.catalogMetadata.current;
@@ -506,12 +565,23 @@ export function PrivateSchemaView(
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      {catalogMissingMessage ? (
-        <MuiAlert severity="warning" sx={{ fontSize: "12px", p: 1 }}>
+      {comparisonIncomplete ? (
+        <MuiAlert
+          severity="warning"
+          aria-label="Incomplete schema comparison"
+          sx={{ fontSize: "0.75rem", p: 1 }}
+        >
+          Schema comparison incomplete for the {affectedEnvironmentText}.{" "}
+          {uncheckedNodeText(schemaCoverage)} Regenerate the{" "}
+          {affectedCatalogText} with <code>dbt docs generate</code>, then rerun
+          the comparison.
+        </MuiAlert>
+      ) : catalogMissingMessage ? (
+        <MuiAlert severity="warning" sx={{ fontSize: "0.75rem", p: 1 }}>
           {catalogMissingMessage}
         </MuiAlert>
       ) : schemaMissingMessage ? (
-        <MuiAlert severity="warning" sx={{ fontSize: "12px", p: 1 }}>
+        <MuiAlert severity="warning" sx={{ fontSize: "0.75rem", p: 1 }}>
           {schemaMissingMessage}
         </MuiAlert>
       ) : (

--- a/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
+++ b/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
@@ -252,6 +252,117 @@ describe("SchemaView comparison coverage", () => {
     expect(warning).not.toHaveTextContent("base/current environments");
   });
 
+  // AC2: base-only, current-only and both-side degradation each get their own
+  // remediation. This ladder reads per-node catalog statuses and is a DIFFERENT
+  // implementation from SchemaSummary's, which keys off artifactHealth[side] —
+  // the summary tests cannot protect it.
+  it.each([
+    ["unchecked", "covered", "base environment", "Regenerate the base catalog"],
+    [
+      "covered",
+      "unchecked",
+      "current environment",
+      "Regenerate the current catalog",
+    ],
+    [
+      "unchecked",
+      "unchecked",
+      "base and current environments",
+      "Regenerate the base and current catalogs",
+    ],
+    [
+      undefined,
+      undefined,
+      "base/current environments",
+      "Regenerate the base/current catalogs",
+    ],
+  ] as const)(
+    "names the affected side for base=%s current=%s",
+    (baseCatalogStatus, currentCatalogStatus, environment, remediation) => {
+      const nodeId = "model.shop.orders";
+      lineageGraph.current = {
+        nodes: {
+          [nodeId]: {
+            data: {
+              schemaComparisonStatus: "unchecked",
+              baseCatalogStatus,
+              currentCatalogStatus,
+            },
+          },
+        },
+        catalogMetadata: { base: {}, current: {} },
+        schemaCoverage: {
+          status: "partial",
+          unchecked_nodes: [nodeId],
+          unchecked_node_count: 1,
+          more: false,
+        },
+      };
+
+      render(wrap(model(nodeId)));
+
+      const warning = screen.getByRole("alert", {
+        name: "Incomplete schema comparison",
+      });
+      // Whole sentences, not fragments: "current environment" is a substring
+      // of "base and current environments", so a partial match would let a
+      // collapsed ladder pass.
+      expect(warning).toHaveTextContent(
+        `Schema comparison incomplete for the ${environment}.`,
+      );
+      expect(warning).toHaveTextContent(
+        `${remediation} with dbt docs generate`,
+      );
+    },
+  );
+
+  it("judges this node on its own status, not the project-wide coverage", () => {
+    // AC6/AC9: another node being unchecked (or an orphan entry existing) must
+    // not put an incomplete banner over a node this comparison did verify.
+    const nodeId = "model.shop.orders";
+    const base = {
+      ...model(nodeId),
+      columns: {
+        id: { name: "id", type: "INT" },
+        legacy: { name: "legacy", type: "VARCHAR" },
+      },
+    };
+    const current = {
+      ...model(nodeId),
+      columns: { id: { name: "id", type: "INT" } },
+    };
+    lineageGraph.current = {
+      nodes: {
+        [nodeId]: {
+          data: {
+            schemaComparisonStatus: "complete",
+            baseCatalogStatus: "covered",
+            currentCatalogStatus: "covered",
+          },
+        },
+      },
+      catalogMetadata: { base: {}, current: {} },
+      schemaCoverage: {
+        status: "partial",
+        unchecked_nodes: ["model.shop.someone_else"],
+        unchecked_node_count: 1,
+        more: false,
+      },
+    };
+
+    render(
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <SchemaView base={base as NodeData} current={current as NodeData} />
+      </ThemeProvider>,
+    );
+
+    expect(
+      screen.queryByRole("alert", { name: "Incomplete schema comparison" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("legacy")).toBeInTheDocument();
+  });
+
   it("still renders a verified removal when the comparison is complete", () => {
     // AC5: "Genuine covered column removals ... remain visible." Without this,
     // the unchecked test above is satisfied by a component that hides every

--- a/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
+++ b/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
@@ -19,36 +19,59 @@ import type { NodeData } from "../../../api";
 import { theme } from "../../../theme";
 import { SchemaView } from "../SchemaView";
 
-const { flags, distribution, lineageViewContext } = vi.hoisted(() => ({
-  flags: {
-    current: { new_cll_experience: true, inline_profile: true } as Record<
-      string,
-      boolean
-    >,
-  },
-  // biome-ignore lint/suspicious/noExplicitAny: minimal hook-return stub
-  distribution: { current: {} as any },
-  lineageViewContext: {
-    current: {
-      impactedColumnIds: new Set<string>(),
-      wholeModelChangedNodeIds: new Set<string>(),
-      viewOptions: {},
-      showColumnLevelLineage: vi.fn(),
-    } as unknown,
-  },
-}));
+const { flags, distribution, lineageGraph, lineageViewContext } = vi.hoisted(
+  () => ({
+    flags: {
+      current: { new_cll_experience: true, inline_profile: true } as Record<
+        string,
+        boolean
+      >,
+    },
+    distribution: { current: {} as Record<string, unknown> },
+    lineageGraph: {
+      current: {
+        nodes: {},
+        catalogMetadata: { base: {}, current: {} },
+        schemaCoverage: {
+          status: "complete",
+          unchecked_nodes: [],
+          unchecked_node_count: 0,
+          more: false,
+        },
+      } as unknown,
+    },
+    lineageViewContext: {
+      current: {
+        impactedColumnIds: new Set<string>(),
+        wholeModelChangedNodeIds: new Set<string>(),
+        viewOptions: {},
+        showColumnLevelLineage: vi.fn(),
+      } as unknown,
+    },
+  }),
+);
 
 vi.mock("../../../contexts", () => ({
   useRecceServerFlag: () => ({ data: flags.current }),
   useLineageViewContext: () => lineageViewContext.current,
   useLineageGraphContext: () => ({
-    lineageGraph: { catalogMetadata: { base: {}, current: {} } },
+    lineageGraph: lineageGraph.current,
     isActionAvailable: () => true,
   }),
 }));
 
 vi.mock("../../../hooks/useInlineProfileDistribution", () => ({
   useInlineProfileDistribution: () => distribution.current,
+}));
+
+vi.mock("ag-grid-react", () => ({
+  AgGridReact: ({ rowData = [] }: { rowData?: Array<{ name: string }> }) => (
+    <div>
+      {rowData.map((row) => (
+        <span key={row.name}>{row.name}</span>
+      ))}
+    </div>
+  ),
 }));
 
 const model = (id: string): NodeData =>
@@ -79,6 +102,113 @@ beforeEach(() => {
     error: undefined,
     isLoading: false,
   };
+  lineageGraph.current = {
+    nodes: {},
+    catalogMetadata: { base: {}, current: {} },
+    schemaCoverage: {
+      status: "complete",
+      unchecked_nodes: [],
+      unchecked_node_count: 0,
+      more: false,
+    },
+  };
+});
+
+describe("SchemaView comparison coverage", () => {
+  it("labels an unchecked current-side comparison and renders no removed row", () => {
+    const nodeId = "model.shop.orders";
+    const base = {
+      ...model(nodeId),
+      columns: {
+        id: { name: "id", type: "INT" },
+        legacy: { name: "legacy", type: "VARCHAR" },
+      },
+    };
+    const current = {
+      ...model(nodeId),
+      columns: { id: { name: "id", type: "INT" } },
+    };
+    lineageGraph.current = {
+      nodes: {
+        [nodeId]: {
+          data: { schemaComparisonStatus: "unchecked" },
+        },
+      },
+      catalogMetadata: { base: {}, current: {} },
+      artifactHealth: {
+        base: {
+          status: "complete",
+          expected_count: 1,
+          covered_count: 1,
+          catalog_entry_count: 1,
+          missing_node_count: 0,
+          missing_nodes: [],
+          missing_more: false,
+          orphan_node_count: 0,
+          orphan_nodes: [],
+          orphan_more: false,
+        },
+        current: {
+          status: "partial",
+          expected_count: 1,
+          covered_count: 0,
+          catalog_entry_count: 0,
+          missing_node_count: 1,
+          missing_nodes: [nodeId],
+          missing_more: false,
+          orphan_node_count: 0,
+          orphan_nodes: [],
+          orphan_more: false,
+        },
+      },
+      schemaCoverage: {
+        status: "partial",
+        unchecked_nodes: [nodeId],
+        unchecked_node_count: 1,
+        more: false,
+      },
+    };
+
+    // Render explicit base/current evidence rather than the helper's identical pair.
+    render(
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <SchemaView base={base as NodeData} current={current as NodeData} />
+      </ThemeProvider>,
+    );
+
+    const warning = screen.getByRole("alert", {
+      name: "Incomplete schema comparison",
+    });
+    expect(warning).toHaveTextContent("current environment");
+    expect(warning).toHaveTextContent("1 node was not checked");
+    expect(warning).toHaveTextContent("Regenerate the current catalog");
+    expect(warning).toHaveTextContent("dbt docs generate");
+    expect(screen.getByText("id")).toBeInTheDocument();
+    expect(screen.queryByText("legacy")).not.toBeInTheDocument();
+  });
+
+  it("renders no comparison warning for complete healthy evidence", () => {
+    const nodeId = "model.shop.orders";
+    lineageGraph.current = {
+      nodes: {
+        [nodeId]: { data: { schemaComparisonStatus: "complete" } },
+      },
+      catalogMetadata: { base: {}, current: {} },
+      schemaCoverage: {
+        status: "complete",
+        unchecked_nodes: [],
+        unchecked_node_count: 0,
+        more: false,
+      },
+    };
+
+    render(wrap(model(nodeId)));
+
+    expect(
+      screen.queryByRole("alert", { name: "Incomplete schema comparison" }),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("SchemaView inline-profile wiring", () => {

--- a/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
+++ b/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
@@ -182,10 +182,52 @@ describe("SchemaView comparison coverage", () => {
     });
     expect(warning).toHaveTextContent("current environment");
     expect(warning).toHaveTextContent("1 node was not checked");
+    expect(warning).toHaveTextContent(nodeId);
     expect(warning).toHaveTextContent("Regenerate the current catalog");
     expect(warning).toHaveTextContent("dbt docs generate");
     expect(screen.getByText("id")).toBeInTheDocument();
     expect(screen.queryByText("legacy")).not.toBeInTheDocument();
+  });
+
+  it("uses generic side wording when bounded samples do not identify the node", () => {
+    const nodeId = "model.shop.orders";
+    const health = (missingNode: string) => ({
+      status: "partial" as const,
+      expected_count: 3,
+      covered_count: 2,
+      catalog_entry_count: 2,
+      missing_node_count: 1,
+      missing_nodes: [missingNode],
+      missing_more: false,
+      orphan_node_count: 0,
+      orphan_nodes: [],
+      orphan_more: false,
+    });
+    lineageGraph.current = {
+      nodes: {
+        [nodeId]: { data: { schemaComparisonStatus: "unchecked" } },
+      },
+      catalogMetadata: { base: {}, current: {} },
+      artifactHealth: {
+        base: health("model.shop.base_only_missing"),
+        current: health("model.shop.current_only_missing"),
+      },
+      schemaCoverage: {
+        status: "partial",
+        unchecked_nodes: [nodeId],
+        unchecked_node_count: 1,
+        more: false,
+      },
+    };
+
+    render(wrap(model(nodeId)));
+
+    const warning = screen.getByRole("alert", {
+      name: "Incomplete schema comparison",
+    });
+    expect(warning).toHaveTextContent("base/current environments");
+    expect(warning).toHaveTextContent("Regenerate the base/current catalogs");
+    expect(warning).not.toHaveTextContent("base and current environments");
   });
 
   it("renders no comparison warning for complete healthy evidence", () => {

--- a/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
+++ b/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
@@ -20,8 +20,8 @@ import { buildLineageGraph } from "../../../contexts/lineage/utils";
 import { theme } from "../../../theme";
 import { SchemaView } from "../SchemaView";
 
-const { flags, distribution, lineageGraph, lineageViewContext } = vi.hoisted(
-  () => ({
+const { flags, distribution, envInfo, lineageGraph, lineageViewContext } =
+  vi.hoisted(() => ({
     flags: {
       current: { new_cll_experience: true, inline_profile: true } as Record<
         string,
@@ -29,6 +29,7 @@ const { flags, distribution, lineageGraph, lineageViewContext } = vi.hoisted(
       >,
     },
     distribution: { current: {} as Record<string, unknown> },
+    envInfo: { current: undefined as { adapterType?: string } | undefined },
     lineageGraph: {
       current: {
         nodes: {},
@@ -49,8 +50,7 @@ const { flags, distribution, lineageGraph, lineageViewContext } = vi.hoisted(
         showColumnLevelLineage: vi.fn(),
       } as unknown,
     },
-  }),
-);
+  }));
 
 vi.mock("../../../contexts", () => ({
   useRecceServerFlag: () => ({ data: flags.current }),
@@ -58,6 +58,7 @@ vi.mock("../../../contexts", () => ({
   useLineageGraphContext: () => ({
     lineageGraph: lineageGraph.current,
     isActionAvailable: () => true,
+    envInfo: envInfo.current,
   }),
 }));
 
@@ -94,6 +95,7 @@ const BUTTON = { name: "Profile all columns" } as const;
 
 beforeEach(() => {
   flags.current = { new_cll_experience: true, inline_profile: true };
+  envInfo.current = undefined;
   distribution.current = {
     status: "disabled",
     columns: {},
@@ -186,12 +188,90 @@ describe("SchemaView comparison coverage", () => {
       name: "Incomplete schema comparison",
     });
     expect(warning).toHaveTextContent("current environment");
-    expect(warning).toHaveTextContent("1 node was not checked");
-    expect(warning).toHaveTextContent(nodeId);
     expect(warning).toHaveTextContent("Regenerate the current catalog");
     expect(warning).toHaveTextContent("dbt docs generate");
     expect(screen.getByText("id")).toBeInTheDocument();
     expect(screen.queryByText("legacy")).not.toBeInTheDocument();
+  });
+
+  it("keeps project-wide coverage numbers out of the node-scoped banner", () => {
+    // The bug this pins: `lineageGraph.schemaCoverage` is the whole project's
+    // coverage, sampled to the first 50 ids. On any project bigger than a
+    // handful of models the node being viewed is not in that sample, so the
+    // banner used to quote a count and a list of unrelated models to a user
+    // asking about one model.
+    const nodeId = "model.shop.zz_widgets";
+    const unrelated = Array.from(
+      { length: 50 },
+      (_, index) => `model.shop.aa_other_${String(index).padStart(2, "0")}`,
+    );
+    lineageGraph.current = {
+      nodes: {
+        [nodeId]: {
+          data: {
+            schemaComparisonStatus: "unchecked",
+            baseCatalogStatus: "covered",
+            currentCatalogStatus: "unchecked",
+          },
+        },
+      },
+      catalogMetadata: { base: {}, current: {} },
+      schemaCoverage: {
+        status: "partial",
+        unchecked_nodes: unrelated,
+        unchecked_node_count: 60,
+        more: true,
+      },
+    };
+
+    render(wrap(model(nodeId)));
+
+    const warning = screen.getByRole("alert", {
+      name: "Incomplete schema comparison",
+    });
+    // The node-relevant claim survives.
+    expect(warning).toHaveTextContent("current environment");
+    expect(warning).toHaveTextContent("Regenerate the current catalog");
+    // The project-wide claims do not.
+    expect(warning).not.toHaveTextContent("60 nodes were not checked");
+    expect(warning).not.toHaveTextContent("Unchecked nodes:");
+    expect(warning).not.toHaveTextContent("and 10 more");
+    expect(warning).not.toHaveTextContent(unrelated[0]);
+  });
+
+  it("does not tell a SQLMesh user to run a dbt command", () => {
+    // SQLMesh has no catalog.json — a snapshot's columns_to_types is its
+    // schema — so `dbt docs generate` is an instruction they cannot follow.
+    envInfo.current = { adapterType: "sqlmesh" };
+    const nodeId = "model.shop.orders";
+    lineageGraph.current = {
+      nodes: {
+        [nodeId]: {
+          data: {
+            schemaComparisonStatus: "unchecked",
+            baseCatalogStatus: "covered",
+            currentCatalogStatus: "unchecked",
+          },
+        },
+      },
+      catalogMetadata: { base: {}, current: {} },
+      schemaCoverage: {
+        status: "partial",
+        unchecked_nodes: [nodeId],
+        unchecked_node_count: 1,
+        more: false,
+      },
+    };
+
+    render(wrap(model(nodeId)));
+
+    const warning = screen.getByRole("alert", {
+      name: "Incomplete schema comparison",
+    });
+    expect(warning).not.toHaveTextContent("dbt docs generate");
+    expect(warning).not.toHaveTextContent("catalog");
+    expect(warning).toHaveTextContent("Refresh the current environment");
+    expect(warning).toHaveTextContent("rerun the comparison");
   });
 
   it("uses exact source-side evidence when bounded samples do not identify the node", () => {

--- a/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
+++ b/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
@@ -252,6 +252,56 @@ describe("SchemaView comparison coverage", () => {
     expect(warning).not.toHaveTextContent("base/current environments");
   });
 
+  it("still renders a verified removal when the comparison is complete", () => {
+    // AC5: "Genuine covered column removals ... remain visible." Without this,
+    // the unchecked test above is satisfied by a component that hides every
+    // removed row unconditionally, and the fix for a false-removal bug becomes
+    // a false-absence bug.
+    const nodeId = "model.shop.orders";
+    const base = {
+      ...model(nodeId),
+      columns: {
+        id: { name: "id", type: "INT" },
+        legacy: { name: "legacy", type: "VARCHAR" },
+      },
+    };
+    const current = {
+      ...model(nodeId),
+      columns: { id: { name: "id", type: "INT" } },
+    };
+    lineageGraph.current = {
+      nodes: {
+        [nodeId]: {
+          data: {
+            schemaComparisonStatus: "complete",
+            baseCatalogStatus: "covered",
+            currentCatalogStatus: "covered",
+          },
+        },
+      },
+      catalogMetadata: { base: {}, current: {} },
+      schemaCoverage: {
+        status: "complete",
+        unchecked_nodes: [],
+        unchecked_node_count: 0,
+        more: false,
+      },
+    };
+
+    render(
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <SchemaView base={base as NodeData} current={current as NodeData} />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText("id")).toBeInTheDocument();
+    expect(screen.getByText("legacy")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("alert", { name: "Incomplete schema comparison" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders no comparison warning for complete healthy evidence", () => {
     const nodeId = "model.shop.orders";
     lineageGraph.current = {

--- a/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
+++ b/js/packages/ui/src/components/schema/__tests__/SchemaView.test.tsx
@@ -15,7 +15,8 @@ import { ThemeProvider } from "@mui/material/styles";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { NodeData } from "../../../api";
+import type { MergedLineageResponse, NodeData } from "../../../api";
+import { buildLineageGraph } from "../../../contexts/lineage/utils";
 import { theme } from "../../../theme";
 import { SchemaView } from "../SchemaView";
 
@@ -131,7 +132,11 @@ describe("SchemaView comparison coverage", () => {
     lineageGraph.current = {
       nodes: {
         [nodeId]: {
-          data: { schemaComparisonStatus: "unchecked" },
+          data: {
+            schemaComparisonStatus: "unchecked",
+            baseCatalogStatus: "covered",
+            currentCatalogStatus: "unchecked",
+          },
         },
       },
       catalogMetadata: { base: {}, current: {} },
@@ -189,8 +194,8 @@ describe("SchemaView comparison coverage", () => {
     expect(screen.queryByText("legacy")).not.toBeInTheDocument();
   });
 
-  it("uses generic side wording when bounded samples do not identify the node", () => {
-    const nodeId = "model.shop.orders";
+  it("uses exact source-side evidence when bounded samples do not identify the node", () => {
+    const nodeId = "source.shop.orders";
     const health = (missingNode: string) => ({
       status: "partial" as const,
       expected_count: 3,
@@ -203,31 +208,48 @@ describe("SchemaView comparison coverage", () => {
       orphan_nodes: [],
       orphan_more: false,
     });
-    lineageGraph.current = {
+    const mergedLineage: MergedLineageResponse = {
       nodes: {
-        [nodeId]: { data: { schemaComparisonStatus: "unchecked" } },
+        [nodeId]: {
+          name: "orders",
+          resource_type: "source",
+          package_name: "shop",
+          schema_comparison_status: "unchecked",
+          base_catalog_status: "covered",
+          current_catalog_status: "unchecked",
+        },
       },
-      catalogMetadata: { base: {}, current: {} },
-      artifactHealth: {
+      edges: [],
+      metadata: {
+        base: { catalog_metadata: {} as never },
+        current: { catalog_metadata: {} as never },
+      },
+      artifact_health: {
         base: health("model.shop.base_only_missing"),
         current: health("model.shop.current_only_missing"),
       },
-      schemaCoverage: {
+      schema_coverage: {
         status: "partial",
         unchecked_nodes: [nodeId],
         unchecked_node_count: 1,
         more: false,
       },
     };
+    lineageGraph.current = buildLineageGraph(mergedLineage);
 
-    render(wrap(model(nodeId)));
+    const source = {
+      ...model(nodeId),
+      resource_type: "source",
+    } as NodeData;
+
+    render(wrap(source));
 
     const warning = screen.getByRole("alert", {
       name: "Incomplete schema comparison",
     });
-    expect(warning).toHaveTextContent("base/current environments");
-    expect(warning).toHaveTextContent("Regenerate the base/current catalogs");
-    expect(warning).not.toHaveTextContent("base and current environments");
+    expect(warning).toHaveTextContent("current environment");
+    expect(warning).toHaveTextContent("Regenerate the current catalog");
+    expect(warning).not.toHaveTextContent("base/current environments");
   });
 
   it("renders no comparison warning for complete healthy evidence", () => {

--- a/js/packages/ui/src/components/schema/formatSchemaCoverage.ts
+++ b/js/packages/ui/src/components/schema/formatSchemaCoverage.ts
@@ -1,0 +1,22 @@
+import type { SchemaCoverage } from "../../api";
+
+export function formatUncheckedNodeText(coverage: SchemaCoverage): string {
+  const countText =
+    coverage.status === "unknown" && coverage.unchecked_node_count === 0
+      ? "The number of unchecked nodes is unknown."
+      : `${coverage.unchecked_node_count} ${
+          coverage.unchecked_node_count === 1 ? "node was" : "nodes were"
+        } not checked.`;
+  if (coverage.unchecked_nodes.length === 0) return countText;
+
+  const remaining =
+    coverage.unchecked_node_count - coverage.unchecked_nodes.length;
+  const sample = coverage.unchecked_nodes.join(", ");
+  const overflow =
+    coverage.more && remaining > 0
+      ? coverage.unchecked_nodes.length === 1
+        ? ` and ${remaining} more`
+        : `, and ${remaining} more`
+      : "";
+  return `${countText} Unchecked nodes: ${sample}${overflow}.`;
+}

--- a/js/packages/ui/src/components/summary/SchemaSummary.test.tsx
+++ b/js/packages/ui/src/components/summary/SchemaSummary.test.tsx
@@ -221,4 +221,35 @@ describe("SchemaSummary comparison coverage", () => {
       ).toHaveTextContent(expected);
     },
   );
+
+  it.each([
+    ["an absent coverage block", undefined],
+    [
+      "an explicit unknown status",
+      {
+        status: "unknown" as const,
+        unchecked_nodes: [],
+        unchecked_node_count: 0,
+        more: false,
+      },
+    ],
+  ])("warns rather than claiming no changes for %s", (_case, coverage) => {
+    // AC8: unknown must never read as healthy. A legacy server sends no
+    // schema_coverage at all, which normalizes to "unknown" — the gate has to
+    // treat that like partial, not like complete.
+    render(
+      <SchemaSummary
+        lineageGraph={graphWithCoverage(
+          coverage as LineageGraph["schemaCoverage"],
+        )}
+      />,
+    );
+
+    expect(
+      screen.getByRole("alert", { name: "Incomplete schema comparison" }),
+    ).toHaveTextContent("The number of unchecked nodes is unknown.");
+    expect(
+      screen.queryByText("No schema changes detected."),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/js/packages/ui/src/components/summary/SchemaSummary.test.tsx
+++ b/js/packages/ui/src/components/summary/SchemaSummary.test.tsx
@@ -1,11 +1,27 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { LineageGraph } from "../../contexts";
 import { SchemaSummary } from "./SchemaSummary";
+
+vi.mock("../../hooks", () => ({
+  useApiConfig: () => ({ apiClient: undefined }),
+}));
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined, isLoading: false }),
+}));
+// The card's children pull in lineage/instance contexts this suite does not
+// stand up. Stubbed so the assertions stay on what the summary itself decides
+// to render.
+vi.mock("../lineage", () => ({
+  NodeTag: () => null,
+  RowCountDiffTag: () => null,
+}));
+vi.mock("../schema", () => ({ SchemaView: () => null }));
 
 function graphWithCoverage(
   schemaCoverage: LineageGraph["schemaCoverage"],
   artifactHealth?: LineageGraph["artifactHealth"],
+  overrides?: Partial<LineageGraph>,
 ): LineageGraph {
   return {
     nodes: {},
@@ -15,7 +31,49 @@ function graphWithCoverage(
     catalogMetadata: {},
     schemaCoverage,
     artifactHealth,
+    ...overrides,
   };
+}
+
+function health(status: string) {
+  return {
+    status,
+    expected_count: 1,
+    covered_count: status === "complete" ? 1 : 0,
+    catalog_entry_count: status === "complete" ? 1 : 0,
+    missing_node_count: status === "complete" ? 0 : 1,
+    missing_nodes: status === "complete" ? [] : ["model.shop.orders"],
+    missing_more: false,
+    orphan_node_count: 0,
+    orphan_nodes: [],
+    orphan_more: false,
+  } as NonNullable<LineageGraph["artifactHealth"]>["base"];
+}
+
+/** A model with a verified column change, so a card must render for it. */
+function graphWithAVerifiedChange(
+  schemaCoverage: LineageGraph["schemaCoverage"],
+  artifactHealth?: LineageGraph["artifactHealth"],
+): LineageGraph {
+  const nodeId = "model.shop.verified";
+  const node = {
+    id: nodeId,
+    position: { x: 0, y: 0 },
+    data: {
+      id: nodeId,
+      name: "verified",
+      resourceType: "model",
+      packageName: "shop",
+      changeStatus: "modified",
+      change: { columns: { amount: { changeStatus: "modified" } } },
+      children: {},
+      parents: {},
+    },
+  } as unknown as LineageGraph["nodes"][string];
+  return graphWithCoverage(schemaCoverage, artifactHealth, {
+    modifiedSet: [nodeId],
+    nodes: { [nodeId]: node },
+  });
 }
 
 describe("SchemaSummary comparison coverage", () => {
@@ -91,4 +149,76 @@ describe("SchemaSummary comparison coverage", () => {
       screen.queryByRole("alert", { name: "Incomplete schema comparison" }),
     ).not.toBeInTheDocument();
   });
+
+  it("keeps verified change cards visible while the comparison is partial", () => {
+    // AC3/AC5: partial coverage must narrow the answer, not erase it. Warning
+    // and verified evidence have to coexist, or "fail closed" degenerates into
+    // suppressing every finding.
+    render(
+      <SchemaSummary
+        lineageGraph={graphWithAVerifiedChange(
+          {
+            status: "partial",
+            unchecked_nodes: ["model.shop.orders"],
+            unchecked_node_count: 1,
+            more: false,
+          },
+          { base: health("complete"), current: health("partial") },
+        )}
+      />,
+    );
+
+    expect(
+      screen.getByRole("alert", { name: "Incomplete schema comparison" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("verified")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No schema changes detected."),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "base",
+      health("partial"),
+      health("complete"),
+      "Regenerate the base catalog",
+    ],
+    [
+      "current",
+      health("complete"),
+      health("partial"),
+      "Regenerate the current catalog",
+    ],
+    [
+      "both",
+      health("partial"),
+      health("empty"),
+      "Regenerate the base and current catalogs",
+    ],
+  ])(
+    "names the %s side in the remediation",
+    (_side, base, current, expected) => {
+      // AC2: base-only, current-only and both-side degradation each get their
+      // own remediation. Telling a reviewer to regenerate the wrong catalog is
+      // a dead end.
+      render(
+        <SchemaSummary
+          lineageGraph={graphWithCoverage(
+            {
+              status: "partial",
+              unchecked_nodes: ["model.shop.orders"],
+              unchecked_node_count: 1,
+              more: false,
+            },
+            { base, current },
+          )}
+        />,
+      );
+
+      expect(
+        screen.getByRole("alert", { name: "Incomplete schema comparison" }),
+      ).toHaveTextContent(expected);
+    },
+  );
 });

--- a/js/packages/ui/src/components/summary/SchemaSummary.test.tsx
+++ b/js/packages/ui/src/components/summary/SchemaSummary.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { LineageGraph } from "../../contexts";
+import { SchemaSummary } from "./SchemaSummary";
+
+function graphWithCoverage(
+  schemaCoverage: LineageGraph["schemaCoverage"],
+  artifactHealth?: LineageGraph["artifactHealth"],
+): LineageGraph {
+  return {
+    nodes: {},
+    edges: {},
+    modifiedSet: [],
+    manifestMetadata: {},
+    catalogMetadata: {},
+    schemaCoverage,
+    artifactHealth,
+  };
+}
+
+describe("SchemaSummary comparison coverage", () => {
+  it("reports an incomplete comparison instead of claiming no changes", () => {
+    render(
+      <SchemaSummary
+        lineageGraph={graphWithCoverage(
+          {
+            status: "partial",
+            unchecked_nodes: ["model.shop.orders"],
+            unchecked_node_count: 1,
+            more: false,
+          },
+          {
+            base: {
+              status: "complete",
+              expected_count: 1,
+              covered_count: 1,
+              catalog_entry_count: 1,
+              missing_node_count: 0,
+              missing_nodes: [],
+              missing_more: false,
+              orphan_node_count: 0,
+              orphan_nodes: [],
+              orphan_more: false,
+            },
+            current: {
+              status: "partial",
+              expected_count: 1,
+              covered_count: 0,
+              catalog_entry_count: 0,
+              missing_node_count: 1,
+              missing_nodes: ["model.shop.orders"],
+              missing_more: false,
+              orphan_node_count: 0,
+              orphan_nodes: [],
+              orphan_more: false,
+            },
+          },
+        )}
+      />,
+    );
+
+    const warning = screen.getByRole("alert", {
+      name: "Incomplete schema comparison",
+    });
+    expect(warning).toHaveTextContent("Schema comparison incomplete");
+    expect(warning).toHaveTextContent("1 node was not checked");
+    expect(warning).toHaveTextContent("Regenerate the current catalog");
+    expect(warning).toHaveTextContent("dbt docs generate");
+    expect(
+      screen.queryByText("No schema changes detected."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the healthy no-change result free of warnings", () => {
+    render(
+      <SchemaSummary
+        lineageGraph={graphWithCoverage({
+          status: "complete",
+          unchecked_nodes: [],
+          unchecked_node_count: 0,
+          more: false,
+        })}
+      />,
+    );
+
+    expect(screen.getByText("No schema changes detected.")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("alert", { name: "Incomplete schema comparison" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/js/packages/ui/src/components/summary/SchemaSummary.test.tsx
+++ b/js/packages/ui/src/components/summary/SchemaSummary.test.tsx
@@ -25,9 +25,9 @@ describe("SchemaSummary comparison coverage", () => {
         lineageGraph={graphWithCoverage(
           {
             status: "partial",
-            unchecked_nodes: ["model.shop.orders"],
-            unchecked_node_count: 1,
-            more: false,
+            unchecked_nodes: ["model.shop.orders", "model.shop.customers"],
+            unchecked_node_count: 3,
+            more: true,
           },
           {
             base: {
@@ -63,7 +63,10 @@ describe("SchemaSummary comparison coverage", () => {
       name: "Incomplete schema comparison",
     });
     expect(warning).toHaveTextContent("Schema comparison incomplete");
-    expect(warning).toHaveTextContent("1 node was not checked");
+    expect(warning).toHaveTextContent("3 nodes were not checked");
+    expect(warning).toHaveTextContent("model.shop.orders");
+    expect(warning).toHaveTextContent("model.shop.customers");
+    expect(warning).toHaveTextContent("and 1 more");
     expect(warning).toHaveTextContent("Regenerate the current catalog");
     expect(warning).toHaveTextContent("dbt docs generate");
     expect(

--- a/js/packages/ui/src/components/summary/SchemaSummary.tsx
+++ b/js/packages/ui/src/components/summary/SchemaSummary.tsx
@@ -11,7 +11,11 @@ import Typography from "@mui/material/Typography";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { getModelInfo } from "../..";
-import type { LineageGraph, LineageGraphNode } from "../../contexts";
+import {
+  type LineageGraph,
+  type LineageGraphNode,
+  useLineageGraphContext,
+} from "../../contexts";
 import { useApiConfig } from "../../hooks";
 import { NodeTag, RowCountDiffTag } from "../lineage";
 import { SchemaView } from "../schema";
@@ -127,6 +131,11 @@ export interface SchemaSummaryProps {
 
 export function SchemaSummary({ lineageGraph }: SchemaSummaryProps) {
   const [changedNodes, setChangedNodes] = useState<LineageGraphNode[]>([]);
+  const { envInfo } = useLineageGraphContext();
+  // Same reason as SchemaView: `dbt docs generate` and catalog.json do not
+  // exist in SQLMesh, so that remediation cannot be followed there. An
+  // unidentified adapter keeps the dbt wording.
+  const usesDbtCatalog = envInfo?.adapterType !== "sqlmesh";
 
   useEffect(() => {
     setChangedNodes(listChangedNodes(lineageGraph));
@@ -162,9 +171,16 @@ export function SchemaSummary({ lineageGraph }: SchemaSummaryProps) {
             sx={{ fontSize: "0.875rem", mb: 2 }}
           >
             Schema comparison incomplete.{" "}
-            {formatUncheckedNodeText(schemaCoverage)} Regenerate the{" "}
-            {affectedCatalogs(lineageGraph)} with <code>dbt docs generate</code>
-            {", then rerun the comparison."}
+            {formatUncheckedNodeText(schemaCoverage)}{" "}
+            {usesDbtCatalog ? (
+              <>
+                Regenerate the {affectedCatalogs(lineageGraph)} with{" "}
+                <code>dbt docs generate</code>
+                {", then rerun the comparison."}
+              </>
+            ) : (
+              "Refresh your environments so model columns are resolved, then rerun the comparison."
+            )}
           </MuiAlert>
         )}
         {changedNodes.length === 0 ? (

--- a/js/packages/ui/src/components/summary/SchemaSummary.tsx
+++ b/js/packages/ui/src/components/summary/SchemaSummary.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import MuiAlert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
@@ -20,6 +21,20 @@ interface SchemaDiffCardProps {
   node: LineageGraphNode;
 }
 
+function affectedCatalogs(lineageGraph: LineageGraph): string {
+  const baseStatus = lineageGraph.artifactHealth?.base?.status;
+  const currentStatus = lineageGraph.artifactHealth?.current?.status;
+  const baseIncomplete =
+    baseStatus != null && !["complete", "not_applicable"].includes(baseStatus);
+  const currentIncomplete =
+    currentStatus != null &&
+    !["complete", "not_applicable"].includes(currentStatus);
+  if (baseIncomplete && currentIncomplete) return "base and current catalogs";
+  if (baseIncomplete) return "base catalog";
+  if (currentIncomplete) return "current catalog";
+  return "affected base/current catalogs";
+}
+
 function SchemaDiffCard({ node, ...props }: SchemaDiffCardProps) {
   const { apiClient } = useApiConfig();
 
@@ -35,7 +50,7 @@ function SchemaDiffCard({ node, ...props }: SchemaDiffCardProps) {
     <Card sx={{ maxWidth: 500 }}>
       <CardHeader
         title={
-          <Typography sx={{ fontSize: 18, fontWeight: "bold" }}>
+          <Typography sx={{ fontSize: "1.125rem", fontWeight: "bold" }}>
             {props.title}
           </Typography>
         }
@@ -116,6 +131,21 @@ export function SchemaSummary({ lineageGraph }: SchemaSummaryProps) {
     setChangedNodes(listChangedNodes(lineageGraph));
   }, [lineageGraph]);
 
+  const schemaCoverage = lineageGraph.schemaCoverage ?? {
+    status: "unknown",
+    unchecked_nodes: [],
+    unchecked_node_count: 0,
+    more: false,
+  };
+  const comparisonIncomplete = schemaCoverage.status !== "complete";
+  const uncheckedText =
+    schemaCoverage.status === "unknown" &&
+    schemaCoverage.unchecked_node_count === 0
+      ? "The number of unchecked nodes is unknown."
+      : `${schemaCoverage.unchecked_node_count} ${
+          schemaCoverage.unchecked_node_count === 1 ? "node was" : "nodes were"
+        } not checked.`;
+
   return (
     <>
       <Box
@@ -126,15 +156,28 @@ export function SchemaSummary({ lineageGraph }: SchemaSummaryProps) {
           mt: "20px",
         }}
       >
-        <Typography variant="h5" sx={{ fontSize: 24 }}>
+        <Typography variant="h5" sx={{ fontSize: "1.5rem" }}>
           Schema Summary
         </Typography>
       </Box>
       <Box sx={{ width: "100%", pb: "10px", mb: "20px" }}>
+        {comparisonIncomplete && (
+          <MuiAlert
+            severity="warning"
+            aria-label="Incomplete schema comparison"
+            sx={{ fontSize: "0.875rem", mb: 2 }}
+          >
+            Schema comparison incomplete. {uncheckedText} Regenerate the{" "}
+            {affectedCatalogs(lineageGraph)} with <code>dbt docs generate</code>
+            , then rerun the comparison.
+          </MuiAlert>
+        )}
         {changedNodes.length === 0 ? (
-          <Typography sx={{ fontSize: 18, color: "grey.600" }}>
-            No schema changes detected.
-          </Typography>
+          !comparisonIncomplete && (
+            <Typography sx={{ fontSize: "1.125rem", color: "grey.600" }}>
+              No schema changes detected.
+            </Typography>
+          )
         ) : (
           <Box
             sx={{

--- a/js/packages/ui/src/components/summary/SchemaSummary.tsx
+++ b/js/packages/ui/src/components/summary/SchemaSummary.tsx
@@ -15,6 +15,7 @@ import type { LineageGraph, LineageGraphNode } from "../../contexts";
 import { useApiConfig } from "../../hooks";
 import { NodeTag, RowCountDiffTag } from "../lineage";
 import { SchemaView } from "../schema";
+import { formatUncheckedNodeText } from "../schema/formatSchemaCoverage";
 
 interface SchemaDiffCardProps {
   title: string;
@@ -138,13 +139,6 @@ export function SchemaSummary({ lineageGraph }: SchemaSummaryProps) {
     more: false,
   };
   const comparisonIncomplete = schemaCoverage.status !== "complete";
-  const uncheckedText =
-    schemaCoverage.status === "unknown" &&
-    schemaCoverage.unchecked_node_count === 0
-      ? "The number of unchecked nodes is unknown."
-      : `${schemaCoverage.unchecked_node_count} ${
-          schemaCoverage.unchecked_node_count === 1 ? "node was" : "nodes were"
-        } not checked.`;
 
   return (
     <>
@@ -167,9 +161,10 @@ export function SchemaSummary({ lineageGraph }: SchemaSummaryProps) {
             aria-label="Incomplete schema comparison"
             sx={{ fontSize: "0.875rem", mb: 2 }}
           >
-            Schema comparison incomplete. {uncheckedText} Regenerate the{" "}
+            Schema comparison incomplete.{" "}
+            {formatUncheckedNodeText(schemaCoverage)} Regenerate the{" "}
             {affectedCatalogs(lineageGraph)} with <code>dbt docs generate</code>
-            , then rerun the comparison.
+            {", then rerun the comparison."}
           </MuiAlert>
         )}
         {changedNodes.length === 0 ? (

--- a/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
+++ b/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
@@ -76,6 +76,68 @@ describe("buildLineageGraph", () => {
     expect(buildLineageGraph(lineage).schemaCoverage?.status).toBe("unknown");
   });
 
+  test.each([
+    {
+      name: "complete status with unchecked nodes",
+      coverage: {
+        status: "complete",
+        unchecked_nodes: ["model.proj.orders"],
+        unchecked_node_count: 1,
+        more: false,
+      },
+    },
+    {
+      name: "partial status with no unchecked nodes",
+      coverage: {
+        status: "partial",
+        unchecked_nodes: [],
+        unchecked_node_count: 0,
+        more: false,
+      },
+    },
+    {
+      name: "truncated sample without the more marker",
+      coverage: {
+        status: "partial",
+        unchecked_nodes: ["model.proj.orders"],
+        unchecked_node_count: 2,
+        more: false,
+      },
+    },
+    {
+      name: "complete sample with the more marker",
+      coverage: {
+        status: "partial",
+        unchecked_nodes: ["model.proj.orders"],
+        unchecked_node_count: 1,
+        more: true,
+      },
+    },
+    {
+      name: "unknown status with unchecked nodes",
+      coverage: {
+        status: "unknown",
+        unchecked_nodes: ["model.proj.orders"],
+        unchecked_node_count: 1,
+        more: false,
+      },
+    },
+  ])("treats contradictory coverage as unknown: $name", ({ coverage }) => {
+    const lineage = {
+      nodes: {},
+      edges: [],
+      metadata: { base: {}, current: {} },
+      schema_coverage: coverage,
+    } as unknown as MergedLineageResponse;
+
+    expect(buildLineageGraph(lineage).schemaCoverage).toEqual({
+      status: "unknown",
+      unchecked_nodes: [],
+      unchecked_node_count: 0,
+      more: false,
+    });
+  });
+
   test("builds graph with correct node and edge counts", () => {
     const lineage: MergedLineageResponse = {
       nodes: {

--- a/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
+++ b/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
@@ -42,6 +42,8 @@ describe("buildLineageGraph", () => {
           resource_type: "model",
           package_name: "proj",
           schema_comparison_status: "unchecked",
+          base_catalog_status: "covered",
+          current_catalog_status: "unchecked",
         },
       },
       edges: [],
@@ -63,6 +65,12 @@ describe("buildLineageGraph", () => {
     expect(
       graph.nodes["model.proj.customers"].data.schemaComparisonStatus,
     ).toBe("unchecked");
+    expect(graph.nodes["model.proj.customers"].data.baseCatalogStatus).toBe(
+      "covered",
+    );
+    expect(graph.nodes["model.proj.customers"].data.currentCatalogStatus).toBe(
+      "unchecked",
+    );
   });
 
   test("treats malformed coverage as unknown", () => {

--- a/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
+++ b/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
@@ -2,6 +2,80 @@ import type { MergedLineageResponse } from "../../../api/info";
 import { buildLineageGraph } from "../utils";
 
 describe("buildLineageGraph", () => {
+  test("treats legacy lineage evidence as unknown", () => {
+    const lineage: MergedLineageResponse = {
+      nodes: {
+        "model.proj.orders": {
+          name: "orders",
+          resource_type: "model",
+          package_name: "proj",
+        },
+      },
+      edges: [],
+      metadata: { base: {}, current: {} },
+    };
+
+    const graph = buildLineageGraph(lineage);
+
+    expect(graph.schemaCoverage).toEqual({
+      status: "unknown",
+      unchecked_nodes: [],
+      unchecked_node_count: 0,
+      more: false,
+    });
+    expect(graph.nodes["model.proj.orders"].data.schemaComparisonStatus).toBe(
+      "unknown",
+    );
+  });
+
+  test("keeps verified nodes when another model is unchecked", () => {
+    const lineage: MergedLineageResponse = {
+      nodes: {
+        "model.proj.orders": {
+          name: "orders",
+          resource_type: "model",
+          package_name: "proj",
+          schema_comparison_status: "complete",
+        },
+        "model.proj.customers": {
+          name: "customers",
+          resource_type: "model",
+          package_name: "proj",
+          schema_comparison_status: "unchecked",
+        },
+      },
+      edges: [],
+      metadata: { base: {}, current: {} },
+      schema_coverage: {
+        status: "partial",
+        unchecked_nodes: ["model.proj.customers"],
+        unchecked_node_count: 1,
+        more: false,
+      },
+    };
+
+    const graph = buildLineageGraph(lineage);
+
+    expect(graph.schemaCoverage?.status).toBe("partial");
+    expect(graph.nodes["model.proj.orders"].data.schemaComparisonStatus).toBe(
+      "complete",
+    );
+    expect(
+      graph.nodes["model.proj.customers"].data.schemaComparisonStatus,
+    ).toBe("unchecked");
+  });
+
+  test("treats malformed coverage as unknown", () => {
+    const lineage = {
+      nodes: {},
+      edges: [],
+      metadata: { base: {}, current: {} },
+      schema_coverage: { status: "complete" },
+    } as unknown as MergedLineageResponse;
+
+    expect(buildLineageGraph(lineage).schemaCoverage?.status).toBe("unknown");
+  });
+
   test("builds graph with correct node and edge counts", () => {
     const lineage: MergedLineageResponse = {
       nodes: {

--- a/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
+++ b/js/packages/ui/src/contexts/lineage/__tests__/utils.test.ts
@@ -2,6 +2,57 @@ import type { MergedLineageResponse } from "../../../api/info";
 import { buildLineageGraph } from "../utils";
 
 describe("buildLineageGraph", () => {
+  test.each(["complete", "unchecked", "not_applicable"] as const)(
+    "carries the %s comparison status through to the node",
+    (status) => {
+      // "not_applicable" is what the classifier returns for every added-only
+      // and removed-only model, plus ephemerals. If it collapsed to "unknown"
+      // a genuine removal would show a false incomplete-comparison warning,
+      // so each literal has to survive normalization intact.
+      const lineage: MergedLineageResponse = {
+        nodes: {
+          "model.proj.orders": {
+            name: "orders",
+            resource_type: "model",
+            package_name: "proj",
+            schema_comparison_status: status,
+          },
+        },
+        edges: [],
+        metadata: { base: {}, current: {} },
+      };
+
+      const graph = buildLineageGraph(lineage);
+
+      expect(graph.nodes["model.proj.orders"].data.schemaComparisonStatus).toBe(
+        status,
+      );
+    },
+  );
+
+  test("treats an unrecognised comparison status as unknown", () => {
+    // AC10 version skew: a producer one version ahead must not have its
+    // literal passed through as though this build understood it.
+    const lineage: MergedLineageResponse = {
+      nodes: {
+        "model.proj.orders": {
+          name: "orders",
+          resource_type: "model",
+          package_name: "proj",
+          schema_comparison_status: "partially_verified_v2",
+        },
+      },
+      edges: [],
+      metadata: { base: {}, current: {} },
+    } as unknown as MergedLineageResponse;
+
+    const graph = buildLineageGraph(lineage);
+
+    expect(graph.nodes["model.proj.orders"].data.schemaComparisonStatus).toBe(
+      "unknown",
+    );
+  });
+
   test("treats legacy lineage evidence as unknown", () => {
     const lineage: MergedLineageResponse = {
       nodes: {

--- a/js/packages/ui/src/contexts/lineage/types.ts
+++ b/js/packages/ui/src/contexts/lineage/types.ts
@@ -2,10 +2,12 @@ import type { Edge, Node } from "@xyflow/react";
 import type React from "react";
 import type { CllInput, ColumnLineageData } from "../../api/cll";
 import type {
+  ArtifactHealthPair,
   CatalogMetadata,
   GitInfo,
   ManifestMetadata,
   PullRequestInfo,
+  SchemaCoverage,
   SQLMeshInfo,
   StateMetadata,
 } from "../../api/info";
@@ -51,6 +53,11 @@ export type LineageGraphNode = Node<
       category: "breaking" | "non_breaking" | "partial_breaking" | "unknown";
       columns?: Record<string, "added" | "removed" | "modified" | "unknown">;
     };
+    schemaComparisonStatus?:
+      | "complete"
+      | "unchecked"
+      | "not_applicable"
+      | "unknown";
     parents: Record<string, LineageGraphEdge>;
     children: Record<string, LineageGraphEdge>;
   },
@@ -104,6 +111,8 @@ export interface LineageGraph {
     base?: CatalogMetadata;
     current?: CatalogMetadata;
   };
+  artifactHealth?: ArtifactHealthPair | null;
+  schemaCoverage?: SchemaCoverage;
 }
 
 /**

--- a/js/packages/ui/src/contexts/lineage/types.ts
+++ b/js/packages/ui/src/contexts/lineage/types.ts
@@ -6,6 +6,7 @@ import type {
   CatalogMetadata,
   GitInfo,
   ManifestMetadata,
+  NodeCatalogStatus,
   PullRequestInfo,
   SchemaCoverage,
   SQLMeshInfo,
@@ -58,6 +59,8 @@ export type LineageGraphNode = Node<
       | "unchecked"
       | "not_applicable"
       | "unknown";
+    baseCatalogStatus?: NodeCatalogStatus;
+    currentCatalogStatus?: NodeCatalogStatus;
     parents: Record<string, LineageGraphEdge>;
     children: Record<string, LineageGraphEdge>;
   },

--- a/js/packages/ui/src/contexts/lineage/utils.ts
+++ b/js/packages/ui/src/contexts/lineage/utils.ts
@@ -1,5 +1,5 @@
 import type { Position } from "@xyflow/react";
-import type { MergedLineageResponse } from "../../api/info";
+import type { MergedLineageResponse, SchemaCoverage } from "../../api/info";
 import { coerceCllChangeStatus } from "../../components/lineage/computeColumnLineage";
 import type {
   LineageGraph,
@@ -20,6 +20,50 @@ export const COLUMN_HEIGHT = 24;
  * Map of node IDs to their column sets
  */
 export type NodeColumnSetMap = Record<string, Set<string>>;
+
+const UNKNOWN_SCHEMA_COVERAGE: SchemaCoverage = {
+  status: "unknown",
+  unchecked_nodes: [],
+  unchecked_node_count: 0,
+  more: false,
+};
+
+function normalizeSchemaCoverage(
+  value: MergedLineageResponse["schema_coverage"],
+): SchemaCoverage {
+  if (value == null) {
+    return { ...UNKNOWN_SCHEMA_COVERAGE, unchecked_nodes: [] };
+  }
+  if (
+    !["complete", "partial", "unknown"].includes(value.status) ||
+    !Array.isArray(value.unchecked_nodes) ||
+    !value.unchecked_nodes.every((nodeId) => typeof nodeId === "string") ||
+    !Number.isInteger(value.unchecked_node_count) ||
+    value.unchecked_node_count < value.unchecked_nodes.length ||
+    typeof value.more !== "boolean"
+  ) {
+    return { ...UNKNOWN_SCHEMA_COVERAGE, unchecked_nodes: [] };
+  }
+  return {
+    status: value.status,
+    unchecked_nodes: [...value.unchecked_nodes],
+    unchecked_node_count: value.unchecked_node_count,
+    more: value.more,
+  };
+}
+
+function normalizeSchemaComparisonStatus(
+  status: string | undefined,
+): LineageGraphNode["data"]["schemaComparisonStatus"] {
+  if (
+    status === "complete" ||
+    status === "unchecked" ||
+    status === "not_applicable"
+  ) {
+    return status;
+  }
+  return "unknown";
+}
 
 // =============================================================================
 // Set Utilities
@@ -128,6 +172,9 @@ export function buildLineageGraph(
         materialized: merged.materialized,
         changeStatus: coerceCllChangeStatus(merged.change_status),
         change: merged.change ?? undefined,
+        schemaComparisonStatus: normalizeSchemaComparisonStatus(
+          merged.schema_comparison_status,
+        ),
         parents: {},
         children: {},
       },
@@ -176,6 +223,8 @@ export function buildLineageGraph(
       base: baseMeta?.catalog_metadata ?? undefined,
       current: currentMeta?.catalog_metadata ?? undefined,
     },
+    artifactHealth: lineage.artifact_health,
+    schemaCoverage: normalizeSchemaCoverage(lineage.schema_coverage),
   };
 }
 

--- a/js/packages/ui/src/contexts/lineage/utils.ts
+++ b/js/packages/ui/src/contexts/lineage/utils.ts
@@ -185,6 +185,8 @@ export function buildLineageGraph(
         schemaComparisonStatus: normalizeSchemaComparisonStatus(
           merged.schema_comparison_status,
         ),
+        baseCatalogStatus: merged.base_catalog_status,
+        currentCatalogStatus: merged.current_catalog_status,
         parents: {},
         children: {},
       },

--- a/js/packages/ui/src/contexts/lineage/utils.ts
+++ b/js/packages/ui/src/contexts/lineage/utils.ts
@@ -44,6 +44,16 @@ function normalizeSchemaCoverage(
   ) {
     return { ...UNKNOWN_SCHEMA_COVERAGE, unchecked_nodes: [] };
   }
+  const hasUncheckedNodes = value.unchecked_node_count > 0;
+  const sampleIsTruncated =
+    value.unchecked_node_count > value.unchecked_nodes.length;
+  const invariantsHold =
+    value.status === "partial"
+      ? hasUncheckedNodes && value.more === sampleIsTruncated
+      : !hasUncheckedNodes && value.unchecked_nodes.length === 0 && !value.more;
+  if (!invariantsHold) {
+    return { ...UNKNOWN_SCHEMA_COVERAGE, unchecked_nodes: [] };
+  }
   return {
     status: value.status,
     unchecked_nodes: [...value.unchecked_nodes],

--- a/js/packages/ui/src/index.ts
+++ b/js/packages/ui/src/index.ts
@@ -5,6 +5,8 @@ export const VERSION = "0.2.0";
 
 // API utilities
 export type {
+  ArtifactHealth,
+  ArtifactHealthPair,
   CatalogMetadata,
   GitInfo,
   LineageData,
@@ -22,6 +24,7 @@ export type {
   RecceInstanceInfo,
   RecceServerFlags,
   RunsAggregated,
+  SchemaCoverage,
   ServerInfoResult,
   ServerMode,
   SQLMeshInfo,

--- a/js/packages/ui/src/lib/dataGrid/generators/__tests__/toSchemaDataGrid.test.ts
+++ b/js/packages/ui/src/lib/dataGrid/generators/__tests__/toSchemaDataGrid.test.ts
@@ -282,39 +282,35 @@ describe("toSchemaDataGrid - Column Structure", () => {
 // ============================================================================
 
 describe("toSchemaDataGrid - Row Generation", () => {
-  test("suppresses unverified added, removed, and type-changed rows", () => {
-    const schemaDiff = mergeColumns(
-      createColumns({
-        stable: "INT",
-        removed: "VARCHAR",
-        changed: "INT",
-      }),
-      createColumns({
-        stable: "INT",
-        added: "VARCHAR",
-        changed: "DECIMAL",
-      }),
-    );
+  // One fixture, every status: this pins the suppression set AND its
+  // complement, so neither narrowing nor widening the gate can slip through.
+  //
+  // Only "unchecked" carries positive evidence that the catalog did not
+  // describe the node, so it is the only status that may hide a difference.
+  // "unknown" means no coverage evidence at all (legacy / version-skewed
+  // producer) — hiding rows there deletes real removals, the inverse of the
+  // bug this guard exists to fix.
+  test.each([
+    ["complete", ["stable", "removed", "changed", "added"]],
+    ["unchecked", ["stable"]],
+    ["unknown", ["stable", "removed", "changed", "added"]],
+    ["not_applicable", ["stable", "removed", "changed", "added"]],
+    [undefined, ["stable", "removed", "changed", "added"]],
+  ] as const)(
+    "schemaComparisonStatus %s keeps rows %j",
+    (schemaComparisonStatus, expected) => {
+      const schemaDiff = mergeColumns(
+        createColumns({ stable: "INT", removed: "VARCHAR", changed: "INT" }),
+        createColumns({ stable: "INT", changed: "DECIMAL", added: "VARCHAR" }),
+      );
 
-    const { rows } = toSchemaDataGrid(schemaDiff, {
-      schemaComparisonStatus: "unchecked",
-    });
+      const { rows } = toSchemaDataGrid(schemaDiff, {
+        schemaComparisonStatus,
+      });
 
-    expect(rows.map((row) => row.name)).toEqual(["stable"]);
-  });
-
-  test("retains verified differences for a complete model", () => {
-    const schemaDiff = mergeColumns(
-      createColumns({ stable: "INT", removed: "VARCHAR" }),
-      createColumns({ stable: "INT", added: "VARCHAR" }),
-    );
-
-    const { rows } = toSchemaDataGrid(schemaDiff, {
-      schemaComparisonStatus: "complete",
-    });
-
-    expect(rows.map((row) => row.name)).toEqual(["stable", "removed", "added"]);
-  });
+      expect(rows.map((row) => row.name).sort()).toEqual([...expected].sort());
+    },
+  );
 
   test("returns rows from schemaDiff", () => {
     const schemaDiff = mergeColumns(

--- a/js/packages/ui/src/lib/dataGrid/generators/__tests__/toSchemaDataGrid.test.ts
+++ b/js/packages/ui/src/lib/dataGrid/generators/__tests__/toSchemaDataGrid.test.ts
@@ -282,6 +282,40 @@ describe("toSchemaDataGrid - Column Structure", () => {
 // ============================================================================
 
 describe("toSchemaDataGrid - Row Generation", () => {
+  test("suppresses unverified added, removed, and type-changed rows", () => {
+    const schemaDiff = mergeColumns(
+      createColumns({
+        stable: "INT",
+        removed: "VARCHAR",
+        changed: "INT",
+      }),
+      createColumns({
+        stable: "INT",
+        added: "VARCHAR",
+        changed: "DECIMAL",
+      }),
+    );
+
+    const { rows } = toSchemaDataGrid(schemaDiff, {
+      schemaComparisonStatus: "unchecked",
+    });
+
+    expect(rows.map((row) => row.name)).toEqual(["stable"]);
+  });
+
+  test("retains verified differences for a complete model", () => {
+    const schemaDiff = mergeColumns(
+      createColumns({ stable: "INT", removed: "VARCHAR" }),
+      createColumns({ stable: "INT", added: "VARCHAR" }),
+    );
+
+    const { rows } = toSchemaDataGrid(schemaDiff, {
+      schemaComparisonStatus: "complete",
+    });
+
+    expect(rows.map((row) => row.name)).toEqual(["stable", "removed", "added"]);
+  });
+
   test("returns rows from schemaDiff", () => {
     const schemaDiff = mergeColumns(
       createColumns({ id: "INT", name: "VARCHAR" }),

--- a/js/packages/ui/src/lib/dataGrid/generators/toSchemaDataGrid.ts
+++ b/js/packages/ui/src/lib/dataGrid/generators/toSchemaDataGrid.ts
@@ -77,6 +77,12 @@ export interface SchemaDataGridOptions {
    * the `inline_profile` flag is off or the adapter is unsupported.
    */
   distribution?: SchemaDistributionData;
+  /** Whether this model's two catalog schemas were actually comparable. */
+  schemaComparisonStatus?:
+    | "complete"
+    | "unchecked"
+    | "not_applicable"
+    | "unknown";
 }
 
 export interface SchemaDataGridResult {
@@ -154,6 +160,7 @@ export function toSchemaDataGrid(
     impactedColumns,
     nodeId,
     distribution,
+    schemaComparisonStatus,
   } = options;
 
   const columns: ColDef<SchemaDiffRow>[] = [
@@ -208,7 +215,18 @@ export function toSchemaDataGrid(
     });
   }
 
-  const rows = Object.values(schemaDiff);
+  const comparisonIncomplete =
+    schemaComparisonStatus === "unchecked" ||
+    schemaComparisonStatus === "unknown";
+  const rows = Object.values(schemaDiff).filter((row) => {
+    if (!comparisonIncomplete) return true;
+    return (
+      row.baseIndex !== undefined &&
+      row.currentIndex !== undefined &&
+      row.baseType === row.currentType &&
+      !row.reordered
+    );
+  });
 
   // Mark columns whose SQL definition changed but have no other visible change
   if (columnChanges) {

--- a/js/packages/ui/src/lib/dataGrid/generators/toSchemaDataGrid.ts
+++ b/js/packages/ui/src/lib/dataGrid/generators/toSchemaDataGrid.ts
@@ -217,7 +217,7 @@ export function toSchemaDataGrid(
 
   // Only "unchecked" suppresses rows. It means we have positive evidence the
   // catalog did not describe this node, so an apparent add/remove/type-change
-  // is unverified — the DRC-3293 fix.
+  // is unverified.
   //
   // "unknown" is different: no coverage evidence exists at all (a legacy or
   // version-skewed producer that never emitted catalog_status). Suppressing

--- a/js/packages/ui/src/lib/dataGrid/generators/toSchemaDataGrid.ts
+++ b/js/packages/ui/src/lib/dataGrid/generators/toSchemaDataGrid.ts
@@ -215,11 +215,19 @@ export function toSchemaDataGrid(
     });
   }
 
-  const comparisonIncomplete =
-    schemaComparisonStatus === "unchecked" ||
-    schemaComparisonStatus === "unknown";
+  // Only "unchecked" suppresses rows. It means we have positive evidence the
+  // catalog did not describe this node, so an apparent add/remove/type-change
+  // is unverified — the DRC-3293 fix.
+  //
+  // "unknown" is different: no coverage evidence exists at all (a legacy or
+  // version-skewed producer that never emitted catalog_status). Suppressing
+  // there turns absence of evidence into affirmative absence of changes and
+  // deletes real removals from the UI — the inverse of the bug this fixes.
+  // The incomplete-comparison warning still fires for "unknown" in SchemaView,
+  // so nothing is presented as verified.
+  const rowsAreUnverified = schemaComparisonStatus === "unchecked";
   const rows = Object.values(schemaDiff).filter((row) => {
-    if (!comparisonIncomplete) return true;
+    if (!rowsAreUnverified) return true;
     return (
       row.baseIndex !== undefined &&
       row.currentIndex !== undefined &&

--- a/js/src/components/summary/__tests__/SchemaSummary.test.tsx
+++ b/js/src/components/summary/__tests__/SchemaSummary.test.tsx
@@ -100,6 +100,12 @@ function createGraph(
     modifiedSet,
     manifestMetadata: { base: undefined, current: undefined },
     catalogMetadata: { base: undefined, current: undefined },
+    schemaCoverage: {
+      status: "complete",
+      unchecked_nodes: [],
+      unchecked_node_count: 0,
+      more: false,
+    },
   };
 }
 

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -833,6 +833,12 @@ class DbtAdapter(BaseAdapter):
             if resource_type not in ["model", "seed", "exposure", "snapshot"]:
                 continue
 
+            materialized = node["config"].get("materialized")
+            is_catalogable = resource_type in {"model", "seed", "snapshot"} and materialized not in {
+                "ephemeral",
+                "semantic_view",
+            }
+
             nodes[unique_id] = {
                 "id": node["unique_id"],
                 "name": node["name"],
@@ -842,7 +848,11 @@ class DbtAdapter(BaseAdapter):
                 "config": node["config"],
                 "checksum": node["checksum"],
                 "raw_code": node["raw_code"],
-                "catalog_status": "covered" if catalog is not None and unique_id in catalog.nodes else "unchecked",
+                "catalog_status": (
+                    "covered"
+                    if is_catalogable and catalog is not None and unique_id in catalog.nodes
+                    else "unchecked" if is_catalogable else "not_applicable"
+                ),
             }
 
             # List of <type>.<package_name>.<node_name>.<hash>

--- a/recce/adapter/dbt_adapter/__init__.py
+++ b/recce/adapter/dbt_adapter/__init__.py
@@ -62,6 +62,7 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from recce.adapter.base import BaseAdapter
+from recce.artifact_health import artifact_health_payload, classify_artifact_health
 from recce.state import ArtifactsRoot
 
 from ...models import RunType
@@ -820,6 +821,8 @@ class DbtAdapter(BaseAdapter):
         catalog_metadata = catalog.metadata if catalog is not None else None
 
         manifest_dict = manifest.to_dict()
+        catalog_dict = catalog.to_dict() if catalog is not None else None
+        artifact_health = artifact_health_payload(classify_artifact_health(manifest_dict, catalog_dict))
 
         nodes = {}
 
@@ -839,6 +842,7 @@ class DbtAdapter(BaseAdapter):
                 "config": node["config"],
                 "checksum": node["checksum"],
                 "raw_code": node["raw_code"],
+                "catalog_status": "covered" if catalog is not None and unique_id in catalog.nodes else "unchecked",
             }
 
             # List of <type>.<package_name>.<node_name>.<hash>
@@ -892,6 +896,7 @@ class DbtAdapter(BaseAdapter):
                 "resource_type": source["resource_type"],
                 "package_name": source["package_name"],
                 "config": source["config"],
+                "catalog_status": "covered" if catalog is not None and unique_id in catalog.sources else "unchecked",
             }
 
             if catalog is not None and unique_id in catalog.sources:
@@ -907,6 +912,7 @@ class DbtAdapter(BaseAdapter):
                 "resource_type": exposure["resource_type"],
                 "package_name": exposure["package_name"],
                 "config": exposure["config"],
+                "catalog_status": "not_applicable",
             }
         for metric in manifest_dict["metrics"].values():
             nodes[metric["unique_id"]] = {
@@ -915,6 +921,7 @@ class DbtAdapter(BaseAdapter):
                 "resource_type": metric["resource_type"],
                 "package_name": metric["package_name"],
                 "config": metric["config"],
+                "catalog_status": "not_applicable",
             }
 
         if "semantic_models" in manifest_dict:
@@ -925,6 +932,7 @@ class DbtAdapter(BaseAdapter):
                     "resource_type": semantic_models["resource_type"],
                     "package_name": semantic_models["package_name"],
                     "config": semantic_models["config"],
+                    "catalog_status": "not_applicable",
                 }
 
         parent_map = self.build_parent_map(nodes, base)
@@ -940,6 +948,7 @@ class DbtAdapter(BaseAdapter):
             nodes=nodes,
             manifest_metadata=manifest_metadata,
             catalog_metadata=catalog_metadata,
+            artifact_health=artifact_health,
         )
 
     @lru_cache(maxsize=1)

--- a/recce/adapter/sqlmesh_adapter.py
+++ b/recce/adapter/sqlmesh_adapter.py
@@ -57,6 +57,11 @@ class SqlmeshAdapter(BaseAdapter):
             for column, type in model.columns_to_types.items():
                 columns[column] = {"name": column, "type": str(type)}
             node["columns"] = columns
+            # SQLMesh has no catalog.json — `columns_to_types` is the
+            # authoritative schema. Declare that coverage explicitly, or the
+            # canonical classifier reads the missing key as legacy evidence and
+            # marks every SQLMesh comparison unchecked (DRC-3303).
+            node["catalog_status"] = "covered" if columns else "unchecked"
 
             nodes[snapshot.name] = node
             parents = [snapshotId.name for snapshotId in snapshot.parents]

--- a/recce/adapter/sqlmesh_adapter.py
+++ b/recce/adapter/sqlmesh_adapter.py
@@ -60,7 +60,7 @@ class SqlmeshAdapter(BaseAdapter):
             # SQLMesh has no catalog.json — `columns_to_types` is the
             # authoritative schema. Declare that coverage explicitly, or the
             # canonical classifier reads the missing key as legacy evidence and
-            # marks every SQLMesh comparison unchecked (DRC-3303).
+            # marks every SQLMesh comparison unchecked.
             node["catalog_status"] = "covered" if columns else "unchecked"
 
             nodes[snapshot.name] = node

--- a/recce/artifact_health.py
+++ b/recce/artifact_health.py
@@ -1,8 +1,9 @@
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
 ArtifactHealthStatus = Literal["complete", "partial", "empty", "absent", "not_applicable", "unknown"]
+SchemaCoverageStatus = Literal["complete", "partial", "unknown"]
 
 
 @dataclass(frozen=True)
@@ -15,8 +16,16 @@ class ArtifactHealth:
     orphan_node_ids: frozenset[str]
 
 
+@dataclass(frozen=True)
+class SchemaCoverage:
+    status: SchemaCoverageStatus
+    checked_node_ids: frozenset[str]
+    unchecked_node_ids: frozenset[str]
+
+
 _ELIGIBLE_RESOURCE_TYPES = frozenset({"model", "seed", "snapshot"})
 _EXCLUDED_MATERIALIZATIONS = frozenset({"ephemeral", "semantic_view"})
+_NON_RELATION_RESOURCE_TYPES = frozenset({"exposure", "metric", "semantic_model", "saved_query"})
 
 
 def _unknown_health(expected_node_ids: frozenset[str] = frozenset()) -> ArtifactHealth:
@@ -128,4 +137,73 @@ def artifact_health_payload(
         "orphan_node_count": len(health.orphan_node_ids),
         "orphan_nodes": sorted(health.orphan_node_ids)[:effective_limit],
         "orphan_more": len(health.orphan_node_ids) > effective_limit,
+    }
+
+
+def _unknown_schema_coverage() -> SchemaCoverage:
+    return SchemaCoverage(
+        status="unknown",
+        checked_node_ids=frozenset(),
+        unchecked_node_ids=frozenset(),
+    )
+
+
+def _catalog_columns_are_applicable(node: Mapping[str, Any]) -> bool:
+    if node.get("catalog_status") == "not_applicable":
+        return False
+    if node.get("resource_type") in _NON_RELATION_RESOURCE_TYPES:
+        return False
+    config = node.get("config")
+    materialized = config.get("materialized") if isinstance(config, Mapping) else None
+    return materialized not in _EXCLUDED_MATERIALIZATIONS
+
+
+def classify_schema_coverage(
+    base_nodes: Mapping[str, Mapping[str, Any]] | None,
+    current_nodes: Mapping[str, Mapping[str, Any]] | None,
+    node_ids: Iterable[str],
+) -> SchemaCoverage:
+    if not isinstance(base_nodes, Mapping) or not isinstance(current_nodes, Mapping):
+        return _unknown_schema_coverage()
+
+    selected_node_ids = frozenset(node_ids)
+    if any(not isinstance(node_id, str) for node_id in selected_node_ids):
+        return _unknown_schema_coverage()
+
+    checked: set[str] = set()
+    unchecked: set[str] = set()
+    for node_id in selected_node_ids:
+        if node_id not in base_nodes or node_id not in current_nodes:
+            continue
+
+        base_node = base_nodes[node_id]
+        current_node = current_nodes[node_id]
+        if not isinstance(base_node, Mapping) or not isinstance(current_node, Mapping):
+            return _unknown_schema_coverage()
+        if not _catalog_columns_are_applicable(base_node) or not _catalog_columns_are_applicable(current_node):
+            continue
+
+        if base_node.get("catalog_status") == current_node.get("catalog_status") == "covered":
+            checked.add(node_id)
+        else:
+            unchecked.add(node_id)
+
+    return SchemaCoverage(
+        status="partial" if unchecked else "complete",
+        checked_node_ids=frozenset(checked),
+        unchecked_node_ids=frozenset(unchecked),
+    )
+
+
+def schema_coverage_payload(
+    coverage: SchemaCoverage,
+    *,
+    sample_limit: int = 50,
+) -> dict[str, Any]:
+    effective_limit = min(sample_limit, 50)
+    return {
+        "status": coverage.status,
+        "unchecked_nodes": sorted(coverage.unchecked_node_ids)[:effective_limit],
+        "unchecked_node_count": len(coverage.unchecked_node_ids),
+        "more": len(coverage.unchecked_node_ids) > effective_limit,
     }

--- a/recce/artifact_health.py
+++ b/recce/artifact_health.py
@@ -228,6 +228,14 @@ def classify_schema_coverage(
             # stays structural evidence rather than being written off.
             one_sided.add(node_id)
 
+    if not (checked or unchecked or one_sided):
+        # Nothing in the selection was comparable at all: an empty selection, or
+        # one made up entirely of nodes the catalog can never describe. That is
+        # absence of evidence, not evidence of absence, so it cannot be
+        # "complete" — "complete" means we compared at least one node and left
+        # none unchecked.
+        return _unknown_schema_coverage()
+
     return SchemaCoverage(
         status="partial" if unchecked else "complete",
         checked_node_ids=frozenset(checked),

--- a/recce/artifact_health.py
+++ b/recce/artifact_health.py
@@ -4,6 +4,7 @@ from typing import Any, Literal
 
 ArtifactHealthStatus = Literal["complete", "partial", "empty", "absent", "not_applicable", "unknown"]
 SchemaCoverageStatus = Literal["complete", "partial", "unknown"]
+SchemaComparisonStatus = Literal["complete", "unchecked", "not_applicable"]
 
 
 @dataclass(frozen=True)
@@ -156,6 +157,31 @@ def _catalog_columns_are_applicable(node: Mapping[str, Any]) -> bool:
     return materialized not in _EXCLUDED_MATERIALIZATIONS
 
 
+def classify_node_schema_comparison(
+    base_nodes: Mapping[str, Mapping[str, Any]],
+    current_nodes: Mapping[str, Mapping[str, Any]],
+    node_id: str,
+) -> SchemaComparisonStatus:
+    """Classify one selected node from exact two-sided lineage evidence."""
+    in_base = node_id in base_nodes
+    in_current = node_id in current_nodes
+    if in_base != in_current:
+        return "not_applicable"
+    if not in_base:
+        # A stale or misspelled selection is not structural one-sided evidence.
+        return "unchecked"
+
+    base_node = base_nodes.get(node_id)
+    current_node = current_nodes.get(node_id)
+    if not isinstance(base_node, Mapping) or not isinstance(current_node, Mapping):
+        return "unchecked"
+    if not _catalog_columns_are_applicable(base_node) or not _catalog_columns_are_applicable(current_node):
+        return "not_applicable"
+    if base_node.get("catalog_status") == current_node.get("catalog_status") == "covered":
+        return "complete"
+    return "unchecked"
+
+
 def classify_schema_coverage(
     base_nodes: Mapping[str, Mapping[str, Any]] | None,
     current_nodes: Mapping[str, Mapping[str, Any]] | None,
@@ -177,14 +203,10 @@ def classify_schema_coverage(
             node_id in current_nodes and not isinstance(current_node, Mapping)
         ):
             return _unknown_schema_coverage()
-        if node_id not in base_nodes or node_id not in current_nodes:
-            continue
-        if not _catalog_columns_are_applicable(base_node) or not _catalog_columns_are_applicable(current_node):
-            continue
-
-        if base_node.get("catalog_status") == current_node.get("catalog_status") == "covered":
+        comparison_status = classify_node_schema_comparison(base_nodes, current_nodes, node_id)
+        if comparison_status == "complete":
             checked.add(node_id)
-        else:
+        elif comparison_status == "unchecked":
             unchecked.add(node_id)
 
     return SchemaCoverage(

--- a/recce/artifact_health.py
+++ b/recce/artifact_health.py
@@ -116,15 +116,16 @@ def artifact_health_payload(
     *,
     sample_limit: int = 50,
 ) -> dict[str, Any]:
+    effective_limit = min(sample_limit, 50)
     return {
         "status": health.status,
         "expected_count": len(health.expected_node_ids),
         "covered_count": len(health.covered_node_ids),
         "catalog_entry_count": len(health.catalog_node_ids),
         "missing_node_count": len(health.missing_node_ids),
-        "missing_nodes": sorted(health.missing_node_ids)[:sample_limit],
-        "missing_more": len(health.missing_node_ids) > sample_limit,
+        "missing_nodes": sorted(health.missing_node_ids)[:effective_limit],
+        "missing_more": len(health.missing_node_ids) > effective_limit,
         "orphan_node_count": len(health.orphan_node_ids),
-        "orphan_nodes": sorted(health.orphan_node_ids)[:sample_limit],
-        "orphan_more": len(health.orphan_node_ids) > sample_limit,
+        "orphan_nodes": sorted(health.orphan_node_ids)[:effective_limit],
+        "orphan_more": len(health.orphan_node_ids) > effective_limit,
     }

--- a/recce/artifact_health.py
+++ b/recce/artifact_health.py
@@ -1,0 +1,130 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+ArtifactHealthStatus = Literal["complete", "partial", "empty", "absent", "not_applicable", "unknown"]
+
+
+@dataclass(frozen=True)
+class ArtifactHealth:
+    status: ArtifactHealthStatus
+    expected_node_ids: frozenset[str]
+    covered_node_ids: frozenset[str]
+    catalog_node_ids: frozenset[str]
+    missing_node_ids: frozenset[str]
+    orphan_node_ids: frozenset[str]
+
+
+_ELIGIBLE_RESOURCE_TYPES = frozenset({"model", "seed", "snapshot"})
+_EXCLUDED_MATERIALIZATIONS = frozenset({"ephemeral", "semantic_view"})
+
+
+def _unknown_health(expected_node_ids: frozenset[str] = frozenset()) -> ArtifactHealth:
+    return ArtifactHealth(
+        status="unknown",
+        expected_node_ids=expected_node_ids,
+        covered_node_ids=frozenset(),
+        catalog_node_ids=frozenset(),
+        missing_node_ids=frozenset(),
+        orphan_node_ids=frozenset(),
+    )
+
+
+def _manifest_expected_node_ids(manifest: Mapping[str, Any]) -> frozenset[str] | None:
+    nodes = manifest.get("nodes")
+    if not isinstance(nodes, Mapping):
+        return None
+
+    expected: set[str] = set()
+    for node_id, node in nodes.items():
+        if not isinstance(node_id, str) or not isinstance(node, Mapping):
+            return None
+        if node.get("resource_type") not in _ELIGIBLE_RESOURCE_TYPES:
+            continue
+        config = node.get("config")
+        materialized = config.get("materialized") if isinstance(config, Mapping) else None
+        if materialized in _EXCLUDED_MATERIALIZATIONS:
+            continue
+        expected.add(node_id)
+    return frozenset(expected)
+
+
+def classify_artifact_health(
+    manifest: Mapping[str, Any] | None,
+    catalog: Mapping[str, Any] | None,
+) -> ArtifactHealth:
+    if manifest is None or not isinstance(manifest, Mapping):
+        return _unknown_health()
+
+    expected_node_ids = _manifest_expected_node_ids(manifest)
+    if expected_node_ids is None:
+        return _unknown_health()
+
+    if catalog is None:
+        if not expected_node_ids:
+            return ArtifactHealth(
+                status="not_applicable",
+                expected_node_ids=expected_node_ids,
+                covered_node_ids=frozenset(),
+                catalog_node_ids=frozenset(),
+                missing_node_ids=frozenset(),
+                orphan_node_ids=frozenset(),
+            )
+        return ArtifactHealth(
+            status="absent",
+            expected_node_ids=expected_node_ids,
+            covered_node_ids=frozenset(),
+            catalog_node_ids=frozenset(),
+            missing_node_ids=expected_node_ids,
+            orphan_node_ids=frozenset(),
+        )
+
+    if not isinstance(catalog, Mapping):
+        return _unknown_health(expected_node_ids)
+    catalog_nodes = catalog.get("nodes")
+    if not isinstance(catalog_nodes, Mapping):
+        return _unknown_health(expected_node_ids)
+    if any(not isinstance(node_id, str) or not isinstance(node, Mapping) for node_id, node in catalog_nodes.items()):
+        return _unknown_health(expected_node_ids)
+
+    catalog_node_ids = frozenset(catalog_nodes)
+    covered_node_ids = expected_node_ids & catalog_node_ids
+    missing_node_ids = expected_node_ids - covered_node_ids
+    orphan_node_ids = catalog_node_ids - expected_node_ids
+
+    if not expected_node_ids:
+        status: ArtifactHealthStatus = "not_applicable"
+    elif not covered_node_ids:
+        status = "empty"
+    elif not missing_node_ids:
+        status = "complete"
+    else:
+        status = "partial"
+
+    return ArtifactHealth(
+        status=status,
+        expected_node_ids=expected_node_ids,
+        covered_node_ids=covered_node_ids,
+        catalog_node_ids=catalog_node_ids,
+        missing_node_ids=missing_node_ids,
+        orphan_node_ids=orphan_node_ids,
+    )
+
+
+def artifact_health_payload(
+    health: ArtifactHealth,
+    *,
+    sample_limit: int = 50,
+) -> dict[str, Any]:
+    return {
+        "status": health.status,
+        "expected_count": len(health.expected_node_ids),
+        "covered_count": len(health.covered_node_ids),
+        "catalog_entry_count": len(health.catalog_node_ids),
+        "missing_node_count": len(health.missing_node_ids),
+        "missing_nodes": sorted(health.missing_node_ids)[:sample_limit],
+        "missing_more": len(health.missing_node_ids) > sample_limit,
+        "orphan_node_count": len(health.orphan_node_ids),
+        "orphan_nodes": sorted(health.orphan_node_ids)[:sample_limit],
+        "orphan_more": len(health.orphan_node_ids) > sample_limit,
+    }

--- a/recce/artifact_health.py
+++ b/recce/artifact_health.py
@@ -149,8 +149,6 @@ def _unknown_schema_coverage() -> SchemaCoverage:
 
 
 def _catalog_columns_are_applicable(node: Mapping[str, Any]) -> bool:
-    if node.get("catalog_status") == "not_applicable":
-        return False
     if node.get("resource_type") in _NON_RELATION_RESOURCE_TYPES:
         return False
     config = node.get("config")
@@ -173,13 +171,14 @@ def classify_schema_coverage(
     checked: set[str] = set()
     unchecked: set[str] = set()
     for node_id in selected_node_ids:
+        base_node = base_nodes.get(node_id)
+        current_node = current_nodes.get(node_id)
+        if (node_id in base_nodes and not isinstance(base_node, Mapping)) or (
+            node_id in current_nodes and not isinstance(current_node, Mapping)
+        ):
+            return _unknown_schema_coverage()
         if node_id not in base_nodes or node_id not in current_nodes:
             continue
-
-        base_node = base_nodes[node_id]
-        current_node = current_nodes[node_id]
-        if not isinstance(base_node, Mapping) or not isinstance(current_node, Mapping):
-            return _unknown_schema_coverage()
         if not _catalog_columns_are_applicable(base_node) or not _catalog_columns_are_applicable(current_node):
             continue
 
@@ -200,7 +199,7 @@ def schema_coverage_payload(
     *,
     sample_limit: int = 50,
 ) -> dict[str, Any]:
-    effective_limit = min(sample_limit, 50)
+    effective_limit = max(0, min(sample_limit, 50))
     return {
         "status": coverage.status,
         "unchecked_nodes": sorted(coverage.unchecked_node_ids)[:effective_limit],

--- a/recce/artifact_health.py
+++ b/recce/artifact_health.py
@@ -22,6 +22,18 @@ class SchemaCoverage:
     status: SchemaCoverageStatus
     checked_node_ids: frozenset[str]
     unchecked_node_ids: frozenset[str]
+    #: Selected nodes present on exactly one manifest side. They carry no
+    #: column-level comparison, but their one-sidedness is *verified* evidence
+    #: of an added or removed relation — not an unchecked node. Consumers must
+    #: report them as differences; dropping them turns a real removal into an
+    #: affirmative "no schema changes".
+    one_sided_node_ids: frozenset[str] = frozenset()
+
+    @property
+    def comparable_node_ids(self) -> frozenset[str]:
+        """Every node this comparison can stand behind: column-checked pairs
+        plus one-sided structural evidence."""
+        return self.checked_node_ids | self.one_sided_node_ids
 
 
 _ELIGIBLE_RESOURCE_TYPES = frozenset({"model", "seed", "snapshot"})
@@ -146,6 +158,7 @@ def _unknown_schema_coverage() -> SchemaCoverage:
         status="unknown",
         checked_node_ids=frozenset(),
         unchecked_node_ids=frozenset(),
+        one_sided_node_ids=frozenset(),
     )
 
 
@@ -196,6 +209,7 @@ def classify_schema_coverage(
 
     checked: set[str] = set()
     unchecked: set[str] = set()
+    one_sided: set[str] = set()
     for node_id in selected_node_ids:
         base_node = base_nodes.get(node_id)
         current_node = current_nodes.get(node_id)
@@ -208,11 +222,17 @@ def classify_schema_coverage(
             checked.add(node_id)
         elif comparison_status == "unchecked":
             unchecked.add(node_id)
+        elif (node_id in base_nodes) != (node_id in current_nodes):
+            # Same precedence as classify_node_schema_comparison: one-sidedness
+            # is decided before catalog applicability, so a one-sided relation
+            # stays structural evidence rather than being written off.
+            one_sided.add(node_id)
 
     return SchemaCoverage(
         status="partial" if unchecked else "complete",
         checked_node_ids=frozenset(checked),
         unchecked_node_ids=frozenset(unchecked),
+        one_sided_node_ids=frozenset(one_sided),
     )
 
 

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -1903,7 +1903,9 @@ class RecceMCPServer:
         # Build schema changes
         schema_changes = []
 
-        for node_id in coverage.checked_node_ids:
+        # One-sided nodes are included: an added or removed relation is verified
+        # structural evidence, and its columns are genuine additions/removals.
+        for node_id in coverage.comparable_node_ids:
             base_node = base_nodes.get(node_id, {})
             current_node = current_nodes.get(node_id, {})
 

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -411,6 +411,7 @@ class CloudBackend:
             limit=limit,
             more=len(changes) > limit,
         ).model_dump(mode="json")
+        result["total_row_count"] = len(changes)
         # The cloud session hands us the column changes it already computed but
         # says nothing about which nodes it could not describe, so coverage is
         # unassessed rather than complete. Emitted under the same key as the
@@ -1875,6 +1876,7 @@ class RecceMCPServer:
             more=has_more,
         )
         result = diff_df.model_dump(mode="json")
+        result["total_row_count"] = len(schema_changes)
 
         # Carried alongside the frame rather than inside it: `DataFrame` backs
         # every tool's payload, and coverage only means something here. Consumers

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -31,7 +31,7 @@ from recce.apis.run_func import submit_run as _submit_run_fn  # noqa: E402
 from recce.artifact_health import classify_schema_coverage, schema_coverage_payload
 from recce.core import RecceContext, load_context
 from recce.exceptions import RecceException
-from recce.run import schema_result_is_approvable
+from recce.schema_evidence import run_result_is_approvable
 from recce.server import RecceServerMode
 from recce.tasks.dataframe import DataFrame
 from recce.tasks.histogram import HistogramDiffTask
@@ -272,7 +272,9 @@ class CloudBackend:
             f"checks/{quote(str(check_id), safe='')}/run",
             json={"nowait": False},
         )
-        if self._run_succeeded(run) and schema_result_is_approvable(run.get("result")):
+        # A schema comparison must prove complete coverage; every other check
+        # type keeps the pre-existing "a successful run is reviewed" rule.
+        if self._run_succeeded(run) and run_result_is_approvable(run.get("result")):
             await self._auto_approve(check_id)
         return run
 
@@ -304,12 +306,12 @@ class CloudBackend:
             run_executed = True
             run_error = run.get("error")
             # Both gates apply: the caller must ask for approval, and the run
-            # must carry verified-complete evidence. Either one alone is not
-            # enough to mark the check reviewed.
+            # must carry evidence its type can stand behind — for a schema
+            # comparison that means complete coverage, not merely a clean run.
             if (
                 self._run_succeeded(run)
                 and arguments.get("approve", True)
-                and schema_result_is_approvable(run.get("result"))
+                and run_result_is_approvable(run.get("result"))
             ):
                 await self._auto_approve(check_id)
         result = {
@@ -2744,9 +2746,11 @@ class RecceMCPServer:
                 raise ValueError(str(e)) from e
 
         if run_succeeded:
-            # Auto-approve only when the run carries a verified empty schema diff
-            # with complete coverage. Successful execution alone is not evidence.
-            if schema_result_is_approvable(approval_result):
+            # A schema comparison auto-approves only on a verified empty diff
+            # with complete coverage — successful execution alone is not
+            # evidence there. Other types keep the standing PM decision that a
+            # passing run is a reviewed check.
+            if run_result_is_approvable(approval_result):
                 check_dao.update_check_by_id(check_id, PatchCheckIn(is_checked=True))
                 logger.info(f"Auto-approved check {check_id} (triggered_by={triggered_by})")
 
@@ -2832,10 +2836,10 @@ class RecceMCPServer:
                 run_error = run.error
 
         # Auto-approve only when the caller asked for approval AND the run
-        # carries complete coverage with a verified empty schema diff.
-        # `approve=False` keeps the check unapproved for human review;
-        # lineage-only and legacy results without coverage fail closed.
-        if run_executed and not run_error and approve and schema_result_is_approvable(approval_result):
+        # carries evidence its type can stand behind. `approve=False` keeps the
+        # check unapproved for human review; a schema comparison additionally
+        # needs complete coverage, so a legacy result without it fails closed.
+        if run_executed and not run_error and approve and run_result_is_approvable(approval_result):
             check_dao.update_check_by_id(check_id, PatchCheckIn(is_checked=True))
 
         # Persist state to cloud/disk (matches REST endpoint pattern)

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -2664,15 +2664,15 @@ class RecceMCPServer:
             except RecceException as e:
                 raise ValueError(str(e)) from e
 
-        # Auto-approve only when the run carries a verified empty schema diff
-        # with complete coverage. Successful execution alone is not evidence.
-        # The auto-approve runs OUTSIDE the RecceException try blocks so a cloud-side
-        # failure (RecceCloudException, which is NOT a RecceException subclass) is not
-        # silently absorbed by the wrapper above. Same persistence policy as
-        # _tool_create_check: state is exported to disk/cloud after the approval.
-        if run_succeeded and schema_result_is_approvable(approval_result):
-            check_dao.update_check_by_id(check_id, PatchCheckIn(is_checked=True))
-            logger.info(f"Auto-approved check {check_id} (triggered_by={triggered_by})")
+        if run_succeeded:
+            # Auto-approve only when the run carries a verified empty schema diff
+            # with complete coverage. Successful execution alone is not evidence.
+            if schema_result_is_approvable(approval_result):
+                check_dao.update_check_by_id(check_id, PatchCheckIn(is_checked=True))
+                logger.info(f"Auto-approved check {check_id} (triggered_by={triggered_by})")
+
+            # Every successful run is durable, including unapproved partial,
+            # unknown, mismatching, lineage-only, and non-schema evidence.
             await asyncio.get_event_loop().run_in_executor(None, export_persistent_state)
 
         return run_dump

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -11,6 +11,7 @@ import logging
 import os
 import textwrap
 import time
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -27,6 +28,7 @@ from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
 # persist Runs to the in-process RecceContext so the state exported to S3
 # at MCP-server shutdown carries the analysis runs.
 from recce.apis.run_func import submit_run as _submit_run_fn  # noqa: E402
+from recce.artifact_health import classify_schema_coverage, schema_coverage_payload
 from recce.core import RecceContext, load_context
 from recce.exceptions import RecceException
 from recce.server import RecceServerMode
@@ -412,7 +414,7 @@ class CloudBackend:
         # says nothing about which nodes it could not describe, so coverage is
         # unassessed rather than complete. Emitted under the same key as the
         # local path so the one shared tool description holds for both backends.
-        result["schema_coverage"] = _schema_coverage(None)
+        result["schema_coverage"] = schema_coverage_payload(classify_schema_coverage(None, None, ()))
         return result
 
     async def _tool_impact_analysis(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -464,8 +466,8 @@ class CloudBackend:
             "confirmed_not_impacted_models": not_impacted_models,
             # Metadata-only triage: the session reports the column changes it
             # found but not what it failed to describe, so coverage is
-            # unassessed. Same key as the local path (see _schema_coverage).
-            "schema_coverage": _schema_coverage(None),
+            # unassessed. Same key as the local path.
+            "schema_coverage": schema_coverage_payload(classify_schema_coverage(None, None, ())),
             "errors": [],
         }
 
@@ -579,84 +581,6 @@ class MCPLogger:
             log_entry["response"] = _truncate_strings(response)
 
         self._write_log(log_entry)
-
-
-# Bounds the node names schema_diff names as unverifiable. Independent of the
-# row cap so an under-catalogued project cannot crowd out the changes it did find.
-_UNCHECKED_NODE_LIMIT = 50
-
-
-def _columns_comparable(base_node: dict, current_node: dict) -> bool:
-    """Whether the two sides carry enough column data to be compared at all.
-
-    Nodes come from the manifest but their columns come from the catalog, so a
-    model a selective build did not rebuild arrives with no column data on the
-    current side. Differencing the two sets anyway turns "we never looked" into
-    a full sweep of added or removed columns.
-
-    Emptiness counts as absence: a relation with no columns cannot exist, so an
-    empty map means the catalog never described the model rather than that it
-    lost everything.
-
-    What this observes is the absence, not its cause. A selective build is the
-    commonest reason but not the only one, so callers must not turn a False here
-    into a claim about what the user's pipeline did.
-    """
-    return bool(base_node.get("columns")) and bool(current_node.get("columns"))
-
-
-# Resource types dbt never describes in catalog.json, because the catalog
-# describes warehouse relations and these are not relations. See
-# `recce/adapter/dbt_adapter/__init__.py`, which builds them with no `columns`
-# key at all.
-_NON_RELATION_RESOURCE_TYPES = frozenset({"exposure", "metric", "semantic_model", "saved_query"})
-
-
-def _can_carry_catalog_columns(node: dict) -> bool:
-    """Whether the catalog could ever have described this node's columns.
-
-    Missing columns on a node dbt never catalogues are the normal state, not a
-    gap in what we checked. Exposures, metrics and semantic models are not
-    relations, and an ephemeral model is inlined as a CTE rather than
-    materialized, so none of them ever get a catalog entry. Counting them as
-    unchecked would pin `status` to "partial" on any project that owns one — a
-    genuinely clean schema_diff could then never be reported as verified — and
-    would spend the capped `unchecked_nodes` slots on nodes that were never
-    comparable to begin with.
-
-    A denylist, not an allowlist: a resource type we have not met, or a node
-    carrying no `resource_type` at all, still counts as a coverage gap. The
-    trade-off is deliberate. Skipping every node with no columns on *either*
-    side would also have covered these cases, but it would silently drop a model
-    that neither environment built — precisely the absence `unchecked_nodes`
-    exists to name — so we over-report a gap rather than hide one.
-    """
-    if node.get("resource_type") in _NON_RELATION_RESOURCE_TYPES:
-        return False
-    return (node.get("config") or {}).get("materialized") != "ephemeral"
-
-
-def _schema_coverage(unchecked_node_ids: Optional[List[str]]) -> Dict[str, Any]:
-    """Build the schema_coverage block shared by schema_diff and impact_analysis.
-
-    `None` means the comparison never ran — it raised, or the backend does not
-    report coverage. That is distinct from an empty list, which means the
-    comparison ran and found nothing it could not check.
-    """
-    if unchecked_node_ids is None:
-        return {
-            "status": "unknown",
-            "unchecked_nodes": [],
-            "unchecked_node_count": 0,
-            "more": False,
-        }
-    ordered = sorted(unchecked_node_ids)
-    return {
-        "status": "partial" if ordered else "complete",
-        "unchecked_nodes": ordered[:_UNCHECKED_NODE_LIMIT],
-        "unchecked_node_count": len(ordered),
-        "more": len(ordered) > _UNCHECKED_NODE_LIMIT,
-    }
 
 
 class RecceMCPServer:
@@ -1882,14 +1806,11 @@ class RecceMCPServer:
         # Get lineage diff from adapter
         lineage_diff = self.context.get_lineage_diff().model_dump(mode="json")
 
-        # Get all nodes from current environment
-        current_nodes = {}
-        if "current" in lineage_diff and "nodes" in lineage_diff["current"]:
-            current_nodes = lineage_diff["current"]["nodes"]
-
-        # Filter to only nodes that exist in both base and current (exclude added nodes)
-        base_nodes = lineage_diff.get("base", {}).get("nodes", {})
-        nodes_to_compare = set(current_nodes.keys()) & set(base_nodes.keys())
+        base_nodes = lineage_diff.get("base", {}).get("nodes")
+        current_nodes = lineage_diff.get("current", {}).get("nodes")
+        nodes_to_compare = set(base_nodes) if isinstance(base_nodes, Mapping) else set()
+        if isinstance(current_nodes, Mapping):
+            nodes_to_compare.update(current_nodes)
 
         # Apply filtering if arguments provided
         if select or exclude or packages:
@@ -1898,28 +1819,19 @@ class RecceMCPServer:
                 exclude=exclude,
                 packages=packages,
             )
-            nodes_to_compare = nodes_to_compare & selected_node_ids
+            nodes_to_compare &= set(selected_node_ids)
+
+        coverage = classify_schema_coverage(base_nodes, current_nodes, nodes_to_compare)
 
         # Build schema changes
         schema_changes = []
-        unchecked_nodes = []
 
-        for node_id in nodes_to_compare:
+        for node_id in coverage.checked_node_ids:
             base_node = base_nodes.get(node_id, {})
             current_node = current_nodes.get(node_id, {})
 
             base_columns = base_node.get("columns") or {}
             current_columns = current_node.get("columns") or {}
-
-            # Skipped before the row cap so unverifiable rows can neither
-            # displace real changes nor inflate `more`. A node the catalog never
-            # describes is skipped without being named: it is not a gap in what
-            # we checked, and naming it would make `status` permanently
-            # "partial" on any project that owns one.
-            if not _columns_comparable(base_node, current_node):
-                if _can_carry_catalog_columns(current_node):
-                    unchecked_nodes.append(node_id)
-                continue
 
             # Get column names in base and current
             base_col_names = set(base_columns.keys())
@@ -1963,7 +1875,7 @@ class RecceMCPServer:
         # that ignore it still see the unchanged shape, minus rows we cannot
         # stand behind. `data == []` means "no column changes" only when
         # `status` is "complete".
-        result["schema_coverage"] = _schema_coverage(unchecked_nodes)
+        result["schema_coverage"] = schema_coverage_payload(coverage)
         return result
 
     async def _tool_row_count_diff(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -2147,39 +2059,27 @@ class RecceMCPServer:
         # Step 2b: Schema diff (compare columns between base and current)
         # Unknown until the step runs, so a failure below leaves it unknown
         # rather than claiming complete coverage.
-        schema_coverage = _schema_coverage(None)
+        schema_coverage = schema_coverage_payload(classify_schema_coverage(None, None, ()))
         try:
-            base_nodes = lineage_diff.get("base", {}).get("nodes", {})
-            current_nodes = lineage_diff.get("current", {}).get("nodes", {})
+            base_nodes = lineage_diff.get("base", {}).get("nodes")
+            current_nodes = lineage_diff.get("current", {}).get("nodes")
+            selected_schema_node_ids = [
+                node_id_by_name[model["name"]] for model in impacted_models if model["name"] in node_id_by_name
+            ]
+            coverage = classify_schema_coverage(base_nodes, current_nodes, selected_schema_node_ids)
+            schema_coverage = schema_coverage_payload(coverage)
 
-            schema_unchecked = []
             for model in impacted_models:
                 node_id = node_id_by_name.get(model["name"])
                 if not node_id:
                     continue
 
+                if coverage.status == "unknown" or node_id in coverage.unchecked_node_ids:
+                    model["schema_changes"] = None
+                    continue
+
                 base_node = base_nodes.get(node_id, {})
                 current_node = current_nodes.get(node_id, {})
-
-                # The same absence guard as the schema_diff tool, but that tool
-                # compares only nodes present in BOTH lineages. Added and removed
-                # models reach this loop too, and a one-sided node is an
-                # observation, not an absence: a new model's columns really are
-                # all added, and a deleted model's really are all removed. Nodes
-                # the catalog never describes fall through as well — comparing
-                # two empty maps yields the honest empty result without claiming
-                # a coverage gap.
-                # `None` rather than `[]` for a real gap: an empty list reads as
-                # "checked, nothing changed", which is the claim we cannot make.
-                exists_in_both = bool(base_node) and bool(current_node)
-                if (
-                    exists_in_both
-                    and not _columns_comparable(base_node, current_node)
-                    and _can_carry_catalog_columns(current_node)
-                ):
-                    model["schema_changes"] = None
-                    schema_unchecked.append(node_id)
-                    continue
 
                 base_columns = base_node.get("columns") or {}
                 current_columns = current_node.get("columns") or {}
@@ -2198,8 +2098,6 @@ class RecceMCPServer:
                         changes.append({"column": col, "change_status": "modified"})
 
                 model["schema_changes"] = changes
-
-            schema_coverage = _schema_coverage(schema_unchecked)
         except Exception as e:
             errors.append({"step": "schema_diff", "message": str(e)})
 

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -31,6 +31,7 @@ from recce.apis.run_func import submit_run as _submit_run_fn  # noqa: E402
 from recce.artifact_health import classify_schema_coverage, schema_coverage_payload
 from recce.core import RecceContext, load_context
 from recce.exceptions import RecceException
+from recce.run import schema_result_is_approvable
 from recce.server import RecceServerMode
 from recce.tasks.dataframe import DataFrame
 from recce.tasks.histogram import HistogramDiffTask
@@ -267,7 +268,7 @@ class CloudBackend:
             f"checks/{quote(str(check_id), safe='')}/run",
             json={"nowait": False},
         )
-        if self._run_succeeded(run):
+        if self._run_succeeded(run) and schema_result_is_approvable(run.get("result")):
             await self._auto_approve(check_id)
         return run
 
@@ -298,7 +299,7 @@ class CloudBackend:
             )
             run_executed = True
             run_error = run.get("error")
-            if self._run_succeeded(run):
+            if self._run_succeeded(run) and schema_result_is_approvable(run.get("result")):
                 await self._auto_approve(check_id)
         result = {
             "check_id": str(check_id),
@@ -310,7 +311,7 @@ class CloudBackend:
         return result
 
     async def _auto_approve(self, check_id) -> None:
-        """Best-effort auto-approve on successful run.
+        """Best-effort auto-approve after evidence satisfies the caller's gate.
 
         The run already succeeded; an approve-side failure must not blow up the
         tool response. Mirrors the local-mode invariant that auto-approve is a
@@ -2628,6 +2629,7 @@ class RecceMCPServer:
 
         triggered_by = arguments.get("triggered_by", "user")
         run_succeeded = False
+        approval_result = None
 
         if check.type in (RunType.LINEAGE_DIFF, RunType.SCHEMA_DIFF):
             try:
@@ -2643,6 +2645,7 @@ class RecceMCPServer:
                     triggered_by=triggered_by,
                 )
                 run_succeeded = True
+                approval_result = result
                 run_dump = run.model_dump(mode="json")
             except RecceException as e:
                 raise ValueError(str(e)) from e
@@ -2656,19 +2659,18 @@ class RecceMCPServer:
                 )
                 run.result = await future
                 run_succeeded = run.status == RunStatus.FINISHED and not run.error
+                approval_result = run.result
                 run_dump = run.model_dump(mode="json")
             except RecceException as e:
                 raise ValueError(str(e)) from e
 
-        # Auto-approve on successful run — same gate as _tool_create_check (line 1832:
-        # run_executed and not run_error). PM decision: Passed = Approved (See: DRC-3307).
-        # For metadata-only types (lineage_diff/schema_diff), an empty result IS valid
-        # evidence: zero changes confirms the upstream PR did not affect lineage/schema.
+        # Auto-approve only when the run carries a verified empty schema diff
+        # with complete coverage. Successful execution alone is not evidence.
         # The auto-approve runs OUTSIDE the RecceException try blocks so a cloud-side
         # failure (RecceCloudException, which is NOT a RecceException subclass) is not
         # silently absorbed by the wrapper above. Same persistence policy as
         # _tool_create_check: state is exported to disk/cloud after the approval.
-        if run_succeeded:
+        if run_succeeded and schema_result_is_approvable(approval_result):
             check_dao.update_check_by_id(check_id, PatchCheckIn(is_checked=True))
             logger.info(f"Auto-approved check {check_id} (triggered_by={triggered_by})")
             await asyncio.get_event_loop().run_in_executor(None, export_persistent_state)
@@ -2719,6 +2721,7 @@ class RecceMCPServer:
         # Auto-run for evidence
         run_executed = False
         run_error = None
+        approval_result = None
         triggered_by = arguments.get("triggered_by", "user")
         if check_type in (RunType.LINEAGE_DIFF, RunType.SCHEMA_DIFF):
             # Metadata-only: read from manifest, create Run record for Activity
@@ -2735,6 +2738,7 @@ class RecceMCPServer:
                     triggered_by=triggered_by,
                 )
                 run_executed = True
+                approval_result = result
             except Exception as e:
                 run_error = str(e)
         else:
@@ -2743,16 +2747,13 @@ class RecceMCPServer:
             # submit_run's future always resolves (errors caught internally).
             # Check run.status, not the return value.
             run_executed = run.status == RunStatus.FINISHED
+            approval_result = run.result
             if run.status == RunStatus.FAILED:
                 run_error = run.error
 
-        # Auto-approve check when run succeeded without errors.
-        # In the PR summary, Passed = Approved (PM decision): a check that
-        # ran successfully is considered reviewed by the agent.
-        # Note: this differs from run_should_be_approved() in run.py, which
-        # only approves ROW_COUNT_DIFF with matching counts.  Here we blanket-
-        # approve any successful run — intentional per PM decision.
-        if run_executed and not run_error:
+        # Auto-approve only with complete coverage and a verified empty schema
+        # diff. Lineage-only and legacy results without coverage fail closed.
+        if run_executed and not run_error and schema_result_is_approvable(approval_result):
             check_dao.update_check_by_id(check_id, PatchCheckIn(is_checked=True))
 
         # Persist state to cloud/disk (matches REST endpoint pattern)

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -1820,7 +1820,12 @@ class RecceMCPServer:
                 exclude=exclude,
                 packages=packages,
             )
-            nodes_to_compare &= set(selected_node_ids)
+            # Preserve the exact selected scope. The canonical classifier must
+            # see stale IDs absent from both manifests so they fail closed; XOR
+            # one-sided nodes remain valid structural evidence.
+            nodes_to_compare = {
+                node_id for node_id in selected_node_ids if isinstance(node_id, str) and not node_id.startswith("test.")
+            }
 
         coverage = classify_schema_coverage(base_nodes, current_nodes, nodes_to_compare)
 

--- a/recce/models/lineage.py
+++ b/recce/models/lineage.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from pydantic import ValidationError
+
 from recce.artifact_health import (
     classify_node_schema_comparison,
     classify_schema_coverage,
     schema_coverage_payload,
 )
 from recce.models.types import (
+    ArtifactHealthPayload,
     LineageDiff,
     MergedEdge,
     MergedLineage,
@@ -25,6 +28,36 @@ def _catalog_status(node: Mapping[str, Any] | None) -> str | None:
         return None
     status = node.get("catalog_status")
     return status if status in _CATALOG_STATUSES else None
+
+
+_UNREADABLE_SIDE_HEALTH = {
+    "status": "unknown",
+    "expected_count": 0,
+    "covered_count": 0,
+    "catalog_entry_count": 0,
+    "missing_node_count": 0,
+    "missing_nodes": [],
+    "missing_more": False,
+    "orphan_node_count": 0,
+    "orphan_nodes": [],
+    "orphan_more": False,
+}
+
+
+def _readable_side_health(raw: Any) -> dict | None:
+    """Degrade one side's health to "unknown" rather than failing the response.
+
+    A producer on a different version can emit a status literal or field shape
+    this build cannot parse. Raising here would take the whole merged-lineage
+    response down — hiding every verified node along with the badge — which is
+    strictly worse than reporting that side's health as unknown.
+    """
+    if raw is None:
+        return None
+    try:
+        return ArtifactHealthPayload.model_validate(raw).model_dump()
+    except ValidationError:
+        return dict(_UNREADABLE_SIDE_HEALTH)
 
 
 def build_merged_lineage(lineage_diff: LineageDiff) -> MergedLineage:
@@ -127,8 +160,8 @@ def build_merged_lineage(lineage_diff: LineageDiff) -> MergedLineage:
         },
     }
 
-    base_artifact_health = base.get("artifact_health")
-    current_artifact_health = current.get("artifact_health")
+    base_artifact_health = _readable_side_health(base.get("artifact_health"))
+    current_artifact_health = _readable_side_health(current.get("artifact_health"))
     artifact_health = None
     if base_artifact_health is not None or current_artifact_health is not None:
         artifact_health = {

--- a/recce/models/lineage.py
+++ b/recce/models/lineage.py
@@ -56,6 +56,20 @@ def build_merged_lineage(lineage_diff: LineageDiff) -> MergedLineage:
             merged.change_status = node_diff.change_status
             merged.change = node_diff.change
 
+        if base_node is None or current_node is None:
+            merged.schema_comparison_status = "not_applicable"
+        else:
+            base_catalog_status = base_node.get("catalog_status")
+            current_catalog_status = current_node.get("catalog_status")
+            if base_catalog_status == current_catalog_status == "not_applicable":
+                merged.schema_comparison_status = "not_applicable"
+            elif base_catalog_status == current_catalog_status == "covered":
+                merged.schema_comparison_status = "complete"
+            else:
+                # Missing markers from old producers are deliberately unchecked:
+                # absent evidence must never be upgraded to a complete comparison.
+                merged.schema_comparison_status = "unchecked"
+
         nodes[node_id] = merged
 
     # 2. Compute edges from dual parent_maps
@@ -100,4 +114,13 @@ def build_merged_lineage(lineage_diff: LineageDiff) -> MergedLineage:
         },
     }
 
-    return MergedLineage(nodes=nodes, edges=edges, metadata=metadata)
+    base_artifact_health = base.get("artifact_health")
+    current_artifact_health = current.get("artifact_health")
+    artifact_health = None
+    if base_artifact_health is not None or current_artifact_health is not None:
+        artifact_health = {
+            "base": base_artifact_health,
+            "current": current_artifact_health,
+        }
+
+    return MergedLineage(nodes=nodes, edges=edges, metadata=metadata, artifact_health=artifact_health)

--- a/recce/models/lineage.py
+++ b/recce/models/lineage.py
@@ -2,14 +2,29 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
+from recce.artifact_health import (
+    classify_node_schema_comparison,
+    classify_schema_coverage,
+    schema_coverage_payload,
+)
 from recce.models.types import (
     LineageDiff,
     MergedEdge,
     MergedLineage,
     MergedNode,
 )
+
+_CATALOG_STATUSES = frozenset({"covered", "unchecked", "not_applicable"})
+
+
+def _catalog_status(node: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(node, Mapping):
+        return None
+    status = node.get("catalog_status")
+    return status if status in _CATALOG_STATUSES else None
 
 
 def build_merged_lineage(lineage_diff: LineageDiff) -> MergedLineage:
@@ -21,13 +36,17 @@ def build_merged_lineage(lineage_diff: LineageDiff) -> MergedLineage:
     base = lineage_diff.base
     current = lineage_diff.current
     diff = lineage_diff.diff
+    base_nodes = base.get("nodes")
+    current_nodes = current.get("nodes")
+    base_node_map = base_nodes if isinstance(base_nodes, Mapping) else {}
+    current_node_map = current_nodes if isinstance(current_nodes, Mapping) else {}
 
     # 1. Merge nodes — prefer current metadata, fall back to base for removed
     nodes: dict[str, MergedNode] = {}
-    all_ids = set(base.get("nodes", {})) | set(current.get("nodes", {}))
+    all_ids = set(base_node_map) | set(current_node_map)
     for node_id in sorted(all_ids):
-        base_node = base.get("nodes", {}).get(node_id)
-        current_node = current.get("nodes", {}).get(node_id)
+        base_node = base_node_map.get(node_id)
+        current_node = current_node_map.get(node_id)
 
         source = current_node if current_node is not None else base_node
         merged = MergedNode(**source)  # extra="ignore" handles unknown keys
@@ -56,19 +75,13 @@ def build_merged_lineage(lineage_diff: LineageDiff) -> MergedLineage:
             merged.change_status = node_diff.change_status
             merged.change = node_diff.change
 
-        if base_node is None or current_node is None:
-            merged.schema_comparison_status = "not_applicable"
-        else:
-            base_catalog_status = base_node.get("catalog_status")
-            current_catalog_status = current_node.get("catalog_status")
-            if base_catalog_status == current_catalog_status == "not_applicable":
-                merged.schema_comparison_status = "not_applicable"
-            elif base_catalog_status == current_catalog_status == "covered":
-                merged.schema_comparison_status = "complete"
-            else:
-                # Missing markers from old producers are deliberately unchecked:
-                # absent evidence must never be upgraded to a complete comparison.
-                merged.schema_comparison_status = "unchecked"
+        merged.base_catalog_status = _catalog_status(base_node)
+        merged.current_catalog_status = _catalog_status(current_node)
+        merged.schema_comparison_status = classify_node_schema_comparison(
+            base_node_map,
+            current_node_map,
+            node_id,
+        )
 
         nodes[node_id] = merged
 
@@ -123,4 +136,12 @@ def build_merged_lineage(lineage_diff: LineageDiff) -> MergedLineage:
             "current": current_artifact_health,
         }
 
-    return MergedLineage(nodes=nodes, edges=edges, metadata=metadata, artifact_health=artifact_health)
+    schema_coverage = schema_coverage_payload(classify_schema_coverage(base_nodes, current_nodes, all_ids))
+
+    return MergedLineage(
+        nodes=nodes,
+        edges=edges,
+        metadata=metadata,
+        artifact_health=artifact_health,
+        schema_coverage=schema_coverage,
+    )

--- a/recce/models/types.py
+++ b/recce/models/types.py
@@ -286,6 +286,8 @@ class MergedNode(BaseModel):
     change_status: ChangeStatus | None = None
     change: NodeChange | None = None
     schema_comparison_status: Literal["complete", "unchecked", "not_applicable"] | None = None
+    base_catalog_status: Literal["covered", "unchecked", "not_applicable"] | None = None
+    current_catalog_status: Literal["covered", "unchecked", "not_applicable"] | None = None
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/recce/models/types.py
+++ b/recce/models/types.py
@@ -233,6 +233,37 @@ class LineageDiff(BaseModel):
     diff: dict[str, NodeDiff]
 
 
+class ArtifactHealthPayload(BaseModel):
+    """Bounded public summary of one side's manifest/catalog health."""
+
+    status: Literal["complete", "partial", "empty", "absent", "not_applicable", "unknown"]
+    expected_count: int
+    covered_count: int
+    catalog_entry_count: int
+    missing_node_count: int
+    missing_nodes: list[str]
+    missing_more: bool
+    orphan_node_count: int
+    orphan_nodes: list[str]
+    orphan_more: bool
+
+
+class ArtifactHealthPair(BaseModel):
+    """Artifact-health summaries for the base and current environments."""
+
+    base: ArtifactHealthPayload | None = None
+    current: ArtifactHealthPayload | None = None
+
+
+class SchemaCoveragePayload(BaseModel):
+    """Bounded summary of schema-comparison coverage when it is available."""
+
+    status: Literal["complete", "partial", "unknown"]
+    unchecked_nodes: list[str]
+    unchecked_node_count: int
+    more: bool
+
+
 class MergedNode(BaseModel):
     """A single node in the merged lineage wire-format response.
 
@@ -254,6 +285,7 @@ class MergedNode(BaseModel):
     source_name: str | None = None
     change_status: ChangeStatus | None = None
     change: NodeChange | None = None
+    schema_comparison_status: Literal["complete", "unchecked", "not_applicable"] | None = None
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -275,6 +307,8 @@ class MergedLineage(BaseModel):
     nodes: dict[str, MergedNode]
     edges: list[MergedEdge]
     metadata: dict[str, Any]
+    artifact_health: ArtifactHealthPair | None = None
+    schema_coverage: SchemaCoveragePayload | None = None
 
 
 # Column Level Linage

--- a/recce/run.py
+++ b/recce/run.py
@@ -2,9 +2,8 @@ import logging
 import os
 import sys
 import time
-from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
 from deepdiff import DeepDiff
 from rich import box
@@ -17,97 +16,18 @@ from recce.apis.check_func import (
     purge_preset_checks,
 )
 from recce.apis.run_func import submit_run
-from recce.artifact_health import classify_schema_coverage, schema_coverage_payload
+from recce.artifact_health import classify_schema_coverage
 from recce.config import RecceConfig
 from recce.core import default_context
 from recce.models import CheckDAO
-from recce.models.types import RunType, SchemaCoveragePayload
+from recce.models.types import RunType
 from recce.summary import generate_markdown_summary
-from recce.tasks.dataframe import DataFrame
 from recce.tasks.rowcount import (
     PERMISSION_DENIED_INDICATORS,
     TABLE_NOT_FOUND_INDICATORS,
 )
 
 logger = logging.getLogger(__name__)
-
-_SCHEMA_DIFF_COLUMNS = {
-    "node_id": "text",
-    "column": "text",
-    "change_status": "text",
-}
-
-
-def _canonical_schema_coverage(result: Mapping[str, Any] | None) -> SchemaCoveragePayload | None:
-    if not isinstance(result, Mapping):
-        return None
-    raw_coverage = result.get("schema_coverage")
-    if not isinstance(raw_coverage, Mapping):
-        return None
-    required_fields = {"status", "unchecked_nodes", "unchecked_node_count", "more"}
-    if not required_fields.issubset(raw_coverage):
-        return None
-    unchecked_nodes = raw_coverage.get("unchecked_nodes")
-    unchecked_node_count = raw_coverage.get("unchecked_node_count")
-    more = raw_coverage.get("more")
-    if (
-        not isinstance(unchecked_nodes, list)
-        or any(not isinstance(node_id, str) for node_id in unchecked_nodes)
-        or not isinstance(unchecked_node_count, int)
-        or isinstance(unchecked_node_count, bool)
-        or unchecked_node_count < len(unchecked_nodes)
-        or not isinstance(more, bool)
-    ):
-        return None
-    try:
-        coverage = SchemaCoveragePayload.model_validate(raw_coverage)
-    except (TypeError, ValueError):
-        return None
-
-    has_unchecked_nodes = coverage.unchecked_node_count > 0
-    sample_is_truncated = coverage.unchecked_node_count > len(coverage.unchecked_nodes)
-    invariants_hold = (
-        has_unchecked_nodes and coverage.more == sample_is_truncated
-        if coverage.status == "partial"
-        else not has_unchecked_nodes and not coverage.unchecked_nodes and not coverage.more
-    )
-    return coverage if invariants_hold else None
-
-
-def result_schema_coverage_status(result: Mapping[str, Any] | None) -> str:
-    coverage = _canonical_schema_coverage(result)
-    return coverage.status if coverage is not None else "unknown"
-
-
-def verified_schema_diff_is_empty(result: Mapping[str, Any] | None) -> bool:
-    if not isinstance(result, Mapping):
-        return False
-    limit = result.get("limit")
-    total_row_count = result.get("total_row_count")
-    if (
-        not isinstance(result.get("columns"), list)
-        or not isinstance(result.get("data"), list)
-        or not isinstance(limit, int)
-        or isinstance(limit, bool)
-        or limit <= 0
-        or result.get("more") is not False
-        or not isinstance(total_row_count, int)
-        or isinstance(total_row_count, bool)
-        or total_row_count != 0
-    ):
-        return False
-    try:
-        frame = DataFrame.model_validate(result)
-    except (TypeError, ValueError):
-        return False
-
-    expected_columns = [(name, name, type_name) for name, type_name in _SCHEMA_DIFF_COLUMNS.items()]
-    actual_columns = [(column.key, column.name, column.type.value) for column in frame.columns]
-    return actual_columns == expected_columns and not frame.data and frame.more is False and frame.total_row_count == 0
-
-
-def schema_result_is_approvable(result: Mapping[str, Any] | None) -> bool:
-    return result_schema_coverage_status(result) == "complete" and verified_schema_diff_is_empty(result)
 
 
 def check_github_ci_env(**kwargs):
@@ -183,16 +103,11 @@ def schema_diff_should_be_approved(check_params: dict) -> bool:
             _checked_node_columns(current_lineage_nodes),
             ignore_order=True,
         )
-        diff_frame = DataFrame.from_data(
-            columns=_SCHEMA_DIFF_COLUMNS,
-            data=[] if not diff else [("selection", "schema", "modified")],
-            limit=100,
-            more=False,
-        )
-        diff_frame.total_row_count = len(diff_frame.data)
-        result = diff_frame.model_dump(mode="json")
-        result["schema_coverage"] = schema_coverage_payload(coverage)
-        return schema_result_is_approvable(result)
+        # The same rule the serialised gate applies, stated directly: only a
+        # comparison that actually covered its whole selection can read an
+        # empty diff as "no schema changes". "complete" already excludes the
+        # vacuous case, where nothing in the selection was comparable at all.
+        return coverage.status == "complete" and not diff
     except Exception as e:
         error_msg = str(e).upper()
         if any(ind in error_msg for ind in TABLE_NOT_FOUND_INDICATORS + PERMISSION_DENIED_INDICATORS):

--- a/recce/run.py
+++ b/recce/run.py
@@ -2,8 +2,9 @@ import logging
 import os
 import sys
 import time
+from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from deepdiff import DeepDiff
 from rich import box
@@ -16,6 +17,7 @@ from recce.apis.check_func import (
     purge_preset_checks,
 )
 from recce.apis.run_func import submit_run
+from recce.artifact_health import classify_schema_coverage, schema_coverage_payload
 from recce.config import RecceConfig
 from recce.core import default_context
 from recce.models import CheckDAO
@@ -27,6 +29,24 @@ from recce.tasks.rowcount import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def result_schema_coverage_status(result: Mapping[str, Any] | None) -> str:
+    if not isinstance(result, Mapping):
+        return "unknown"
+    coverage = result.get("schema_coverage")
+    if not isinstance(coverage, Mapping):
+        return "unknown"
+    status = coverage.get("status")
+    return status if status in {"complete", "partial", "unknown"} else "unknown"
+
+
+def verified_schema_diff_is_empty(result: Mapping[str, Any] | None) -> bool:
+    return isinstance(result, Mapping) and isinstance(result.get("data"), list) and not result["data"]
+
+
+def schema_result_is_approvable(result: Mapping[str, Any] | None) -> bool:
+    return result_schema_coverage_status(result) == "complete" and verified_schema_diff_is_empty(result)
 
 
 def check_github_ci_env(**kwargs):
@@ -85,20 +105,23 @@ def schema_diff_should_be_approved(check_params: dict) -> bool:
 
         selected_node_ids = [node for node in selected_node_ids if not node.startswith("test.")]
 
-        def _get_selected_node_columns_from_lineage(lineage, node_ids: list[str]):
-            nodes = {}
-            for node_id, node in lineage.get("nodes", {}).items():
-                if node_id in node_ids:
-                    nodes[node_id] = node.get("columns", {})
-            return nodes
+        base_lineage_nodes = context.get_lineage(base=True).get("nodes", {})
+        current_lineage_nodes = context.get_lineage(base=False).get("nodes", {})
+        coverage = classify_schema_coverage(base_lineage_nodes, current_lineage_nodes, selected_node_ids)
 
-        base_nodes = _get_selected_node_columns_from_lineage(context.get_lineage(base=True), selected_node_ids)
-        curr_nodes = _get_selected_node_columns_from_lineage(context.get_lineage(base=False), selected_node_ids)
-        diff = DeepDiff(base_nodes, curr_nodes, ignore_order=True)
+        def _checked_node_columns(lineage_nodes):
+            return {node_id: lineage_nodes[node_id].get("columns", {}) for node_id in coverage.checked_node_ids}
 
-        # If the diff is empty, then the check should be approved
-        if bool(diff) is False:
-            return True
+        diff = DeepDiff(
+            _checked_node_columns(base_lineage_nodes),
+            _checked_node_columns(current_lineage_nodes),
+            ignore_order=True,
+        )
+        result = {
+            "data": [] if not diff else [True],
+            "schema_coverage": schema_coverage_payload(coverage),
+        }
+        return schema_result_is_approvable(result)
     except Exception as e:
         error_msg = str(e).upper()
         if any(ind in error_msg for ind in TABLE_NOT_FOUND_INDICATORS + PERMISSION_DENIED_INDICATORS):

--- a/recce/run.py
+++ b/recce/run.py
@@ -21,8 +21,9 @@ from recce.artifact_health import classify_schema_coverage, schema_coverage_payl
 from recce.config import RecceConfig
 from recce.core import default_context
 from recce.models import CheckDAO
-from recce.models.types import RunType
+from recce.models.types import RunType, SchemaCoveragePayload
 from recce.summary import generate_markdown_summary
+from recce.tasks.dataframe import DataFrame
 from recce.tasks.rowcount import (
     PERMISSION_DENIED_INDICATORS,
     TABLE_NOT_FOUND_INDICATORS,
@@ -30,19 +31,75 @@ from recce.tasks.rowcount import (
 
 logger = logging.getLogger(__name__)
 
+_SCHEMA_DIFF_COLUMNS = {
+    "node_id": "text",
+    "column": "text",
+    "change_status": "text",
+}
+
+
+def _canonical_schema_coverage(result: Mapping[str, Any] | None) -> SchemaCoveragePayload | None:
+    if not isinstance(result, Mapping):
+        return None
+    raw_coverage = result.get("schema_coverage")
+    if not isinstance(raw_coverage, Mapping):
+        return None
+    required_fields = {"status", "unchecked_nodes", "unchecked_node_count", "more"}
+    if not required_fields.issubset(raw_coverage):
+        return None
+    unchecked_nodes = raw_coverage.get("unchecked_nodes")
+    unchecked_node_count = raw_coverage.get("unchecked_node_count")
+    more = raw_coverage.get("more")
+    if (
+        not isinstance(unchecked_nodes, list)
+        or any(not isinstance(node_id, str) for node_id in unchecked_nodes)
+        or not isinstance(unchecked_node_count, int)
+        or isinstance(unchecked_node_count, bool)
+        or unchecked_node_count < len(unchecked_nodes)
+        or not isinstance(more, bool)
+    ):
+        return None
+    try:
+        coverage = SchemaCoveragePayload.model_validate(raw_coverage)
+    except (TypeError, ValueError):
+        return None
+
+    has_unchecked_nodes = coverage.unchecked_node_count > 0
+    sample_is_truncated = coverage.unchecked_node_count > len(coverage.unchecked_nodes)
+    invariants_hold = (
+        has_unchecked_nodes and coverage.more == sample_is_truncated
+        if coverage.status == "partial"
+        else not has_unchecked_nodes and not coverage.unchecked_nodes and not coverage.more
+    )
+    return coverage if invariants_hold else None
+
 
 def result_schema_coverage_status(result: Mapping[str, Any] | None) -> str:
-    if not isinstance(result, Mapping):
-        return "unknown"
-    coverage = result.get("schema_coverage")
-    if not isinstance(coverage, Mapping):
-        return "unknown"
-    status = coverage.get("status")
-    return status if status in {"complete", "partial", "unknown"} else "unknown"
+    coverage = _canonical_schema_coverage(result)
+    return coverage.status if coverage is not None else "unknown"
 
 
 def verified_schema_diff_is_empty(result: Mapping[str, Any] | None) -> bool:
-    return isinstance(result, Mapping) and isinstance(result.get("data"), list) and not result["data"]
+    if not isinstance(result, Mapping):
+        return False
+    limit = result.get("limit")
+    if (
+        not isinstance(result.get("columns"), list)
+        or not isinstance(result.get("data"), list)
+        or not isinstance(limit, int)
+        or isinstance(limit, bool)
+        or limit <= 0
+        or result.get("more") is not False
+    ):
+        return False
+    try:
+        frame = DataFrame.model_validate(result)
+    except (TypeError, ValueError):
+        return False
+
+    expected_columns = [(name, name, type_name) for name, type_name in _SCHEMA_DIFF_COLUMNS.items()]
+    actual_columns = [(column.key, column.name, column.type.value) for column in frame.columns]
+    return actual_columns == expected_columns and not frame.data and frame.more is False
 
 
 def schema_result_is_approvable(result: Mapping[str, Any] | None) -> bool:
@@ -117,10 +174,14 @@ def schema_diff_should_be_approved(check_params: dict) -> bool:
             _checked_node_columns(current_lineage_nodes),
             ignore_order=True,
         )
-        result = {
-            "data": [] if not diff else [True],
-            "schema_coverage": schema_coverage_payload(coverage),
-        }
+        diff_frame = DataFrame.from_data(
+            columns=_SCHEMA_DIFF_COLUMNS,
+            data=[] if not diff else [("selection", "schema", "modified")],
+            limit=100,
+            more=False,
+        )
+        result = diff_frame.model_dump(mode="json")
+        result["schema_coverage"] = schema_coverage_payload(coverage)
         return schema_result_is_approvable(result)
     except Exception as e:
         error_msg = str(e).upper()

--- a/recce/run.py
+++ b/recce/run.py
@@ -83,6 +83,7 @@ def verified_schema_diff_is_empty(result: Mapping[str, Any] | None) -> bool:
     if not isinstance(result, Mapping):
         return False
     limit = result.get("limit")
+    total_row_count = result.get("total_row_count")
     if (
         not isinstance(result.get("columns"), list)
         or not isinstance(result.get("data"), list)
@@ -90,6 +91,9 @@ def verified_schema_diff_is_empty(result: Mapping[str, Any] | None) -> bool:
         or isinstance(limit, bool)
         or limit <= 0
         or result.get("more") is not False
+        or not isinstance(total_row_count, int)
+        or isinstance(total_row_count, bool)
+        or total_row_count != 0
     ):
         return False
     try:
@@ -99,7 +103,7 @@ def verified_schema_diff_is_empty(result: Mapping[str, Any] | None) -> bool:
 
     expected_columns = [(name, name, type_name) for name, type_name in _SCHEMA_DIFF_COLUMNS.items()]
     actual_columns = [(column.key, column.name, column.type.value) for column in frame.columns]
-    return actual_columns == expected_columns and not frame.data and frame.more is False
+    return actual_columns == expected_columns and not frame.data and frame.more is False and frame.total_row_count == 0
 
 
 def schema_result_is_approvable(result: Mapping[str, Any] | None) -> bool:
@@ -180,6 +184,7 @@ def schema_diff_should_be_approved(check_params: dict) -> bool:
             limit=100,
             more=False,
         )
+        diff_frame.total_row_count = len(diff_frame.data)
         result = diff_frame.model_dump(mode="json")
         result["schema_coverage"] = schema_coverage_payload(coverage)
         return schema_result_is_approvable(result)

--- a/recce/run.py
+++ b/recce/run.py
@@ -171,7 +171,12 @@ def schema_diff_should_be_approved(check_params: dict) -> bool:
         coverage = classify_schema_coverage(base_lineage_nodes, current_lineage_nodes, selected_node_ids)
 
         def _checked_node_columns(lineage_nodes):
-            return {node_id: lineage_nodes[node_id].get("columns", {}) for node_id in coverage.checked_node_ids}
+            # `comparable_node_ids`, not `checked_node_ids`: a one-sided node is
+            # absent from one map, so its columns diff against {} and the check
+            # stays unapproved instead of reading as "no schema differences".
+            return {
+                node_id: lineage_nodes.get(node_id, {}).get("columns", {}) for node_id in coverage.comparable_node_ids
+            }
 
         diff = DeepDiff(
             _checked_node_columns(base_lineage_nodes),

--- a/recce/schema_evidence.py
+++ b/recce/schema_evidence.py
@@ -1,0 +1,153 @@
+"""Evidence predicates for auto-approving a run result.
+
+The classifier half of the contract lives in `recce.artifact_health`: it turns
+two manifest sides into a `SchemaCoverage`. This module is the reader half — it
+takes a serialised run result back off the wire and decides whether it carries
+enough verified evidence to mark a check reviewed.
+
+Kept out of `recce.run` so the CLI summary path and the MCP server share one
+definition without the MCP server importing the CLI module, and kept out of
+`recce.artifact_health` so the classifier stays free of any dependency on the
+rest of the package.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+from recce.models.types import SchemaCoveragePayload
+from recce.tasks.dataframe import DataFrame
+
+#: The exact frame a schema_diff produces. Both the local and cloud backends
+#: emit these three text columns and nothing else, which is what makes a result
+#: identifiable as a schema comparison after serialisation.
+SCHEMA_DIFF_COLUMNS = {
+    "node_id": "text",
+    "column": "text",
+    "change_status": "text",
+}
+
+
+def _canonical_schema_coverage(result: Mapping[str, Any] | None) -> SchemaCoveragePayload | None:
+    if not isinstance(result, Mapping):
+        return None
+    raw_coverage = result.get("schema_coverage")
+    if not isinstance(raw_coverage, Mapping):
+        return None
+    required_fields = {"status", "unchecked_nodes", "unchecked_node_count", "more"}
+    if not required_fields.issubset(raw_coverage):
+        return None
+    unchecked_nodes = raw_coverage.get("unchecked_nodes")
+    unchecked_node_count = raw_coverage.get("unchecked_node_count")
+    more = raw_coverage.get("more")
+    if (
+        not isinstance(unchecked_nodes, list)
+        or any(not isinstance(node_id, str) for node_id in unchecked_nodes)
+        or not isinstance(unchecked_node_count, int)
+        or isinstance(unchecked_node_count, bool)
+        or unchecked_node_count < len(unchecked_nodes)
+        or not isinstance(more, bool)
+    ):
+        return None
+    try:
+        coverage = SchemaCoveragePayload.model_validate(raw_coverage)
+    except (TypeError, ValueError):
+        return None
+
+    has_unchecked_nodes = coverage.unchecked_node_count > 0
+    sample_is_truncated = coverage.unchecked_node_count > len(coverage.unchecked_nodes)
+    invariants_hold = (
+        has_unchecked_nodes and coverage.more == sample_is_truncated
+        if coverage.status == "partial"
+        else not has_unchecked_nodes and not coverage.unchecked_nodes and not coverage.more
+    )
+    return coverage if invariants_hold else None
+
+
+def result_schema_coverage_status(result: Mapping[str, Any] | None) -> str:
+    coverage = _canonical_schema_coverage(result)
+    return coverage.status if coverage is not None else "unknown"
+
+
+def result_is_schema_comparison(result: Mapping[str, Any] | None) -> bool:
+    """Whether this result is a schema comparison, and so bound by the coverage
+    contract.
+
+    Only a schema comparison can silently compare nothing and still hand back
+    an empty result, so only a schema comparison has to prove coverage before
+    an empty result reads as "nothing changed". Row-count, value, profile and
+    lineage results carry their evidence in their own shape, so the gate has to
+    tell them apart.
+
+    Two markers, either one sufficient:
+
+    * a `schema_coverage` block — whatever else is wrong with the payload, a
+      result making a coverage claim is answerable for it; and
+    * the exact three-column frame a schema_diff emits, matched on column keys,
+      names and types together, so a frame that merely happens to carry three
+      text columns is not mistaken for one of ours.
+
+    The first marker is what keeps a truncated or malformed schema result
+    failing closed instead of slipping out of the gate as "some other type".
+    """
+    if not isinstance(result, Mapping):
+        return False
+    if "schema_coverage" in result:
+        return True
+    columns = result.get("columns")
+    if not isinstance(columns, list) or len(columns) != len(SCHEMA_DIFF_COLUMNS):
+        return False
+    actual: list[tuple[Any, Any, Any]] = []
+    for column in columns:
+        if not isinstance(column, Mapping):
+            return False
+        actual.append((column.get("key"), column.get("name"), column.get("type")))
+    expected = [(name, name, type_name) for name, type_name in SCHEMA_DIFF_COLUMNS.items()]
+    return actual == expected
+
+
+def verified_schema_diff_is_empty(result: Mapping[str, Any] | None) -> bool:
+    if not isinstance(result, Mapping):
+        return False
+    limit = result.get("limit")
+    total_row_count = result.get("total_row_count")
+    if (
+        not isinstance(result.get("columns"), list)
+        or not isinstance(result.get("data"), list)
+        or not isinstance(limit, int)
+        or isinstance(limit, bool)
+        or limit <= 0
+        or result.get("more") is not False
+        or not isinstance(total_row_count, int)
+        or isinstance(total_row_count, bool)
+        or total_row_count != 0
+    ):
+        return False
+    try:
+        frame = DataFrame.model_validate(result)
+    except (TypeError, ValueError):
+        return False
+
+    expected_columns = [(name, name, type_name) for name, type_name in SCHEMA_DIFF_COLUMNS.items()]
+    actual_columns = [(column.key, column.name, column.type.value) for column in frame.columns]
+    return actual_columns == expected_columns and not frame.data and frame.more is False and frame.total_row_count == 0
+
+
+def schema_result_is_approvable(result: Mapping[str, Any] | None) -> bool:
+    return result_schema_coverage_status(result) == "complete" and verified_schema_diff_is_empty(result)
+
+
+def run_result_is_approvable(result: Mapping[str, Any] | None) -> bool:
+    """The evidence half of the auto-approve gate, applied by result type.
+
+    A schema comparison must carry complete coverage and an empty diff: an
+    empty frame means "no column changes" only when the comparison actually
+    looked at something. Every other result type keeps the pre-existing rule
+    that a successful run is itself the evidence (PM decision: Passed =
+    Approved), so row-count, value, profile and lineage checks are unaffected.
+
+    Callers still apply their own gates around this — the run must have
+    succeeded, and where it applies the caller must have asked to approve.
+    """
+    if result_is_schema_comparison(result):
+        return schema_result_is_approvable(result)
+    return True

--- a/recce/summary.py
+++ b/recce/summary.py
@@ -8,8 +8,10 @@ if TYPE_CHECKING:
 from pydantic import BaseModel
 
 from recce.apis.check_func import get_node_name_by_id
+from recce.artifact_health import schema_coverage_payload
 from recce.core import RecceContext
 from recce.models import CheckDAO, Run, RunDAO, RunType
+from recce.models.types import SchemaCoveragePayload
 from recce.tasks.core import TaskResultDiffer
 from recce.tasks.histogram import HistogramDiffTaskResultDiffer
 from recce.tasks.profile import ProfileDiffResultDiffer
@@ -241,6 +243,7 @@ class CheckSummary(BaseModel):
     changes: dict
     node_ids: Optional[List[str]]
     changed_nodes: Optional[List[str]]
+    schema_coverage: SchemaCoveragePayload | None = None
 
     @property
     def related_nodes(self):
@@ -464,6 +467,8 @@ def generate_check_summary(base_lineage, curr_lineage) -> (List[CheckSummary], D
     checks = CheckDAO().list()
     checks_summary: List[CheckSummary] = []
     failed_checks_count = 0
+    incomplete_checks_count = 0
+    mismatch_checks_count = 0
 
     # TODO: find a way to count failed checks, currently the state file won't include failed checks
 
@@ -497,23 +502,37 @@ def generate_check_summary(base_lineage, curr_lineage) -> (List[CheckSummary], D
             # Check the result is changed or not
             differ = differ_factory(run)
 
-        if differ and differ.changes is not None:
+        coverage = None
+        is_incomplete = False
+        if isinstance(differ, SchemaDiffResultDiffer):
+            coverage = SchemaCoveragePayload(**schema_coverage_payload(differ.schema_coverage))
+            is_incomplete = coverage.status != "complete"
+            if is_incomplete:
+                incomplete_checks_count += 1
+
+        has_mismatch = differ is not None and differ.changes is not None
+        if has_mismatch:
+            mismatch_checks_count += 1
+
+        if differ and (has_mismatch or is_incomplete):
             checks_summary.append(
                 CheckSummary(
                     id=check.check_id,
                     type=check.type,
                     name=check.name,
                     description=check.description,
-                    changes=differ.changes,
+                    changes=differ.changes or {},
                     node_ids=differ.related_node_ids,
                     changed_nodes=differ.changed_nodes,
+                    schema_coverage=coverage,
                 )
             )
 
     return checks_summary, {
         "total": len(checks),
-        "mismatch": len(checks_summary),
+        "mismatch": mismatch_checks_count,
         "failed": failed_checks_count,
+        "incomplete": incomplete_checks_count,
     }
 
 
@@ -606,10 +625,16 @@ def generate_check_content(graph, check_statistics):
 
     content = ""
     check_content = None
+    mismatched_checks = [check for check in graph.checks if check.changes]
+    incomplete_checks = [
+        check
+        for check in graph.checks
+        if check.schema_coverage is not None and check.schema_coverage.status != "complete"
+    ]
     # Generate the check summary if we found any changes
-    if len(graph.checks) > 0:
+    if mismatched_checks:
         data = []
-        for check in graph.checks:
+        for check in mismatched_checks:
             data.append(
                 {
                     "Name": check.name,
@@ -635,6 +660,7 @@ def generate_check_content(graph, check_statistics):
         statistics = {
             "Checks Run": check_statistics.get("total", 0),
             "Data Mismatch Detected": check_statistics.get("mismatch", 0),
+            "Incomplete Schema Comparisons": check_statistics.get("incomplete", 0),
         }
         if check_statistics.get("failed", 0) > 0:
             statistics["Incomplete Checks"] = check_statistics.get("failed", 0)
@@ -653,4 +679,20 @@ Please check the output of `recce run` for more information
 ### Checks of Data Mismatch Detected
 {check_content}
 """
+    for check in incomplete_checks:
+        coverage = check.schema_coverage
+        if coverage.status == "unknown":
+            scope = "The unchecked scope could not be determined."
+        else:
+            noun = "node" if coverage.unchecked_node_count == 1 else "nodes"
+            sample = ", ".join(f"`{node_id}`" for node_id in coverage.unchecked_nodes)
+            scope = f"{coverage.unchecked_node_count} unchecked {noun}"
+            if sample:
+                scope += f" (sample: {sample}{', more not shown' if coverage.more else ''})"
+            scope += "."
+        content += (
+            f"\n:warning: **Schema comparison incomplete for {check.name}.** "
+            f"{scope} Regenerate the affected base/current catalog with `dbt docs generate` "
+            "after its build completes.\n"
+        )
     return content

--- a/recce/tasks/schema.py
+++ b/recce/tasks/schema.py
@@ -39,7 +39,9 @@ class SchemaDiffResultDiffer:
         if self.schema_coverage.status == "unknown":
             return None
 
-        for node_id in self.schema_coverage.checked_node_ids:
+        # Includes one-sided nodes so an added or removed model still reaches
+        # the PR summary as a change rather than vanishing from it.
+        for node_id in self.schema_coverage.comparable_node_ids:
             node = curr_nodes.get(node_id) or base_nodes.get(node_id)
             if not node:
                 continue

--- a/recce/tasks/schema.py
+++ b/recce/tasks/schema.py
@@ -1,13 +1,16 @@
+from collections.abc import Mapping
 from typing import List, Literal, Optional, Union
 
 from pydantic import BaseModel
 
+from recce.artifact_health import SchemaCoverage, classify_schema_coverage
 from recce.models import Check
 from recce.tasks.core import CheckValidator, TaskResultDiffer
 
 
 class SchemaDiffResultDiffer:
     related_node_ids: List[str] = None
+    schema_coverage: SchemaCoverage
 
     def __init__(self, check, base_lineage, curr_lineage):
         self.check = check
@@ -30,9 +33,13 @@ class SchemaDiffResultDiffer:
     def _check_result_changed_fn(self, base_lineage, curr_lineage):
         base = {}
         current = {}
-        base_nodes = base_lineage.get("nodes", {})
-        curr_nodes = curr_lineage.get("nodes", {})
-        for node_id in self.related_node_ids:
+        base_nodes = base_lineage.get("nodes") if isinstance(base_lineage, Mapping) else None
+        curr_nodes = curr_lineage.get("nodes") if isinstance(curr_lineage, Mapping) else None
+        self.schema_coverage = classify_schema_coverage(base_nodes, curr_nodes, self.related_node_ids or [])
+        if self.schema_coverage.status == "unknown":
+            return None
+
+        for node_id in self.schema_coverage.checked_node_ids:
             node = curr_nodes.get(node_id) or base_nodes.get(node_id)
             if not node:
                 continue

--- a/recce/util/info_emitter.py
+++ b/recce/util/info_emitter.py
@@ -55,7 +55,7 @@ def _build_info_payload(adapter: BaseAdapter, lineage_diff: LineageDiff) -> dict
     merged_lineage = build_merged_lineage(lineage_diff)
     return {
         "adapter_type": _resolve_adapter_type(adapter),
-        "lineage": merged_lineage.model_dump(exclude_none=True, by_alias=True),
+        "lineage": merged_lineage.model_dump(mode="json", exclude_none=True, by_alias=True),
     }
 
 

--- a/tests/adapter/dbt_adapter/test_dbt_adapter.py
+++ b/tests/adapter/dbt_adapter/test_dbt_adapter.py
@@ -1,6 +1,8 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from recce.adapter.dbt_adapter import DbtAdapter, dbt_supported_registry
 
 
@@ -67,3 +69,23 @@ def test_get_lineage_catalog_status_marks_missing_current_model_unchecked(dbt_te
     assert lineage["nodes"][node_id]["catalog_status"] == "unchecked"
     assert lineage["artifact_health"]["missing_node_count"] >= 1
     assert "covered_node_ids" not in lineage["artifact_health"]
+
+
+@pytest.mark.parametrize("materialized", ["ephemeral", "semantic_view"])
+def test_get_lineage_catalog_status_marks_excluded_materializations_not_applicable(dbt_test_helper, materialized):
+    node_id = f"model.recce_test.{materialized}_model"
+
+    def exclude_from_catalog_coverage(node):
+        node["config"]["materialized"] = materialized
+
+    dbt_test_helper.create_model(
+        f"{materialized}_model",
+        base_sql="select 1 as id",
+        curr_sql="select 1 as id",
+        unique_id=node_id,
+        patch_func=exclude_from_catalog_coverage,
+    )
+
+    lineage = dbt_test_helper.adapter.get_lineage()
+
+    assert lineage["nodes"][node_id]["catalog_status"] == "not_applicable"

--- a/tests/adapter/dbt_adapter/test_dbt_adapter.py
+++ b/tests/adapter/dbt_adapter/test_dbt_adapter.py
@@ -49,3 +49,21 @@ def test_recce_context_propagates_duckdb_external_access():
         )
 
     assert ctx.adapter.duckdb_external_access is True
+
+
+def test_get_lineage_catalog_status_marks_missing_current_model_unchecked(dbt_test_helper):
+    """Catalog membership, not timestamps, controls current-side coverage."""
+    node_id = "model.recce_test.not_cataloged"
+    dbt_test_helper.create_model(
+        "not_cataloged",
+        base_sql="select 1 as id",
+        curr_sql="select 1 as id",
+        unique_id=node_id,
+        base_columns={"id": "integer"},
+    )
+
+    lineage = dbt_test_helper.adapter.get_lineage()
+
+    assert lineage["nodes"][node_id]["catalog_status"] == "unchecked"
+    assert lineage["artifact_health"]["missing_node_count"] >= 1
+    assert "covered_node_ids" not in lineage["artifact_health"]

--- a/tests/adapter/dbt_adapter/test_dbt_adapter.py
+++ b/tests/adapter/dbt_adapter/test_dbt_adapter.py
@@ -67,8 +67,38 @@ def test_get_lineage_catalog_status_marks_missing_current_model_unchecked(dbt_te
     lineage = dbt_test_helper.adapter.get_lineage()
 
     assert lineage["nodes"][node_id]["catalog_status"] == "unchecked"
-    assert lineage["artifact_health"]["missing_node_count"] >= 1
     assert "covered_node_ids" not in lineage["artifact_health"]
+
+    # Assert the STATUS, not just a count: passing catalog=None to the
+    # classifier also produces a non-zero missing count, but it yields "empty"
+    # here only when a real catalog was consulted and covered nothing. That
+    # distinction drives which catalog the UI tells the user to regenerate.
+    health = lineage["artifact_health"]
+    assert health["status"] == "empty"
+    assert health["covered_count"] == 0
+    assert node_id in health["missing_nodes"]
+
+
+def test_get_lineage_artifact_health_is_complete_when_every_model_is_catalogued(dbt_test_helper):
+    """The still-healthy half: a covered project reports no coverage gap."""
+    node_id = "model.recce_test.cataloged"
+    dbt_test_helper.create_model(
+        "cataloged",
+        base_sql="select 1 as id",
+        curr_sql="select 1 as id",
+        unique_id=node_id,
+        base_columns={"id": "integer"},
+        curr_columns={"id": "integer"},
+    )
+
+    lineage = dbt_test_helper.adapter.get_lineage()
+
+    health = lineage["artifact_health"]
+    assert lineage["nodes"][node_id]["catalog_status"] == "covered"
+    assert health["status"] == "complete"
+    assert health["missing_node_count"] == 0
+    assert health["missing_nodes"] == []
+    assert health["covered_count"] == health["expected_count"]
 
 
 @pytest.mark.parametrize("materialized", ["ephemeral", "semantic_view"])

--- a/tests/adapter/test_sqlmesh_adapter.py
+++ b/tests/adapter/test_sqlmesh_adapter.py
@@ -1,0 +1,101 @@
+"""SQLMesh lineage must declare its own schema coverage (DRC-3303 / AC7).
+
+SQLMesh has no `catalog.json`: a snapshot's `columns_to_types` *is* the
+authoritative schema. The canonical classifier treats a node with no
+`catalog_status` as legacy evidence and fails closed, so an adapter that stays
+silent leaves every SQLMesh comparison permanently "unchecked" — schema diffs
+suppressed, and remediation copy telling a SQLMesh user to run
+`dbt docs generate`.
+
+`sqlmesh` is an integration-only dependency (see
+.github/workflows/integration-tests-sqlmesh.yaml), so the module graph is
+stubbed here to keep this regression pinned in the normal unit-test run.
+"""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+from recce.artifact_health import classify_schema_coverage
+
+
+def _install_sqlmesh_stubs(monkeypatch):
+    for name in (
+        "sqlmesh",
+        "sqlmesh.core",
+        "sqlmesh.core.context",
+        "sqlmesh.core.environment",
+        "sqlmesh.core.state_sync",
+    ):
+        monkeypatch.setitem(sys.modules, name, ModuleType(name))
+    sys.modules["sqlmesh.core.context"].Context = type("Context", (), {})
+    sys.modules["sqlmesh.core.environment"].Environment = type("Environment", (), {})
+    sys.modules["sqlmesh.core.state_sync"].StateReader = type("StateReader", (), {})
+
+    # The adapter imports `sqlglot.Expression`, which only the sqlglot pin that
+    # sqlmesh brings re-exports at the top level. Alias the real class rather
+    # than stubbing sqlglot wholesale.
+    import sqlglot
+    import sqlglot.expressions
+
+    monkeypatch.setattr(sqlglot, "Expression", sqlglot.expressions.Expression, raising=False)
+
+
+def _snapshot(name, columns):
+    snapshot = MagicMock()
+    snapshot.node_type = "MODEL"
+    snapshot.name = name
+    snapshot.fingerprint.data_hash = "hash"
+    snapshot.parents = []
+    snapshot.model.name = name
+    snapshot.model.columns_to_types = {column: "INT" for column in columns}
+    return snapshot
+
+
+@pytest.fixture
+def sqlmesh_adapter(monkeypatch):
+    _install_sqlmesh_stubs(monkeypatch)
+    monkeypatch.delitem(sys.modules, "recce.adapter.sqlmesh_adapter", raising=False)
+    from recce.adapter.sqlmesh_adapter import SqlmeshAdapter
+
+    return SqlmeshAdapter
+
+
+def _lineage(adapter_cls, snapshots):
+    # Called unbound: SqlmeshAdapter still leaves BaseAdapter.select_nodes
+    # abstract, so the class cannot be instantiated. get_lineage only reads
+    # `context`, `base_env` and `curr_env`, so a stand-in exercises the real
+    # method body.
+    adapter = MagicMock()
+    adapter.context.state_reader.get_snapshots.return_value = {s.name: s for s in snapshots}
+    return adapter_cls.get_lineage(adapter, base=False)
+
+
+def test_sqlmesh_models_are_comparable_without_a_dbt_catalog(sqlmesh_adapter):
+    """A SQLMesh model whose columns are known is covered evidence."""
+    lineage = _lineage(sqlmesh_adapter, [_snapshot("db.orders", ["id", "amount"])])
+
+    assert lineage["nodes"]["db.orders"]["catalog_status"] == "covered"
+
+
+def test_sqlmesh_schema_comparison_is_complete_not_partial(sqlmesh_adapter):
+    """AC9: a healthy SQLMesh project must not report a coverage gap, and its
+    real column removals must survive to the consumer."""
+    base = _lineage(sqlmesh_adapter, [_snapshot("db.orders", ["id", "gone"])])
+    current = _lineage(sqlmesh_adapter, [_snapshot("db.orders", ["id"])])
+
+    coverage = classify_schema_coverage(base["nodes"], current["nodes"], ["db.orders"])
+
+    assert coverage.status == "complete"
+    assert coverage.unchecked_node_ids == frozenset()
+    assert coverage.checked_node_ids == frozenset({"db.orders"})
+
+
+def test_sqlmesh_model_with_unknown_columns_fails_closed(sqlmesh_adapter):
+    """Honesty in the other direction: if SQLMesh resolved no columns, the
+    adapter must not claim coverage it does not have."""
+    lineage = _lineage(sqlmesh_adapter, [_snapshot("db.opaque", [])])
+
+    assert lineage["nodes"]["db.opaque"]["catalog_status"] == "unchecked"

--- a/tests/adapter/test_sqlmesh_adapter.py
+++ b/tests/adapter/test_sqlmesh_adapter.py
@@ -1,4 +1,4 @@
-"""SQLMesh lineage must declare its own schema coverage (DRC-3303 / AC7).
+"""SQLMesh lineage must declare its own schema coverage.
 
 SQLMesh has no `catalog.json`: a snapshot's `columns_to_types` *is* the
 authoritative schema. The canonical classifier treats a node with no

--- a/tests/dbt_flags.py
+++ b/tests/dbt_flags.py
@@ -1,0 +1,20 @@
+from collections.abc import Callable
+
+from dbt.flags import get_flags
+
+
+def temporarily_set_state_modified_compare_flag() -> Callable[[], None]:
+    """Set dbt's optional comparison flag and return its restoration callback."""
+    flags = get_flags()
+    flag_name = "state_modified_compare_more_unrendered_values"
+    had_flag = hasattr(flags, flag_name)
+    previous_flag = getattr(flags, flag_name, None)
+    object.__setattr__(flags, flag_name, False)
+
+    def restore() -> None:
+        if had_flag:
+            object.__setattr__(flags, flag_name, previous_flag)
+        else:
+            object.__delattr__(flags, flag_name)
+
+    return restore

--- a/tests/tasks/test_schema.py
+++ b/tests/tasks/test_schema.py
@@ -3,10 +3,13 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 import pytest
+from dbt.flags import get_flags
 
 from recce.adapter.dbt_adapter import DbtAdapter, load_catalog, load_manifest
 from recce.core import RecceContext, set_default_context
+from recce.models import Check
 from recce.run import schema_diff_should_be_approved
+from recce.tasks.schema import SchemaDiffResultDiffer
 
 
 def test_validator():
@@ -82,6 +85,18 @@ class TestSchemaDiffAutoApprove(TestCase):
 
     def setUp(self):
         self.default_context = MagicMock(spec=RecceContext)
+        flags = get_flags()
+        had_flag = hasattr(flags, "state_modified_compare_more_unrendered_values")
+        previous_flag = getattr(flags, "state_modified_compare_more_unrendered_values", None)
+        flags.state_modified_compare_more_unrendered_values = False
+
+        def restore_flag():
+            if had_flag:
+                flags.state_modified_compare_more_unrendered_values = previous_flag
+            else:
+                del flags.state_modified_compare_more_unrendered_values
+
+        self.addCleanup(restore_flag)
         manifest = load_manifest(path=os.path.join(test_root_path, "manifest.json"))
         catalog = load_catalog(path=os.path.join(test_root_path, "catalog.json"))
         dbt_adapter = DbtAdapter(curr_manifest=manifest, curr_catalog=catalog)
@@ -120,3 +135,56 @@ class TestSchemaDiffAutoApprove(TestCase):
             }
         )
         assert is_approved is True
+
+
+def test_schema_diff_result_differ_keeps_verified_changes_and_filters_unchecked_nodes():
+    checked_id = "model.project.verified"
+    unchecked_id = "model.project.not_rebuilt"
+    check = Check(
+        name="schema",
+        type="schema_diff",
+        params={"node_id": [checked_id, unchecked_id]},
+    )
+    base_lineage = {
+        "nodes": {
+            checked_id: {
+                "name": "verified",
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "catalog_status": "covered",
+                "columns": {"id": {"type": "integer"}, "removed": {"type": "text"}},
+            },
+            unchecked_id: {
+                "name": "not_rebuilt",
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "catalog_status": "covered",
+                "columns": {"id": {"type": "integer"}, "not_removed": {"type": "text"}},
+            },
+        }
+    }
+    current_lineage = {
+        "nodes": {
+            checked_id: {
+                "name": "verified",
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "catalog_status": "covered",
+                "columns": {"id": {"type": "integer"}},
+            },
+            unchecked_id: {
+                "name": "not_rebuilt",
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "catalog_status": "unchecked",
+            },
+        }
+    }
+
+    differ = SchemaDiffResultDiffer(check, base_lineage, current_lineage)
+
+    assert differ.schema_coverage.status == "partial"
+    assert differ.schema_coverage.checked_node_ids == frozenset({checked_id})
+    assert differ.schema_coverage.unchecked_node_ids == frozenset({unchecked_id})
+    assert differ.changes is not None
+    assert differ.changed_nodes == ["verified"]

--- a/tests/tasks/test_schema.py
+++ b/tests/tasks/test_schema.py
@@ -3,13 +3,13 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 import pytest
-from dbt.flags import get_flags
 
 from recce.adapter.dbt_adapter import DbtAdapter, load_catalog, load_manifest
 from recce.core import RecceContext, set_default_context
 from recce.models import Check
 from recce.run import schema_diff_should_be_approved
 from recce.tasks.schema import SchemaDiffResultDiffer
+from tests.dbt_flags import temporarily_set_state_modified_compare_flag
 
 
 def test_validator():
@@ -85,18 +85,7 @@ class TestSchemaDiffAutoApprove(TestCase):
 
     def setUp(self):
         self.default_context = MagicMock(spec=RecceContext)
-        flags = get_flags()
-        had_flag = hasattr(flags, "state_modified_compare_more_unrendered_values")
-        previous_flag = getattr(flags, "state_modified_compare_more_unrendered_values", None)
-        flags.state_modified_compare_more_unrendered_values = False
-
-        def restore_flag():
-            if had_flag:
-                flags.state_modified_compare_more_unrendered_values = previous_flag
-            else:
-                del flags.state_modified_compare_more_unrendered_values
-
-        self.addCleanup(restore_flag)
+        self.addCleanup(temporarily_set_state_modified_compare_flag())
         manifest = load_manifest(path=os.path.join(test_root_path, "manifest.json"))
         catalog = load_catalog(path=os.path.join(test_root_path, "catalog.json"))
         dbt_adapter = DbtAdapter(curr_manifest=manifest, curr_catalog=catalog)

--- a/tests/tasks/test_schema.py
+++ b/tests/tasks/test_schema.py
@@ -177,3 +177,45 @@ def test_schema_diff_result_differ_keeps_verified_changes_and_filters_unchecked_
     assert differ.schema_coverage.unchecked_node_ids == frozenset({unchecked_id})
     assert differ.changes is not None
     assert differ.changed_nodes == ["verified"]
+
+
+def test_schema_diff_result_differ_keeps_a_one_sided_model_removal_visible():
+    """AC5: a model present on only one manifest side stays in the PR summary.
+
+    It has no two-sided column comparison, so it lands in neither the checked
+    nor the unchecked bucket. Reporting only checked nodes would drop a dropped
+    model out of the summary entirely — the reviewer would never see it.
+    """
+    dropped_id = "model.project.dropped"
+    kept_id = "model.project.kept"
+    check = Check(
+        name="schema",
+        type="schema_diff",
+        params={"node_id": [dropped_id, kept_id]},
+    )
+
+    def node(name, columns):
+        return {
+            "name": name,
+            "resource_type": "model",
+            "config": {"materialized": "table"},
+            "catalog_status": "covered",
+            "columns": {column: {"type": "text"} for column in columns},
+        }
+
+    base_lineage = {
+        "nodes": {
+            dropped_id: node("dropped", ["id", "gone"]),
+            kept_id: node("kept", ["id"]),
+        }
+    }
+    current_lineage = {"nodes": {kept_id: node("kept", ["id"])}}
+
+    differ = SchemaDiffResultDiffer(check, base_lineage, current_lineage)
+
+    assert differ.changes is not None
+    assert differ.changed_nodes == ["dropped"]
+    # The removal is verified, not unchecked: it must not be reported as a
+    # coverage gap that needs a regenerated catalog.
+    assert differ.schema_coverage.status == "complete"
+    assert differ.schema_coverage.unchecked_node_ids == frozenset()

--- a/tests/test_artifact_health.py
+++ b/tests/test_artifact_health.py
@@ -79,6 +79,49 @@ def test_classify_artifact_health(
     assert len(health.orphan_node_ids) == orphans
 
 
+def test_zero_model_coverage_is_empty_even_when_the_catalog_is_full() -> None:
+    """AC1: "Do not use raw catalog totals."
+
+    A catalog can be large and still describe none of the project's relations
+    — entries from a different project, or `store_failures` test relations.
+    Coverage is set intersection, so this is empty, not partial.
+    """
+    catalog = _catalog(models=("model.other_project.a", "test.pkg.store_failure"))
+
+    health = classify_artifact_health(_manifest(models=2), catalog)
+
+    assert health.status == "empty"
+    assert health.catalog_node_ids  # the catalog is not empty
+    assert health.covered_node_ids == frozenset()
+    assert len(health.orphan_node_ids) == 2
+
+
+def test_no_comparable_relations_is_not_applicable_even_with_a_catalog() -> None:
+    """AC4: "A project with no comparable relations is not applicable, not
+    empty." Pinned on the catalog-present path, not just the early return for a
+    missing catalog — an all-ephemeral project that uploads a catalog must not
+    be reported as a coverage failure."""
+    health = classify_artifact_health(_manifest(ephemeral=2), _catalog(models=("model.pkg.other",)))
+
+    assert health.status == "not_applicable"
+    assert health.expected_node_ids == frozenset()
+
+
+def test_missing_node_sample_is_bounded_and_flags_truncation() -> None:
+    """AC3: bounded samples. The DRC-3293 shape makes `missing_node_ids` the
+    project's entire model set, and this payload ships inside every lineage
+    response."""
+    health = classify_artifact_health(_manifest(models=60), _catalog(models=()))
+
+    payload = artifact_health_payload(health)
+
+    assert health.status == "empty"
+    assert payload["missing_node_count"] == 60
+    assert len(payload["missing_nodes"]) == 50
+    assert payload["missing_more"] is True
+    assert payload["missing_nodes"] == sorted(payload["missing_nodes"])
+
+
 def test_sources_only_catalog_does_not_cover_expected_nodes() -> None:
     health = classify_artifact_health(_manifest(models=1), _catalog(sources=("source.pkg.raw",)))
 

--- a/tests/test_artifact_health.py
+++ b/tests/test_artifact_health.py
@@ -245,6 +245,25 @@ def test_schema_coverage_excludes_one_sided_structural_nodes() -> None:
 
 
 @pytest.mark.parametrize(
+    ("base_nodes", "current_nodes"),
+    [
+        ({"model.pkg.broken": []}, {}),
+        ({}, {"model.pkg.broken": []}),
+    ],
+    ids=["malformed-base", "malformed-current"],
+)
+def test_schema_coverage_rejects_malformed_one_sided_nodes(
+    base_nodes: dict[str, Any],
+    current_nodes: dict[str, Any],
+) -> None:
+    coverage = classify_schema_coverage(base_nodes, current_nodes, ["model.pkg.broken"])
+
+    assert coverage.status == "unknown"
+    assert coverage.checked_node_ids == frozenset()
+    assert coverage.unchecked_node_ids == frozenset()
+
+
+@pytest.mark.parametrize(
     ("node_id", "node"),
     [
         ("model.pkg.inlined", _lineage_node(materialized="ephemeral", catalog_status="not_applicable", columns=())),
@@ -288,6 +307,34 @@ def test_schema_coverage_treats_legacy_nodes_without_catalog_status_as_unchecked
     assert coverage.unchecked_node_ids == frozenset({node_id})
 
 
+@pytest.mark.parametrize(
+    ("node_id", "resource_type"),
+    [
+        ("model.pkg.orders", "model"),
+        ("source.pkg.raw_orders", "source"),
+    ],
+    ids=["table-model", "source"],
+)
+def test_schema_coverage_does_not_let_not_applicable_marker_hide_a_relation(
+    node_id: str,
+    resource_type: str,
+) -> None:
+    malformed_node = _lineage_node(
+        resource_type=resource_type,
+        catalog_status="not_applicable",
+    )
+
+    coverage = classify_schema_coverage(
+        {node_id: malformed_node},
+        {node_id: malformed_node},
+        [node_id],
+    )
+
+    assert coverage.status == "partial"
+    assert coverage.checked_node_ids == frozenset()
+    assert coverage.unchecked_node_ids == frozenset({node_id})
+
+
 def test_schema_coverage_payload_sorts_and_bounds_unchecked_nodes() -> None:
     node_ids = [f"model.pkg.m{index:02d}" for index in range(55)]
     base_nodes = {node_id: _lineage_node() for node_id in node_ids}
@@ -301,6 +348,24 @@ def test_schema_coverage_payload_sorts_and_bounds_unchecked_nodes() -> None:
     assert payload == {
         "status": "partial",
         "unchecked_nodes": sorted(node_ids)[:50],
+        "unchecked_node_count": 55,
+        "more": True,
+    }
+
+
+def test_schema_coverage_payload_clamps_negative_sample_limit_to_zero() -> None:
+    node_ids = [f"model.pkg.m{index:02d}" for index in range(55)]
+    base_nodes = {node_id: _lineage_node() for node_id in node_ids}
+    current_nodes = {node_id: _lineage_node(catalog_status="unchecked", columns=()) for node_id in node_ids}
+
+    payload = schema_coverage_payload(
+        classify_schema_coverage(base_nodes, current_nodes, node_ids),
+        sample_limit=-1,
+    )
+
+    assert payload == {
+        "status": "partial",
+        "unchecked_nodes": [],
         "unchecked_node_count": 55,
         "more": True,
     }

--- a/tests/test_artifact_health.py
+++ b/tests/test_artifact_health.py
@@ -188,6 +188,90 @@ def test_payload_caps_samples_at_fifty_even_when_limit_is_larger() -> None:
     assert payload["orphan_more"] is True
 
 
+@pytest.mark.parametrize("sample_limit", [50, 2])
+def test_sample_at_the_cap_is_complete_and_not_flagged_as_truncated(sample_limit: int) -> None:
+    """Boundary: exactly at the limit every id is listed and nothing is hidden.
+
+    Every other bounded-sample case is strictly over the cap, so `>` vs `>=`
+    is invisible. At the boundary the wrong operator claims further unchecked
+    nodes that do not exist, and downstream that breaks the
+    `more == (count > len(sample))` invariant recce/run.py enforces, silently
+    degrading coverage from "partial" to "unknown".
+    """
+    health = classify_artifact_health(_manifest(models=sample_limit), _catalog(models=()))
+
+    payload = artifact_health_payload(health, sample_limit=sample_limit)
+
+    assert payload["missing_node_count"] == sample_limit
+    assert len(payload["missing_nodes"]) == sample_limit
+    assert payload["missing_more"] is False
+
+
+def test_orphan_sample_at_the_cap_is_not_flagged_as_truncated() -> None:
+    orphans = tuple(f"model.other.o{index}" for index in range(2))
+    health = classify_artifact_health(_manifest(models=1), _catalog(models=("model.pkg.m0", *orphans)))
+
+    payload = artifact_health_payload(health, sample_limit=2)
+
+    assert payload["orphan_node_count"] == 2
+    assert len(payload["orphan_nodes"]) == 2
+    assert payload["orphan_more"] is False
+
+
+def test_schema_coverage_sample_at_the_cap_is_not_flagged_as_truncated() -> None:
+    base = {f"model.pkg.m{index}": {"resource_type": "model", "catalog_status": "covered"} for index in range(2)}
+    current = {f"model.pkg.m{index}": {"resource_type": "model", "catalog_status": "unchecked"} for index in range(2)}
+
+    payload = schema_coverage_payload(classify_schema_coverage(base, current, base), sample_limit=2)
+
+    assert payload == {
+        "status": "partial",
+        "unchecked_nodes": sorted(base),
+        "unchecked_node_count": 2,
+        "more": False,
+    }
+
+
+@pytest.mark.parametrize(
+    "catalog",
+    [
+        {"nodes": []},
+        {"nodes": {"model.pkg.m0": "oops"}},
+        {"nodes": {5: {}}},
+    ],
+    ids=["nodes-not-a-mapping", "entry-not-a-mapping", "key-not-a-string"],
+)
+def test_unreadable_catalog_entries_are_unknown_not_evidence(catalog: dict[str, Any]) -> None:
+    """AC8: a catalog Recce cannot read is not evidence of coverage.
+
+    The whole-mapping guard alone lets both per-entry guards be deleted: a
+    string-valued entry would then read as "complete" and an int key as
+    "empty", so a half-parsed catalog becomes an affirmative answer.
+    """
+    health = classify_artifact_health(_manifest(models=1), catalog)
+
+    assert health.status == "unknown"
+    assert health.covered_node_ids == frozenset()
+    assert health.catalog_node_ids == frozenset()
+    assert health.missing_node_ids == frozenset()
+    assert health.orphan_node_ids == frozenset()
+    assert health.expected_node_ids == frozenset({"model.pkg.m0"})
+
+
+def test_unreadable_manifest_entry_shrinks_nothing_and_stays_unknown() -> None:
+    """The manifest twin. The catalog deliberately covers the readable model,
+    so a per-entry guard downgraded to `continue` would report "complete" off a
+    partially parsed expected set — quietly breaking the set-intersection rule
+    the whole design rests on."""
+    manifest = {**_manifest(models=1)}
+    manifest["nodes"] = {**manifest["nodes"], "model.pkg.bad": "oops"}
+
+    health = classify_artifact_health(manifest, _catalog(models=("model.pkg.m0",)))
+
+    assert health.status == "unknown"
+    assert health.expected_node_ids == frozenset()
+
+
 def test_malformed_non_dict_manifest_nodes_are_unknown() -> None:
     health = classify_artifact_health({"nodes": []}, _catalog(models=()))
 

--- a/tests/test_artifact_health.py
+++ b/tests/test_artifact_health.py
@@ -2,7 +2,12 @@ from typing import Any
 
 import pytest
 
-from recce.artifact_health import artifact_health_payload, classify_artifact_health
+from recce.artifact_health import (
+    artifact_health_payload,
+    classify_artifact_health,
+    classify_schema_coverage,
+    schema_coverage_payload,
+)
 
 
 def _manifest(
@@ -139,3 +144,163 @@ def test_malformed_non_dict_catalog_nodes_are_unknown() -> None:
     assert health.covered_node_ids == frozenset()
     assert health.missing_node_ids == frozenset()
     assert health.orphan_node_ids == frozenset()
+
+
+def _lineage_node(
+    *,
+    resource_type: str = "model",
+    materialized: str = "table",
+    catalog_status: str | None = "covered",
+    columns: tuple[str, ...] = ("id",),
+) -> dict[str, Any]:
+    node: dict[str, Any] = {
+        "resource_type": resource_type,
+        "config": {"materialized": materialized},
+        "columns": {column: {"type": "text"} for column in columns},
+    }
+    if catalog_status is not None:
+        node["catalog_status"] = catalog_status
+    return node
+
+
+@pytest.mark.parametrize(
+    ("base_nodes", "current_nodes"),
+    [
+        (None, {}),
+        ({}, None),
+        (None, None),
+    ],
+    ids=["missing-base", "missing-current", "missing-both"],
+)
+def test_schema_coverage_is_unknown_when_either_node_mapping_is_missing(
+    base_nodes: dict[str, dict[str, Any]] | None,
+    current_nodes: dict[str, dict[str, Any]] | None,
+) -> None:
+    coverage = classify_schema_coverage(base_nodes, current_nodes, ["model.pkg.orders"])
+
+    assert coverage.status == "unknown"
+    assert coverage.checked_node_ids == frozenset()
+    assert coverage.unchecked_node_ids == frozenset()
+
+
+@pytest.mark.parametrize(
+    ("base_status", "current_status"),
+    [
+        ("unchecked", "covered"),
+        ("covered", "unchecked"),
+        ("unchecked", "unchecked"),
+    ],
+    ids=["missing-base-catalog", "missing-current-catalog", "missing-both-catalogs"],
+)
+def test_schema_coverage_is_partial_when_either_catalog_side_is_unchecked(
+    base_status: str,
+    current_status: str,
+) -> None:
+    node_id = "model.pkg.orders"
+
+    coverage = classify_schema_coverage(
+        {node_id: _lineage_node(catalog_status=base_status)},
+        {node_id: _lineage_node(catalog_status=current_status)},
+        [node_id],
+    )
+
+    assert coverage.status == "partial"
+    assert coverage.checked_node_ids == frozenset()
+    assert coverage.unchecked_node_ids == frozenset({node_id})
+
+
+def test_schema_coverage_keeps_checked_nodes_when_other_nodes_are_unchecked() -> None:
+    checked_id = "model.pkg.verified_removal"
+    unchecked_id = "model.pkg.not_rebuilt"
+
+    coverage = classify_schema_coverage(
+        {
+            checked_id: _lineage_node(columns=("id", "removed")),
+            unchecked_id: _lineage_node(),
+        },
+        {
+            checked_id: _lineage_node(columns=("id",)),
+            unchecked_id: _lineage_node(catalog_status="unchecked", columns=()),
+        },
+        [unchecked_id, checked_id],
+    )
+
+    assert coverage.status == "partial"
+    assert coverage.checked_node_ids == frozenset({checked_id})
+    assert coverage.unchecked_node_ids == frozenset({unchecked_id})
+
+
+def test_schema_coverage_excludes_one_sided_structural_nodes() -> None:
+    removed_id = "model.pkg.removed"
+
+    coverage = classify_schema_coverage(
+        {removed_id: _lineage_node()},
+        {},
+        [removed_id],
+    )
+
+    assert coverage.status == "complete"
+    assert coverage.checked_node_ids == frozenset()
+    assert coverage.unchecked_node_ids == frozenset()
+
+
+@pytest.mark.parametrize(
+    ("node_id", "node"),
+    [
+        ("model.pkg.inlined", _lineage_node(materialized="ephemeral", catalog_status="not_applicable", columns=())),
+        (
+            "model.pkg.semantic",
+            _lineage_node(materialized="semantic_view", catalog_status="not_applicable", columns=()),
+        ),
+    ],
+    ids=["ephemeral", "semantic-view"],
+)
+def test_schema_coverage_excludes_models_that_cannot_carry_catalog_columns(
+    node_id: str,
+    node: dict[str, Any],
+) -> None:
+    coverage = classify_schema_coverage({node_id: node}, {node_id: node}, [node_id])
+
+    assert coverage.status == "complete"
+    assert coverage.checked_node_ids == frozenset()
+    assert coverage.unchecked_node_ids == frozenset()
+
+
+def test_schema_coverage_checks_catalogued_sources() -> None:
+    source_id = "source.pkg.raw_orders"
+    source = _lineage_node(resource_type="source")
+
+    coverage = classify_schema_coverage({source_id: source}, {source_id: source}, [source_id])
+
+    assert coverage.status == "complete"
+    assert coverage.checked_node_ids == frozenset({source_id})
+    assert coverage.unchecked_node_ids == frozenset()
+
+
+def test_schema_coverage_treats_legacy_nodes_without_catalog_status_as_unchecked() -> None:
+    node_id = "model.pkg.legacy"
+    legacy_node = _lineage_node(catalog_status=None)
+
+    coverage = classify_schema_coverage({node_id: legacy_node}, {node_id: legacy_node}, [node_id])
+
+    assert coverage.status == "partial"
+    assert coverage.checked_node_ids == frozenset()
+    assert coverage.unchecked_node_ids == frozenset({node_id})
+
+
+def test_schema_coverage_payload_sorts_and_bounds_unchecked_nodes() -> None:
+    node_ids = [f"model.pkg.m{index:02d}" for index in range(55)]
+    base_nodes = {node_id: _lineage_node() for node_id in node_ids}
+    current_nodes = {node_id: _lineage_node(catalog_status="unchecked", columns=()) for node_id in reversed(node_ids)}
+
+    payload = schema_coverage_payload(
+        classify_schema_coverage(base_nodes, current_nodes, reversed(node_ids)),
+        sample_limit=100,
+    )
+
+    assert payload == {
+        "status": "partial",
+        "unchecked_nodes": sorted(node_ids)[:50],
+        "unchecked_node_count": 55,
+        "more": True,
+    }

--- a/tests/test_artifact_health.py
+++ b/tests/test_artifact_health.py
@@ -96,6 +96,25 @@ def test_ephemeral_and_semantic_view_models_are_not_expected() -> None:
     assert health.expected_node_ids == frozenset({"model.pkg.m0"})
 
 
+@pytest.mark.parametrize("resource_type", ["seed", "snapshot"])
+def test_seed_and_snapshot_relations_are_expected(resource_type: str) -> None:
+    node_id = f"{resource_type}.pkg.orders"
+    manifest = {
+        "nodes": {
+            node_id: {
+                "resource_type": resource_type,
+                "config": {"materialized": resource_type},
+            }
+        }
+    }
+
+    health = classify_artifact_health(manifest, _catalog(models=(node_id,)))
+
+    assert health.status == "complete"
+    assert health.expected_node_ids == frozenset({node_id})
+    assert health.covered_node_ids == frozenset({node_id})
+
+
 def test_payload_sorts_and_bounds_orphan_ids() -> None:
     manifest = _manifest(models=1)
     catalog = _catalog(models=("model.pkg.z", "model.pkg.a", "model.pkg.m0", "model.pkg.b"))
@@ -244,6 +263,16 @@ def test_schema_coverage_excludes_one_sided_structural_nodes() -> None:
     assert coverage.unchecked_node_ids == frozenset()
 
 
+def test_schema_coverage_fails_closed_for_selected_id_absent_from_both_manifests() -> None:
+    stale_id = "model.pkg.misspelled_orders"
+
+    coverage = classify_schema_coverage({}, {}, [stale_id])
+
+    assert coverage.status == "partial"
+    assert coverage.checked_node_ids == frozenset()
+    assert coverage.unchecked_node_ids == frozenset({stale_id})
+
+
 @pytest.mark.parametrize(
     ("base_nodes", "current_nodes"),
     [
@@ -279,6 +308,36 @@ def test_schema_coverage_excludes_models_that_cannot_carry_catalog_columns(
     node: dict[str, Any],
 ) -> None:
     coverage = classify_schema_coverage({node_id: node}, {node_id: node}, [node_id])
+
+    assert coverage.status == "complete"
+    assert coverage.checked_node_ids == frozenset()
+    assert coverage.unchecked_node_ids == frozenset()
+
+
+@pytest.mark.parametrize(
+    ("base_materialized", "current_materialized"),
+    [("table", "ephemeral"), ("semantic_view", "table")],
+    ids=["table-to-ephemeral", "semantic-view-to-table"],
+)
+def test_schema_coverage_excludes_transitions_with_a_non_catalogable_side(
+    base_materialized: str,
+    current_materialized: str,
+) -> None:
+    node_id = "model.pkg.transitioned"
+    base_node = _lineage_node(
+        materialized=base_materialized,
+        catalog_status="covered" if base_materialized == "table" else "not_applicable",
+    )
+    current_node = _lineage_node(
+        materialized=current_materialized,
+        catalog_status="covered" if current_materialized == "table" else "not_applicable",
+    )
+
+    coverage = classify_schema_coverage(
+        {node_id: base_node},
+        {node_id: current_node},
+        [node_id],
+    )
 
     assert coverage.status == "complete"
     assert coverage.checked_node_ids == frozenset()

--- a/tests/test_artifact_health.py
+++ b/tests/test_artifact_health.py
@@ -111,6 +111,16 @@ def test_payload_sorts_and_bounds_orphan_ids() -> None:
     }
 
 
+def test_payload_caps_samples_at_fifty_even_when_limit_is_larger() -> None:
+    orphan_ids = tuple(f"model.pkg.orphan{index:02d}" for index in range(51))
+    health = classify_artifact_health(_manifest(models=1), _catalog(models=orphan_ids))
+
+    payload = artifact_health_payload(health, sample_limit=100)
+
+    assert len(payload["orphan_nodes"]) == 50
+    assert payload["orphan_more"] is True
+
+
 def test_malformed_non_dict_manifest_nodes_are_unknown() -> None:
     health = classify_artifact_health({"nodes": []}, _catalog(models=()))
 

--- a/tests/test_artifact_health.py
+++ b/tests/test_artifact_health.py
@@ -108,7 +108,7 @@ def test_no_comparable_relations_is_not_applicable_even_with_a_catalog() -> None
 
 
 def test_missing_node_sample_is_bounded_and_flags_truncation() -> None:
-    """AC3: bounded samples. The DRC-3293 shape makes `missing_node_ids` the
+    """Bounded samples. An uncatalogued project makes `missing_node_ids` the
     project's entire model set, and this payload ships inside every lineage
     response."""
     health = classify_artifact_health(_manifest(models=60), _catalog(models=()))
@@ -436,8 +436,43 @@ def test_schema_coverage_excludes_models_that_cannot_carry_catalog_columns(
 ) -> None:
     coverage = classify_schema_coverage({node_id: node}, {node_id: node}, [node_id])
 
-    assert coverage.status == "complete"
+    # Excluded from BOTH buckets: a node the catalog never describes is not a
+    # coverage gap. With nothing else in the selection there is also nothing to
+    # stand behind, so the selection as a whole is unknown rather than clean.
+    assert coverage.status == "unknown"
     assert coverage.checked_node_ids == frozenset()
+    assert coverage.unchecked_node_ids == frozenset()
+
+
+@pytest.mark.parametrize(
+    ("node_id", "node"),
+    [
+        ("model.pkg.inlined", _lineage_node(materialized="ephemeral", catalog_status="not_applicable", columns=())),
+        (
+            "model.pkg.semantic",
+            _lineage_node(materialized="semantic_view", catalog_status="not_applicable", columns=()),
+        ),
+    ],
+    ids=["ephemeral", "semantic-view"],
+)
+def test_non_catalogable_models_do_not_drag_a_real_selection_off_complete(
+    node_id: str,
+    node: dict[str, Any],
+) -> None:
+    """The point of the exclusion: owning an ephemeral model must not pin a
+    project to "partial" forever. Alongside one genuinely checked node the
+    selection is still complete."""
+    checked_id = "model.pkg.orders"
+    checked = _lineage_node()
+
+    coverage = classify_schema_coverage(
+        {node_id: node, checked_id: checked},
+        {node_id: node, checked_id: checked},
+        [node_id, checked_id],
+    )
+
+    assert coverage.status == "complete"
+    assert coverage.checked_node_ids == frozenset({checked_id})
     assert coverage.unchecked_node_ids == frozenset()
 
 
@@ -466,7 +501,9 @@ def test_schema_coverage_excludes_transitions_with_a_non_catalogable_side(
         [node_id],
     )
 
-    assert coverage.status == "complete"
+    # As above: excluded from both buckets, and with nothing else selected the
+    # comparison covered nothing it could stand behind.
+    assert coverage.status == "unknown"
     assert coverage.checked_node_ids == frozenset()
     assert coverage.unchecked_node_ids == frozenset()
 
@@ -555,3 +592,57 @@ def test_schema_coverage_payload_clamps_negative_sample_limit_to_zero() -> None:
         "unchecked_node_count": 55,
         "more": True,
     }
+
+
+def test_schema_coverage_of_an_empty_selection_is_unknown_not_complete() -> None:
+    """A selector that matched nothing compared nothing.
+
+    "complete" is the one status downstream reads as affirmative evidence that
+    no schema changed, so it has to mean at least one node was compared. With
+    every bucket empty the old rule fell through to "complete" and an empty
+    diff over zero nodes was auto-approved as verified clean.
+    """
+    coverage = classify_schema_coverage(
+        {"model.pkg.orders": _lineage_node()},
+        {"model.pkg.orders": _lineage_node()},
+        [],
+    )
+
+    assert coverage.status == "unknown"
+    assert coverage.comparable_node_ids == frozenset()
+
+
+def test_schema_coverage_of_an_entirely_not_applicable_selection_is_unknown() -> None:
+    """Same vacuous case reached the long way round.
+
+    An ephemeral model is never catalogued, so it is neither checked nor a
+    coverage gap — it drops out of all three buckets. A selection made only of
+    those nodes still compared nothing.
+    """
+    ephemeral_id = "model.pkg.staging"
+    ephemeral = _lineage_node(materialized="ephemeral")
+
+    coverage = classify_schema_coverage(
+        {ephemeral_id: ephemeral},
+        {ephemeral_id: ephemeral},
+        [ephemeral_id],
+    )
+
+    assert coverage.status == "unknown"
+    assert coverage.comparable_node_ids == frozenset()
+
+
+def test_schema_coverage_stays_complete_when_one_sided_evidence_is_all_there_is() -> None:
+    """The vacuous guard must not swallow real one-sided evidence.
+
+    A removed relation is verified structural evidence, so a selection of only
+    one-sided nodes did compare something and stays "complete".
+    """
+    coverage = classify_schema_coverage(
+        {"model.pkg.removed": _lineage_node()},
+        {},
+        ["model.pkg.removed"],
+    )
+
+    assert coverage.status == "complete"
+    assert coverage.one_sided_node_ids == frozenset({"model.pkg.removed"})

--- a/tests/test_artifact_health.py
+++ b/tests/test_artifact_health.py
@@ -1,0 +1,131 @@
+from typing import Any
+
+import pytest
+
+from recce.artifact_health import artifact_health_payload, classify_artifact_health
+
+
+def _manifest(
+    *,
+    models: int = 0,
+    ephemeral: int = 0,
+    semantic_views: int = 0,
+) -> dict[str, Any]:
+    nodes: dict[str, dict[str, Any]] = {}
+    for index in range(models):
+        node_id = f"model.pkg.m{index}"
+        nodes[node_id] = {
+            "resource_type": "model",
+            "config": {"materialized": "table"},
+        }
+    for index in range(ephemeral):
+        node_id = f"model.pkg.e{index}"
+        nodes[node_id] = {
+            "resource_type": "model",
+            "config": {"materialized": "ephemeral"},
+        }
+    for index in range(semantic_views):
+        node_id = f"model.pkg.sv{index}"
+        nodes[node_id] = {
+            "resource_type": "model",
+            "config": {"materialized": "semantic_view"},
+        }
+    return {"nodes": nodes}
+
+
+def _catalog(*, models: tuple[str, ...] = (), sources: tuple[str, ...] = ()) -> dict[str, Any]:
+    return {
+        "nodes": {node_id: {"metadata": {}} for node_id in models},
+        "sources": {source_id: {"metadata": {}} for source_id in sources},
+    }
+
+
+@pytest.mark.parametrize(
+    ("manifest", "catalog", "status", "covered", "missing", "orphans"),
+    [
+        (_manifest(models=2), _catalog(models=()), "empty", 0, 2, 0),
+        (_manifest(models=2), _catalog(models=("model.pkg.m0",)), "partial", 1, 1, 0),
+        (
+            _manifest(models=2),
+            _catalog(models=("model.pkg.m0", "model.pkg.m1")),
+            "complete",
+            2,
+            0,
+            0,
+        ),
+        (_manifest(models=2), None, "absent", 0, 2, 0),
+        (_manifest(ephemeral=2), None, "not_applicable", 0, 0, 0),
+        (None, _catalog(models=()), "unknown", 0, 0, 0),
+    ],
+)
+def test_classify_artifact_health(
+    manifest: dict[str, Any] | None,
+    catalog: dict[str, Any] | None,
+    status: str,
+    covered: int,
+    missing: int,
+    orphans: int,
+) -> None:
+    health = classify_artifact_health(manifest, catalog)
+
+    assert health.status == status
+    assert len(health.covered_node_ids) == covered
+    assert len(health.missing_node_ids) == missing
+    assert len(health.orphan_node_ids) == orphans
+
+
+def test_sources_only_catalog_does_not_cover_expected_nodes() -> None:
+    health = classify_artifact_health(_manifest(models=1), _catalog(sources=("source.pkg.raw",)))
+
+    assert health.status == "empty"
+    assert health.covered_node_ids == frozenset()
+    assert health.missing_node_ids == frozenset({"model.pkg.m0"})
+
+
+def test_ephemeral_and_semantic_view_models_are_not_expected() -> None:
+    manifest = _manifest(models=1, ephemeral=1, semantic_views=1)
+
+    health = classify_artifact_health(manifest, _catalog(models=("model.pkg.m0",)))
+
+    assert health.status == "complete"
+    assert health.expected_node_ids == frozenset({"model.pkg.m0"})
+
+
+def test_payload_sorts_and_bounds_orphan_ids() -> None:
+    manifest = _manifest(models=1)
+    catalog = _catalog(models=("model.pkg.z", "model.pkg.a", "model.pkg.m0", "model.pkg.b"))
+
+    payload = artifact_health_payload(classify_artifact_health(manifest, catalog), sample_limit=2)
+
+    assert payload == {
+        "status": "complete",
+        "expected_count": 1,
+        "covered_count": 1,
+        "catalog_entry_count": 4,
+        "missing_node_count": 0,
+        "missing_nodes": [],
+        "missing_more": False,
+        "orphan_node_count": 3,
+        "orphan_nodes": ["model.pkg.a", "model.pkg.b"],
+        "orphan_more": True,
+    }
+
+
+def test_malformed_non_dict_manifest_nodes_are_unknown() -> None:
+    health = classify_artifact_health({"nodes": []}, _catalog(models=()))
+
+    assert health.status == "unknown"
+    assert health.expected_node_ids == frozenset()
+    assert health.covered_node_ids == frozenset()
+    assert health.missing_node_ids == frozenset()
+    assert health.orphan_node_ids == frozenset()
+
+
+def test_malformed_non_dict_catalog_nodes_are_unknown() -> None:
+    health = classify_artifact_health(_manifest(models=1), {"nodes": []})
+
+    assert health.status == "unknown"
+    assert health.expected_node_ids == frozenset({"model.pkg.m0"})
+    assert health.covered_node_ids == frozenset()
+    assert health.missing_node_ids == frozenset()
+    assert health.orphan_node_ids == frozenset()

--- a/tests/test_dbt_flags.py
+++ b/tests/test_dbt_flags.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from tests.dbt_flags import temporarily_set_state_modified_compare_flag
+
+
+@dataclass(frozen=True)
+class FrozenFlags:
+    """Mirror dbt 1.12's immutable flag object."""
+
+
+def test_temporarily_set_state_modified_compare_flag_handles_frozen_flags(monkeypatch):
+    flags = FrozenFlags()
+    monkeypatch.setattr("tests.dbt_flags.get_flags", lambda: flags)
+
+    restore = temporarily_set_state_modified_compare_flag()
+
+    assert flags.state_modified_compare_more_unrendered_values is False
+    restore()
+    assert not hasattr(flags, "state_modified_compare_more_unrendered_values")

--- a/tests/test_dbt_flags.py
+++ b/tests/test_dbt_flags.py
@@ -1,14 +1,25 @@
 from dataclasses import dataclass
 
+import pytest
+
 from tests.dbt_flags import temporarily_set_state_modified_compare_flag
 
 
 @dataclass(frozen=True)
 class FrozenFlags:
-    """Mirror dbt 1.12's immutable flag object."""
+    """Mirror dbt 1.12's immutable flag object, before set_from_args."""
 
 
-def test_temporarily_set_state_modified_compare_flag_handles_frozen_flags(monkeypatch):
+@dataclass(frozen=True)
+class FrozenFlagsWithValue:
+    """The shape real dbt produces: get_flags() after set_from_args already
+    carries the attribute, so the restore path that actually fires in a test
+    run is the `had_flag` one."""
+
+    state_modified_compare_more_unrendered_values: bool = True
+
+
+def test_absent_flag_is_deleted_on_restore(monkeypatch):
     flags = FrozenFlags()
     monkeypatch.setattr("tests.dbt_flags.get_flags", lambda: flags)
 
@@ -17,3 +28,18 @@ def test_temporarily_set_state_modified_compare_flag_handles_frozen_flags(monkey
     assert flags.state_modified_compare_more_unrendered_values is False
     restore()
     assert not hasattr(flags, "state_modified_compare_more_unrendered_values")
+
+
+@pytest.mark.parametrize("previous", [True, False], ids=["was-true", "was-false"])
+def test_pre_existing_flag_is_restored_not_deleted(monkeypatch, previous: bool):
+    """Deleting a real dbt flag instead of restoring it leaks mutated global
+    state into every later test in the process."""
+    flags = FrozenFlagsWithValue(state_modified_compare_more_unrendered_values=previous)
+    monkeypatch.setattr("tests.dbt_flags.get_flags", lambda: flags)
+
+    restore = temporarily_set_state_modified_compare_flag()
+
+    assert flags.state_modified_compare_more_unrendered_values is False
+    restore()
+    assert hasattr(flags, "state_modified_compare_more_unrendered_values")
+    assert flags.state_modified_compare_more_unrendered_values is previous

--- a/tests/test_info_emitter.py
+++ b/tests/test_info_emitter.py
@@ -99,7 +99,18 @@ class TestBuildInfoPayload:
         payload = _build_info_payload(adapter, diff)
 
         assert payload["adapter_type"] == "duckdb"
-        assert set(payload["lineage"].keys()) == {"nodes", "edges", "metadata"}
+        assert set(payload["lineage"].keys()) == {
+            "nodes",
+            "edges",
+            "metadata",
+            "schema_coverage",
+        }
+        assert payload["lineage"]["schema_coverage"] == {
+            "status": "partial",
+            "unchecked_nodes": ["model.demo.a"],
+            "unchecked_node_count": 1,
+            "more": False,
+        }
         # Both nodes present in merged output
         assert set(payload["lineage"]["nodes"].keys()) == {"model.demo.a", "model.demo.b"}
         # change_status baked into node

--- a/tests/test_info_emitter.py
+++ b/tests/test_info_emitter.py
@@ -132,6 +132,40 @@ class TestWriteJsonAtomic:
 
 
 class TestEmitInfoAndLineageDiff:
+
+    def test_retains_catalog_evidence_in_both_static_artifacts(self, tmp_path: Path):
+        node_id = "model.demo.unchecked"
+        health = {
+            "status": "partial",
+            "expected_count": 1,
+            "covered_count": 0,
+            "catalog_entry_count": 0,
+            "missing_node_count": 1,
+            "missing_nodes": [node_id],
+            "missing_more": False,
+            "orphan_node_count": 0,
+            "orphan_nodes": [],
+            "orphan_more": False,
+        }
+        diff = _make_lineage_diff(base_node_ids=[node_id], curr_node_ids=[node_id])
+        diff.base["nodes"][node_id]["catalog_status"] = "unchecked"
+        diff.current["nodes"][node_id]["catalog_status"] = "unchecked"
+        diff.base["artifact_health"] = health
+        diff.current["artifact_health"] = health
+        adapter = _make_adapter(diff)
+        info_path = tmp_path / "info.json"
+        lineage_diff_path = tmp_path / "lineage_diff.json"
+
+        emit_info_and_lineage_diff(adapter, info_path, lineage_diff_path)
+
+        info = json.loads(info_path.read_text())
+        raw_lineage_diff = json.loads(lineage_diff_path.read_text())
+        assert info["lineage"]["artifact_health"] == {"base": health, "current": health}
+        assert info["lineage"]["nodes"][node_id]["schema_comparison_status"] == "unchecked"
+        assert raw_lineage_diff["current"]["artifact_health"] == health
+        assert raw_lineage_diff["current"]["nodes"][node_id]["catalog_status"] == "unchecked"
+        assert "expected_node_ids" not in info_path.read_text()
+
     def test_writes_both_files(self, tmp_path: Path):
         diff = _make_lineage_diff(
             base_node_ids=["model.demo.a"],

--- a/tests/test_mcp_cloud_backend.py
+++ b/tests/test_mcp_cloud_backend.py
@@ -205,7 +205,7 @@ async def test_cloud_run_check_approves_only_complete_empty_schema_results(
 
     # The coverage the approval decision was made on must also reach the agent.
     # Withholding approval silently, while handing back an empty frame with no
-    # incompleteness marker, is the DRC-3293 read all over again.
+    # incompleteness marker, is the same misread this contract exists to stop.
     expected_coverage = schema_result.get("schema_coverage") if isinstance(schema_result, dict) else None
     if expected_coverage is not None:
         assert result["result"]["schema_coverage"] == expected_coverage
@@ -289,6 +289,7 @@ async def test_create_check_runs_lineage_diff_via_checks_run_endpoint(cloud_requ
         MockResponse(204),
         MockResponse(200, {"check_id": "check-1"}),
         MockResponse(200, {"run_id": "run-1", "status": "finished", "result": {"nodes": []}}),
+        MockResponse(200, {"check_id": "check-1", "is_checked": True}),
     ]
     backend = await CloudBackend.create(session_id="sess-123", api_token="token-abc")
 
@@ -299,7 +300,9 @@ async def test_create_check_runs_lineage_diff_via_checks_run_endpoint(cloud_requ
 
     urls = [call.args[1] for call in cloud_requests.call_args_list]
     assert urls[2] == "https://cloud.reccehq.com/api/v2/sessions/sess-123/checks/check-1/run"
-    assert len(urls) == 3
+    # A lineage result makes no schema-coverage claim, so it keeps the standing
+    # rule that a successful run is a reviewed check and still auto-approves.
+    assert urls[3] == "https://cloud.reccehq.com/api/v2/sessions/sess-123/checks/check-1"
     assert result["run_executed"] is True
 
 
@@ -380,6 +383,44 @@ async def test_create_check_honours_the_callers_approve_gate(cloud_requests, arg
 
     methods = [call.args[0] for call in cloud_requests.call_args_list]
     assert ("PATCH" in methods) is expect_approved
+    assert result["run_executed"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("check_type", "run_result"),
+    [
+        ("row_count_diff", {"customers": {"base": 100, "curr": 100}}),
+        ("value_diff", {"summary": {"total": 10, "added": 0, "removed": 0}}),
+        ("lineage_diff", {"nodes": []}),
+        ("query", {"ok": True}),
+    ],
+    ids=["row-count", "value", "lineage", "query"],
+)
+async def test_cloud_non_schema_checks_still_auto_approve_on_a_successful_run(
+    cloud_requests,
+    check_type,
+    run_result,
+):
+    """The schema-coverage contract must not reach other check types.
+
+    A cloud run result for these types carries no `schema_coverage` key and
+    never will, so gating them on one would leave every non-schema check
+    permanently unapproved in cloud mode.
+    """
+    cloud_requests.side_effect = [
+        MockResponse(204),
+        MockResponse(200, {"check_id": "check-1"}),
+        MockResponse(200, {"run_id": "run-1", "status": "finished", "result": run_result}),
+        MockResponse(200, {"check_id": "check-1", "is_checked": True}),
+    ]
+    backend = await CloudBackend.create(session_id="sess-123", api_token="token-abc")
+
+    result = await backend.call_tool("create_check", {"name": check_type, "type": check_type, "params": {}})
+
+    patch_calls = [call for call in cloud_requests.call_args_list if call.args[0] == "PATCH"]
+    assert len(patch_calls) == 1
+    assert patch_calls[0].kwargs["json"] == {"is_checked": True}
     assert result["run_executed"] is True
 
 

--- a/tests/test_mcp_cloud_backend.py
+++ b/tests/test_mcp_cloud_backend.py
@@ -33,6 +33,7 @@ def _schema_result(
     unchecked_node_count=None,
     coverage_more=False,
     frame_more=False,
+    total_row_count=0,
 ):
     result = {
         "columns": [
@@ -43,6 +44,7 @@ def _schema_result(
         "data": [] if data is None else data,
         "limit": 100,
         "more": frame_more,
+        "total_row_count": total_row_count,
     }
     if coverage_status is not None:
         if unchecked_nodes is None:
@@ -175,6 +177,7 @@ async def test_run_check_auto_approve_failure_does_not_mask_run_result(cloud_req
             False,
         ),
         (_schema_result("complete", coverage_more=True), False),
+        (_schema_result("complete", total_row_count=1), False),
         ({"data": [], "schema_coverage": _schema_result("complete")["schema_coverage"]}, False),
         (_schema_result("complete"), True),
     ],
@@ -311,6 +314,7 @@ async def test_create_check_runs_lineage_diff_via_checks_run_endpoint(cloud_requ
             False,
         ),
         (_schema_result("complete", coverage_more=True), False),
+        (_schema_result("complete", total_row_count=1), False),
         ({"data": [], "schema_coverage": _schema_result("complete")["schema_coverage"]}, False),
         (_schema_result("complete"), True),
     ],

--- a/tests/test_mcp_cloud_backend.py
+++ b/tests/test_mcp_cloud_backend.py
@@ -25,6 +25,18 @@ class MockResponse:
         return self._payload
 
 
+def _schema_result(coverage_status=None, data=None):
+    result = {
+        "columns": [],
+        "data": [] if data is None else data,
+        "limit": 100,
+        "more": False,
+    }
+    if coverage_status is not None:
+        result["schema_coverage"] = {"status": coverage_status}
+    return result
+
+
 @pytest.fixture
 def cloud_requests():
     with patch("recce.mcp_server.requests.request") as mock_request:
@@ -54,7 +66,7 @@ async def test_cloud_backend_uses_session_proxy_paths_without_inner_api_segment(
         MockResponse(200, {"current": {"nodes": {}}}),
         MockResponse(200, {"run_id": "run-1", "result": {"ok": True}}),
         MockResponse(200, [{"check_id": "check-1", "name": "check", "type": "query", "is_checked": False}]),
-        MockResponse(200, {"run_id": "run-2", "status": "finished", "result": {"ok": True}}),
+        MockResponse(200, {"run_id": "run-2", "status": "finished", "result": _schema_result("complete")}),
         MockResponse(200, {"check_id": "check-1", "is_checked": True}),
     ]
     backend = await CloudBackend.create(session_id="sess-123", api_token="token-abc")
@@ -113,7 +125,7 @@ async def test_cloud_backend_raises_cloud_exception_for_non_2xx(cloud_requests):
 async def test_run_check_auto_approve_failure_does_not_mask_run_result(cloud_requests):
     cloud_requests.side_effect = [
         MockResponse(204),
-        MockResponse(200, {"run_id": "run-1", "status": "finished", "result": {"ok": True}}),
+        MockResponse(200, {"run_id": "run-1", "status": "finished", "result": _schema_result("complete")}),
         MockResponse(500, {"detail": "approve failed"}, '{"detail":"approve failed"}'),
     ]
     backend = await CloudBackend.create(session_id="sess-123", api_token="token-abc")
@@ -121,7 +133,40 @@ async def test_run_check_auto_approve_failure_does_not_mask_run_result(cloud_req
     result = await backend.call_tool("run_check", {"check_id": "check-1"})
 
     assert result["status"] == "finished"
-    assert result["result"] == {"ok": True}
+    assert result["result"] == _schema_result("complete")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("schema_result", "expected_approval"),
+    [
+        (_schema_result("partial"), False),
+        (_schema_result("unknown"), False),
+        (_schema_result(), False),
+        (_schema_result("complete", [["model.project.orders", "customer_id", "added"]]), False),
+        (_schema_result("complete"), True),
+    ],
+)
+async def test_cloud_run_check_approves_only_complete_empty_schema_results(
+    cloud_requests,
+    schema_result,
+    expected_approval,
+):
+    responses = [
+        MockResponse(204),
+        MockResponse(200, {"run_id": "run-1", "status": "finished", "result": schema_result}),
+    ]
+    if expected_approval:
+        responses.append(MockResponse(200, {"check_id": "check-1", "is_checked": True}))
+    cloud_requests.side_effect = responses
+    backend = await CloudBackend.create(session_id="sess-123", api_token="token-abc")
+
+    await backend.call_tool("run_check", {"check_id": "check-1"})
+
+    patch_calls = [call for call in cloud_requests.call_args_list if call.args[0] == "PATCH"]
+    assert bool(patch_calls) is expected_approval
+    if patch_calls:
+        assert patch_calls[0].kwargs["json"] == {"is_checked": True}
 
 
 @pytest.mark.asyncio
@@ -202,7 +247,6 @@ async def test_create_check_runs_lineage_diff_via_checks_run_endpoint(cloud_requ
         MockResponse(204),
         MockResponse(200, {"check_id": "check-1"}),
         MockResponse(200, {"run_id": "run-1", "status": "finished", "result": {"nodes": []}}),
-        MockResponse(200, {"check_id": "check-1", "is_checked": True}),
     ]
     backend = await CloudBackend.create(session_id="sess-123", api_token="token-abc")
 
@@ -213,7 +257,43 @@ async def test_create_check_runs_lineage_diff_via_checks_run_endpoint(cloud_requ
 
     urls = [call.args[1] for call in cloud_requests.call_args_list]
     assert urls[2] == "https://cloud.reccehq.com/api/v2/sessions/sess-123/checks/check-1/run"
-    assert urls[3] == "https://cloud.reccehq.com/api/v2/sessions/sess-123/checks/check-1"
+    assert len(urls) == 3
+    assert result["run_executed"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("schema_result", "expected_approval"),
+    [
+        (_schema_result("partial"), False),
+        (_schema_result("unknown"), False),
+        (_schema_result(), False),
+        (_schema_result("complete", [["model.project.orders", "customer_id", "added"]]), False),
+        (_schema_result("complete"), True),
+    ],
+)
+async def test_cloud_create_schema_check_approves_only_complete_empty_results(
+    cloud_requests,
+    schema_result,
+    expected_approval,
+):
+    responses = [
+        MockResponse(204),
+        MockResponse(200, {"check_id": "check-1"}),
+        MockResponse(200, {"run_id": "run-1", "status": "finished", "result": schema_result}),
+    ]
+    if expected_approval:
+        responses.append(MockResponse(200, {"check_id": "check-1", "is_checked": True}))
+    cloud_requests.side_effect = responses
+    backend = await CloudBackend.create(session_id="sess-123", api_token="token-abc")
+
+    result = await backend.call_tool(
+        "create_check",
+        {"name": "schema", "type": "schema_diff", "params": {}},
+    )
+
+    patch_calls = [call for call in cloud_requests.call_args_list if call.args[0] == "PATCH"]
+    assert bool(patch_calls) is expected_approval
     assert result["run_executed"] is True
 
 

--- a/tests/test_mcp_cloud_backend.py
+++ b/tests/test_mcp_cloud_backend.py
@@ -25,15 +25,36 @@ class MockResponse:
         return self._payload
 
 
-def _schema_result(coverage_status=None, data=None):
+def _schema_result(
+    coverage_status=None,
+    data=None,
+    *,
+    unchecked_nodes=None,
+    unchecked_node_count=None,
+    coverage_more=False,
+    frame_more=False,
+):
     result = {
-        "columns": [],
+        "columns": [
+            {"key": "node_id", "name": "node_id", "type": "text"},
+            {"key": "column", "name": "column", "type": "text"},
+            {"key": "change_status", "name": "change_status", "type": "text"},
+        ],
         "data": [] if data is None else data,
         "limit": 100,
-        "more": False,
+        "more": frame_more,
     }
     if coverage_status is not None:
-        result["schema_coverage"] = {"status": coverage_status}
+        if unchecked_nodes is None:
+            unchecked_nodes = ["model.project.unchecked"] if coverage_status == "partial" else []
+        if unchecked_node_count is None:
+            unchecked_node_count = len(unchecked_nodes)
+        result["schema_coverage"] = {
+            "status": coverage_status,
+            "unchecked_nodes": unchecked_nodes,
+            "unchecked_node_count": unchecked_node_count,
+            "more": coverage_more,
+        }
     return result
 
 
@@ -144,6 +165,17 @@ async def test_run_check_auto_approve_failure_does_not_mask_run_result(cloud_req
         (_schema_result("unknown"), False),
         (_schema_result(), False),
         (_schema_result("complete", [["model.project.orders", "customer_id", "added"]]), False),
+        ({**_schema_result("complete"), "schema_coverage": {"status": "complete"}}, False),
+        (
+            _schema_result(
+                "complete",
+                unchecked_nodes=["model.project.orders"],
+                unchecked_node_count=1,
+            ),
+            False,
+        ),
+        (_schema_result("complete", coverage_more=True), False),
+        ({"data": [], "schema_coverage": _schema_result("complete")["schema_coverage"]}, False),
         (_schema_result("complete"), True),
     ],
 )
@@ -269,6 +301,17 @@ async def test_create_check_runs_lineage_diff_via_checks_run_endpoint(cloud_requ
         (_schema_result("unknown"), False),
         (_schema_result(), False),
         (_schema_result("complete", [["model.project.orders", "customer_id", "added"]]), False),
+        ({**_schema_result("complete"), "schema_coverage": {"status": "complete"}}, False),
+        (
+            _schema_result(
+                "complete",
+                unchecked_nodes=["model.project.orders"],
+                unchecked_node_count=1,
+            ),
+            False,
+        ),
+        (_schema_result("complete", coverage_more=True), False),
+        ({"data": [], "schema_coverage": _schema_result("complete")["schema_coverage"]}, False),
         (_schema_result("complete"), True),
     ],
 )

--- a/tests/test_mcp_cloud_backend.py
+++ b/tests/test_mcp_cloud_backend.py
@@ -196,12 +196,19 @@ async def test_cloud_run_check_approves_only_complete_empty_schema_results(
     cloud_requests.side_effect = responses
     backend = await CloudBackend.create(session_id="sess-123", api_token="token-abc")
 
-    await backend.call_tool("run_check", {"check_id": "check-1"})
+    result = await backend.call_tool("run_check", {"check_id": "check-1"})
 
     patch_calls = [call for call in cloud_requests.call_args_list if call.args[0] == "PATCH"]
     assert bool(patch_calls) is expected_approval
     if patch_calls:
         assert patch_calls[0].kwargs["json"] == {"is_checked": True}
+
+    # The coverage the approval decision was made on must also reach the agent.
+    # Withholding approval silently, while handing back an empty frame with no
+    # incompleteness marker, is the DRC-3293 read all over again.
+    expected_coverage = schema_result.get("schema_coverage") if isinstance(schema_result, dict) else None
+    if expected_coverage is not None:
+        assert result["result"]["schema_coverage"] == expected_coverage
 
 
 @pytest.mark.asyncio
@@ -345,11 +352,22 @@ async def test_cloud_create_schema_check_approves_only_complete_empty_results(
 
 
 @pytest.mark.asyncio
-async def test_create_check_approve_false_leaves_check_unapproved(cloud_requests):
+@pytest.mark.parametrize(
+    ("arguments", "expect_approved"),
+    [({}, True), ({"approve": True}, True), ({"approve": False}, False)],
+    ids=["default", "approve-true", "approve-false"],
+)
+async def test_create_check_honours_the_callers_approve_gate(cloud_requests, arguments, expect_approved):
+    """The caller's gate must be load-bearing on its own.
+
+    The run result here is approvable — complete coverage, verified empty diff
+    — so `approve` alone decides. An unapprovable fixture would pass with the
+    gate deleted.
+    """
     cloud_requests.side_effect = [
         MockResponse(204),
         MockResponse(200, {"check_id": "check-1"}),
-        MockResponse(200, {"run_id": "run-1", "status": "finished", "result": {"nodes": []}}),
+        MockResponse(200, {"run_id": "run-1", "status": "finished", "result": _schema_result("complete")}),
         # Spare: an unwanted approve must fail the assertion below, not an empty side_effect list.
         MockResponse(200, {"check_id": "check-1", "is_checked": True}),
     ]
@@ -357,11 +375,11 @@ async def test_create_check_approve_false_leaves_check_unapproved(cloud_requests
 
     result = await backend.call_tool(
         "create_check",
-        {"name": "lineage", "type": "lineage_diff", "params": {}, "approve": False},
+        {"name": "schema", "type": "schema_diff", "params": {}, **arguments},
     )
 
     methods = [call.args[0] for call in cloud_requests.call_args_list]
-    assert "PATCH" not in methods
+    assert ("PATCH" in methods) is expect_approved
     assert result["run_executed"] is True
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -38,6 +38,7 @@ def _schema_result(
     unchecked_node_count=None,
     coverage_more=False,
     frame_more=False,
+    total_row_count=0,
 ):
     result = {
         "columns": [
@@ -48,6 +49,7 @@ def _schema_result(
         "data": [] if data is None else data,
         "limit": 100,
         "more": frame_more,
+        "total_row_count": total_row_count,
     }
     if coverage_status is not None:
         if unchecked_nodes is None:
@@ -771,6 +773,7 @@ class TestRecceMCPServer:
                 False,
             ),
             (_schema_result("complete", coverage_more=True), False),
+            (_schema_result("complete", total_row_count=1), False),
             ({"data": [], "schema_coverage": _schema_result("complete")["schema_coverage"]}, False),
             (_schema_result("complete"), True),
         ],
@@ -1051,6 +1054,7 @@ class TestRecceMCPServer:
                 False,
             ),
             (_schema_result("complete", coverage_more=True), False),
+            (_schema_result("complete", total_row_count=1), False),
             ({"data": [], "schema_coverage": _schema_result("complete")["schema_coverage"]}, False),
             (_schema_result("complete"), True),
         ],

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7,11 +7,7 @@ import pytest
 pytest.importorskip("mcp")
 
 from recce.core import RecceContext  # noqa: E402
-from recce.mcp_server import (  # noqa: E402
-    _UNCHECKED_NODE_LIMIT,
-    RecceMCPServer,
-    run_mcp_server,
-)
+from recce.mcp_server import RecceMCPServer, run_mcp_server  # noqa: E402
 from recce.models.types import LineageDiff  # noqa: E402
 from recce.server import RecceServerMode  # noqa: E402
 from recce.tasks.histogram import HistogramDiffTask  # noqa: E402
@@ -199,6 +195,7 @@ class TestRecceMCPServer:
                     "model.project.model_a": {
                         "name": "model_a",
                         "resource_type": "model",
+                        "catalog_status": "covered",
                         "columns": {
                             "id": {"name": "id", "type": "integer"},
                             "name": {"name": "name", "type": "text"},
@@ -211,6 +208,7 @@ class TestRecceMCPServer:
                     "model.project.model_a": {
                         "name": "model_a",
                         "resource_type": "model",
+                        "catalog_status": "covered",
                         "columns": {
                             "id": {"name": "id", "type": "integer"},
                             "name": {"name": "name", "type": "text"},
@@ -245,14 +243,10 @@ class TestRecceMCPServer:
     async def test_tool_schema_diff_does_not_report_an_unbuilt_model_as_removed(self, mcp_server):
         """A model the run did not rebuild must not read as a column drop.
 
-        `_build_lineage` in the dbt adapter builds every node from the manifest
-        but assigns `columns` only when the catalog holds that node, so a
-        selective build leaves an unrebuilt model present on both sides with no
-        `columns` key on the current side. Comparing the two column sets then
-        turns "we never looked" into "every column was dropped".
-
-        Node keys below mirror what that builder emits, so the absent-`columns`
-        shape is the producer's, not the test's invention.
+        `_build_lineage` marks exact catalog membership with `catalog_status`.
+        Retained columns can still be present after state merging, so column-map
+        truthiness must not overrule an unchecked evidence marker and turn "we
+        never looked" into "columns were dropped".
         """
         server, mock_context = mcp_server
 
@@ -277,22 +271,25 @@ class TestRecceMCPServer:
                 "nodes": {
                     "model.project.not_rebuilt": node("not_rebuilt", columns=["a", "b", "c"]),
                     "model.project.rebuilt": node("rebuilt", columns=["kept", "dropped"]),
-                    "model.project.empty_entry": node("empty_entry", columns=["x", "y"]),
                 },
             },
             "current": {
                 "nodes": {
                     # Absent from this run's catalog, so the builder never set
-                    # the key at all.
-                    "model.project.not_rebuilt": node("not_rebuilt"),
+                    # the status to covered. Retained columns are deliberately
+                    # present to prove exact catalog membership, rather than a
+                    # truthiness check, decides whether comparison is safe.
+                    "model.project.not_rebuilt": {
+                        **node("not_rebuilt", columns=["a"]),
+                        "catalog_status": "unchecked",
+                    },
                     "model.project.rebuilt": node("rebuilt", columns=["kept"]),
-                    # Catalogued but described nothing. A relation with no
-                    # columns cannot exist, so this is the same gap wearing a
-                    # different shape and must not read as a wholesale drop.
-                    "model.project.empty_entry": node("empty_entry", columns=[]),
                 },
             },
         }
+        for side in ("base", "current"):
+            for node_data in mock_lineage_diff.model_dump.return_value[side]["nodes"].values():
+                node_data.setdefault("catalog_status", "covered")
         mock_context.get_lineage_diff.return_value = mock_lineage_diff
 
         result = await server._tool_schema_diff({})
@@ -302,10 +299,6 @@ class TestRecceMCPServer:
         assert not [
             row for row in removed if row[0] == "model.project.not_rebuilt"
         ], "columns of a model that was not rebuilt were reported as removed"
-        assert not [
-            row for row in removed if row[0] == "model.project.empty_entry"
-        ], "columns of a model with an empty catalog entry were reported as removed"
-
         # A real drop on a model that WAS rebuilt still reports, so the guard
         # cannot be satisfied by suppressing everything.
         assert ["model.project.rebuilt", "dropped", "removed"] in result["data"]
@@ -315,8 +308,7 @@ class TestRecceMCPServer:
         coverage = result["schema_coverage"]
         assert coverage["status"] == "partial"
         assert "model.project.not_rebuilt" in coverage["unchecked_nodes"]
-        assert "model.project.empty_entry" in coverage["unchecked_nodes"]
-        assert coverage["unchecked_node_count"] == 2
+        assert coverage["unchecked_node_count"] == 1
 
     @pytest.mark.asyncio
     async def test_tool_schema_diff_coverage_ignores_nodes_the_catalog_never_describes(self, mcp_server):
@@ -338,6 +330,7 @@ class TestRecceMCPServer:
                 "name": "clean",
                 "resource_type": "model",
                 "config": {"materialized": "table"},
+                "catalog_status": "covered",
                 "columns": {"id": {"name": "id", "type": "text"}},
             },
             "exposure.project.dash": {
@@ -345,24 +338,28 @@ class TestRecceMCPServer:
                 "name": "dash",
                 "resource_type": "exposure",
                 "config": {},
+                "catalog_status": "not_applicable",
             },
             "metric.project.revenue": {
                 "id": "metric.project.revenue",
                 "name": "revenue",
                 "resource_type": "metric",
                 "config": {},
+                "catalog_status": "not_applicable",
             },
             "semantic_model.project.orders_sm": {
                 "id": "semantic_model.project.orders_sm",
                 "name": "orders_sm",
                 "resource_type": "semantic_model",
                 "config": {},
+                "catalog_status": "not_applicable",
             },
             "model.project.inlined": {
                 "id": "model.project.inlined",
                 "name": "inlined",
                 "resource_type": "model",
                 "config": {"materialized": "ephemeral"},
+                "catalog_status": "not_applicable",
             },
         }
 
@@ -390,7 +387,8 @@ class TestRecceMCPServer:
         """
         server, mock_context = mcp_server
 
-        node_ids = [f"model.project.m{i:03d}" for i in range(_UNCHECKED_NODE_LIMIT + 5)]
+        unchecked_node_limit = 50
+        node_ids = [f"model.project.m{i:03d}" for i in range(unchecked_node_limit + 5)]
 
         def node(node_id, *, catalogued):
             n = {
@@ -398,6 +396,7 @@ class TestRecceMCPServer:
                 "name": node_id.rsplit(".", 1)[-1],
                 "resource_type": "model",
                 "config": {"materialized": "table"},
+                "catalog_status": "covered" if catalogued else "unchecked",
             }
             if catalogued:
                 n["columns"] = {"id": {"name": "id", "type": "text"}}
@@ -416,10 +415,10 @@ class TestRecceMCPServer:
         coverage = result["schema_coverage"]
         assert coverage["status"] == "partial"
         assert coverage["unchecked_node_count"] == len(node_ids)
-        assert len(coverage["unchecked_nodes"]) == _UNCHECKED_NODE_LIMIT
+        assert len(coverage["unchecked_nodes"]) == unchecked_node_limit
         assert coverage["more"] is True
         # Sorted, so the truncation is a stable prefix rather than dict order.
-        assert coverage["unchecked_nodes"] == sorted(node_ids)[:_UNCHECKED_NODE_LIMIT]
+        assert coverage["unchecked_nodes"] == sorted(node_ids)[:unchecked_node_limit]
 
     @pytest.mark.asyncio
     async def test_tool_query(self, mcp_server):
@@ -2457,6 +2456,9 @@ class TestSchemaDiffEdgeCases:
                 "nodes": {
                     "model.project.model_a": {
                         "name": "model_a",
+                        "resource_type": "model",
+                        "config": {"materialized": "table"},
+                        "catalog_status": "covered",
                         "columns": {
                             "id": {"name": "id", "type": "integer"},
                             "legacy_col": {"name": "legacy_col", "type": "text"},
@@ -2468,6 +2470,9 @@ class TestSchemaDiffEdgeCases:
                 "nodes": {
                     "model.project.model_a": {
                         "name": "model_a",
+                        "resource_type": "model",
+                        "config": {"materialized": "table"},
+                        "catalog_status": "covered",
                         "columns": {
                             "id": {"name": "id", "type": "integer"},
                         },
@@ -2495,6 +2500,9 @@ class TestSchemaDiffEdgeCases:
                 "nodes": {
                     "model.project.model_a": {
                         "name": "model_a",
+                        "resource_type": "model",
+                        "config": {"materialized": "table"},
+                        "catalog_status": "covered",
                         "columns": {
                             "id": {"name": "id", "type": "integer"},
                             "amount": {"name": "amount", "type": "integer"},
@@ -2506,6 +2514,9 @@ class TestSchemaDiffEdgeCases:
                 "nodes": {
                     "model.project.model_a": {
                         "name": "model_a",
+                        "resource_type": "model",
+                        "config": {"materialized": "table"},
+                        "catalog_status": "covered",
                         "columns": {
                             "id": {"name": "id", "type": "integer"},
                             "amount": {"name": "amount", "type": "float"},
@@ -3057,6 +3068,7 @@ class TestImpactAnalysisBehavior:
                     "name": "deleted_model",
                     "resource_type": "model",
                     "config": {"materialized": "table"},
+                    "catalog_status": "covered",
                     "columns": {
                         "id": {"type": "INTEGER"},
                         "gone": {"type": "TEXT"},
@@ -3071,6 +3083,7 @@ class TestImpactAnalysisBehavior:
                     "name": "new_model",
                     "resource_type": "model",
                     "config": {"materialized": "table"},
+                    "catalog_status": "covered",
                     "columns": {
                         "id": {"type": "INTEGER"},
                         "new_col": {"type": "TEXT"},
@@ -3138,6 +3151,68 @@ class TestImpactAnalysisBehavior:
         assert coverage["status"] == "complete", "one-sided models were counted as a coverage gap"
 
     @pytest.mark.asyncio
+    async def test_impact_analysis_keeps_verified_schema_changes_and_nulls_unchecked_models(self, mcp_server):
+        server, mock_context = mcp_server
+        verified_id = "model.project.verified"
+        unchecked_id = "model.project.not_rebuilt"
+
+        def node(name, status, columns):
+            return {
+                "name": name,
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "catalog_status": status,
+                "columns": {column: {"type": "TEXT"} for column in columns},
+            }
+
+        mock_context.get_lineage_diff.return_value = MagicMock(
+            model_dump=MagicMock(
+                return_value={
+                    "base": {
+                        "nodes": {
+                            verified_id: node("verified", "covered", ["id", "removed"]),
+                            unchecked_id: node("not_rebuilt", "covered", ["id", "not_removed"]),
+                        },
+                        "parent_map": {},
+                    },
+                    "current": {
+                        "nodes": {
+                            verified_id: node("verified", "covered", ["id"]),
+                            unchecked_id: node("not_rebuilt", "unchecked", ["id"]),
+                        },
+                        "parent_map": {},
+                    },
+                    "diff": {
+                        verified_id: {"change_status": "modified"},
+                        unchecked_id: {"change_status": "modified"},
+                    },
+                }
+            )
+        )
+
+        adapter = MagicMock()
+        adapter.select_nodes.return_value = {verified_id, unchecked_id}
+        adapter.get_model.return_value = {}
+        mock_context.adapter = adapter
+
+        with (
+            patch("recce.mcp_server.sentry_metrics", None),
+            patch.object(RowCountDiffTask, "execute", return_value={}),
+        ):
+            result = await server._tool_impact_analysis({"skip_value_diff": True})
+
+        assert result["errors"] == []
+        by_name = {model["name"]: model for model in result["confirmed_impacted_models"]}
+        assert by_name["verified"]["schema_changes"] == [{"column": "removed", "change_status": "removed"}]
+        assert by_name["not_rebuilt"]["schema_changes"] is None
+        assert result["schema_coverage"] == {
+            "status": "partial",
+            "unchecked_nodes": [unchecked_id],
+            "unchecked_node_count": 1,
+            "more": False,
+        }
+
+    @pytest.mark.asyncio
     async def test_ephemeral_model_is_not_a_coverage_gap(self, mcp_server):
         """An ephemeral model is inlined as a CTE, so it never enters the catalog.
 
@@ -3150,6 +3225,7 @@ class TestImpactAnalysisBehavior:
             "name": "inlined",
             "resource_type": "model",
             "config": {"materialized": "ephemeral"},
+            "catalog_status": "not_applicable",
         }
         mock_context.get_lineage_diff.return_value = MagicMock(
             model_dump=MagicMock(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1007,6 +1007,25 @@ class TestRecceMCPServer:
         assert check.is_checked is expected_checked
 
     @pytest.mark.asyncio
+    async def test_tool_run_check_persists_successful_unapproved_run(self, mcp_server):
+        server, context = mcp_server
+        check = Check(name="Partial Schema Check", type=RunType.SCHEMA_DIFF, params={"select": "orders"})
+        context.checks = [check]
+        context.runs = []
+        context.state_loader = None
+
+        with (
+            patch("recce.core.default_context", return_value=context),
+            patch.object(server, "_tool_schema_diff", new=AsyncMock(return_value=_schema_result("partial"))),
+            patch("recce.apis.check_func.export_persistent_state") as mock_export,
+        ):
+            await server._tool_run_check({"check_id": str(check.check_id)})
+
+        assert check.is_checked is False
+        assert len(context.runs) == 1
+        mock_export.assert_called_once_with()
+
+    @pytest.mark.asyncio
     async def test_tool_run_check_metadata_branch_recce_exception_no_auto_approve(self, mcp_server):
         """Negative-path coverage: when _tool_lineage_diff raises RecceException,
         control jumps to `raise ValueError(str(e))` and update_check_by_id MUST

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,7 +8,7 @@ pytest.importorskip("mcp")
 
 from recce.core import RecceContext  # noqa: E402
 from recce.mcp_server import RecceMCPServer, run_mcp_server  # noqa: E402
-from recce.models.types import LineageDiff  # noqa: E402
+from recce.models.types import Check, LineageDiff, RunType  # noqa: E402
 from recce.server import RecceServerMode  # noqa: E402
 from recce.tasks.histogram import HistogramDiffTask  # noqa: E402
 from recce.tasks.profile import ProfileDiffTask  # noqa: E402
@@ -28,6 +28,18 @@ def mcp_server():
     """Fixture to create a RecceMCPServer instance for testing"""
     mock_context = MagicMock(spec=RecceContext)
     return RecceMCPServer(mock_context), mock_context
+
+
+def _schema_result(coverage_status=None, data=None):
+    result = {
+        "columns": [],
+        "data": [] if data is None else data,
+        "limit": 100,
+        "more": False,
+    }
+    if coverage_status is not None:
+        result["schema_coverage"] = {"status": coverage_status}
+    return result
 
 
 class TestRecceMCPServer:
@@ -602,11 +614,8 @@ class TestRecceMCPServer:
             check_id=check_id,
             triggered_by="user",
         )
-        # Auto-approve: successful run → is_checked=True
-        mock_check_dao.update_check_by_id.assert_called_once()
-        approve_call = mock_check_dao.update_check_by_id.call_args
-        assert approve_call[0][0] == check_id
-        assert approve_call[0][1].is_checked is True
+        # Successful execution without complete empty schema evidence stays unapproved.
+        mock_check_dao.update_check_by_id.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_tool_create_check_idempotent_update(self, mcp_server):
@@ -646,17 +655,14 @@ class TestRecceMCPServer:
 
         assert result["check_id"] == str(check_id)
         assert result["created"] is False
-        # Two calls: (1) name/desc update, (2) auto-approve after successful run
-        assert mock_check_dao.update_check_by_id.call_count == 2
-        first_call = mock_check_dao.update_check_by_id.call_args_list[0]
-        assert first_call[0][0] == check_id
-        patch_in = first_call[0][1]
+        # Only the idempotent name/description update occurs; the run carries no
+        # complete empty schema evidence for a second approval update.
+        mock_check_dao.update_check_by_id.assert_called_once()
+        update_call = mock_check_dao.update_check_by_id.call_args
+        assert update_call[0][0] == check_id
+        patch_in = update_call[0][1]
         assert patch_in.name == "Updated name"
         assert patch_in.description == "Updated description"
-        # Second call: auto-approve (is_checked=True) after run succeeded
-        second_call = mock_check_dao.update_check_by_id.call_args_list[1]
-        assert second_call[0][0] == check_id
-        assert second_call[0][1].is_checked is True
 
     @pytest.mark.asyncio
     async def test_tool_create_check_metadata_run_for_schema_diff(self, mcp_server):
@@ -702,11 +708,45 @@ class TestRecceMCPServer:
         mock_submit.assert_not_called()
         # Verify a metadata run was created via RunDAO
         mock_run_dao.create.assert_called_once()
-        # Auto-approve: metadata run succeeded → is_checked=True
-        mock_check_dao.update_check_by_id.assert_called_once()
-        approve_call = mock_check_dao.update_check_by_id.call_args
-        assert approve_call[0][0] == check_id
-        assert approve_call[0][1].is_checked is True
+        # Approval behavior is covered against real check state below.
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("schema_result", "expected_checked"),
+        [
+            (_schema_result("partial"), False),
+            (_schema_result("unknown"), False),
+            (_schema_result(), False),
+            (_schema_result("complete", [["model.project.orders", "customer_id", "added"]]), False),
+            (_schema_result("complete"), True),
+        ],
+    )
+    async def test_tool_create_schema_check_approves_only_complete_empty_results(
+        self,
+        mcp_server,
+        schema_result,
+        expected_checked,
+    ):
+        server, context = mcp_server
+        context.checks = []
+        context.runs = []
+        context.state_loader = None
+
+        with (
+            patch("recce.core.default_context", return_value=context),
+            patch.object(server, "_tool_schema_diff", new=AsyncMock(return_value=schema_result)),
+            patch("recce.apis.check_func.export_persistent_state"),
+        ):
+            await server._tool_create_check(
+                {
+                    "type": "schema_diff",
+                    "params": {"select": "orders"},
+                    "name": "Schema Diff of orders",
+                }
+            )
+
+        assert len(context.checks) == 1
+        assert context.checks[0].is_checked is expected_checked
 
     @pytest.mark.asyncio
     async def test_tool_create_check_run_failure(self, mcp_server):
@@ -797,7 +837,7 @@ class TestRecceMCPServer:
         mock_check.type = RunType.ROW_COUNT_DIFF
         mock_check.params = {"node_names": ["model_a"]}
 
-        # Create mock run — status must be FINISHED for auto-approve to trigger
+        # Create a successful run without schema evidence; it must not approve.
         from recce.models.types import RunStatus
 
         mock_run = MagicMock()
@@ -835,12 +875,8 @@ class TestRecceMCPServer:
         assert "check_id" in result
         assert result["check_id"] == str(check_id)
 
-        # Regression: successful task-branch run must auto-approve (DRC-3307 root cause).
-        # If this fails, the auto-approve gate (run.status == FINISHED and not run.error)
-        # has been changed and preset checks will silently stay Unapproved.
-        from recce.apis.check_api import PatchCheckIn
-
-        mock_check_dao.update_check_by_id.assert_called_once_with(str(check_id), PatchCheckIn(is_checked=True))
+        # A successful non-schema run has no complete schema evidence.
+        mock_check_dao.update_check_by_id.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_tool_run_check_with_lineage_diff(self, mcp_server):
@@ -886,11 +922,8 @@ class TestRecceMCPServer:
         assert "check_id" in result
         # Verify a metadata run was persisted
         mock_run_dao.create.assert_called_once()
-        # Regression: metadata-branch (lineage_diff) success must auto-approve.
-        # An empty result IS valid evidence (zero changes confirms no lineage shift).
-        from recce.apis.check_api import PatchCheckIn
-
-        mock_check_dao.update_check_by_id.assert_called_once_with(str(check_id), PatchCheckIn(is_checked=True))
+        # Lineage-only results have no complete schema comparison contract.
+        mock_check_dao.update_check_by_id.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_tool_run_check_with_schema_diff(self, mcp_server):
@@ -936,11 +969,42 @@ class TestRecceMCPServer:
         assert "check_id" in result
         # Verify a metadata run was persisted
         mock_run_dao.create.assert_called_once()
-        # Regression: metadata-branch (schema_diff) success must auto-approve.
-        # An empty result IS valid evidence (zero schema changes is a meaningful signal).
+        # Empty schema diff with complete coverage is valid approval evidence.
         from recce.apis.check_api import PatchCheckIn
 
         mock_check_dao.update_check_by_id.assert_called_once_with(str(check_id), PatchCheckIn(is_checked=True))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("schema_result", "expected_checked"),
+        [
+            (_schema_result("partial"), False),
+            (_schema_result("unknown"), False),
+            (_schema_result(), False),
+            (_schema_result("complete", [["model.project.orders", "customer_id", "added"]]), False),
+            (_schema_result("complete"), True),
+        ],
+    )
+    async def test_tool_run_schema_check_approves_only_complete_empty_results(
+        self,
+        mcp_server,
+        schema_result,
+        expected_checked,
+    ):
+        server, context = mcp_server
+        check = Check(name="Schema Check", type=RunType.SCHEMA_DIFF, params={"select": "orders"})
+        context.checks = [check]
+        context.runs = []
+        context.state_loader = None
+
+        with (
+            patch("recce.core.default_context", return_value=context),
+            patch.object(server, "_tool_schema_diff", new=AsyncMock(return_value=schema_result)),
+            patch("recce.apis.check_func.export_persistent_state"),
+        ):
+            await server._tool_run_check({"check_id": str(check.check_id)})
+
+        assert check.is_checked is expected_checked
 
     @pytest.mark.asyncio
     async def test_tool_run_check_metadata_branch_recce_exception_no_auto_approve(self, mcp_server):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -710,8 +710,12 @@ class TestRecceMCPServer:
             check_id=check_id,
             triggered_by="user",
         )
-        # Successful execution without complete empty schema evidence stays unapproved.
-        mock_check_dao.update_check_by_id.assert_not_called()
+        # A non-schema check keeps the standing rule: a successful run is a
+        # reviewed check. The coverage contract binds schema comparisons only.
+        mock_check_dao.update_check_by_id.assert_called_once()
+        approve_call = mock_check_dao.update_check_by_id.call_args
+        assert approve_call[0][0] == check_id
+        assert approve_call[0][1].is_checked is True
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -841,14 +845,18 @@ class TestRecceMCPServer:
 
         assert result["check_id"] == str(check_id)
         assert result["created"] is False
-        # Only the idempotent name/description update occurs; the run carries no
-        # complete empty schema evidence for a second approval update.
-        mock_check_dao.update_check_by_id.assert_called_once()
-        update_call = mock_check_dao.update_check_by_id.call_args
-        assert update_call[0][0] == check_id
-        patch_in = update_call[0][1]
+        # Two calls: (1) name/desc update, (2) auto-approve after successful run
+        assert mock_check_dao.update_check_by_id.call_count == 2
+        first_call = mock_check_dao.update_check_by_id.call_args_list[0]
+        assert first_call[0][0] == check_id
+        patch_in = first_call[0][1]
         assert patch_in.name == "Updated name"
         assert patch_in.description == "Updated description"
+        # Second call: auto-approve (is_checked=True) after a non-schema run
+        # succeeded. Only schema comparisons owe complete coverage.
+        second_call = mock_check_dao.update_check_by_id.call_args_list[1]
+        assert second_call[0][0] == check_id
+        assert second_call[0][1].is_checked is True
 
     @pytest.mark.asyncio
     async def test_tool_create_check_metadata_run_for_schema_diff(self, mcp_server):
@@ -1078,8 +1086,12 @@ class TestRecceMCPServer:
         assert "check_id" in result
         assert result["check_id"] == str(check_id)
 
-        # A successful non-schema run has no complete schema evidence.
-        mock_check_dao.update_check_by_id.assert_not_called()
+        # Regression: a successful task-branch run must auto-approve. If this
+        # fails, the auto-approve gate has been widened to non-schema types and
+        # preset checks will silently stay Unapproved.
+        from recce.apis.check_api import PatchCheckIn
+
+        mock_check_dao.update_check_by_id.assert_called_once_with(str(check_id), PatchCheckIn(is_checked=True))
 
     @pytest.mark.asyncio
     async def test_tool_run_check_with_lineage_diff(self, mcp_server):
@@ -1125,12 +1137,21 @@ class TestRecceMCPServer:
         assert "check_id" in result
         # Verify a metadata run was persisted
         mock_run_dao.create.assert_called_once()
-        # Lineage-only results have no complete schema comparison contract.
-        mock_check_dao.update_check_by_id.assert_not_called()
+        # Regression: metadata-branch (lineage_diff) success must auto-approve.
+        # A lineage result makes no schema-coverage claim, so it is judged on
+        # the standing rule that an empty result IS evidence of zero changes.
+        from recce.apis.check_api import PatchCheckIn
+
+        mock_check_dao.update_check_by_id.assert_called_once_with(str(check_id), PatchCheckIn(is_checked=True))
 
     @pytest.mark.asyncio
     async def test_tool_run_check_with_schema_diff(self, mcp_server):
-        """Test running a schema_diff check delegates to _tool_schema_diff"""
+        """Test running a schema_diff check delegates to _tool_schema_diff.
+
+        The selector here matches no nodes, which is the vacuous case: the run
+        succeeds and the frame is empty because there was nothing to compare.
+        That is absence of evidence, so the check must NOT be auto-approved.
+        """
         server, mock_context = mcp_server
         from uuid import uuid4
 
@@ -1172,10 +1193,8 @@ class TestRecceMCPServer:
         assert "check_id" in result
         # Verify a metadata run was persisted
         mock_run_dao.create.assert_called_once()
-        # Empty schema diff with complete coverage is valid approval evidence.
-        from recce.apis.check_api import PatchCheckIn
-
-        mock_check_dao.update_check_by_id.assert_called_once_with(str(check_id), PatchCheckIn(is_checked=True))
+        # An empty diff over an empty selection is not approval evidence.
+        mock_check_dao.update_check_by_id.assert_not_called()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -3609,6 +3628,14 @@ class TestImpactAnalysisBehavior:
 
         It reaches impact_analysis like any other model, but "no columns on
         either side" is its normal state rather than something the run skipped.
+        So it must not be named in `unchecked_nodes`, which would pin any
+        project owning one to "partial" forever.
+
+        It is the only model here, so nothing in this run was comparable and
+        the coverage as a whole is unknown — not "complete", which would be a
+        clean bill of health for a comparison that looked at nothing. That an
+        ephemeral model does not drag a real selection off "complete" is pinned
+        in tests/test_artifact_health.py.
         """
         server, mock_context = mcp_server
 
@@ -3643,8 +3670,9 @@ class TestImpactAnalysisBehavior:
 
         assert result["errors"] == []
         coverage = result["schema_coverage"]
-        assert coverage["unchecked_nodes"] == []
-        assert coverage["status"] == "complete", "an ephemeral model was counted as a coverage gap"
+        assert coverage["unchecked_nodes"] == [], "an ephemeral model was counted as a coverage gap"
+        assert coverage["unchecked_node_count"] == 0
+        assert coverage["status"] == "unknown", "a comparison that covered nothing claimed a clean result"
 
 
 class TestLocalModeRunBacked:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -714,41 +714,44 @@ class TestRecceMCPServer:
         mock_check_dao.update_check_by_id.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_tool_create_check_approve_false_leaves_check_unapproved(self, mcp_server):
-        """create_check with approve=False runs the check but does not approve it."""
-        server, _ = mcp_server
-        from uuid import uuid4
+    @pytest.mark.parametrize(
+        ("arguments", "expected_checked"),
+        [
+            ({}, True),
+            ({"approve": True}, True),
+            ({"approve": False}, False),
+        ],
+        ids=["default", "approve-true", "approve-false"],
+    )
+    async def test_tool_create_check_honours_the_callers_approve_gate(self, mcp_server, arguments, expected_checked):
+        """The caller's gate must be load-bearing on its own.
 
-        from recce.models.types import Check, RunStatus
-
-        check_id = uuid4()
-        mock_check = MagicMock(spec=Check)
-        mock_check.check_id = check_id
-
-        mock_run = MagicMock()
-        mock_run.status = RunStatus.FINISHED
-        mock_run.error = None
-
-        mock_check_dao = MagicMock()
-        mock_check_dao.list.return_value = []
+        The evidence here is approvable — complete coverage, verified empty
+        diff — so `approve` is the only thing standing between the call and an
+        approved check. A fixture that is unapprovable anyway would pass with
+        the gate deleted.
+        """
+        server, context = mcp_server
+        context.checks = []
+        context.runs = []
+        context.state_loader = None
 
         with (
-            patch("recce.models.CheckDAO", return_value=mock_check_dao),
-            patch("recce.apis.check_func.create_check_without_run", return_value=mock_check),
-            patch("recce.apis.run_func.submit_run", return_value=(mock_run, asyncio.sleep(0))),
+            patch("recce.core.default_context", return_value=context),
+            patch.object(server, "_tool_schema_diff", new=AsyncMock(return_value=_schema_result("complete"))),
             patch("recce.apis.check_func.export_persistent_state"),
         ):
-            result = await server._tool_create_check(
+            await server._tool_create_check(
                 {
-                    "type": "row_count_diff",
-                    "params": {"node_names": ["orders"]},
-                    "name": "Row Count Diff of orders",
-                    "approve": False,
+                    "type": "schema_diff",
+                    "params": {"select": "orders"},
+                    "name": "Schema Diff of orders",
+                    **arguments,
                 }
             )
 
-        assert result["run_executed"] is True
-        mock_check_dao.update_check_by_id.assert_not_called()
+        assert len(context.checks) == 1
+        assert context.checks[0].is_checked is expected_checked
 
     @pytest.mark.asyncio
     async def test_tool_update_check_unapproves_and_persists(self, mcp_server):
@@ -1231,11 +1234,104 @@ class TestRecceMCPServer:
             patch.object(server, "_tool_schema_diff", new=AsyncMock(return_value=_schema_result("partial"))),
             patch("recce.apis.check_func.export_persistent_state") as mock_export,
         ):
-            await server._tool_run_check({"check_id": str(check.check_id)})
+            result = await server._tool_run_check({"check_id": str(check.check_id)})
 
         assert check.is_checked is False
         assert len(context.runs) == 1
         mock_export.assert_called_once_with()
+        # The agent calling the tool must be able to tell the answer is
+        # incomplete. Approving-side state is not enough: without coverage in
+        # the returned payload, an empty frame reads as "no schema changes".
+        assert result["result"]["schema_coverage"] == {
+            "status": "partial",
+            "unchecked_nodes": ["model.project.unchecked"],
+            "unchecked_node_count": 1,
+            "more": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_tool_run_check_reports_a_real_producers_coverage_and_row_count(self, mcp_server):
+        """The producer -> gate contract, with no mocked schema_diff.
+
+        Both approval suites hand the gate a hand-built dict, and the one
+        real-producer test selects zero nodes — so nothing pins what
+        _tool_schema_diff actually computes for a covered, unchanged project.
+        total_row_count is the load-bearing assertion: if it counted compared
+        nodes instead of changes, no clean schema check could ever approve.
+        """
+        server, context = mcp_server
+        check = Check(name="Schema Check", type=RunType.SCHEMA_DIFF, params={})
+        context.checks = [check]
+        context.runs = []
+        context.state_loader = None
+
+        def node(name, columns):
+            return {
+                "name": name,
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "catalog_status": "covered",
+                "columns": {c: {"name": c, "type": "text"} for c in columns},
+            }
+
+        nodes = {
+            "model.project.orders": node("orders", ["id", "amount"]),
+            "model.project.customers": node("customers", ["id"]),
+        }
+        mock_lineage_diff = MagicMock(spec=LineageDiff)
+        mock_lineage_diff.model_dump.return_value = {
+            "base": {"nodes": nodes},
+            "current": {"nodes": nodes},
+        }
+        context.get_lineage_diff.return_value = mock_lineage_diff
+
+        with (
+            patch("recce.core.default_context", return_value=context),
+            patch("recce.apis.check_func.export_persistent_state"),
+        ):
+            result = await server._tool_run_check({"check_id": str(check.check_id)})
+
+        assert result["result"]["schema_coverage"]["status"] == "complete"
+        assert result["result"]["total_row_count"] == 0
+        assert result["result"]["data"] == []
+        assert check.is_checked is True
+
+    @pytest.mark.asyncio
+    async def test_tool_run_check_keeps_a_covered_removal_and_withholds_approval(self, mcp_server):
+        """The mirror half: the same real producer, one genuinely dropped
+        column. Complete coverage is necessary for approval, never sufficient."""
+        server, context = mcp_server
+        check = Check(name="Schema Check", type=RunType.SCHEMA_DIFF, params={})
+        context.checks = [check]
+        context.runs = []
+        context.state_loader = None
+
+        def node(name, columns):
+            return {
+                "name": name,
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "catalog_status": "covered",
+                "columns": {c: {"name": c, "type": "text"} for c in columns},
+            }
+
+        mock_lineage_diff = MagicMock(spec=LineageDiff)
+        mock_lineage_diff.model_dump.return_value = {
+            "base": {"nodes": {"model.project.orders": node("orders", ["id", "amount"])}},
+            "current": {"nodes": {"model.project.orders": node("orders", ["id"])}},
+        }
+        context.get_lineage_diff.return_value = mock_lineage_diff
+
+        with (
+            patch("recce.core.default_context", return_value=context),
+            patch("recce.apis.check_func.export_persistent_state"),
+        ):
+            result = await server._tool_run_check({"check_id": str(check.check_id)})
+
+        assert ["model.project.orders", "amount", "removed"] in result["result"]["data"]
+        assert result["result"]["total_row_count"] == 1
+        assert result["result"]["schema_coverage"]["status"] == "complete"
+        assert check.is_checked is False
 
     @pytest.mark.asyncio
     async def test_tool_run_check_metadata_branch_recce_exception_no_auto_approve(self, mcp_server):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -346,6 +346,57 @@ class TestRecceMCPServer:
         assert coverage["unchecked_node_count"] == 1
 
     @pytest.mark.asyncio
+    async def test_tool_schema_diff_reports_a_dropped_model_as_removed_columns(self, mcp_server):
+        """AC5: a model present on only one manifest side is a real removal.
+
+        It carries no two-sided column comparison, so it is neither `checked`
+        nor `unchecked` — and if the tool reports only checked nodes, the agent
+        is handed `data: []` with `status: "complete"`, an affirmative "no
+        schema changes" for a model that was dropped.
+        """
+        server, mock_context = mcp_server
+        mock_context.adapter.select_nodes.return_value = {
+            "model.project.dropped",
+            "model.project.kept",
+        }
+
+        def node(name, columns):
+            return {
+                "name": name,
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "catalog_status": "covered",
+                "columns": {c: {"name": c, "type": "text"} for c in columns},
+            }
+
+        mock_lineage_diff = MagicMock(spec=LineageDiff)
+        mock_lineage_diff.model_dump.return_value = {
+            "base": {
+                "nodes": {
+                    "model.project.dropped": node("dropped", ["id", "gone"]),
+                    "model.project.kept": node("kept", ["id"]),
+                },
+            },
+            "current": {
+                "nodes": {
+                    "model.project.kept": node("kept", ["id"]),
+                },
+            },
+        }
+        mock_context.get_lineage_diff.return_value = mock_lineage_diff
+
+        result = await server._tool_schema_diff({"select": "state:modified"})
+
+        assert ["model.project.dropped", "id", "removed"] in result["data"]
+        assert ["model.project.dropped", "gone", "removed"] in result["data"]
+
+        # The removal is verified structural evidence, not an unchecked node:
+        # coverage stays complete and the dropped model is not listed as a gap.
+        coverage = result["schema_coverage"]
+        assert coverage["status"] == "complete"
+        assert coverage["unchecked_nodes"] == []
+
+    @pytest.mark.asyncio
     async def test_tool_schema_diff_coverage_ignores_nodes_the_catalog_never_describes(self, mcp_server):
         """A node dbt never catalogues is not a coverage gap.
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -30,15 +30,36 @@ def mcp_server():
     return RecceMCPServer(mock_context), mock_context
 
 
-def _schema_result(coverage_status=None, data=None):
+def _schema_result(
+    coverage_status=None,
+    data=None,
+    *,
+    unchecked_nodes=None,
+    unchecked_node_count=None,
+    coverage_more=False,
+    frame_more=False,
+):
     result = {
-        "columns": [],
+        "columns": [
+            {"key": "node_id", "name": "node_id", "type": "text"},
+            {"key": "column", "name": "column", "type": "text"},
+            {"key": "change_status", "name": "change_status", "type": "text"},
+        ],
         "data": [] if data is None else data,
         "limit": 100,
-        "more": False,
+        "more": frame_more,
     }
     if coverage_status is not None:
-        result["schema_coverage"] = {"status": coverage_status}
+        if unchecked_nodes is None:
+            unchecked_nodes = ["model.project.unchecked"] if coverage_status == "partial" else []
+        if unchecked_node_count is None:
+            unchecked_node_count = len(unchecked_nodes)
+        result["schema_coverage"] = {
+            "status": coverage_status,
+            "unchecked_nodes": unchecked_nodes,
+            "unchecked_node_count": unchecked_node_count,
+            "more": coverage_more,
+        }
     return result
 
 
@@ -433,6 +454,28 @@ class TestRecceMCPServer:
         assert coverage["unchecked_nodes"] == sorted(node_ids)[:unchecked_node_limit]
 
     @pytest.mark.asyncio
+    async def test_tool_schema_diff_fails_closed_for_stale_selected_id(self, mcp_server):
+        server, mock_context = mcp_server
+        stale_id = "model.project.misspelled_orders"
+        mock_lineage_diff = MagicMock(spec=LineageDiff)
+        mock_lineage_diff.model_dump.return_value = {
+            "base": {"nodes": {}},
+            "current": {"nodes": {}},
+        }
+        mock_context.get_lineage_diff.return_value = mock_lineage_diff
+        mock_context.adapter.select_nodes.return_value = {stale_id}
+
+        result = await server._tool_schema_diff({"select": "misspelled_orders"})
+
+        assert result["data"] == []
+        assert result["schema_coverage"] == {
+            "status": "partial",
+            "unchecked_nodes": [stale_id],
+            "unchecked_node_count": 1,
+            "more": False,
+        }
+
+    @pytest.mark.asyncio
     async def test_tool_query(self, mcp_server):
         """Test the query tool"""
         server, _ = mcp_server
@@ -718,6 +761,17 @@ class TestRecceMCPServer:
             (_schema_result("unknown"), False),
             (_schema_result(), False),
             (_schema_result("complete", [["model.project.orders", "customer_id", "added"]]), False),
+            ({**_schema_result("complete"), "schema_coverage": {"status": "complete"}}, False),
+            (
+                _schema_result(
+                    "complete",
+                    unchecked_nodes=["model.project.orders"],
+                    unchecked_node_count=1,
+                ),
+                False,
+            ),
+            (_schema_result("complete", coverage_more=True), False),
+            ({"data": [], "schema_coverage": _schema_result("complete")["schema_coverage"]}, False),
             (_schema_result("complete"), True),
         ],
     )
@@ -780,6 +834,7 @@ class TestRecceMCPServer:
 
         assert result["run_executed"] is False
         assert result["run_error"] == "Table not found: orders"
+        mock_check_dao.update_check_by_id.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_tool_create_check_idempotent_update_with_run_failure(self, mcp_server):
@@ -818,6 +873,10 @@ class TestRecceMCPServer:
         assert result["created"] is False
         assert result["run_executed"] is False
         assert result["run_error"] == "Permission denied"
+        assert all(
+            update_call.args[1].is_checked is not True
+            for update_call in mock_check_dao.update_check_by_id.call_args_list
+        )
 
     @pytest.mark.asyncio
     async def test_tool_run_check_row_count_diff(self, mcp_server):
@@ -982,6 +1041,17 @@ class TestRecceMCPServer:
             (_schema_result("unknown"), False),
             (_schema_result(), False),
             (_schema_result("complete", [["model.project.orders", "customer_id", "added"]]), False),
+            ({**_schema_result("complete"), "schema_coverage": {"status": "complete"}}, False),
+            (
+                _schema_result(
+                    "complete",
+                    unchecked_nodes=["model.project.orders"],
+                    unchecked_node_count=1,
+                ),
+                False,
+            ),
+            (_schema_result("complete", coverage_more=True), False),
+            ({"data": [], "schema_coverage": _schema_result("complete")["schema_coverage"]}, False),
             (_schema_result("complete"), True),
         ],
     )

--- a/tests/test_merged_lineage.py
+++ b/tests/test_merged_lineage.py
@@ -238,6 +238,23 @@ class TestBuildMergedLineageNodes:
 
         assert merged.schema_comparison_status == "unchecked"
 
+    def test_excluded_materialization_schema_comparison_status_is_not_applicable(self):
+        node = {
+            "name": "ephemeral_model",
+            "resource_type": "model",
+            "package_name": "pkg",
+            "config": {"materialized": "ephemeral"},
+            "catalog_status": "not_applicable",
+        }
+        ld = _make_lineage_diff(
+            base_nodes={"model.pkg.ephemeral_model": node},
+            current_nodes={"model.pkg.ephemeral_model": node},
+        )
+
+        merged = build_merged_lineage(ld).nodes["model.pkg.ephemeral_model"]
+
+        assert merged.schema_comparison_status == "not_applicable"
+
     def test_one_sided_removal_preserves_structural_change_status(self):
         node = {
             "name": "removed",

--- a/tests/test_merged_lineage.py
+++ b/tests/test_merged_lineage.py
@@ -321,6 +321,45 @@ class TestBuildMergedLineageNodes:
 
         assert merged.schema_comparison_status == "unchecked"
 
+    def test_unchecked_node_keeps_its_verified_manifest_change(self):
+        """ "Preserve verified changes while marking unchecked nodes incomplete."
+
+        Only the marking half is pinned elsewhere: every unchecked node in this
+        file has no diff entry, so a plausible "don't render unverified
+        changes" tightening would strip change_status and change from a model
+        whose SQL genuinely changed, for as long as its catalog is stale.
+        /api/info and info.json are what consumers read, so assert the wire too.
+        """
+        node_id = "model.pkg.stale_catalog"
+        base_node = {
+            "name": "stale_catalog",
+            "resource_type": "model",
+            "package_name": "pkg",
+            "catalog_status": "covered",
+        }
+        current_node = {**base_node, "catalog_status": "unchecked"}
+        ld = _make_lineage_diff(
+            base_nodes={node_id: base_node},
+            current_nodes={node_id: current_node},
+            diff={
+                node_id: NodeDiff(
+                    change_status="modified",
+                    change=NodeChange(category="breaking", columns={"col_a": "removed"}),
+                )
+            },
+        )
+
+        merged = build_merged_lineage(ld).nodes[node_id]
+
+        assert merged.schema_comparison_status == "unchecked"
+        assert merged.current_catalog_status == "unchecked"
+        assert merged.change_status == "modified"
+        assert merged.change.columns == {"col_a": "removed"}
+
+        wire = merged.model_dump(exclude_none=True, by_alias=True)
+        assert wire["change_status"] == "modified"
+        assert wire["change"]["columns"] == {"col_a": "removed"}
+
     def test_excluded_materialization_schema_comparison_status_is_not_applicable(self):
         node = {
             "name": "ephemeral_model",

--- a/tests/test_merged_lineage.py
+++ b/tests/test_merged_lineage.py
@@ -1,3 +1,5 @@
+import pytest
+
 from recce.models.lineage import build_merged_lineage
 from recce.models.types import (
     LineageDiff,
@@ -222,6 +224,59 @@ class TestBuildMergedLineageNodes:
             "current": current_health,
         }
 
+    def test_full_merged_selection_emits_canonical_schema_coverage(self):
+        checked_id = "model.pkg.checked"
+        unchecked_id = "source.pkg.not_rebuilt"
+        checked = {
+            "name": "checked",
+            "resource_type": "model",
+            "package_name": "pkg",
+            "config": {"materialized": "table"},
+            "catalog_status": "covered",
+        }
+        source_base = {
+            "name": "not_rebuilt",
+            "resource_type": "source",
+            "package_name": "pkg",
+            "catalog_status": "covered",
+        }
+        source_current = {**source_base, "catalog_status": "unchecked"}
+        ld = _make_lineage_diff(
+            base_nodes={checked_id: checked, unchecked_id: source_base},
+            current_nodes={checked_id: checked, unchecked_id: source_current},
+        )
+
+        merged = build_merged_lineage(ld)
+
+        assert merged.schema_coverage.model_dump() == {
+            "status": "partial",
+            "unchecked_nodes": [unchecked_id],
+            "unchecked_node_count": 1,
+            "more": False,
+        }
+
+    def test_merged_node_retains_exact_catalog_status_for_both_sides(self):
+        node_id = "source.pkg.orders"
+        base_node = {
+            "name": "orders",
+            "resource_type": "source",
+            "package_name": "pkg",
+            "catalog_status": "covered",
+        }
+        current_node = {**base_node, "catalog_status": "unchecked"}
+        ld = _make_lineage_diff(
+            base_nodes={node_id: base_node},
+            current_nodes={node_id: current_node},
+        )
+
+        merged = build_merged_lineage(ld).nodes[node_id]
+        wire = merged.model_dump(exclude_none=True)
+
+        assert merged.base_catalog_status == "covered"
+        assert merged.current_catalog_status == "unchecked"
+        assert wire["base_catalog_status"] == "covered"
+        assert wire["current_catalog_status"] == "unchecked"
+
     def test_both_uncovered_manifest_nodes_are_schema_unchecked(self):
         node = {
             "name": "unchecked",
@@ -252,6 +307,36 @@ class TestBuildMergedLineageNodes:
         )
 
         merged = build_merged_lineage(ld).nodes["model.pkg.ephemeral_model"]
+
+        assert merged.schema_comparison_status == "not_applicable"
+
+    @pytest.mark.parametrize(
+        ("base_materialized", "current_materialized"),
+        [("table", "ephemeral"), ("semantic_view", "table")],
+        ids=["table-to-ephemeral", "semantic-view-to-table"],
+    )
+    def test_transition_with_either_non_catalogable_side_is_not_applicable(
+        self,
+        base_materialized,
+        current_materialized,
+    ):
+        node_id = "model.pkg.transitioned"
+
+        def node(materialized):
+            return {
+                "name": "transitioned",
+                "resource_type": "model",
+                "package_name": "pkg",
+                "config": {"materialized": materialized},
+                "catalog_status": "covered" if materialized == "table" else "not_applicable",
+            }
+
+        ld = _make_lineage_diff(
+            base_nodes={node_id: node(base_materialized)},
+            current_nodes={node_id: node(current_materialized)},
+        )
+
+        merged = build_merged_lineage(ld).nodes[node_id]
 
         assert merged.schema_comparison_status == "not_applicable"
 

--- a/tests/test_merged_lineage.py
+++ b/tests/test_merged_lineage.py
@@ -224,6 +224,34 @@ class TestBuildMergedLineageNodes:
             "current": current_health,
         }
 
+    def test_unreadable_side_health_degrades_to_unknown_not_a_broken_response(self):
+        """AC10 version skew: a producer one version ahead emits a status this
+        build has never seen. That must degrade the badge to "unknown", not
+        take the whole lineage response down — a hard failure hides the verified
+        nodes too, which is strictly worse than an unknown health state."""
+        ld = _make_lineage_diff()
+        ld.base["artifact_health"] = {**_artifact_health("complete"), "status": "degraded_v2"}
+        ld.current["artifact_health"] = _artifact_health("partial")
+
+        merged = build_merged_lineage(ld)
+
+        assert merged.artifact_health.base.status == "unknown"
+        # The readable side is untouched, and the rest of the response survives.
+        assert merged.artifact_health.current.status == "partial"
+        assert merged.schema_coverage is not None
+
+    def test_malformed_side_health_degrades_to_unknown(self):
+        """The same fail-soft rule for a payload that is the wrong shape
+        entirely, not merely an unrecognised status."""
+        ld = _make_lineage_diff()
+        ld.base["artifact_health"] = {"status": "complete", "missing_nodes": "not-a-list"}
+        ld.current["artifact_health"] = "not-a-mapping"
+
+        merged = build_merged_lineage(ld)
+
+        assert merged.artifact_health.base.status == "unknown"
+        assert merged.artifact_health.current.status == "unknown"
+
     def test_full_merged_selection_emits_canonical_schema_coverage(self):
         checked_id = "model.pkg.checked"
         unchecked_id = "source.pkg.not_rebuilt"

--- a/tests/test_merged_lineage.py
+++ b/tests/test_merged_lineage.py
@@ -144,6 +144,21 @@ class TestMergedLineage:
         assert len(lineage.edges) == 1
         assert lineage.metadata["generated_at"] == "2024-01-01"
 
+    def test_artifact_health_serializes_only_bounded_public_payload(self):
+        health = _artifact_health("partial")
+        lineage = MergedLineage(
+            nodes={},
+            edges=[],
+            metadata={},
+            artifact_health={"base": health, "current": health},
+        )
+
+        wire = lineage.model_dump(exclude_none=True, mode="json")
+
+        assert wire["artifact_health"] == {"base": health, "current": health}
+        assert "expected_node_ids" not in str(wire)
+        assert "covered_node_ids" not in str(wire)
+
 
 def _make_lineage_diff(
     *,
@@ -175,7 +190,70 @@ def _make_lineage_diff(
     return LineageDiff(base=base, current=current, diff=node_diffs)
 
 
+def _artifact_health(status: str, **counts: int) -> dict:
+    """Build the bounded public artifact-health payload produced by adapters."""
+    return {
+        "status": status,
+        "expected_count": counts.get("expected_count", 1),
+        "covered_count": counts.get("covered_count", 0),
+        "catalog_entry_count": counts.get("catalog_entry_count", 0),
+        "missing_node_count": counts.get("missing_node_count", 1),
+        "missing_nodes": counts.get("missing_nodes", ["model.pkg.unchecked"]),
+        "missing_more": counts.get("missing_more", False),
+        "orphan_node_count": counts.get("orphan_node_count", 0),
+        "orphan_nodes": counts.get("orphan_nodes", []),
+        "orphan_more": counts.get("orphan_more", False),
+    }
+
+
 class TestBuildMergedLineageNodes:
+
+    def test_side_artifact_health_blocks_survive_the_merge(self):
+        base_health = _artifact_health("complete", covered_count=1, missing_node_count=0, missing_nodes=[])
+        current_health = _artifact_health("partial")
+        ld = _make_lineage_diff()
+        ld.base["artifact_health"] = base_health
+        ld.current["artifact_health"] = current_health
+
+        merged = build_merged_lineage(ld)
+
+        assert merged.artifact_health.model_dump(exclude_none=True) == {
+            "base": base_health,
+            "current": current_health,
+        }
+
+    def test_both_uncovered_manifest_nodes_are_schema_unchecked(self):
+        node = {
+            "name": "unchecked",
+            "resource_type": "model",
+            "package_name": "pkg",
+            "catalog_status": "unchecked",
+        }
+        ld = _make_lineage_diff(
+            base_nodes={"model.pkg.unchecked": node},
+            current_nodes={"model.pkg.unchecked": node},
+        )
+
+        merged = build_merged_lineage(ld).nodes["model.pkg.unchecked"]
+
+        assert merged.schema_comparison_status == "unchecked"
+
+    def test_one_sided_removal_preserves_structural_change_status(self):
+        node = {
+            "name": "removed",
+            "resource_type": "model",
+            "package_name": "pkg",
+            "catalog_status": "covered",
+        }
+        ld = _make_lineage_diff(
+            base_nodes={"model.pkg.removed": node},
+            diff={"model.pkg.removed": {"change_status": "removed"}},
+        )
+
+        merged = build_merged_lineage(ld).nodes["model.pkg.removed"]
+
+        assert merged.change_status == "removed"
+        assert merged.schema_comparison_status == "not_applicable"
 
     def test_unchanged_node_in_both_envs(self):
         node = {"name": "a", "resource_type": "model", "package_name": "pkg", "schema": "public", "id": "model.pkg.a"}

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,8 +1,14 @@
 import logging
 from unittest.mock import patch
 
+import pytest
+
 from recce.models.types import Run, RunType
-from recce.run import run_should_be_approved, schema_diff_should_be_approved
+from recce.run import (
+    run_should_be_approved,
+    schema_diff_should_be_approved,
+    schema_result_is_approvable,
+)
 
 
 def _make_run(result=None, error=None, run_type=RunType.ROW_COUNT_DIFF):
@@ -96,3 +102,30 @@ class TestSchemaDiffShouldBeApproved:
             result = schema_diff_should_be_approved({"select": "state:modified"})
         assert result is False
         assert "schema_diff approval check failed (unexpected)" in caplog.text
+
+
+@pytest.mark.parametrize("coverage", ["partial", "unknown", None])
+def test_schema_result_is_not_approvable_without_complete_coverage(coverage):
+    result = {"data": []}
+    if coverage is not None:
+        result["schema_coverage"] = {"status": coverage}
+
+    assert schema_result_is_approvable(result) is False
+
+
+def test_schema_result_is_not_approvable_when_verified_diff_has_a_mismatch():
+    result = {
+        "data": [["model.project.orders", "customer_id", "added"]],
+        "schema_coverage": {"status": "complete"},
+    }
+
+    assert schema_result_is_approvable(result) is False
+
+
+def test_complete_empty_schema_result_is_approvable():
+    result = {
+        "data": [],
+        "schema_coverage": {"status": "complete"},
+    }
+
+    assert schema_result_is_approvable(result) is True

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -31,7 +31,7 @@ def _schema_coverage(
     }
 
 
-def _schema_result(*, data=None, coverage=None, frame_more=False):
+def _schema_result(*, data=None, coverage=None, frame_more=False, total_row_count=0):
     return {
         "columns": [
             {"key": "node_id", "name": "node_id", "type": "text"},
@@ -41,6 +41,7 @@ def _schema_result(*, data=None, coverage=None, frame_more=False):
         "data": [] if data is None else data,
         "limit": 100,
         "more": frame_more,
+        "total_row_count": total_row_count,
         "schema_coverage": _schema_coverage() if coverage is None else coverage,
     }
 
@@ -141,6 +142,24 @@ class TestSchemaDiffShouldBeApproved:
 
         assert result is False
 
+    @patch("recce.run.default_context")
+    def test_complete_covered_explicit_node_is_auto_approved(self, mock_ctx):
+        node_id = "model.project.orders"
+        node = {
+            "resource_type": "model",
+            "config": {"materialized": "table"},
+            "catalog_status": "covered",
+            "columns": {"id": {"type": "INTEGER"}},
+        }
+        mock_ctx.return_value.get_lineage.side_effect = [
+            {"nodes": {node_id: node}},
+            {"nodes": {node_id: node}},
+        ]
+
+        result = schema_diff_should_be_approved({"node_id": node_id})
+
+        assert result is True
+
 
 @pytest.mark.parametrize("coverage", ["partial", "unknown", None])
 def test_schema_result_is_not_approvable_without_complete_coverage(coverage):
@@ -195,4 +214,15 @@ def test_complete_contradictory_schema_coverage_is_not_approvable(coverage):
     ids=["missing-columns", "wrong-schema", "more-rows"],
 )
 def test_malformed_or_incomplete_empty_dataframe_is_not_approvable(result):
+    assert schema_result_is_approvable(result) is False
+
+
+@pytest.mark.parametrize(
+    "total_row_count",
+    [1, True, "0", None],
+    ids=["nonzero", "boolean", "string", "missing"],
+)
+def test_empty_schema_result_requires_exact_zero_total_row_count(total_row_count):
+    result = _schema_result(total_row_count=total_row_count)
+
     assert schema_result_is_approvable(result) is False

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,49 +1,13 @@
 import logging
 from unittest.mock import patch
 
-import pytest
-
 from recce.models.types import Run, RunType
-from recce.run import (
-    run_should_be_approved,
-    schema_diff_should_be_approved,
-    schema_result_is_approvable,
-)
+from recce.run import run_should_be_approved, schema_diff_should_be_approved
 
 
 def _make_run(result=None, error=None, run_type=RunType.ROW_COUNT_DIFF):
     """Helper to create a Run with minimal required fields."""
     return Run(type=run_type, result=result, error=error)
-
-
-def _schema_coverage(
-    status="complete",
-    *,
-    unchecked_nodes=None,
-    unchecked_node_count=0,
-    more=False,
-):
-    return {
-        "status": status,
-        "unchecked_nodes": [] if unchecked_nodes is None else unchecked_nodes,
-        "unchecked_node_count": unchecked_node_count,
-        "more": more,
-    }
-
-
-def _schema_result(*, data=None, coverage=None, frame_more=False, total_row_count=0):
-    return {
-        "columns": [
-            {"key": "node_id", "name": "node_id", "type": "text"},
-            {"key": "column", "name": "column", "type": "text"},
-            {"key": "change_status", "name": "change_status", "type": "text"},
-        ],
-        "data": [] if data is None else data,
-        "limit": 100,
-        "more": frame_more,
-        "total_row_count": total_row_count,
-        "schema_coverage": _schema_coverage() if coverage is None else coverage,
-    }
 
 
 class TestRunShouldBeApproved:
@@ -143,6 +107,33 @@ class TestSchemaDiffShouldBeApproved:
         assert result is False
 
     @patch("recce.run.default_context")
+    def test_selector_matching_zero_nodes_is_not_auto_approved(self, mock_ctx):
+        """A selector that matched nothing compared nothing.
+
+        The columns diff is trivially empty because there was nothing to
+        difference, which is absence of evidence, not a verified clean result.
+        """
+        node = {
+            "resource_type": "model",
+            "config": {"materialized": "table"},
+            "catalog_status": "covered",
+            "columns": {"id": {"type": "INTEGER"}},
+        }
+        mock_ctx.return_value.adapter.select_nodes.return_value = set()
+        mock_ctx.return_value.get_lineage.side_effect = [
+            {"nodes": {"model.project.orders": node}},
+            {"nodes": {"model.project.orders": node}},
+        ]
+
+        assert schema_diff_should_be_approved({"select": "tag:nonexistent"}) is False
+
+    @patch("recce.run.default_context")
+    def test_explicit_empty_node_id_list_is_not_auto_approved(self, mock_ctx):
+        mock_ctx.return_value.get_lineage.return_value = {"nodes": {}}
+
+        assert schema_diff_should_be_approved({"node_id": []}) is False
+
+    @patch("recce.run.default_context")
     def test_complete_covered_explicit_node_is_auto_approved(self, mock_ctx):
         node_id = "model.project.orders"
         node = {
@@ -162,7 +153,7 @@ class TestSchemaDiffShouldBeApproved:
 
     @patch("recce.run.default_context")
     def test_two_sided_node_missing_from_one_catalog_is_not_auto_approved(self, mock_ctx):
-        """The DRC-3293 shape itself: a model in BOTH manifests that the current
+        """The core bug shape: a model in BOTH manifests that the current
         catalog does not describe. Its columns look dropped, but nothing
         verified them, so the check must not be approved as reviewed."""
         node_id = "model.project.orders"
@@ -282,7 +273,34 @@ class TestSchemaDiffShouldBeApproved:
     def test_ephemeral_model_stays_auto_approvable(self, mock_ctx):
         """A non-relation cannot carry catalog columns, so its exclusion is
         genuinely not-applicable and must not block approval the way a
-        one-sided relation does."""
+        one-sided relation does.
+
+        Selected alongside a real covered model, so approval rests on that
+        model rather than on an empty comparison: an ephemeral model on its own
+        covers nothing and is unknown, not clean.
+        """
+        ephemeral_id = "model.project.ephemeral"
+        ephemeral = {
+            "resource_type": "model",
+            "config": {"materialized": "ephemeral"},
+            "columns": {},
+        }
+        covered_id = "model.project.orders"
+        covered = {
+            "resource_type": "model",
+            "config": {"materialized": "table"},
+            "catalog_status": "covered",
+            "columns": {"id": {"type": "INTEGER"}},
+        }
+        nodes = {ephemeral_id: ephemeral, covered_id: covered}
+        mock_ctx.return_value.get_lineage.side_effect = [{"nodes": nodes}, {"nodes": nodes}]
+
+        assert schema_diff_should_be_approved({"node_id": [ephemeral_id, covered_id]}) is True
+
+    @patch("recce.run.default_context")
+    def test_selection_of_only_non_relations_is_not_auto_approved(self, mock_ctx):
+        """The other half of the rule above: with nothing comparable in the
+        selection there is no evidence to approve on."""
         node_id = "model.project.ephemeral"
         node = {
             "resource_type": "model",
@@ -294,71 +312,4 @@ class TestSchemaDiffShouldBeApproved:
             {"nodes": {node_id: node}},
         ]
 
-        assert schema_diff_should_be_approved({"node_id": node_id}) is True
-
-
-@pytest.mark.parametrize("coverage", ["partial", "unknown", None])
-def test_schema_result_is_not_approvable_without_complete_coverage(coverage):
-    result = {"data": []}
-    if coverage is not None:
-        result["schema_coverage"] = {"status": coverage}
-
-    assert schema_result_is_approvable(result) is False
-
-
-def test_schema_result_is_not_approvable_when_verified_diff_has_a_mismatch():
-    result = _schema_result(data=[["model.project.orders", "customer_id", "added"]])
-
-    assert schema_result_is_approvable(result) is False
-
-
-def test_complete_empty_schema_result_is_approvable():
-    result = _schema_result()
-
-    assert schema_result_is_approvable(result) is True
-
-
-def test_complete_schema_result_allows_additive_coverage_fields():
-    coverage = {**_schema_coverage(), "computed_at": "2026-08-28T00:00:00Z"}
-
-    assert schema_result_is_approvable(_schema_result(coverage=coverage)) is True
-
-
-@pytest.mark.parametrize(
-    "coverage",
-    [
-        {"status": "complete"},
-        _schema_coverage(
-            unchecked_nodes=["model.project.orders"],
-            unchecked_node_count=1,
-        ),
-        _schema_coverage(more=True),
-    ],
-    ids=["missing-fields", "unchecked-node", "more-marker"],
-)
-def test_complete_contradictory_schema_coverage_is_not_approvable(coverage):
-    assert schema_result_is_approvable(_schema_result(coverage=coverage)) is False
-
-
-@pytest.mark.parametrize(
-    "result",
-    [
-        {"data": [], "schema_coverage": _schema_coverage()},
-        {**_schema_result(), "columns": []},
-        _schema_result(frame_more=True),
-    ],
-    ids=["missing-columns", "wrong-schema", "more-rows"],
-)
-def test_malformed_or_incomplete_empty_dataframe_is_not_approvable(result):
-    assert schema_result_is_approvable(result) is False
-
-
-@pytest.mark.parametrize(
-    "total_row_count",
-    [1, True, "0", None],
-    ids=["nonzero", "boolean", "string", "missing"],
-)
-def test_empty_schema_result_requires_exact_zero_total_row_count(total_row_count):
-    result = _schema_result(total_row_count=total_row_count)
-
-    assert schema_result_is_approvable(result) is False
+        assert schema_diff_should_be_approved({"node_id": node_id}) is False

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -161,6 +161,84 @@ class TestSchemaDiffShouldBeApproved:
         assert result is True
 
     @patch("recce.run.default_context")
+    def test_two_sided_node_missing_from_one_catalog_is_not_auto_approved(self, mock_ctx):
+        """The DRC-3293 shape itself: a model in BOTH manifests that the current
+        catalog does not describe. Its columns look dropped, but nothing
+        verified them, so the check must not be approved as reviewed."""
+        node_id = "model.project.orders"
+        base_node = {
+            "resource_type": "model",
+            "config": {"materialized": "table"},
+            "catalog_status": "covered",
+            "columns": {"id": {"type": "INTEGER"}, "gone": {"type": "TEXT"}},
+        }
+        # The real adapter shape for a model absent from catalog.json: no
+        # "columns" key at all.
+        current_node = {
+            "resource_type": "model",
+            "config": {"materialized": "table"},
+            "catalog_status": "unchecked",
+        }
+        mock_ctx.return_value.get_lineage.side_effect = [
+            {"nodes": {node_id: base_node}},
+            {"nodes": {node_id: current_node}},
+        ]
+
+        assert schema_diff_should_be_approved({"node_id": node_id}) is False
+
+    @patch("recce.run.default_context")
+    def test_one_uncovered_node_blocks_approval_of_a_clean_sibling(self, mock_ctx):
+        """AC3 + AC8: partial coverage blocks approval even when every node the
+        comparison could verify came back diff-free. A clean verified half is
+        not evidence about the unverified half."""
+        covered_id = "model.project.covered"
+        uncovered_id = "model.project.uncovered"
+        covered = {
+            "resource_type": "model",
+            "config": {"materialized": "table"},
+            "catalog_status": "covered",
+            "columns": {"id": {"type": "INTEGER"}},
+        }
+        mock_ctx.return_value.adapter.select_nodes.return_value = {covered_id, uncovered_id}
+        mock_ctx.return_value.get_lineage.side_effect = [
+            {
+                "nodes": {
+                    covered_id: covered,
+                    uncovered_id: {**covered, "columns": {"id": {"type": "INTEGER"}}},
+                }
+            },
+            {
+                "nodes": {
+                    covered_id: covered,
+                    uncovered_id: {
+                        "resource_type": "model",
+                        "config": {"materialized": "table"},
+                        "catalog_status": "unchecked",
+                    },
+                }
+            },
+        ]
+
+        assert schema_diff_should_be_approved({"select": "state:modified"}) is False
+
+    @patch("recce.run.default_context")
+    def test_covered_column_drop_is_not_auto_approved(self, mock_ctx):
+        """AC5: a removal both catalogs describe is a real difference. Complete
+        coverage is necessary for approval, never sufficient."""
+        node_id = "model.project.orders"
+        node = {
+            "resource_type": "model",
+            "config": {"materialized": "table"},
+            "catalog_status": "covered",
+        }
+        mock_ctx.return_value.get_lineage.side_effect = [
+            {"nodes": {node_id: {**node, "columns": {"id": {"type": "INTEGER"}, "gone": {"type": "TEXT"}}}}},
+            {"nodes": {node_id: {**node, "columns": {"id": {"type": "INTEGER"}}}}},
+        ]
+
+        assert schema_diff_should_be_approved({"node_id": node_id}) is False
+
+    @patch("recce.run.default_context")
     def test_dropped_model_is_not_auto_approved_as_unchanged(self, mock_ctx):
         """AC5: a model present only on the base side is a real removal.
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -16,6 +16,35 @@ def _make_run(result=None, error=None, run_type=RunType.ROW_COUNT_DIFF):
     return Run(type=run_type, result=result, error=error)
 
 
+def _schema_coverage(
+    status="complete",
+    *,
+    unchecked_nodes=None,
+    unchecked_node_count=0,
+    more=False,
+):
+    return {
+        "status": status,
+        "unchecked_nodes": [] if unchecked_nodes is None else unchecked_nodes,
+        "unchecked_node_count": unchecked_node_count,
+        "more": more,
+    }
+
+
+def _schema_result(*, data=None, coverage=None, frame_more=False):
+    return {
+        "columns": [
+            {"key": "node_id", "name": "node_id", "type": "text"},
+            {"key": "column", "name": "column", "type": "text"},
+            {"key": "change_status", "name": "change_status", "type": "text"},
+        ],
+        "data": [] if data is None else data,
+        "limit": 100,
+        "more": frame_more,
+        "schema_coverage": _schema_coverage() if coverage is None else coverage,
+    }
+
+
 class TestRunShouldBeApproved:
     """Tests for run_should_be_approved handling None values and edge cases."""
 
@@ -103,6 +132,15 @@ class TestSchemaDiffShouldBeApproved:
         assert result is False
         assert "schema_diff approval check failed (unexpected)" in caplog.text
 
+    @patch("recce.run.default_context")
+    def test_stale_explicit_node_id_is_not_auto_approved(self, mock_ctx):
+        stale_id = "model.project.misspelled_orders"
+        mock_ctx.return_value.get_lineage.return_value = {"nodes": {}}
+
+        result = schema_diff_should_be_approved({"node_id": stale_id})
+
+        assert result is False
+
 
 @pytest.mark.parametrize("coverage", ["partial", "unknown", None])
 def test_schema_result_is_not_approvable_without_complete_coverage(coverage):
@@ -114,18 +152,47 @@ def test_schema_result_is_not_approvable_without_complete_coverage(coverage):
 
 
 def test_schema_result_is_not_approvable_when_verified_diff_has_a_mismatch():
-    result = {
-        "data": [["model.project.orders", "customer_id", "added"]],
-        "schema_coverage": {"status": "complete"},
-    }
+    result = _schema_result(data=[["model.project.orders", "customer_id", "added"]])
 
     assert schema_result_is_approvable(result) is False
 
 
 def test_complete_empty_schema_result_is_approvable():
-    result = {
-        "data": [],
-        "schema_coverage": {"status": "complete"},
-    }
+    result = _schema_result()
 
     assert schema_result_is_approvable(result) is True
+
+
+def test_complete_schema_result_allows_additive_coverage_fields():
+    coverage = {**_schema_coverage(), "computed_at": "2026-08-28T00:00:00Z"}
+
+    assert schema_result_is_approvable(_schema_result(coverage=coverage)) is True
+
+
+@pytest.mark.parametrize(
+    "coverage",
+    [
+        {"status": "complete"},
+        _schema_coverage(
+            unchecked_nodes=["model.project.orders"],
+            unchecked_node_count=1,
+        ),
+        _schema_coverage(more=True),
+    ],
+    ids=["missing-fields", "unchecked-node", "more-marker"],
+)
+def test_complete_contradictory_schema_coverage_is_not_approvable(coverage):
+    assert schema_result_is_approvable(_schema_result(coverage=coverage)) is False
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"data": [], "schema_coverage": _schema_coverage()},
+        {**_schema_result(), "columns": []},
+        _schema_result(frame_more=True),
+    ],
+    ids=["missing-columns", "wrong-schema", "more-rows"],
+)
+def test_malformed_or_incomplete_empty_dataframe_is_not_approvable(result):
+    assert schema_result_is_approvable(result) is False

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -160,6 +160,64 @@ class TestSchemaDiffShouldBeApproved:
 
         assert result is True
 
+    @patch("recce.run.default_context")
+    def test_dropped_model_is_not_auto_approved_as_unchanged(self, mock_ctx):
+        """AC5: a model present only on the base side is a real removal.
+
+        The node is not two-sided, so it carries no column-level comparison —
+        but its absence is verified structural evidence, not an unchecked node.
+        Approving it would tell the reviewer a dropped model has no schema
+        differences.
+        """
+        node_id = "model.project.dropped"
+        base_node = {
+            "resource_type": "model",
+            "config": {"materialized": "table"},
+            "catalog_status": "covered",
+            "columns": {"id": {"type": "INTEGER"}, "gone": {"type": "TEXT"}},
+        }
+        mock_ctx.return_value.get_lineage.side_effect = [
+            {"nodes": {node_id: base_node}},
+            {"nodes": {}},
+        ]
+
+        assert schema_diff_should_be_approved({"node_id": node_id}) is False
+
+    @patch("recce.run.default_context")
+    def test_added_model_is_not_auto_approved_as_unchanged(self, mock_ctx):
+        """AC5: the mirror case — a model that exists only on the current side."""
+        node_id = "model.project.added"
+        current_node = {
+            "resource_type": "model",
+            "config": {"materialized": "table"},
+            "catalog_status": "covered",
+            "columns": {"id": {"type": "INTEGER"}},
+        }
+        mock_ctx.return_value.get_lineage.side_effect = [
+            {"nodes": {}},
+            {"nodes": {node_id: current_node}},
+        ]
+
+        assert schema_diff_should_be_approved({"node_id": node_id}) is False
+
+    @patch("recce.run.default_context")
+    def test_ephemeral_model_stays_auto_approvable(self, mock_ctx):
+        """A non-relation cannot carry catalog columns, so its exclusion is
+        genuinely not-applicable and must not block approval the way a
+        one-sided relation does."""
+        node_id = "model.project.ephemeral"
+        node = {
+            "resource_type": "model",
+            "config": {"materialized": "ephemeral"},
+            "columns": {},
+        }
+        mock_ctx.return_value.get_lineage.side_effect = [
+            {"nodes": {node_id: node}},
+            {"nodes": {node_id: node}},
+        ]
+
+        assert schema_diff_should_be_approved({"node_id": node_id}) is True
+
 
 @pytest.mark.parametrize("coverage", ["partial", "unknown", None])
 def test_schema_result_is_not_approvable_without_complete_coverage(coverage):

--- a/tests/test_schema_evidence.py
+++ b/tests/test_schema_evidence.py
@@ -1,0 +1,197 @@
+"""Tests for the run-result evidence predicates in `recce.schema_evidence`."""
+
+import pytest
+
+from recce.schema_evidence import (
+    result_is_schema_comparison,
+    run_result_is_approvable,
+    schema_result_is_approvable,
+)
+
+
+def _schema_coverage(
+    status="complete",
+    *,
+    unchecked_nodes=None,
+    unchecked_node_count=0,
+    more=False,
+):
+    return {
+        "status": status,
+        "unchecked_nodes": [] if unchecked_nodes is None else unchecked_nodes,
+        "unchecked_node_count": unchecked_node_count,
+        "more": more,
+    }
+
+
+def _schema_result(*, data=None, coverage=None, frame_more=False, total_row_count=0):
+    return {
+        "columns": [
+            {"key": "node_id", "name": "node_id", "type": "text"},
+            {"key": "column", "name": "column", "type": "text"},
+            {"key": "change_status", "name": "change_status", "type": "text"},
+        ],
+        "data": [] if data is None else data,
+        "limit": 100,
+        "more": frame_more,
+        "total_row_count": total_row_count,
+        "schema_coverage": _schema_coverage() if coverage is None else coverage,
+    }
+
+
+@pytest.mark.parametrize("coverage", ["partial", "unknown", None])
+def test_schema_result_is_not_approvable_without_complete_coverage(coverage):
+    result = {"data": []}
+    if coverage is not None:
+        result["schema_coverage"] = {"status": coverage}
+
+    assert schema_result_is_approvable(result) is False
+
+
+def test_schema_result_is_not_approvable_when_verified_diff_has_a_mismatch():
+    result = _schema_result(data=[["model.project.orders", "customer_id", "added"]])
+
+    assert schema_result_is_approvable(result) is False
+
+
+def test_complete_empty_schema_result_is_approvable():
+    result = _schema_result()
+
+    assert schema_result_is_approvable(result) is True
+
+
+def test_complete_schema_result_allows_additive_coverage_fields():
+    coverage = {**_schema_coverage(), "computed_at": "2026-08-28T00:00:00Z"}
+
+    assert schema_result_is_approvable(_schema_result(coverage=coverage)) is True
+
+
+@pytest.mark.parametrize(
+    "coverage",
+    [
+        {"status": "complete"},
+        _schema_coverage(
+            unchecked_nodes=["model.project.orders"],
+            unchecked_node_count=1,
+        ),
+        _schema_coverage(more=True),
+    ],
+    ids=["missing-fields", "unchecked-node", "more-marker"],
+)
+def test_complete_contradictory_schema_coverage_is_not_approvable(coverage):
+    assert schema_result_is_approvable(_schema_result(coverage=coverage)) is False
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"data": [], "schema_coverage": _schema_coverage()},
+        {**_schema_result(), "columns": []},
+        _schema_result(frame_more=True),
+    ],
+    ids=["missing-columns", "wrong-schema", "more-rows"],
+)
+def test_malformed_or_incomplete_empty_dataframe_is_not_approvable(result):
+    assert schema_result_is_approvable(result) is False
+
+
+@pytest.mark.parametrize(
+    "total_row_count",
+    [1, True, "0", None],
+    ids=["nonzero", "boolean", "string", "missing"],
+)
+def test_empty_schema_result_requires_exact_zero_total_row_count(total_row_count):
+    result = _schema_result(total_row_count=total_row_count)
+
+    assert schema_result_is_approvable(result) is False
+
+
+def _uncovered(result):
+    """A schema-diff frame stripped of its coverage block, so only the column
+    shape is left to identify it."""
+    return {key: value for key, value in result.items() if key != "schema_coverage"}
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        None,
+        {"customers": {"base": 100, "curr": 100}},
+        {"nodes": [], "edges": []},
+        {**_uncovered(_schema_result()), "columns": _schema_result()["columns"][:2]},
+        {
+            **_uncovered(_schema_result()),
+            "columns": [
+                {"key": "node_id", "name": "node_id", "type": "text"},
+                {"key": "column", "name": "column", "type": "text"},
+                {"key": "change_status", "name": "change_status", "type": "number"},
+            ],
+        },
+    ],
+    ids=["none", "row-count", "lineage", "too-few-columns", "wrong-column-type"],
+)
+def test_results_that_are_neither_shaped_nor_coverage_bearing_are_not_schema_comparisons(result):
+    assert result_is_schema_comparison(result) is False
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        _uncovered(_schema_result()),
+        _uncovered(_schema_result(data=[["model.project.orders", "customer_id", "added"]])),
+    ],
+    ids=["empty", "with-changes"],
+)
+def test_schema_diff_frames_are_recognised_by_their_column_shape(result):
+    assert result_is_schema_comparison(result) is True
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"data": [], "schema_coverage": _schema_coverage()},
+        {"schema_coverage": {"status": "garbage"}},
+        {**_schema_result(), "columns": []},
+    ],
+    ids=["no-columns", "malformed-coverage", "columns-stripped"],
+)
+def test_a_coverage_claim_alone_makes_a_result_a_schema_comparison(result):
+    """A schema result that lost its frame must fail closed, not fall out of
+    the gate as "some other check type"."""
+    assert result_is_schema_comparison(result) is True
+    assert run_result_is_approvable(result) is False
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"customers": {"base": 100, "curr": 100}},
+        {"customers": {"base": 100, "curr": 200}},
+        {"nodes": [], "edges": []},
+        {"summary": {}},
+        None,
+    ],
+    ids=["row-count-match", "row-count-mismatch", "lineage", "profile-ish", "none"],
+)
+def test_non_schema_results_keep_the_passed_equals_approved_gate(result):
+    """The schema-coverage contract must not repeal the standing PM decision.
+
+    Only a schema comparison can silently compare nothing and still hand back
+    an empty frame, so only a schema comparison has to prove coverage. Every
+    other type is gated by its caller on a successful run, exactly as before.
+    """
+    assert run_result_is_approvable(result) is True
+
+
+@pytest.mark.parametrize(
+    ("result", "approvable"),
+    [
+        (_schema_result(), True),
+        (_schema_result(coverage=_schema_coverage("partial", unchecked_nodes=["a"], unchecked_node_count=1)), False),
+        (_schema_result(coverage=_schema_coverage("unknown")), False),
+        (_schema_result(data=[["model.project.orders", "customer_id", "added"]], total_row_count=1), False),
+    ],
+    ids=["complete-empty", "partial", "unknown", "with-changes"],
+)
+def test_schema_shaped_results_still_face_the_strict_coverage_gate(result, approvable):
+    assert run_result_is_approvable(result) is approvable

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -534,6 +534,28 @@ def test_missing_catalog_legacy_input_reports_unknown_schema_coverage():
     assert "dbt docs generate" in markdown
 
 
+def test_stale_selected_node_id_reports_incomplete_schema_coverage():
+    stale_id = "model.project.misspelled_orders"
+
+    checks, statistics = _generate_schema_check_summary(
+        {"nodes": {}},
+        {"nodes": {}},
+        [stale_id],
+    )
+
+    assert statistics == {"total": 1, "mismatch": 0, "failed": 0, "incomplete": 1}
+    assert len(checks) == 1
+    assert checks[0].schema_coverage.model_dump() == {
+        "status": "partial",
+        "unchecked_nodes": [stale_id],
+        "unchecked_node_count": 1,
+        "more": False,
+    }
+    markdown = _render_check_summary(checks, statistics)
+    assert stale_id in markdown
+    assert "Schema comparison incomplete" in markdown
+
+
 def test_complete_schema_coverage_without_changes_remains_silent():
     node_id = "model.project.healthy"
     columns = {"id": {"type": "integer"}}

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -4,14 +4,17 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from dbt.flags import get_flags
 
 from recce.adapter.dbt_adapter import DbtAdapter, DbtVersion, load_manifest
 from recce.core import RecceContext, set_default_context
-from recce.models.types import NodeDiff
+from recce.models.types import Check, NodeDiff
 from recce.summary import (
     MERMAID_NODE_SHAPES,
     Node,
     _build_lineage_graph,
+    generate_check_content,
+    generate_check_summary,
     generate_mermaid_lineage_graph,
     generate_summary_metadata,
 )
@@ -19,6 +22,20 @@ from recce.summary import (
 current_dir = os.path.dirname(os.path.abspath(__file__))
 base_manifest_dir = os.path.join(current_dir, "data", "manifest", "base")
 pr2_manifest_dir = os.path.join(current_dir, "data", "manifest", "pr2")  # Pull Request 2l
+
+
+@pytest.fixture
+def dbt_state_modified_flag():
+    """Supply the dbt 1.12 flag absent from the repository's older fixtures."""
+    flags = get_flags()
+    had_flag = hasattr(flags, "state_modified_compare_more_unrendered_values")
+    previous_flag = getattr(flags, "state_modified_compare_more_unrendered_values", None)
+    flags.state_modified_compare_more_unrendered_values = False
+    yield
+    if had_flag:
+        flags.state_modified_compare_more_unrendered_values = previous_flag
+    else:
+        del flags.state_modified_compare_more_unrendered_values
 
 
 def test_generate_summary_metadata():
@@ -71,7 +88,7 @@ def test_generate_summary_metadata_without_artifact_timestamps(missing_metadata)
     )
 
 
-def test_generate_summary_metadata_accepts_adapter_lineage():
+def test_generate_summary_metadata_accepts_adapter_lineage(dbt_state_modified_flag):
     """
     The literal shapes above are only worth anything if they are the shapes an
     adapter really hands over, so run the dbt adapter's own get_lineage output
@@ -102,7 +119,7 @@ def test_generate_summary_metadata_accepts_adapter_lineage():
     assert diff_summary.count("N/A") == 2
 
 
-def test_build_lineage_graph():
+def test_build_lineage_graph(dbt_state_modified_flag):
     dbt_version = DbtVersion()
     if dbt_version < "1.8.1":
         pytest.skip("Dbt version is less than 1.8.1")
@@ -121,7 +138,7 @@ def test_build_lineage_graph():
     assert len(lineage_graph.modified_set) == 3
 
 
-def test_generate_mermaid_lineage_graph():
+def test_generate_mermaid_lineage_graph(dbt_state_modified_flag):
     dbt_version = DbtVersion()
     if dbt_version < "1.8.1":
         pytest.skip("Dbt version is less than 1.8.1")
@@ -370,7 +387,7 @@ class TestBuildLineageGraphWithDiff:
         changes = graph.nodes["model.test.a"]._what_changed()
         assert "Code" in changes
 
-    def test_no_diff_preserves_existing_behavior(self):
+    def test_no_diff_preserves_existing_behavior(self, dbt_state_modified_flag):
         """Passing diff=None should behave identically to the original implementation."""
         dbt_version = DbtVersion()
         if dbt_version < "1.8.1":
@@ -387,3 +404,151 @@ class TestBuildLineageGraphWithDiff:
         graph_no_diff = _build_lineage_graph(base_lineage, curr_lineage)
         graph_with_none = _build_lineage_graph(base_lineage, curr_lineage, None)
         assert graph_no_diff.modified_set == graph_with_none.modified_set
+
+
+def _catalogued_schema_node(name, columns, catalog_status="covered"):
+    return {
+        "name": name,
+        "resource_type": "model",
+        "config": {"materialized": "table"},
+        "catalog_status": catalog_status,
+        "columns": columns,
+    }
+
+
+def _generate_schema_check_summary(base_lineage, current_lineage, node_ids):
+    check = Check(
+        name="schema coverage",
+        description="schema evidence",
+        type="schema_diff",
+        params={"node_id": node_ids},
+    )
+    with (
+        patch("recce.summary.CheckDAO.list", return_value=[check]),
+        patch("recce.summary.RunDAO.list", return_value=[]),
+    ):
+        return generate_check_summary(base_lineage, current_lineage)
+
+
+def _render_check_summary(checks, statistics):
+    graph = SimpleNamespace(checks=checks)
+    with patch("recce.summary.get_node_name_by_id", side_effect=lambda node_id: node_id.rsplit(".", 1)[-1]):
+        return generate_check_content(graph, statistics)
+
+
+def test_partial_schema_coverage_preserves_verified_removal_before_incomplete_scope():
+    verified_id = "model.project.verified"
+    unchecked_id = "model.project.not_rebuilt"
+    base_lineage = {
+        "nodes": {
+            verified_id: _catalogued_schema_node(
+                "verified",
+                {"id": {"type": "integer"}, "removed": {"type": "text"}},
+            ),
+            unchecked_id: _catalogued_schema_node(
+                "not_rebuilt",
+                {"id": {"type": "integer"}, "not_removed": {"type": "text"}},
+            ),
+        }
+    }
+    current_lineage = {
+        "nodes": {
+            verified_id: _catalogued_schema_node("verified", {"id": {"type": "integer"}}),
+            unchecked_id: _catalogued_schema_node(
+                "not_rebuilt",
+                {"id": {"type": "integer"}},
+                catalog_status="unchecked",
+            ),
+        }
+    }
+
+    checks, statistics = _generate_schema_check_summary(
+        base_lineage,
+        current_lineage,
+        [verified_id, unchecked_id],
+    )
+
+    assert statistics == {"total": 1, "mismatch": 1, "failed": 0, "incomplete": 1}
+    assert len(checks) == 1
+    assert checks[0].changed_nodes == ["verified"]
+    assert checks[0].schema_coverage.model_dump() == {
+        "status": "partial",
+        "unchecked_nodes": [unchecked_id],
+        "unchecked_node_count": 1,
+        "more": False,
+    }
+
+    markdown = _render_check_summary(checks, statistics)
+    mismatch_section, incomplete_section = markdown.split(":warning: **Schema comparison incomplete", 1)
+    assert "verified" in mismatch_section
+    assert "not_rebuilt" not in mismatch_section
+    assert unchecked_id in incomplete_section
+    assert markdown.index("verified") < markdown.index(unchecked_id)
+    assert "1 unchecked node" in incomplete_section
+    assert "dbt docs generate" in incomplete_section
+
+
+def test_incomplete_schema_coverage_without_verified_change_is_not_a_clean_pass():
+    checked_id = "model.project.checked"
+    unchecked_id = "model.project.not_rebuilt"
+    columns = {"id": {"type": "integer"}}
+    base_lineage = {
+        "nodes": {
+            checked_id: _catalogued_schema_node("checked", columns),
+            unchecked_id: _catalogued_schema_node("not_rebuilt", columns),
+        }
+    }
+    current_lineage = {
+        "nodes": {
+            checked_id: _catalogued_schema_node("checked", columns),
+            unchecked_id: _catalogued_schema_node("not_rebuilt", columns, catalog_status="unchecked"),
+        }
+    }
+
+    checks, statistics = _generate_schema_check_summary(
+        base_lineage,
+        current_lineage,
+        [checked_id, unchecked_id],
+    )
+
+    assert statistics == {"total": 1, "mismatch": 0, "failed": 0, "incomplete": 1}
+    assert len(checks) == 1
+    markdown = _render_check_summary(checks, statistics)
+    assert "Checks of Data Mismatch Detected" not in markdown
+    assert "Incomplete Schema Comparisons" in markdown
+    assert ":warning: **Schema comparison incomplete" in markdown
+    assert unchecked_id in markdown
+
+
+def test_missing_catalog_legacy_input_reports_unknown_schema_coverage():
+    checks, statistics = _generate_schema_check_summary(
+        {},
+        {"nodes": {}},
+        ["model.project.legacy"],
+    )
+
+    assert statistics == {"total": 1, "mismatch": 0, "failed": 0, "incomplete": 1}
+    assert len(checks) == 1
+    assert checks[0].schema_coverage.model_dump() == {
+        "status": "unknown",
+        "unchecked_nodes": [],
+        "unchecked_node_count": 0,
+        "more": False,
+    }
+    markdown = _render_check_summary(checks, statistics)
+    assert "unchecked scope could not be determined" in markdown
+    assert "dbt docs generate" in markdown
+
+
+def test_complete_schema_coverage_without_changes_remains_silent():
+    node_id = "model.project.healthy"
+    columns = {"id": {"type": "integer"}}
+    lineage = {"nodes": {node_id: _catalogued_schema_node("healthy", columns)}}
+
+    checks, statistics = _generate_schema_check_summary(lineage, lineage, [node_id])
+
+    assert checks == []
+    assert statistics == {"total": 1, "mismatch": 0, "failed": 0, "incomplete": 0}
+    markdown = _render_check_summary(checks, statistics)
+    assert "Schema comparison incomplete" not in markdown
+    assert "Checks of Data Mismatch Detected" not in markdown

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -482,6 +482,47 @@ def test_partial_schema_coverage_preserves_verified_removal_before_incomplete_sc
     assert "dbt docs generate" in incomplete_section
 
 
+@pytest.mark.parametrize("dropped", [True, False], ids=["removed-model", "added-model"])
+def test_one_sided_model_is_a_mismatch_not_a_coverage_gap(dropped: bool):
+    """AC5 at the surface that renders the PR summary.
+
+    A model on only one manifest side is a verified structural change. The
+    summary must report it as a mismatch and must NOT report a coverage gap —
+    nothing here needs a regenerated catalog. Only two-sided nodes are tested
+    elsewhere, so a refactor that treats one-sided nodes as out of scope would
+    delete the removal from the summary entirely.
+    """
+    one_sided_id = "model.project.dropped_orders"
+    healthy_id = "model.project.healthy"
+    columns = {"id": {"type": "integer"}, "amount": {"type": "numeric"}}
+    one_sided = {one_sided_id: _catalogued_schema_node("dropped_orders", columns)}
+    healthy = {healthy_id: _catalogued_schema_node("healthy", {"id": {"type": "integer"}})}
+
+    base_lineage = {"nodes": {**healthy, **(one_sided if dropped else {})}}
+    current_lineage = {"nodes": {**healthy, **({} if dropped else one_sided)}}
+
+    checks, statistics = _generate_schema_check_summary(
+        base_lineage,
+        current_lineage,
+        [one_sided_id, healthy_id],
+    )
+
+    assert statistics == {"total": 1, "mismatch": 1, "failed": 0, "incomplete": 0}
+    assert len(checks) == 1
+    assert checks[0].changed_nodes == ["dropped_orders"]
+    assert checks[0].schema_coverage.model_dump() == {
+        "status": "complete",
+        "unchecked_nodes": [],
+        "unchecked_node_count": 0,
+        "more": False,
+    }
+
+    markdown = _render_check_summary(checks, statistics)
+    assert "Checks of Data Mismatch Detected" in markdown
+    assert "dropped_orders" in markdown
+    assert ":warning: **Schema comparison incomplete" not in markdown
+
+
 def test_incomplete_schema_coverage_without_verified_change_is_not_a_clean_pass():
     checked_id = "model.project.checked"
     unchecked_id = "model.project.not_rebuilt"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
-from dbt.flags import get_flags
 
 from recce.adapter.dbt_adapter import DbtAdapter, DbtVersion, load_manifest
 from recce.core import RecceContext, set_default_context
@@ -18,6 +17,7 @@ from recce.summary import (
     generate_mermaid_lineage_graph,
     generate_summary_metadata,
 )
+from tests.dbt_flags import temporarily_set_state_modified_compare_flag
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 base_manifest_dir = os.path.join(current_dir, "data", "manifest", "base")
@@ -27,15 +27,9 @@ pr2_manifest_dir = os.path.join(current_dir, "data", "manifest", "pr2")  # Pull 
 @pytest.fixture
 def dbt_state_modified_flag():
     """Supply the dbt 1.12 flag absent from the repository's older fixtures."""
-    flags = get_flags()
-    had_flag = hasattr(flags, "state_modified_compare_more_unrendered_values")
-    previous_flag = getattr(flags, "state_modified_compare_more_unrendered_values", None)
-    flags.state_modified_compare_more_unrendered_values = False
+    restore = temporarily_set_state_modified_compare_flag()
     yield
-    if had_flag:
-        flags.state_modified_compare_more_unrendered_values = previous_flag
-    else:
-        del flags.state_modified_compare_more_unrendered_values
+    restore()
 
 
 def test_generate_summary_metadata():


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

- Classifies base and current dbt artifacts independently and exposes bounded, side-aware health through Recce's info contract.
- Carries catalog evidence through lineage and schema coverage so checks, summaries, MCP approval, and persisted results fail closed when either side is incomplete.
- Adds shared UI types and helpers that render targeted base/current warnings without treating an incomplete comparison as a schema match.

**Which issue(s) this PR fixes**:

Closes DRC-3303

**Special notes for your reviewer**:

- Companion Recce Cloud PR: https://github.com/DataRecce/recce-cloud-infra/pull/1703
- Merged with `main` to resolve the conflict with #1533 (`create_check`'s new `approve` argument). Both gates now apply: a check is approved only when the caller asked for approval **and** the evidence is complete-coverage with a verified-empty schema diff.

### Bugs found and fixed after an adversarial review of the tests

Three were regressions this branch itself introduced:

1. **One-sided models auto-approved as "no changes."** `classify_node_schema_comparison` returns `not_applicable` for a node present on exactly one manifest side, so it landed in neither the checked nor the unchecked bucket, and every consumer iterated `checked_node_ids` alone. `schema_diff_should_be_approved` returned `True` for a dropped model on this branch and `False` on `main`. The removal also vanished from the PR summary and the MCP payload. One-sidedness now has its own bucket — it is verified structural evidence, not a coverage gap.
2. **`unknown` coverage erased every schema row.** The grid suppressed rows for both `unchecked` and `unknown`. Only `unchecked` earns that; `unknown` means no coverage evidence exists at all, and suppressing there turns absence of evidence into affirmative absence of changes. This was live for Recce Cloud, whose lineage graph carries no `schema_comparison_status` — every Cloud schema check would have shown an incomplete banner over a table with only unchanged columns. (Cloud also now carries the field, in the companion PR.)
3. **Every SQLMesh project broken.** SQLMesh has no `catalog.json`; `columns_to_types` is authoritative. The adapter never set `catalog_status`, so the classifier read the missing key as legacy evidence: permanently partial coverage, all schema diffs suppressed, and remediation copy telling SQLMesh users to run `dbt docs generate`.

Also: `build_merged_lineage` now degrades an unparseable side health to `unknown` instead of raising, where a status literal from a producer on another version took down the entire lineage response.

### Test strengthening

Roughly 30 assertions added or rewritten, each verified to fail against a specific mutation the previous suite passed — including AC1 (empty by set intersection, not raw catalog totals), AC2 (all three degradation sides), AC3 (bounded samples at *and* over the cap), AC4 (`not_applicable` with a catalog present), AC5 (verified removals still visible in grid, summary and MCP payload), and AC10 (version skew). Two notable rewrites:

- The `approve=False` tests in **both** MCP backends were vacuous — their fixtures were unapprovable anyway, so deleting the gate was green in both. Rewritten so `approve` alone decides.
- No test asserted the payload an agent actually receives. Stripping `schema_coverage` from the `run_check` response, or counting compared nodes instead of changes, were both green.

### Open product questions for the reviewer

1. **MCP no longer auto-approves any non-schema check.** This branch removes `main`'s "blanket-approve any successful run — intentional per PM decision" and gates everything on `schema_result_is_approvable()`, which requires a schema-diff-shaped result. A `row_count_diff` check with matching counts created via MCP no longer auto-approves, though the CLI path (`run_should_be_approved`) still would. Intended?
2. **A schema check whose selector matches zero nodes reports `complete` and auto-approves** — an affirmative "verified clean" from a comparison that examined nothing. Currently pinned as desired by `test_tool_run_check_with_schema_diff`.

**Verification at this head**

- Backend: 1,803 passed, 5 skipped.
- Frontend: 4,324 passed, 5 skipped; lint and type-check pass.
- CI: 24 checks passing, 0 failures.

**Does this PR introduce a user-facing change?**:

Yes. Recce now identifies which artifact side is incomplete, shows side-specific warnings, and prevents unsafe schema approval or match reporting. Genuine removals — including models present on only one side — stay visible, and a comparison with no coverage evidence no longer hides the diff it computed.
