### PR TITLE
feat(mcp): let a caller leave a check unapproved and change it later

### DIFF
--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -2950,8 +2950,9 @@ class RecceMCPServer:
         if not check_dao.find_check_by_id(check_id):
             raise ValueError(f"Check with ID {check_id} not found")
 
-        check_dao.update_check_by_id(check_id, PatchCheckIn(**fields))
-        updated = check_dao.find_check_by_id(check_id)
+        updated = check_dao.update_check_by_id(check_id, PatchCheckIn(**fields))
+        if updated is None:
+            raise ValueError(f"Failed to update check {check_id}")
         await asyncio.get_event_loop().run_in_executor(None, export_persistent_state)
 
         return {

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -296,7 +296,7 @@ class CloudBackend:
             )
             run_executed = True
             run_error = run.get("error")
-            if self._run_succeeded(run):
+            if self._run_succeeded(run) and arguments.get("approve", True):
                 await self._auto_approve(check_id)
         result = {
             "check_id": str(check_id),
@@ -1521,6 +1521,14 @@ class RecceMCPServer:
                                         "type": "string",
                                         "enum": ["user", "recce_ai"],
                                         "description": "Who triggered this run. Defaults to 'user'.",
+                                    },
+                                    "approve": {
+                                        "type": "boolean",
+                                        "description": (
+                                            "Mark the check approved when its run succeeds. "
+                                            "Defaults to true. Set false to leave the check "
+                                            "unapproved for review."
+                                        ),
                                     },
                                 },
                                 "required": ["type", "params", "name"],
@@ -2792,6 +2800,7 @@ class RecceMCPServer:
         params = arguments.get("params", {})
         name = arguments["name"]
         description = arguments.get("description", "")
+        approve = arguments.get("approve", True)
 
         # Idempotency: find existing check with same (type, params)
         check_dao = CheckDAO()
@@ -2854,7 +2863,7 @@ class RecceMCPServer:
         # Note: this differs from run_should_be_approved() in run.py, which
         # only approves ROW_COUNT_DIFF with matching counts.  Here we blanket-
         # approve any successful run — intentional per PM decision.
-        if run_executed and not run_error:
+        if run_executed and not run_error and approve:
             check_dao.update_check_by_id(check_id, PatchCheckIn(is_checked=True))
 
         # Persist state to cloud/disk (matches REST endpoint pattern)

--- a/recce/mcp_server.py
+++ b/recce/mcp_server.py
@@ -93,6 +93,8 @@ SELECTOR_SYNTAX_NOTE = (
 # 25k cap (~43k chars / ~14.4k tokens for 300 long-id nodes, edges included).
 VIEW_ALL_MAX_NODES = 300
 
+UPDATABLE_CHECK_FIELDS = ("name", "description", "is_checked")
+
 
 class InstanceSpawningError(RuntimeError):
     """Raised when a Recce Cloud session instance is not ready yet."""
@@ -176,6 +178,8 @@ class CloudBackend:
             return await self._tool_run_check(arguments)
         if name == "create_check":
             return await self._tool_create_check(arguments)
+        if name == "update_check":
+            return await self._tool_update_check(arguments)
         if name == "impact_analysis":
             return await self._tool_impact_analysis(arguments)
         raise ValueError(f"Unknown tool: {name}")
@@ -322,6 +326,24 @@ class CloudBackend:
             )
         except (RecceCloudException, InstanceSpawningError) as e:
             logger.warning(f"[MCP] Auto-approve failed for check {check_id}: {e}")
+
+    async def _tool_update_check(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        check_id = arguments.get("check_id")
+        if not check_id:
+            raise ValueError("check_id is required")
+        fields = {key: arguments[key] for key in UPDATABLE_CHECK_FIELDS if key in arguments}
+        if not fields:
+            raise ValueError(f"At least one of {', '.join(UPDATABLE_CHECK_FIELDS)} is required")
+        check = await self._request(
+            "PATCH",
+            f"checks/{quote(str(check_id), safe='')}",
+            json=fields,
+        )
+        return {
+            "check_id": str(check_id),
+            "updated": sorted(fields),
+            "is_checked": check.get("is_checked"),
+        }
 
     async def _tool_lineage_diff(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         info = await self._request("GET", "info")
@@ -1534,6 +1556,36 @@ class RecceMCPServer:
                                 "required": ["type", "params", "name"],
                             },
                         ),
+                        Tool(
+                            name="update_check",
+                            description=(
+                                "Update an existing check. Approve it (is_checked=true), unapprove it "
+                                "(is_checked=false), or edit its name or description. Only the fields "
+                                "passed are changed."
+                            ),
+                            inputSchema={
+                                "type": "object",
+                                "properties": {
+                                    "check_id": {
+                                        "type": "string",
+                                        "description": "The ID of the check to update",
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "New check name",
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "description": "New check description",
+                                    },
+                                    "is_checked": {
+                                        "type": "boolean",
+                                        "description": "Approval state of the check",
+                                    },
+                                },
+                                "required": ["check_id"],
+                            },
+                        ),
                     ]
                 )
 
