### PR TITLE
fix(lineage): scope column transformation legend

### DIFF
--- a/js/packages/storybook/stories/lineage/LineageLegend.stories.tsx
+++ b/js/packages/storybook/stories/lineage/LineageLegend.stories.tsx
@@ -69,7 +69,19 @@ export const ChangeStatusCllDark: Story = {
 export const Transformation: Story = {
   args: {
     variant: "transformation",
-    title: "Transformations",
+    title: "Column transformations",
+    showTooltips: true,
+  },
+};
+
+/**
+ * A displayed chain containing only passthrough and derived columns.
+ */
+export const FilteredTransformation: Story = {
+  args: {
+    variant: "transformation",
+    title: "Column transformations",
+    transformationTypes: ["passthrough", "derived"],
     showTooltips: true,
   },
 };

--- a/js/packages/ui/src/components/lineage/GraphColumnNodeOss.tsx
+++ b/js/packages/ui/src/components/lineage/GraphColumnNodeOss.tsx
@@ -18,6 +18,7 @@ import type { LineageGraphColumnNode } from "../..";
 import { useLineageViewContextSafe } from "../../contexts";
 import { useThemeColors } from "../../hooks";
 import { LineageColumnNode, type LineageColumnNodeData } from "./columns";
+import { CONTENT_VISIBILITY_MIN_ZOOM } from "./config/zoomConstants";
 
 // =============================================================================
 // TYPES
@@ -49,7 +50,9 @@ function GraphColumnNodeComponent(nodeProps: GraphColumnNodeProps) {
   } = data;
 
   // Get zoom level for content visibility
-  const showContent = useStore((s) => s.transform[2] > 0.3);
+  const showContent = useStore(
+    (s) => s.transform[2] > CONTENT_VISIBILITY_MIN_ZOOM,
+  );
 
   // Get theme colors
   const { isDark } = useThemeColors();

--- a/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
+++ b/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
@@ -33,6 +33,7 @@ import { getSemanticColorTheme } from "../../theme";
 import { deltaPercentageString, getRowCountChangeDirection } from "../../utils";
 import { findByRunType } from "../run";
 import { resolveChangeCategory } from "./changeCategory";
+import { CONTENT_VISIBILITY_MIN_ZOOM } from "./config/zoomConstants";
 import {
   ActionTag,
   LineageNode,
@@ -299,7 +300,9 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
   const { id, resourceType, changeStatus, name } = data;
 
   // Get zoom level for content visibility
-  const showContent = useStore((s) => s.transform[2] > 0.3);
+  const showContent = useStore(
+    (s) => s.transform[2] > CONTENT_VISIBILITY_MIN_ZOOM,
+  );
 
   // Get theme colors
   const { isDark } = useThemeColors();

--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -90,6 +90,7 @@ import {
   nextChangeAnalysisMode,
   resolveResetCllInput,
 } from "./changeAnalysisState";
+import { getDisplayedColumnTransformationTypes } from "./columnTransformation";
 import { computeColumnLineage } from "./computeColumnLineage";
 import { computeImpactedColumns } from "./computeImpactedColumns";
 import { computeIsImpacted } from "./computeIsImpacted";
@@ -323,6 +324,19 @@ export function PrivateLineageView(
   const isModelsChanged = useMemo(() => {
     return !!(lineageGraph && lineageGraph.modifiedSet.length > 0);
   }, [lineageGraph]);
+
+  const displayedColumnTransformationTypes = useMemo(
+    () =>
+      getDisplayedColumnTransformationTypes(nodes, (nodeId) =>
+        isNodeShowingChangeAnalysis({
+          nodeId,
+          changeAnalysisMode,
+          cllInput: viewOptions.column_level_lineage,
+          lineageGraph,
+        }),
+      ),
+    [nodes, changeAnalysisMode, viewOptions.column_level_lineage, lineageGraph],
+  );
 
   /**
    * View mode
@@ -1671,8 +1685,12 @@ export function PrivateLineageView(
                     newCllExperience={newCllExperience}
                   />
                 )}
-                {viewOptions.column_level_lineage && (
-                  <LineageLegend variant="transformation" />
+                {displayedColumnTransformationTypes.length > 0 && (
+                  <LineageLegend
+                    variant="transformation"
+                    title="Column transformations"
+                    transformationTypes={displayedColumnTransformationTypes}
+                  />
                 )}
               </Stack>
             </Panel>

--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -63,6 +63,7 @@ import {
   useEdgesState,
   useNodesState,
   useReactFlow,
+  useStore,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import React, {
@@ -96,6 +97,7 @@ import { computeImpactedColumns } from "./computeImpactedColumns";
 import { computeIsImpacted } from "./computeIsImpacted";
 import { computeWholeModelImpact } from "./computeWholeModelImpact";
 import {
+  CONTENT_VISIBILITY_MIN_ZOOM,
   EXPLORE_MIN_ZOOM,
   edgeTypes,
   FIT_VIEW_PADDING,
@@ -227,6 +229,9 @@ export function PrivateLineageView(
   const { apiClient } = useApiConfig();
   const queryClient = useQueryClient();
   const reactFlow = useReactFlow();
+  const isNodeContentVisible = useStore(
+    (state) => state.transform[2] > CONTENT_VISIBILITY_MIN_ZOOM,
+  );
   const refResize = useRef<HTMLDivElement>(null);
   const {
     copyToClipboard,
@@ -325,18 +330,26 @@ export function PrivateLineageView(
     return !!(lineageGraph && lineageGraph.modifiedSet.length > 0);
   }, [lineageGraph]);
 
-  const displayedColumnTransformationTypes = useMemo(
-    () =>
-      getDisplayedColumnTransformationTypes(nodes, (nodeId) =>
-        isNodeShowingChangeAnalysis({
-          nodeId,
-          changeAnalysisMode,
-          cllInput: viewOptions.column_level_lineage,
-          lineageGraph,
-        }),
-      ),
-    [nodes, changeAnalysisMode, viewOptions.column_level_lineage, lineageGraph],
-  );
+  const displayedColumnTransformationTypes = useMemo(() => {
+    if (!isNodeContentVisible) {
+      return [];
+    }
+
+    return getDisplayedColumnTransformationTypes(nodes, (nodeId) =>
+      isNodeShowingChangeAnalysis({
+        nodeId,
+        changeAnalysisMode,
+        cllInput: viewOptions.column_level_lineage,
+        lineageGraph,
+      }),
+    );
+  }, [
+    nodes,
+    isNodeContentVisible,
+    changeAnalysisMode,
+    viewOptions.column_level_lineage,
+    lineageGraph,
+  ]);
 
   /**
    * View mode

--- a/js/packages/ui/src/components/lineage/__tests__/LineageColumnNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageColumnNode.test.tsx
@@ -47,6 +47,7 @@ vi.mock("@xyflow/react", () => ({
 // ============================================================================
 
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   type ColumnTransformationType,
   LineageColumnNode,
@@ -260,17 +261,39 @@ describe("LineageColumnNode", () => {
   // ==========================================================================
 
   describe("transformation type indicator", () => {
-    const transformationLetters: Record<ColumnTransformationType, string> = {
-      passthrough: "P",
-      renamed: "R",
-      derived: "D",
-      source: "S",
-      unknown: "U",
+    const transformationDetails: Record<
+      ColumnTransformationType,
+      { letter: string; accessibleName: string }
+    > = {
+      passthrough: {
+        letter: "P",
+        accessibleName:
+          "Passthrough transformation: Same-name reference to an upstream column",
+      },
+      renamed: {
+        letter: "R",
+        accessibleName:
+          "Renamed transformation: Direct upstream column reference with a different output name",
+      },
+      derived: {
+        letter: "D",
+        accessibleName:
+          "Derived transformation: Expression derived from one or more upstream columns",
+      },
+      source: {
+        letter: "S",
+        accessibleName: "Source transformation: No upstream column dependency",
+      },
+      unknown: {
+        letter: "U",
+        accessibleName:
+          "Unknown transformation: Transformation could not be determined",
+      },
     };
 
-    it.each(Object.entries(transformationLetters))(
+    it.each(Object.entries(transformationDetails))(
       "shows %s chip for %s transformation",
-      (type, letter) => {
+      (type, { letter, accessibleName }) => {
         const props = createMockColumnNodeProps(
           {},
           {
@@ -282,8 +305,28 @@ describe("LineageColumnNode", () => {
         render(<LineageColumnNode {...props} />);
 
         expect(screen.getByText(letter)).toBeInTheDocument();
+        expect(screen.getByLabelText(accessibleName)).toBeInTheDocument();
       },
     );
+
+    it("shows the full transformation meaning on the chip tooltip", async () => {
+      const user = userEvent.setup();
+      const props = createMockColumnNodeProps(
+        {},
+        { transformationType: "derived" },
+      );
+
+      render(<LineageColumnNode {...props} />);
+      await user.hover(
+        screen.getByLabelText(
+          "Derived transformation: Expression derived from one or more upstream columns",
+        ),
+      );
+
+      expect(await screen.findByRole("tooltip")).toHaveTextContent(
+        "Derived: Expression derived from one or more upstream columns",
+      );
+    });
 
     it("shows transformation type by default even when change status is present", () => {
       const props = createMockColumnNodeProps(

--- a/js/packages/ui/src/components/lineage/__tests__/LineageColumnNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageColumnNode.test.tsx
@@ -267,27 +267,23 @@ describe("LineageColumnNode", () => {
     > = {
       passthrough: {
         letter: "P",
-        accessibleName:
-          "Passthrough transformation: Same-name reference to an upstream column",
+        accessibleName: "Passthrough transformation",
       },
       renamed: {
         letter: "R",
-        accessibleName:
-          "Renamed transformation: Direct upstream column reference with a different output name",
+        accessibleName: "Renamed transformation",
       },
       derived: {
         letter: "D",
-        accessibleName:
-          "Derived transformation: Expression derived from one or more upstream columns",
+        accessibleName: "Derived transformation",
       },
       source: {
         letter: "S",
-        accessibleName: "Source transformation: No upstream column dependency",
+        accessibleName: "Source transformation",
       },
       unknown: {
         letter: "U",
-        accessibleName:
-          "Unknown transformation: Transformation could not be determined",
+        accessibleName: "Unknown transformation",
       },
     };
 
@@ -318,11 +314,29 @@ describe("LineageColumnNode", () => {
 
       render(<LineageColumnNode {...props} />);
       await user.hover(
-        screen.getByLabelText(
-          "Derived transformation: Expression derived from one or more upstream columns",
-        ),
+        screen.getByRole("img", { name: "Derived transformation" }),
       );
 
+      expect(await screen.findByRole("tooltip")).toHaveTextContent(
+        "Derived: Expression derived from one or more upstream columns",
+      );
+    });
+
+    it("opens the transformation tooltip from the keyboard focus target", async () => {
+      const user = userEvent.setup();
+      const props = createMockColumnNodeProps(
+        {},
+        { transformationType: "derived" },
+      );
+
+      render(<LineageColumnNode {...props} />);
+
+      const indicator = screen.getByRole("img", {
+        name: "Derived transformation",
+      });
+      await user.tab();
+
+      expect(indicator).toHaveFocus();
       expect(await screen.findByRole("tooltip")).toHaveTextContent(
         "Derived: Expression derived from one or more upstream columns",
       );

--- a/js/packages/ui/src/components/lineage/__tests__/LineageLegend.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageLegend.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { LineageLegend } from "../legend";
 import { getGraphBadgeLegendEntries } from "../wholeModelTreatment";
@@ -33,6 +34,69 @@ describe("LineageLegend", () => {
     render(<LineageLegend variant="transformation" />);
 
     expect(screen.queryByText("Change Categories")).not.toBeInTheDocument();
+  });
+
+  it("shows only the transformation types present in the displayed chain", () => {
+    render(
+      <LineageLegend
+        variant="transformation"
+        transformationTypes={["derived", "passthrough"]}
+      />,
+    );
+
+    expect(
+      screen.getAllByText(/^(Passthrough|Renamed|Derived|Source|Unknown)$/),
+    ).toHaveLength(2);
+    expect(screen.getByText("Passthrough")).toBeInTheDocument();
+    expect(screen.getByText("Derived")).toBeInTheDocument();
+    expect(screen.queryByText("Renamed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Source")).not.toBeInTheDocument();
+    expect(screen.queryByText("Unknown")).not.toBeInTheDocument();
+  });
+
+  it("keeps filtered transformation types in the established legend order", () => {
+    render(
+      <LineageLegend
+        variant="transformation"
+        transformationTypes={["unknown", "derived", "passthrough"]}
+      />,
+    );
+
+    expect(
+      screen
+        .getAllByText(/^(Passthrough|Renamed|Derived|Source|Unknown)$/)
+        .map((element) => element.textContent),
+    ).toEqual(["Passthrough", "Derived", "Unknown"]);
+  });
+
+  it("renders no transformation legend when the displayed chain has no chips", () => {
+    render(
+      <LineageLegend
+        variant="transformation"
+        title="Column transformations"
+        transformationTypes={[]}
+      />,
+    );
+
+    expect(
+      screen.queryByText("Column transformations"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("explains transformation semantics without implying an environment diff", async () => {
+    const user = userEvent.setup();
+    render(<LineageLegend variant="transformation" />);
+
+    await user.hover(screen.getByText("Passthrough"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Same-name reference to an upstream column",
+    );
+
+    await user.unhover(screen.getByText("Passthrough"));
+    await user.hover(screen.getByText("Source"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "No upstream column dependency",
+    );
   });
 
   it("leaves category treatment to the new CLL experience", () => {

--- a/js/packages/ui/src/components/lineage/__tests__/LineageLegend.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageLegend.test.tsx
@@ -99,6 +99,23 @@ describe("LineageLegend", () => {
     );
   });
 
+  it("uses the visible transformation label without nested accessible labels", () => {
+    render(
+      <LineageLegend
+        variant="transformation"
+        transformationTypes={["passthrough"]}
+      />,
+    );
+
+    const label = screen.getByText("Passthrough");
+    const row = label.parentElement;
+    const swatch = screen.getByText("P").closest(".MuiChip-root");
+
+    expect(row).not.toHaveAttribute("aria-label");
+    expect(swatch).toHaveAttribute("aria-hidden", "true");
+    expect(swatch).not.toHaveAttribute("aria-label");
+  });
+
   it("leaves category treatment to the new CLL experience", () => {
     render(<LineageLegend variant="changeStatus" newCllExperience />);
 

--- a/js/packages/ui/src/components/lineage/__tests__/LineageTransformationLegend.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageTransformationLegend.test.tsx
@@ -1,44 +1,36 @@
-/**
- * MiniMap auto-disable tests.
- *
- * The lineage view drops the MiniMap once a graph gets large enough that its
- * extra DOM costs more than it helps. This drives the real view with a mocked
- * graph boundary (`toReactFlow`) so the 500/501 boundary is observed the way a
- * user would see it — MiniMap present or absent — instead of restating the
- * threshold arithmetic.
- */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import type { Node } from "@xyflow/react";
 import React from "react";
-import { vi } from "vitest";
-import type { LineageGraph } from "../../../contexts/lineage/types";
+import { beforeEach, vi } from "vitest";
+import type {
+  LineageGraph,
+  LineageGraphNodes,
+} from "../../../contexts/lineage/types";
 import { LineageViewOss } from "../LineageViewOss";
 
-const MODIFIED_NODE = "model.test.orders";
+const MODEL_ID = "model.test.orders";
 
 const mockToReactFlow = vi.fn();
+let mockZoom = 1;
 
-// Graph boundary: hand the view an exact node count without laying anything out.
 vi.mock("../lineage", () => ({
   toReactFlow: (...args: unknown[]) => mockToReactFlow(...args),
 }));
 
-// React Flow renders nothing meaningful in happy-dom; keep the pieces the view
-// mounts as identifiable stubs so MiniMap presence is observable.
 vi.mock("@xyflow/react", () => ({
   ReactFlow: ({ children }: { children?: React.ReactNode }) => (
     <div data-testid="reactflow">{children}</div>
   ),
-  Background: () => <div data-testid="background" />,
+  Background: () => null,
   BackgroundVariant: { Dots: "dots" },
   Controls: ({ children }: { children?: React.ReactNode }) => (
-    <div data-testid="controls">{children}</div>
+    <div>{children}</div>
   ),
   ControlButton: ({ children }: { children?: React.ReactNode }) => (
     <button type="button">{children}</button>
   ),
-  MiniMap: () => <div data-testid="minimap" />,
+  MiniMap: () => null,
   Panel: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -55,10 +47,10 @@ vi.mock("@xyflow/react", () => ({
     fitView: vi.fn(async () => true),
     setCenter: vi.fn(async () => undefined),
     getNodes: () => [],
-    getZoom: () => 1,
+    getZoom: () => mockZoom,
   }),
   useStore: (selector: (state: { transform: number[] }) => unknown) =>
-    selector({ transform: [0, 0, 1] }),
+    selector({ transform: [0, 0, mockZoom] }),
 }));
 
 vi.mock("../../../lib/api/track", () => ({
@@ -104,65 +96,98 @@ vi.mock("../../../hooks", async (importOriginal) => ({
   useThemeColors: () => ({ isDark: false }),
 }));
 
+const modelData = {
+  id: MODEL_ID,
+  name: "orders",
+  resourceType: "model",
+  packageName: "test",
+  changeStatus: "modified",
+  parents: {},
+  children: {},
+};
+
 const lineageGraph = {
   nodes: {
-    [MODIFIED_NODE]: {
-      id: MODIFIED_NODE,
+    [MODEL_ID]: {
+      id: MODEL_ID,
       type: "lineageGraphNode",
       position: { x: 0, y: 0 },
-      data: {
-        id: MODIFIED_NODE,
-        name: "orders",
-        resourceType: "model",
-        packageName: "test",
-        changeStatus: "modified",
-        parents: {},
-        children: {},
-      },
+      data: modelData,
     },
   },
   edges: {},
-  modifiedSet: [MODIFIED_NODE],
+  modifiedSet: [MODEL_ID],
   manifestMetadata: { base: undefined, current: undefined },
   catalogMetadata: { base: undefined, current: undefined },
 } as unknown as LineageGraph;
 
-function makeNodes(count: number): Node[] {
-  return Array.from({ length: count }, (_, i) => ({
-    id: `node-${i}`,
-    type: "lineageGraphNode",
-    position: { x: i * 400, y: 0 },
-    data: { id: `node-${i}`, name: `model ${i}` },
-  }));
-}
+const modelNode = lineageGraph.nodes[MODEL_ID] as unknown as LineageGraphNodes;
+const derivedColumnNode = {
+  id: `${MODEL_ID}_total`,
+  type: "lineageGraphColumnNode",
+  parentId: MODEL_ID,
+  position: { x: 0, y: 70 },
+  data: {
+    node: modelData,
+    column: "total",
+    type: "INTEGER",
+    transformationType: "derived",
+  },
+} as LineageGraphNodes;
 
-/** Render the lineage view over a graph that lays out `nodeCount` nodes. */
-async function renderWithNodeCount(nodeCount: number) {
-  mockToReactFlow.mockResolvedValue([makeNodes(nodeCount), [], {}]);
+function renderView(nodes: Node[]) {
+  mockToReactFlow.mockResolvedValue([nodes, [], {}]);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  render(
+  return render(
     <QueryClientProvider client={queryClient}>
-      <LineageViewOss viewOptions={{ node_ids: [MODIFIED_NODE] }} />
+      <LineageViewOss viewOptions={{ node_ids: [MODEL_ID] }} />
     </QueryClientProvider>,
   );
-  await screen.findByTestId("reactflow");
 }
 
-// The boundary is stated here as literals on purpose: 500 nodes still get a
-// MiniMap, 501 do not. Deriving these from the production constant would let
-// the threshold move without a test noticing.
-describe("MiniMap auto-disable for large graphs", () => {
-  it("shows the MiniMap on a 500-node graph", async () => {
-    await renderWithNodeCount(500);
-
-    expect(screen.getByTestId("minimap")).toBeInTheDocument();
+describe("LineageViewOss transformation legend", () => {
+  beforeEach(() => {
+    mockZoom = 1;
+    mockToReactFlow.mockReset();
   });
 
-  it("hides the MiniMap on a 501-node graph", async () => {
-    await renderWithNodeCount(501);
+  it("omits the legend for a model-only impact-radius graph", async () => {
+    renderView([modelNode]);
 
-    expect(screen.queryByTestId("minimap")).not.toBeInTheDocument();
+    await screen.findByTestId("reactflow");
+    expect(
+      screen.queryByText("Column transformations"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the transformation types rendered by column nodes", async () => {
+    renderView([modelNode, derivedColumnNode]);
+
+    expect(await screen.findByText("Column transformations")).toBeVisible();
+    expect(screen.getByText("Derived")).toBeVisible();
+    expect(screen.queryByText("Passthrough")).not.toBeInTheDocument();
+  });
+
+  it("hides the legend at the same zoom boundary as column content", async () => {
+    mockZoom = 0.31;
+    const { rerender } = renderView([modelNode, derivedColumnNode]);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    expect(await screen.findByText("Column transformations")).toBeVisible();
+
+    mockZoom = 0.3;
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <LineageViewOss viewOptions={{ node_ids: [MODEL_ID] }} />
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.queryByText("Column transformations"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/js/packages/ui/src/components/lineage/__tests__/columnTransformation.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/columnTransformation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type {
+  LineageGraphNode,
+  LineageGraphNodes,
+} from "../../../contexts/lineage/types";
+import { getDisplayedColumnTransformationTypes } from "../columnTransformation";
+
+const MODEL_ID = "model.test.orders";
+const MODEL_DATA: LineageGraphNode["data"] = {
+  id: MODEL_ID,
+  name: "orders",
+  resourceType: "model",
+  packageName: "test",
+  parents: {},
+  children: {},
+};
+
+function modelNode(): LineageGraphNodes {
+  return {
+    id: MODEL_ID,
+    type: "lineageGraphNode",
+    position: { x: 0, y: 0 },
+    data: MODEL_DATA,
+  };
+}
+
+function columnNode(
+  id: string,
+  transformationType: string,
+  changeStatus?: "added" | "removed" | "modified",
+): LineageGraphNodes {
+  return {
+    id,
+    type: "lineageGraphColumnNode",
+    position: { x: 0, y: 0 },
+    data: {
+      node: MODEL_DATA,
+      column: id,
+      type: "INTEGER",
+      transformationType,
+      changeStatus,
+    },
+  };
+}
+
+describe("getDisplayedColumnTransformationTypes", () => {
+  it("returns no transformations for a model-only impact-radius graph", () => {
+    expect(
+      getDisplayedColumnTransformationTypes([modelNode()], () => true),
+    ).toEqual([]);
+  });
+
+  it("returns only valid types in canonical order without duplicates", () => {
+    const nodes = [
+      columnNode("derived_one", "derived"),
+      columnNode("passthrough", "passthrough"),
+      columnNode("derived_two", "derived"),
+      columnNode("unexpected", "not-a-transformation"),
+    ];
+
+    expect(getDisplayedColumnTransformationTypes(nodes, () => false)).toEqual([
+      "passthrough",
+      "derived",
+    ]);
+  });
+
+  it("excludes a changed column when change analysis replaces its chip", () => {
+    const nodes = [
+      columnNode("renamed", "renamed", "modified"),
+      columnNode("source", "source"),
+    ];
+
+    expect(getDisplayedColumnTransformationTypes(nodes, () => true)).toEqual([
+      "source",
+    ]);
+  });
+
+  it("keeps a changed column type when its model is not showing change analysis", () => {
+    const nodes = [columnNode("renamed", "renamed", "modified")];
+
+    expect(getDisplayedColumnTransformationTypes(nodes, () => false)).toEqual([
+      "renamed",
+    ]);
+  });
+});

--- a/js/packages/ui/src/components/lineage/columnTransformation.ts
+++ b/js/packages/ui/src/components/lineage/columnTransformation.ts
@@ -1,0 +1,93 @@
+import type { LineageGraphNodes } from "../../contexts/lineage/types";
+import { hasOwn } from "../../utils/hasOwn";
+
+export const COLUMN_TRANSFORMATION_ORDER = [
+  "passthrough",
+  "renamed",
+  "derived",
+  "source",
+  "unknown",
+] as const;
+
+export type ColumnTransformationType =
+  (typeof COLUMN_TRANSFORMATION_ORDER)[number];
+
+export interface ColumnTransformationDetails {
+  letter: string;
+  label: string;
+  description: string;
+  color: "default" | "warning" | "info" | "error";
+}
+
+export const COLUMN_TRANSFORMATION_DETAILS: Record<
+  ColumnTransformationType,
+  ColumnTransformationDetails
+> = {
+  passthrough: {
+    letter: "P",
+    label: "Passthrough",
+    description: "Same-name reference to an upstream column",
+    color: "default",
+  },
+  renamed: {
+    letter: "R",
+    label: "Renamed",
+    description:
+      "Direct upstream column reference with a different output name",
+    color: "warning",
+  },
+  derived: {
+    letter: "D",
+    label: "Derived",
+    description: "Expression derived from one or more upstream columns",
+    color: "warning",
+  },
+  source: {
+    letter: "S",
+    label: "Source",
+    description: "No upstream column dependency",
+    color: "info",
+  },
+  unknown: {
+    letter: "U",
+    label: "Unknown",
+    description: "Transformation could not be determined",
+    color: "error",
+  },
+};
+
+export function isColumnTransformationType(
+  value: unknown,
+): value is ColumnTransformationType {
+  return (
+    typeof value === "string" && hasOwn(COLUMN_TRANSFORMATION_DETAILS, value)
+  );
+}
+
+/**
+ * Return the transformation keys represented by chips in the current graph.
+ *
+ * A changed column replaces its transformation chip with a structural-change
+ * indicator while its model is showing change analysis, so it must not add an
+ * otherwise invisible key to the legend. The canonical order keeps the legend
+ * stable as graph nodes are filtered or laid out differently.
+ */
+export function getDisplayedColumnTransformationTypes(
+  nodes: LineageGraphNodes[],
+  isModelShowingChangeAnalysis: (nodeId: string) => boolean,
+): ColumnTransformationType[] {
+  const displayedTypes = new Set<ColumnTransformationType>();
+
+  for (const node of nodes) {
+    if (node.type !== "lineageGraphColumnNode") continue;
+
+    const { changeStatus, transformationType } = node.data;
+    if (!isColumnTransformationType(transformationType)) continue;
+    if (changeStatus && isModelShowingChangeAnalysis(node.data.node.id)) {
+      continue;
+    }
+    displayedTypes.add(transformationType);
+  }
+
+  return COLUMN_TRANSFORMATION_ORDER.filter((type) => displayedTypes.has(type));
+}

--- a/js/packages/ui/src/components/lineage/columns/LineageColumnNode.tsx
+++ b/js/packages/ui/src/components/lineage/columns/LineageColumnNode.tsx
@@ -172,24 +172,36 @@ function TransformationIndicator({
   }
 
   const config = COLUMN_TRANSFORMATION_DETAILS[transformationType];
-  const accessibleName = `${config.label} transformation: ${config.description}`;
+  const accessibleName = `${config.label} transformation`;
 
   return (
-    <Tooltip title={`${config.label}: ${config.description}`} placement="top">
-      <Chip
+    <Tooltip
+      describeChild
+      title={`${config.label}: ${config.description}`}
+      placement="top"
+    >
+      <Box
+        component="span"
+        role="img"
         aria-label={accessibleName}
-        label={config.letter}
-        size="small"
-        color={config.color}
-        sx={{
-          fontSize: "0.6667rem",
-          height: 18,
-          minWidth: 18,
-          "& .MuiChip-label": {
-            px: 0.5,
-          },
-        }}
-      />
+        tabIndex={0}
+        sx={{ display: "inline-flex" }}
+      >
+        <Chip
+          aria-hidden="true"
+          label={config.letter}
+          size="small"
+          color={config.color}
+          sx={{
+            fontSize: "0.6667rem",
+            height: 18,
+            minWidth: 18,
+            "& .MuiChip-label": {
+              px: 0.5,
+            },
+          }}
+        />
+      </Box>
     </Tooltip>
   );
 }
@@ -277,7 +289,7 @@ function HiddenLineageIndicator({
  * // In change analysis mode, shows change status instead of transformation type
  * <LineageColumnNode
  *   showChangeAnalysis={true}
- *   showContent={zoomLevel > 0.3}
+ *   showContent={zoomLevel > CONTENT_VISIBILITY_MIN_ZOOM}
  *   onContextMenu={(e, columnId) => showMenu(e, columnId)}
  * />
  * ```

--- a/js/packages/ui/src/components/lineage/columns/LineageColumnNode.tsx
+++ b/js/packages/ui/src/components/lineage/columns/LineageColumnNode.tsx
@@ -2,24 +2,24 @@
 
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
+import Tooltip from "@mui/material/Tooltip";
 import { Handle, Position } from "@xyflow/react";
 import type { MouseEvent } from "react";
 import { memo, useState } from "react";
 import { getSemanticColorTheme } from "../../../theme";
 import { DataTypeIcon } from "../../ui/DataTypeIcon";
 import { StructuralChangeIndicator } from "../../ui/StructuralChangeIndicator";
+import {
+  COLUMN_TRANSFORMATION_DETAILS,
+  type ColumnTransformationType,
+} from "../columnTransformation";
 import { DIM_FILTER } from "../config/zoomConstants";
 import { getStyleForImpacted } from "../styles";
 
 /**
  * Transformation type for column-level lineage
  */
-export type ColumnTransformationType =
-  | "passthrough"
-  | "renamed"
-  | "derived"
-  | "source"
-  | "unknown";
+export type { ColumnTransformationType } from "../columnTransformation";
 
 /**
  * Column change status for diff views
@@ -120,20 +120,6 @@ export const COLUMN_NODE_HEIGHT = 24;
 export const COLUMN_NODE_WIDTH = 280;
 
 /**
- * Colors for transformation type chips
- */
-const transformationColors: Record<
-  ColumnTransformationType,
-  { letter: string; color: "default" | "warning" | "info" | "error" }
-> = {
-  passthrough: { letter: "P", color: "default" },
-  renamed: { letter: "R", color: "warning" },
-  derived: { letter: "D", color: "warning" },
-  source: { letter: "S", color: "info" },
-  unknown: { letter: "U", color: "error" },
-};
-
-/**
  * KebabMenuIcon - Inline SVG to avoid react-icons dependency
  */
 function KebabMenuIcon({ size = 14 }: { size?: number }) {
@@ -185,22 +171,26 @@ function TransformationIndicator({
     return null;
   }
 
-  const config = transformationColors[transformationType];
+  const config = COLUMN_TRANSFORMATION_DETAILS[transformationType];
+  const accessibleName = `${config.label} transformation: ${config.description}`;
 
   return (
-    <Chip
-      label={config.letter}
-      size="small"
-      color={config.color}
-      sx={{
-        fontSize: "0.6667rem",
-        height: 18,
-        minWidth: 18,
-        "& .MuiChip-label": {
-          px: 0.5,
-        },
-      }}
-    />
+    <Tooltip title={`${config.label}: ${config.description}`} placement="top">
+      <Chip
+        aria-label={accessibleName}
+        label={config.letter}
+        size="small"
+        color={config.color}
+        sx={{
+          fontSize: "0.6667rem",
+          height: 18,
+          minWidth: 18,
+          "& .MuiChip-label": {
+            px: 0.5,
+          },
+        }}
+      />
+    </Tooltip>
   );
 }
 

--- a/js/packages/ui/src/components/lineage/config/index.ts
+++ b/js/packages/ui/src/components/lineage/config/index.ts
@@ -8,6 +8,7 @@ export {
 } from "./nodeTypes";
 
 export {
+  CONTENT_VISIBILITY_MIN_ZOOM,
   DIM_FILTER,
   EXPLORE_MIN_ZOOM,
   FIT_VIEW_PADDING,

--- a/js/packages/ui/src/components/lineage/config/zoomConstants.ts
+++ b/js/packages/ui/src/components/lineage/config/zoomConstants.ts
@@ -20,6 +20,9 @@ export const LEGIBLE_MIN_ZOOM = 0.35;
 /** Minimum zoom for manual exploration */
 export const EXPLORE_MIN_ZOOM = 0.1;
 
+/** Zoom must exceed this boundary before node and column content is rendered. */
+export const CONTENT_VISIBILITY_MIN_ZOOM = 0.3;
+
 /** Padding for fitView calls */
 export const FIT_VIEW_PADDING = 0.15;
 

--- a/js/packages/ui/src/components/lineage/legend/LineageLegend.tsx
+++ b/js/packages/ui/src/components/lineage/legend/LineageLegend.tsx
@@ -10,6 +10,11 @@ import {
   CHANGE_CATEGORY_DETAILS,
   CHANGE_CATEGORY_LABELS,
 } from "../changeCategory";
+import {
+  COLUMN_TRANSFORMATION_DETAILS,
+  COLUMN_TRANSFORMATION_ORDER,
+  type ColumnTransformationType,
+} from "../columnTransformation";
 import { cllImpactedAccent } from "../styles";
 import { TreatmentChip } from "../TreatmentChip";
 import { getGraphBadgeLegendEntries } from "../wholeModelTreatment";
@@ -27,7 +32,7 @@ export interface ChangeStatusLegendItem {
  * Legend item for transformation type
  */
 export interface TransformationLegendItem {
-  type: "passthrough" | "renamed" | "derived" | "source" | "unknown";
+  type: ColumnTransformationType;
   label: string;
   description?: string;
 }
@@ -65,6 +70,12 @@ export interface LineageLegendProps {
    * @default false
    */
   newCllExperience?: boolean;
+
+  /**
+   * Transformation types represented by chips in the displayed column chain.
+   * When omitted, all transformation types are shown.
+   */
+  transformationTypes?: readonly ColumnTransformationType[];
 }
 
 /**
@@ -84,47 +95,16 @@ const defaultChangeStatusItems: ChangeStatusLegendItem[] = [
 /**
  * Default transformation items
  */
-const defaultTransformationItems: TransformationLegendItem[] = [
-  {
-    type: "passthrough",
-    label: "Passthrough",
-    description: "Column passes through unchanged",
-  },
-  {
-    type: "renamed",
-    label: "Renamed",
-    description: "Column was renamed from source",
-  },
-  {
-    type: "derived",
-    label: "Derived",
-    description: "Column is derived from other columns",
-  },
-  { type: "source", label: "Source", description: "Original source column" },
-  {
-    type: "unknown",
-    label: "Unknown",
-    description: "Transformation type could not be determined",
-  },
-];
+const defaultTransformationItems: TransformationLegendItem[] =
+  COLUMN_TRANSFORMATION_ORDER.map((type) => ({
+    type,
+    label: COLUMN_TRANSFORMATION_DETAILS[type].label,
+    description: COLUMN_TRANSFORMATION_DETAILS[type].description,
+  }));
 
 /**
  * Colors and symbols for change status indicators (default Tailwind palette).
  */
-/**
- * Colors for transformation type chips
- */
-const transformationStyles: Record<
-  string,
-  { letter: string; color: "default" | "warning" | "info" | "error" }
-> = {
-  passthrough: { letter: "P", color: "default" },
-  renamed: { letter: "R", color: "warning" },
-  derived: { letter: "D", color: "warning" },
-  source: { letter: "S", color: "info" },
-  unknown: { letter: "U", color: "error" },
-};
-
 /**
  * ChangeStatusIcon - Renders a change status indicator
  */
@@ -168,17 +148,14 @@ function ChangeStatusIcon({
 /**
  * TransformationChip - Renders a transformation type chip
  */
-function TransformationChip({
-  type,
-}: {
-  type: "passthrough" | "renamed" | "derived" | "source" | "unknown";
-}) {
-  const style = transformationStyles[type];
+function TransformationChip({ type }: { type: ColumnTransformationType }) {
+  const details = COLUMN_TRANSFORMATION_DETAILS[type];
   return (
     <Chip
-      label={style.letter}
+      aria-label={`${details.label} transformation: ${details.description}`}
+      label={details.letter}
       size="small"
-      color={style.color}
+      color={details.color}
       sx={{
         fontSize: "0.6667rem",
         height: 18,
@@ -237,13 +214,26 @@ export function LineageLegend({
   title,
   className,
   newCllExperience = false,
+  transformationTypes,
 }: LineageLegendProps) {
   const isDark = useIsDark();
   const changeStatusItems = newCllExperience
     ? defaultChangeStatusItems
     : defaultChangeStatusItems.filter((item) => item.status !== "impacted");
+  const displayedTransformationTypes = transformationTypes
+    ? new Set(transformationTypes)
+    : undefined;
+  const transformationItems = displayedTransformationTypes
+    ? defaultTransformationItems.filter((item) =>
+        displayedTransformationTypes.has(item.type),
+      )
+    : defaultTransformationItems;
   const items =
-    variant === "changeStatus" ? changeStatusItems : defaultTransformationItems;
+    variant === "changeStatus" ? changeStatusItems : transformationItems;
+
+  if (variant === "transformation" && transformationItems.length === 0) {
+    return null;
+  }
 
   return (
     <Box

--- a/js/packages/ui/src/components/lineage/legend/LineageLegend.tsx
+++ b/js/packages/ui/src/components/lineage/legend/LineageLegend.tsx
@@ -152,7 +152,7 @@ function TransformationChip({ type }: { type: ColumnTransformationType }) {
   const details = COLUMN_TRANSFORMATION_DETAILS[type];
   return (
     <Chip
-      aria-label={`${details.label} transformation: ${details.description}`}
+      aria-hidden="true"
       label={details.letter}
       size="small"
       color={details.color}
@@ -383,6 +383,7 @@ export function LineageLegend({
           const content = (
             <Box
               key={item.type}
+              tabIndex={showTooltips && item.description ? 0 : undefined}
               sx={{
                 display: "flex",
                 alignItems: "center",
@@ -397,7 +398,12 @@ export function LineageLegend({
           );
 
           return showTooltips && item.description ? (
-            <Tooltip key={item.type} title={item.description} placement="right">
+            <Tooltip
+              describeChild
+              key={item.type}
+              title={item.description}
+              placement="right"
+            >
               {content}
             </Tooltip>
           ) : (

--- a/js/src/components/lineage/__tests__/LineageView.component.test.tsx
+++ b/js/src/components/lineage/__tests__/LineageView.component.test.tsx
@@ -174,6 +174,9 @@ vi.mock("@xyflow/react", () => ({
     getZoom: vi.fn().mockReturnValue(1),
     getNodes: mockReactFlowGetNodes,
   })),
+  useStore: vi.fn((selector: (state: { transform: number[] }) => unknown) =>
+    selector({ transform: [0, 0, 1] }),
+  ),
   useNodesState: vi.fn((initial: unknown[]) => {
     const [nodes, setNodes] = React.useState(
       mockUseRealInitialNodes ? initial : mockUseNodesStateReturnValue[0],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Bug fix and UI cleanup.

**What this PR does / why we need it**:

- Hides the column-transformation legend when the current lineage graph has no visible transformation chips, including the model-only Impact Radius layer.
- Filters the legend to transformation types represented in the displayed column chain and gives it the explicit title "Column transformations".
- Centralizes transformation labels, symbols, colors, and corrected SQL-lineage descriptions.
- Adds full chip tooltips and accessible names for P/R/D/S/U indicators.

**Which issue(s) this PR fixes**:

Follow-up to the [Danyel handoff project](https://linear.app/recce/project/danyel-handoff-19c95e723c9d/overview).

**Special notes for your reviewer**:

The transformation legend is intentionally retained for column-level lineage. Its visibility now follows the chips the graph can display, rather than the broader `column_level_lineage` request state.

Validation:

- `cd js && pnpm lint:fix`
- `cd js && pnpm type:check`
- `cd js && pnpm test` (208 files; 4,335 passed, 5 skipped)
- `cd js && pnpm run build`
- Push hook: 93 related files; 1,899 passed, 5 skipped

**Does this PR introduce a user-facing change?**:

```release-note
Lineage now shows the column-transformation legend only when transformation markers are present, and each marker includes clearer explanatory text.
```