@@ -1633,6 +1685,7 @@ class RecceMCPServer:
                     "list_checks",
                     "run_check",
                     "create_check",
+                    "update_check",
                     "impact_analysis",
                 }
                 # Unconfigured-mode gate: when neither a local context nor a cloud
@@ -1705,6 +1758,8 @@ class RecceMCPServer:
                     result = await self._tool_run_check(arguments)
                 elif name == "create_check":
                     result = await self._tool_create_check(arguments)
+                elif name == "update_check":
+                    result = await self._tool_update_check(arguments)
                 else:
                     raise ValueError(f"Unknown tool: {name}")
 
@@ -2877,6 +2932,33 @@ class RecceMCPServer:
         if run_error:
             result["run_error"] = run_error
         return result
+
+    async def _tool_update_check(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Update a check's name, description, or approval state."""
+        from recce.apis.check_api import PatchCheckIn
+        from recce.apis.check_func import export_persistent_state
+        from recce.models import CheckDAO
+
+        check_id = arguments.get("check_id")
+        if not check_id:
+            raise ValueError("check_id is required")
+        fields = {key: arguments[key] for key in UPDATABLE_CHECK_FIELDS if key in arguments}
+        if not fields:
+            raise ValueError(f"At least one of {', '.join(UPDATABLE_CHECK_FIELDS)} is required")
+
+        check_dao = CheckDAO()
+        if not check_dao.find_check_by_id(check_id):
+            raise ValueError(f"Check with ID {check_id} not found")
+
+        check_dao.update_check_by_id(check_id, PatchCheckIn(**fields))
+        updated = check_dao.find_check_by_id(check_id)
+        await asyncio.get_event_loop().run_in_executor(None, export_persistent_state)
+
+        return {
+            "check_id": str(check_id),
+            "updated": sorted(fields),
+            "is_checked": updated.is_checked,
+        }
 
     async def run(self):
         """Run the MCP server in stdio mode"""

--- a/tests/test_mcp_cloud_backend.py
+++ b/tests/test_mcp_cloud_backend.py
@@ -218,6 +218,27 @@ async def test_create_check_runs_lineage_diff_via_checks_run_endpoint(cloud_requ
 
 
 @pytest.mark.asyncio
+async def test_create_check_approve_false_leaves_check_unapproved(cloud_requests):
+    cloud_requests.side_effect = [
+        MockResponse(204),
+        MockResponse(200, {"check_id": "check-1"}),
+        MockResponse(200, {"run_id": "run-1", "status": "finished", "result": {"nodes": []}}),
+        # Spare: an unwanted approve must fail the assertion below, not an empty side_effect list.
+        MockResponse(200, {"check_id": "check-1", "is_checked": True}),
+    ]
+    backend = await CloudBackend.create(session_id="sess-123", api_token="token-abc")
+
+    result = await backend.call_tool(
+        "create_check",
+        {"name": "lineage", "type": "lineage_diff", "params": {}, "approve": False},
+    )
+
+    methods = [call.args[0] for call in cloud_requests.call_args_list]
+    assert "PATCH" not in methods
+    assert result["run_executed"] is True
+
+
+@pytest.mark.asyncio
 async def test_cloud_backend_lineage_diff_view_all_truncates(monkeypatch):
     """DRC-3758: CloudBackend caps view_mode='all', keeping changed + impacted first."""
     from recce.mcp_server import CloudBackend

--- a/tests/test_mcp_cloud_backend.py
+++ b/tests/test_mcp_cloud_backend.py
@@ -239,6 +239,41 @@ async def test_create_check_approve_false_leaves_check_unapproved(cloud_requests
 
 
 @pytest.mark.asyncio
+async def test_update_check_patches_only_the_given_fields(cloud_requests):
+    cloud_requests.side_effect = [
+        MockResponse(204),
+        MockResponse(200, {"check_id": "check-1", "is_checked": False}),
+    ]
+    backend = await CloudBackend.create(session_id="sess-123", api_token="token-abc")
+
+    result = await backend.call_tool(
+        "update_check",
+        {"check_id": "check-1", "is_checked": False, "description": "still open"},
+    )
+
+    method, url = cloud_requests.call_args.args[:2]
+    assert method == "PATCH"
+    assert url == "https://cloud.reccehq.com/api/v2/sessions/sess-123/checks/check-1"
+    assert cloud_requests.call_args.kwargs["json"] == {"description": "still open", "is_checked": False}
+    assert result == {
+        "check_id": "check-1",
+        "updated": ["description", "is_checked"],
+        "is_checked": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_check_rejects_a_call_with_no_field_to_change(cloud_requests):
+    cloud_requests.side_effect = [MockResponse(204)]
+    backend = await CloudBackend.create(session_id="sess-123", api_token="token-abc")
+
+    with pytest.raises(ValueError, match="At least one of"):
+        await backend.call_tool("update_check", {"check_id": "check-1"})
+
+    assert cloud_requests.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_cloud_backend_lineage_diff_view_all_truncates(monkeypatch):
     """DRC-3758: CloudBackend caps view_mode='all', keeping changed + impacted first."""
     from recce.mcp_server import CloudBackend

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -1236,6 +1236,7 @@ class TestMCPProtocolE2E:
                 "list_checks",
                 "run_check",
                 "create_check",
+                "update_check",
             }
             assert expected == tool_names
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -647,6 +647,55 @@ class TestRecceMCPServer:
         mock_check_dao.update_check_by_id.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_tool_update_check_unapproves_and_persists(self, mcp_server):
+        """update_check patches only the given fields and exports the state."""
+        server, _ = mcp_server
+        from uuid import uuid4
+
+        from recce.models.types import Check
+
+        check_id = uuid4()
+        existing = MagicMock(spec=Check)
+        existing.check_id = check_id
+        existing.is_checked = False
+
+        mock_check_dao = MagicMock()
+        mock_check_dao.find_check_by_id.return_value = existing
+
+        with (
+            patch("recce.models.CheckDAO", return_value=mock_check_dao),
+            patch("recce.apis.check_func.export_persistent_state") as mock_export,
+        ):
+            result = await server._tool_update_check(
+                {"check_id": str(check_id), "is_checked": False, "description": "still open"}
+            )
+
+        patch_in = mock_check_dao.update_check_by_id.call_args[0][1]
+        assert patch_in.is_checked is False
+        assert patch_in.description == "still open"
+        assert patch_in.name is None
+        assert result == {
+            "check_id": str(check_id),
+            "updated": ["description", "is_checked"],
+            "is_checked": False,
+        }
+        mock_export.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tool_update_check_unknown_check_id(self, mcp_server):
+        """update_check raises when the check does not exist."""
+        server, _ = mcp_server
+
+        mock_check_dao = MagicMock()
+        mock_check_dao.find_check_by_id.return_value = None
+
+        with patch("recce.models.CheckDAO", return_value=mock_check_dao):
+            with pytest.raises(ValueError, match="not found"):
+                await server._tool_update_check({"check_id": "missing", "is_checked": True})
+
+        mock_check_dao.update_check_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_tool_create_check_idempotent_update(self, mcp_server):
         """create_check with same (type, params) updates instead of creating."""
         server, _ = mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -661,6 +661,7 @@ class TestRecceMCPServer:
 
         mock_check_dao = MagicMock()
         mock_check_dao.find_check_by_id.return_value = existing
+        mock_check_dao.update_check_by_id.return_value = existing
 
         with (
             patch("recce.models.CheckDAO", return_value=mock_check_dao),

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -610,6 +610,43 @@ class TestRecceMCPServer:
         assert approve_call[0][1].is_checked is True
 
     @pytest.mark.asyncio
+    async def test_tool_create_check_approve_false_leaves_check_unapproved(self, mcp_server):
+        """create_check with approve=False runs the check but does not approve it."""
+        server, _ = mcp_server
+        from uuid import uuid4
+
+        from recce.models.types import Check, RunStatus
+
+        check_id = uuid4()
+        mock_check = MagicMock(spec=Check)
+        mock_check.check_id = check_id
+
+        mock_run = MagicMock()
+        mock_run.status = RunStatus.FINISHED
+        mock_run.error = None
+
+        mock_check_dao = MagicMock()
+        mock_check_dao.list.return_value = []
+
+        with (
+            patch("recce.models.CheckDAO", return_value=mock_check_dao),
+            patch("recce.apis.check_func.create_check_without_run", return_value=mock_check),
+            patch("recce.apis.run_func.submit_run", return_value=(mock_run, asyncio.sleep(0))),
+            patch("recce.apis.check_func.export_persistent_state"),
+        ):
+            result = await server._tool_create_check(
+                {
+                    "type": "row_count_diff",
+                    "params": {"node_names": ["orders"]},
+                    "name": "Row Count Diff of orders",
+                    "approve": False,
+                }
+            )
+
+        assert result["run_executed"] is True
+        mock_check_dao.update_check_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_tool_create_check_idempotent_update(self, mcp_server):
         """create_check with same (type, params) updates instead of creating."""
         server, _ = mcp_server


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

feature

**What this PR does / why we need it**:

`create_check` marks a check approved as soon as its run succeeds. A caller that creates a check for work a person still has to review cannot opt out, so the checklist reports the item as done. No tool changes a check after it exists, so the caller cannot correct it afterwards either.

This PR adds two things:

- An optional `approve` argument on `create_check`, default true. Existing callers are unchanged.
- A new `update_check` tool, to approve a check, unapprove it, or edit its name or description.

**Which issue(s) this PR fixes**:

Fixes DRC-4309

**Special notes for your reviewer**:

This does not reverse DRC-3307. "Passed = Approved" stays the default, and `approve` is an opt-out for callers that need it.

`run_check` still approves on a successful run. Gating it is out of scope here.

**Does this PR introduce a user-facing change?**:

Two new MCP capabilities for `recce mcp-server`: an optional `approve` argument on `create_check`, and a new `update_check` tool to approve, unapprove, or edit a check.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ccc81463-8e09-4301-b078-56ab551bb9fa)
