### PR TITLE
feat(lineage): add conditional validation summary chip

### DIFF
--- a/js/packages/ui/src/__tests__/nodeDetailsPublicTypes.test.ts
+++ b/js/packages/ui/src/__tests__/nodeDetailsPublicTypes.test.ts
@@ -1,0 +1,36 @@
+import type {
+  NodeDetailsOpenRequest as ContextsNodeDetailsOpenRequest,
+  NodeDetailsView as ContextsNodeDetailsView,
+} from "../contexts-entry";
+import type {
+  NodeDetailsOpenRequest as RootNodeDetailsOpenRequest,
+  NodeDetailsView as RootNodeDetailsView,
+} from "../index";
+import type {
+  NodeDetailsOpenRequest as TypesNodeDetailsOpenRequest,
+  NodeDetailsView as TypesNodeDetailsView,
+} from "../types";
+
+type PublicRequest = ContextsNodeDetailsOpenRequest &
+  RootNodeDetailsOpenRequest &
+  TypesNodeDetailsOpenRequest;
+type PublicView = ContextsNodeDetailsView &
+  RootNodeDetailsView &
+  TypesNodeDetailsView;
+
+describe("public node-details contract", () => {
+  it("is nameable through the contexts, root, and type entrypoints", () => {
+    const view: PublicView = "analysis";
+    const request: PublicRequest = {
+      nodeId: "model.test.orders",
+      view,
+      requestToken: 1,
+    };
+
+    expect(request).toEqual({
+      nodeId: "model.test.orders",
+      view: "analysis",
+      requestToken: 1,
+    });
+  });
+});

--- a/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
+++ b/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
@@ -133,6 +133,17 @@ function validationSummaryLabel(summary: ValidationSummary) {
   return `${resultLabel} · ${countLabel(summary.types.value_diff.difference_count, "diff")}`;
 }
 
+function hasPositiveValidationResultCount(
+  summary: ValidationSummary | undefined,
+) {
+  const resultCount = summary?.result_count;
+  return (
+    typeof resultCount === "number" &&
+    Number.isFinite(resultCount) &&
+    resultCount > 0
+  );
+}
+
 function ValidationSummaryDetails({ summary }: { summary: ValidationSummary }) {
   const { value_diff, profile_diff, top_k_diff, histogram_diff } =
     summary.types;
@@ -313,6 +324,7 @@ function ValidationSummaryChip({
             aria-label={`${nodeName} validation details`}
             className="nodrag nopan nokey"
             onClick={stopPropagation}
+            onContextMenu={stopPropagation}
             onDoubleClick={stopPropagation}
             onKeyDown={handlePopoverKeyDown}
             onKeyUp={stopPropagation}
@@ -340,6 +352,7 @@ function NodeRunsAggregatedDisplay({
   nodeName,
   runs,
   schemaChanged,
+  showValidationSummary,
   onOpenAnalysis,
 }: {
   inverted: boolean;
@@ -347,6 +360,7 @@ function NodeRunsAggregatedDisplay({
   nodeName: string;
   runs: NodeRunsAggregated | undefined;
   schemaChanged: boolean | undefined;
+  showValidationSummary: boolean;
   onOpenAnalysis: (nodeId: string) => void;
 }) {
   const { text, isDark } = useThemeColors();
@@ -397,7 +411,7 @@ function NodeRunsAggregatedDisplay({
         </MuiTooltip>
       )}
       <Box sx={{ flexGrow: 1 }} />
-      {runs?.validation_summary && (
+      {showValidationSummary && runs?.validation_summary && (
         <ValidationSummaryChip
           nodeId={nodeId}
           nodeName={nodeName}
@@ -600,10 +614,13 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
     data.change?.columns == null
       ? undefined
       : Object.keys(data.change.columns).length > 0;
+  const showValidationSummary = hasPositiveValidationResultCount(
+    nodeRuns?.validation_summary,
+  );
   const hasVisibleRunsAggregatedData =
     schemaChanged !== undefined ||
     nodeRuns?.row_count_diff !== undefined ||
-    nodeRuns?.validation_summary !== undefined;
+    showValidationSummary;
   const runsAggregatedTag =
     selectMode !== "action_result" &&
     data.resourceType === "model" &&
@@ -615,6 +632,7 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
         onOpenAnalysis={(nodeId) => openNodeDetails(nodeId, "analysis")}
         runs={nodeRuns}
         schemaChanged={schemaChanged}
+        showValidationSummary={showValidationSummary}
       />
     ) : undefined;
 

--- a/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
+++ b/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
@@ -18,12 +18,21 @@
 
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
+import Paper from "@mui/material/Paper";
+import Popper from "@mui/material/Popper";
+import Stack from "@mui/material/Stack";
 import MuiTooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 import { type NodeProps, useStore } from "@xyflow/react";
-import { memo } from "react";
+import { memo, useCallback, useEffect, useId, useRef, useState } from "react";
 import type { LineageGraphNode } from "../..";
 import { COLUMN_HEIGHT } from "../..";
-import { isRowCountDiffRun, type RowCountDiff } from "../../api";
+import {
+  isRowCountDiffRun,
+  type NodeRunsAggregated,
+  type RowCountDiff,
+  type ValidationSummary,
+} from "../../api";
 import {
   useLineageGraphContext,
   useLineageViewContextSafe,
@@ -101,6 +110,7 @@ function RowCountDiffTag({
       sx={{
         height: 20,
         fontSize: "0.7rem",
+        maxWidth: "100%",
         ...(directionStyle && {
           bgcolor: directionStyle.background,
           border: `1px solid ${directionStyle.border}`,
@@ -111,30 +121,216 @@ function RowCountDiffTag({
   );
 }
 
+function countLabel(count: number, singular: string, plural = `${singular}s`) {
+  return `${count.toLocaleString()} ${count === 1 ? singular : plural}`;
+}
+
+function validationSummaryLabel(summary: ValidationSummary) {
+  const resultLabel = countLabel(summary.result_count, "result");
+  if (!summary.types.value_diff) {
+    return resultLabel;
+  }
+  return `${resultLabel} · ${countLabel(summary.types.value_diff.difference_count, "diff")}`;
+}
+
+function ValidationSummaryDetails({ summary }: { summary: ValidationSummary }) {
+  const { value_diff, profile_diff, top_k_diff, histogram_diff } =
+    summary.types;
+
+  return (
+    <Stack component="dl" spacing={0.75} sx={{ m: 0 }}>
+      {value_diff && (
+        <Box>
+          <Typography component="dt" variant="caption" sx={{ fontWeight: 600 }}>
+            Value diff
+          </Typography>
+          <Typography component="dd" variant="caption" sx={{ m: 0 }}>
+            {countLabel(1, "result")} ·{" "}
+            {countLabel(value_diff.difference_count, "diff")}
+          </Typography>
+        </Box>
+      )}
+      {profile_diff && (
+        <Box>
+          <Typography component="dt" variant="caption" sx={{ fontWeight: 600 }}>
+            Profile diff
+          </Typography>
+          <Typography component="dd" variant="caption" sx={{ m: 0 }}>
+            {countLabel(profile_diff.result_count, "result")}
+          </Typography>
+        </Box>
+      )}
+      {top_k_diff && (
+        <Box>
+          <Typography component="dt" variant="caption" sx={{ fontWeight: 600 }}>
+            Top-k diff
+          </Typography>
+          <Typography component="dd" variant="caption" sx={{ m: 0 }}>
+            {countLabel(top_k_diff.column_count, "column")}
+          </Typography>
+        </Box>
+      )}
+      {histogram_diff && (
+        <Box>
+          <Typography component="dt" variant="caption" sx={{ fontWeight: 600 }}>
+            Histogram diff
+          </Typography>
+          <Typography component="dd" variant="caption" sx={{ m: 0 }}>
+            {countLabel(histogram_diff.column_count, "column")}
+          </Typography>
+        </Box>
+      )}
+    </Stack>
+  );
+}
+
+function ValidationSummaryChip({
+  nodeId,
+  nodeName,
+  summary,
+  onOpenAnalysis,
+}: {
+  nodeId: string;
+  nodeName: string;
+  summary: ValidationSummary;
+  onOpenAnalysis: (nodeId: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const popoverId = useId();
+  const label = validationSummaryLabel(summary);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current !== undefined) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = undefined;
+    }
+  }, []);
+  const showPopover = useCallback(() => {
+    cancelClose();
+    setOpen(true);
+  }, [cancelClose]);
+  const closePopover = useCallback(() => {
+    cancelClose();
+    setOpen(false);
+  }, [cancelClose]);
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    closeTimerRef.current = setTimeout(() => setOpen(false), 100);
+  }, [cancelClose]);
+  const scheduleCloseUnlessFocused = useCallback(() => {
+    if (document.activeElement === buttonRef.current) return;
+    scheduleClose();
+  }, [scheduleClose]);
+
+  useEffect(() => cancelClose, [cancelClose]);
+
+  const handleEscape = (event: React.KeyboardEvent) => {
+    if (event.key !== "Escape") return;
+    event.preventDefault();
+    event.stopPropagation();
+    closePopover();
+    buttonRef.current?.focus();
+  };
+
+  return (
+    <>
+      <Box
+        ref={buttonRef}
+        component="button"
+        type="button"
+        aria-controls={open ? popoverId : undefined}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-label={`Open validation analysis for ${nodeName}: ${label}`}
+        onBlur={closePopover}
+        onClick={(event) => {
+          event.stopPropagation();
+          showPopover();
+          onOpenAnalysis(nodeId);
+        }}
+        onDoubleClick={(event) => event.stopPropagation()}
+        onFocus={showPopover}
+        onKeyDown={handleEscape}
+        onMouseEnter={showPopover}
+        onMouseLeave={scheduleCloseUnlessFocused}
+        onPointerDown={(event) => event.stopPropagation()}
+        sx={{
+          alignItems: "center",
+          appearance: "none",
+          background: "transparent",
+          border: 0,
+          color: "inherit",
+          cursor: "pointer",
+          display: "flex",
+          flex: "0 1 auto",
+          margin: 0,
+          maxWidth: 150,
+          minHeight: 24,
+          minWidth: 0,
+          padding: "2px 0",
+        }}
+      >
+        <Chip
+          data-testid="validation-summary-chip"
+          label={label}
+          size="small"
+          variant="outlined"
+          sx={{
+            height: 20,
+            fontSize: "0.7rem",
+            maxWidth: "100%",
+            pointerEvents: "none",
+          }}
+        />
+      </Box>
+      {open && (
+        <Popper
+          open
+          anchorEl={buttonRef.current}
+          placement="bottom-start"
+          sx={{ zIndex: 1500 }}
+        >
+          <Paper
+            id={popoverId}
+            role="dialog"
+            aria-label={`${nodeName} validation details`}
+            onKeyDown={handleEscape}
+            onMouseEnter={cancelClose}
+            onMouseLeave={scheduleCloseUnlessFocused}
+            sx={{ minWidth: 160, p: 1.25 }}
+          >
+            <ValidationSummaryDetails summary={summary} />
+          </Paper>
+        </Popper>
+      )}
+    </>
+  );
+}
+
 /**
  * Node runs aggregated display component with OSS-specific icons
  * Shows schema diff indicator and row count diff for models
  */
 function NodeRunsAggregatedDisplay({
-  id,
   inverted,
+  nodeId,
+  nodeName,
+  runs,
+  schemaChanged,
+  onOpenAnalysis,
 }: {
-  id: string;
   inverted: boolean;
+  nodeId: string;
+  nodeName: string;
+  runs: NodeRunsAggregated | undefined;
+  schemaChanged: boolean | undefined;
+  onOpenAnalysis: (nodeId: string) => void;
 }) {
-  const { lineageGraph, runsAggregated } = useLineageGraphContext();
   const { text, isDark } = useThemeColors();
-  const runs = runsAggregated?.[id];
-  const node = lineageGraph?.nodes[id];
-
-  if (!runs && !node) {
-    return null;
-  }
-
-  let schemaChanged: boolean | undefined;
-  if (node?.data.change?.columns) {
-    schemaChanged = Object.keys(node.data.change.columns).length > 0;
-  }
 
   let rowCountChanged: boolean | undefined;
   if (runs?.row_count_diff) {
@@ -155,7 +351,17 @@ function NodeRunsAggregatedDisplay({
   const SchemaDiffIcon = findByRunType("schema_diff").icon;
 
   return (
-    <Box sx={{ display: "flex", flex: 1, alignItems: "center" }}>
+    <Box
+      data-testid="node-runs-aggregated-display"
+      sx={{
+        alignItems: "center",
+        display: "flex",
+        flex: 1,
+        gap: 0.5,
+        minWidth: 0,
+        overflow: "hidden",
+      }}
+    >
       {schemaChanged !== undefined && (
         <MuiTooltip
           title={`Schema (${schemaChanged ? "changed" : "no change"})`}
@@ -172,12 +378,20 @@ function NodeRunsAggregatedDisplay({
         </MuiTooltip>
       )}
       <Box sx={{ flexGrow: 1 }} />
+      {runs?.validation_summary && (
+        <ValidationSummaryChip
+          nodeId={nodeId}
+          nodeName={nodeName}
+          summary={runs.validation_summary}
+          onOpenAnalysis={onOpenAnalysis}
+        />
+      )}
       {runs?.row_count_diff && rowCountChanged !== undefined && (
         <MuiTooltip
           title={`Row count (${rowCountChanged ? "changed" : "="})`}
           enterDelay={500}
         >
-          <Box>
+          <Box sx={{ maxWidth: 120, minWidth: 0, overflow: "hidden" }}>
             <RowCountDiffTag
               rowCount={runs.row_count_diff.result as RowCountDiff}
               isDark={isDark}
@@ -309,8 +523,10 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
 
   // Get context values
   const lineageViewCtx = useLineageViewContextSafe();
+  const { runsAggregated } = useLineageGraphContext();
   const {
     interactive,
+    openNodeDetails,
     selectNode,
     selectMode,
     focusedNode,
@@ -360,11 +576,26 @@ function GraphNodeComponent(nodeProps: GraphNodeProps) {
     ) : undefined;
 
   // Create runs aggregated tag if model and not in action_result mode
+  const nodeRuns = runsAggregated?.[id];
+  const schemaChanged =
+    data.change?.columns == null
+      ? undefined
+      : Object.keys(data.change.columns).length > 0;
+  const hasVisibleRunsAggregatedData =
+    schemaChanged !== undefined ||
+    nodeRuns?.row_count_diff !== undefined ||
+    nodeRuns?.validation_summary !== undefined;
   const runsAggregatedTag =
-    selectMode !== "action_result" && data.resourceType === "model" ? (
+    selectMode !== "action_result" &&
+    data.resourceType === "model" &&
+    hasVisibleRunsAggregatedData ? (
       <NodeRunsAggregatedDisplay
-        id={data.id}
         inverted={selectMode === "selecting" && isSelected}
+        nodeId={id}
+        nodeName={name}
+        onOpenAnalysis={(nodeId) => openNodeDetails(nodeId, "analysis")}
+        runs={nodeRuns}
+        schemaChanged={schemaChanged}
       />
     ) : undefined;
 

--- a/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
+++ b/js/packages/ui/src/components/lineage/GraphNodeOss.tsx
@@ -228,13 +228,24 @@ function ValidationSummaryChip({
 
   useEffect(() => cancelClose, [cancelClose]);
 
-  const handleEscape = (event: React.KeyboardEvent) => {
-    if (event.key !== "Escape") return;
-    event.preventDefault();
+  const handleTriggerKeyDown = (event: React.KeyboardEvent) => {
     event.stopPropagation();
-    closePopover();
-    buttonRef.current?.focus();
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closePopover();
+      buttonRef.current?.focus();
+    }
   };
+  const handlePopoverKeyDown = (event: React.KeyboardEvent) => {
+    event.stopPropagation();
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closePopover();
+      buttonRef.current?.focus();
+    }
+  };
+  const stopPropagation = (event: React.SyntheticEvent) =>
+    event.stopPropagation();
 
   return (
     <>
@@ -246,6 +257,7 @@ function ValidationSummaryChip({
         aria-expanded={open}
         aria-haspopup="dialog"
         aria-label={`Open validation analysis for ${nodeName}: ${label}`}
+        className="nodrag nopan nokey"
         onBlur={closePopover}
         onClick={(event) => {
           event.stopPropagation();
@@ -254,7 +266,8 @@ function ValidationSummaryChip({
         }}
         onDoubleClick={(event) => event.stopPropagation()}
         onFocus={showPopover}
-        onKeyDown={handleEscape}
+        onKeyDown={handleTriggerKeyDown}
+        onKeyUp={stopPropagation}
         onMouseEnter={showPopover}
         onMouseLeave={scheduleCloseUnlessFocused}
         onPointerDown={(event) => event.stopPropagation()}
@@ -298,9 +311,15 @@ function ValidationSummaryChip({
             id={popoverId}
             role="dialog"
             aria-label={`${nodeName} validation details`}
-            onKeyDown={handleEscape}
+            className="nodrag nopan nokey"
+            onClick={stopPropagation}
+            onDoubleClick={stopPropagation}
+            onKeyDown={handlePopoverKeyDown}
+            onKeyUp={stopPropagation}
+            onMouseDown={stopPropagation}
             onMouseEnter={cancelClose}
             onMouseLeave={scheduleCloseUnlessFocused}
+            onPointerDown={stopPropagation}
             sx={{ minWidth: 160, p: 1.25 }}
           >
             <ValidationSummaryDetails summary={summary} />

--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -26,6 +26,8 @@ import {
   type LineageGraphNode,
   type LineageGraphNodes,
   type LineageViewContextType,
+  type NodeDetailsOpenRequest,
+  type NodeDetailsView,
 } from "../../contexts/lineage/types";
 import {
   type NodeColumnSetMap,
@@ -142,6 +144,14 @@ export function nextFocusedNodeId(
   clickedNodeId: string,
 ): string | undefined {
   return currentNodeId === clickedNodeId ? undefined : clickedNodeId;
+}
+
+export function createNodeDetailsOpenRequest(
+  currentToken: number,
+  nodeId: string,
+  view: NodeDetailsView,
+): NodeDetailsOpenRequest {
+  return { nodeId, view, requestToken: currentToken + 1 };
 }
 
 /**
@@ -374,6 +384,9 @@ export function PrivateLineageView(
    * Focused node: the node that is currently focused. Show the NodeView when a node is focused
    */
   const [focusedNodeId, setFocusedNodeId] = useState<string>();
+  const [nodeDetailsOpenRequest, setNodeDetailsOpenRequest] =
+    useState<NodeDetailsOpenRequest>();
+  const nodeDetailsRequestTokenRef = useRef(0);
   const focusedNode = focusedNodeId
     ? lineageGraph?.nodes[focusedNodeId]
     : undefined;
@@ -732,6 +745,21 @@ export function PrivateLineageView(
   const onNodeViewClosed = () => {
     supersedeCllInteraction();
     setFocusedNodeId(undefined);
+    setNodeDetailsOpenRequest(undefined);
+    setFocusedHistory([]);
+  };
+
+  const openNodeDetails = (nodeId: string, view: NodeDetailsView) => {
+    if (!lineageGraph?.nodes[nodeId]) return;
+    supersedeCllInteraction();
+    const request = createNodeDetailsOpenRequest(
+      nodeDetailsRequestTokenRef.current,
+      nodeId,
+      view,
+    );
+    nodeDetailsRequestTokenRef.current = request.requestToken;
+    setNodeDetailsOpenRequest(request);
+    setFocusedNodeId(nodeId);
     setFocusedHistory([]);
   };
 
@@ -744,6 +772,7 @@ export function PrivateLineageView(
   const navigateToNode = (nodeId: string) => {
     if (!lineageGraph?.nodes[nodeId]) return;
     supersedeCllInteraction();
+    setNodeDetailsOpenRequest(undefined);
     if (focusedNodeId === nodeId) return;
     if (focusedNodeId && focusedNodeId !== nodeId) {
       setFocusedHistory((h) => [...h, focusedNodeId]);
@@ -756,6 +785,7 @@ export function PrivateLineageView(
     const previous = focusedHistory[focusedHistory.length - 1];
     if (!lineageGraph?.nodes[previous]) return;
     supersedeCllInteraction();
+    setNodeDetailsOpenRequest(undefined);
     setFocusedNodeId(previous);
     setFocusedHistory((h) => h.slice(0, -1));
   };
@@ -769,6 +799,7 @@ export function PrivateLineageView(
     const target = focusedHistory[index];
     if (!lineageGraph?.nodes[target]) return;
     supersedeCllInteraction();
+    setNodeDetailsOpenRequest(undefined);
     setFocusedNodeId(target);
     setFocusedHistory((h) => h.slice(0, index));
   };
@@ -912,6 +943,7 @@ export function PrivateLineageView(
 
     closeContextMenu();
     supersedeCllInteraction();
+    setNodeDetailsOpenRequest(undefined);
     if (!selectMode) {
       setFocusedNodeId(nextFocusedNodeId(focusedNodeId, node.id));
       setFocusedHistory([]);
@@ -1402,6 +1434,7 @@ export function PrivateLineageView(
     onViewOptionsChanged: handleViewOptionsChanged,
     selectMode,
     selectNode,
+    openNodeDetails,
     selectParentNodes,
     selectChildNodes,
     deselect,
@@ -1767,6 +1800,7 @@ export function PrivateLineageView(
             <NodeView
               node={focusedNode}
               onCloseNode={onNodeViewClosed}
+              openRequest={nodeDetailsOpenRequest}
               onNavigateToNode={navigateToNode}
               onBack={focusedHistory.length > 0 ? navigateBack : undefined}
               onCenterFocused={centerFocusedNode}

--- a/js/packages/ui/src/components/lineage/LineageViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/LineageViewOss.tsx
@@ -762,6 +762,11 @@ export function PrivateLineageView(
     setFocusedNodeId(nodeId);
     setFocusedHistory([]);
   };
+  const consumeNodeDetailsOpenRequest = useCallback((requestToken: number) => {
+    setNodeDetailsOpenRequest((current) =>
+      current?.requestToken === requestToken ? undefined : current,
+    );
+  }, []);
 
   /**
    * Navigate the Model Detail panel to a different node without touching the
@@ -1801,6 +1806,7 @@ export function PrivateLineageView(
               node={focusedNode}
               onCloseNode={onNodeViewClosed}
               openRequest={nodeDetailsOpenRequest}
+              onOpenRequestConsumed={consumeNodeDetailsOpenRequest}
               onNavigateToNode={navigateToNode}
               onBack={focusedHistory.length > 0 ? navigateBack : undefined}
               onCenterFocused={centerFocusedNode}

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -13,11 +13,14 @@ import {
   type ComponentType,
   type ReactElement,
   type ReactNode,
+  useEffect,
+  useRef,
   useState,
 } from "react";
 import { IoClose } from "react-icons/io5";
 import type { NodeData } from "../../api/info";
 import { DisableTooltipMessages } from "../../constants";
+import type { NodeDetailsOpenRequest } from "../../contexts/lineage/types";
 import { useThemeColors } from "../../hooks";
 import { formatTimeToNow } from "../../utils";
 import { getChangeCategoryLabel } from "./changeCategory";
@@ -210,6 +213,8 @@ export interface NodeViewProps<
   recentAnalysisRuns?: RecentAnalysisRun[];
   /** Reopen a prior analysis result in the consumer's result pane. */
   onViewAnalysisRun?: (runId: string) => void;
+  /** Explicit, repeatable request to select a detail-panel view. */
+  openRequest?: NodeDetailsOpenRequest;
 
   // =========================================================================
   // DEPENDENCY INJECTION: Icons
@@ -680,6 +685,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
   rowCountDisplay,
   recentAnalysisRuns = [],
   onViewAnalysisRun,
+  openRequest,
 }: NodeViewProps<TNode>) {
   const withColumns =
     node.data.resourceType === "model" ||
@@ -714,6 +720,24 @@ export function NodeView<TNode extends NodeViewNodeData>({
     node.data.resourceType === "seed" ||
     node.data.resourceType === "snapshot";
   const showAnalysisTab = !isSingleEnv && isModelSeedOrSnapshot;
+  const appliedRequestTokenRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (
+      openRequest === undefined ||
+      appliedRequestTokenRef.current === openRequest.requestToken
+    ) {
+      return;
+    }
+    if (
+      openRequest.nodeId === node.id &&
+      openRequest.view === "analysis" &&
+      showAnalysisTab
+    ) {
+      appliedRequestTokenRef.current = openRequest.requestToken;
+      setTabState({ nodeId: node.id, value: "analysis" });
+    }
+  }, [node.id, openRequest, showAnalysisTab]);
 
   const showAddSchemaDiff =
     !isSingleEnv &&

--- a/js/packages/ui/src/components/lineage/NodeView.tsx
+++ b/js/packages/ui/src/components/lineage/NodeView.tsx
@@ -215,6 +215,8 @@ export interface NodeViewProps<
   onViewAnalysisRun?: (runId: string) => void;
   /** Explicit, repeatable request to select a detail-panel view. */
   openRequest?: NodeDetailsOpenRequest;
+  /** Acknowledge that an explicit detail-panel request was applied. */
+  onOpenRequestConsumed?: (requestToken: number) => void;
 
   // =========================================================================
   // DEPENDENCY INJECTION: Icons
@@ -686,6 +688,7 @@ export function NodeView<TNode extends NodeViewNodeData>({
   recentAnalysisRuns = [],
   onViewAnalysisRun,
   openRequest,
+  onOpenRequestConsumed,
 }: NodeViewProps<TNode>) {
   const withColumns =
     node.data.resourceType === "model" ||
@@ -736,8 +739,9 @@ export function NodeView<TNode extends NodeViewNodeData>({
     ) {
       appliedRequestTokenRef.current = openRequest.requestToken;
       setTabState({ nodeId: node.id, value: "analysis" });
+      onOpenRequestConsumed?.(openRequest.requestToken);
     }
-  }, [node.id, openRequest, showAnalysisTab]);
+  }, [node.id, onOpenRequestConsumed, openRequest, showAnalysisTab]);
 
   const showAddSchemaDiff =
     !isSingleEnv &&

--- a/js/packages/ui/src/components/lineage/NodeViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/NodeViewOss.tsx
@@ -70,6 +70,8 @@ interface NodeViewProps {
   onCloseNode: () => void;
   /** Explicit, repeatable request to select a detail-panel view. */
   openRequest?: NodeDetailsOpenRequest;
+  /** Acknowledge that an explicit detail-panel request was applied. */
+  onOpenRequestConsumed?: (requestToken: number) => void;
   /** Navigate to another node: refocus the panel (canvas is not re-centered). */
   onNavigateToNode?: (nodeId: string) => void;
   /** Return to the previously focused node. Omit to hide the back button. */
@@ -141,6 +143,7 @@ export function NodeViewOss({
   node,
   onCloseNode,
   openRequest,
+  onOpenRequestConsumed,
   onNavigateToNode,
   onBack,
   onCenterFocused,
@@ -404,6 +407,7 @@ export function NodeViewOss({
       node={node}
       onCloseNode={onCloseNode}
       openRequest={openRequest}
+      onOpenRequestConsumed={onOpenRequestConsumed}
       isSingleEnv={isSingleEnv}
       featureToggles={featureToggles}
       isWholeModelChanged={wholeModelFlags.isWholeModelChanged}

--- a/js/packages/ui/src/components/lineage/NodeViewOss.tsx
+++ b/js/packages/ui/src/components/lineage/NodeViewOss.tsx
@@ -31,6 +31,7 @@ import {
   useRecceInstanceContext,
   useRouteConfig,
 } from "../../contexts";
+import type { NodeDetailsOpenRequest } from "../../contexts/lineage/types";
 import {
   useApiConfig,
   useModelColumns,
@@ -67,6 +68,8 @@ import { pickWholeModelFlags } from "./wholeModelTreatment";
 interface NodeViewProps {
   node: LineageGraphNode;
   onCloseNode: () => void;
+  /** Explicit, repeatable request to select a detail-panel view. */
+  openRequest?: NodeDetailsOpenRequest;
   /** Navigate to another node: refocus the panel (canvas is not re-centered). */
   onNavigateToNode?: (nodeId: string) => void;
   /** Return to the previously focused node. Omit to hide the back button. */
@@ -137,6 +140,7 @@ function OssNotificationComponent({ onClose }: { onClose: () => void }) {
 export function NodeViewOss({
   node,
   onCloseNode,
+  openRequest,
   onNavigateToNode,
   onBack,
   onCenterFocused,
@@ -399,6 +403,7 @@ export function NodeViewOss({
     <BaseNodeView
       node={node}
       onCloseNode={onCloseNode}
+      openRequest={openRequest}
       isSingleEnv={isSingleEnv}
       featureToggles={featureToggles}
       isWholeModelChanged={wholeModelFlags.isWholeModelChanged}

--- a/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.reactFlow.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.reactFlow.test.tsx
@@ -1,0 +1,184 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type NodeTypes, ReactFlow } from "@xyflow/react";
+import { vi } from "vitest";
+import type { NodeRunsAggregated } from "../../../api";
+import {
+  type LineageGraph,
+  type LineageGraphNode,
+  LineageGraphProvider,
+  LineageViewContext,
+  type LineageViewContextType,
+  type SelectMode,
+} from "../../../contexts";
+import { GraphNode } from "../GraphNodeOss";
+
+const nodeTypes = { lineageGraphNode: GraphNode } satisfies NodeTypes;
+
+function createNode(): LineageGraphNode {
+  return {
+    id: "model.test.orders",
+    type: "lineageGraphNode",
+    position: { x: 0, y: 0 },
+    width: 300,
+    height: 60,
+    data: {
+      id: "model.test.orders",
+      name: "orders",
+      resourceType: "model",
+      parents: {},
+      children: {},
+    },
+  };
+}
+
+function createGraph(node: LineageGraphNode): LineageGraph {
+  return {
+    nodes: { [node.id]: node },
+    edges: {},
+    modifiedSet: [],
+    manifestMetadata: {},
+    catalogMetadata: {},
+  };
+}
+
+function createViewContext(
+  selectMode: SelectMode,
+  openNodeDetails: ReturnType<typeof vi.fn>,
+): LineageViewContextType {
+  return {
+    interactive: true,
+    nodes: [],
+    selectedNodes: [],
+    cll: undefined,
+    showContextMenu: vi.fn(),
+    viewOptions: {},
+    onViewOptionsChanged: vi.fn(),
+    selectMode,
+    selectNode: vi.fn(),
+    openNodeDetails,
+    getNodeAction: vi.fn(),
+    getNodeColumnSet: vi.fn(() => new Set()),
+    isNodeHighlighted: vi.fn(() => false),
+    isNodeSelected: vi.fn(() => false),
+    isNodeShowingChangeAnalysis: vi.fn(() => false),
+    newCllExperience: false,
+    impactedNodeIds: new Set(),
+    impactedColumnIds: new Set(),
+    wholeModelChangedNodeIds: new Set(),
+    wholeModelImpactedNodeIds: new Set(),
+  } as unknown as LineageViewContextType;
+}
+
+function renderInReactFlow(selectMode: SelectMode = undefined) {
+  const node = createNode();
+  const onNodeClick = vi.fn();
+  const onNodeDoubleClick = vi.fn();
+  const onNodeDragStart = vi.fn();
+  const onNodesChange = vi.fn();
+  const openNodeDetails = vi.fn();
+  const runsAggregated: NodeRunsAggregated = {
+    validation_summary: {
+      result_count: 1,
+      difference_count: 0,
+      types: {
+        profile_diff: {
+          result_available: true,
+          latest_run_id: "profile-1",
+          result_count: 1,
+        },
+      },
+    },
+  };
+
+  render(
+    <LineageGraphProvider
+      lineageGraph={createGraph(node)}
+      runsAggregated={{ [node.id]: runsAggregated }}
+      isLoading={false}
+    >
+      <LineageViewContext.Provider
+        value={createViewContext(selectMode, openNodeDetails)}
+      >
+        <div style={{ width: 800, height: 600 }}>
+          <ReactFlow
+            nodes={[node]}
+            edges={[]}
+            nodeTypes={nodeTypes}
+            onNodeClick={onNodeClick}
+            onNodeDoubleClick={onNodeDoubleClick}
+            onNodeDragStart={onNodeDragStart}
+            onNodesChange={onNodesChange}
+            elementsSelectable
+            nodesDraggable
+            nodesFocusable
+          />
+        </div>
+      </LineageViewContext.Provider>
+    </LineageGraphProvider>,
+  );
+
+  return {
+    onNodeClick,
+    onNodeDoubleClick,
+    onNodeDragStart,
+    onNodesChange,
+    openNodeDetails,
+  };
+}
+
+describe("GraphNode React Flow interaction isolation", () => {
+  it("uses React Flow interaction guards while preserving native Enter and Space activation", async () => {
+    const user = userEvent.setup();
+    const callbacks = renderInReactFlow();
+    const trigger = screen.getByRole("button", {
+      name: /orders.*1 result/i,
+    });
+
+    expect(trigger).toHaveClass("nodrag", "nopan", "nokey");
+    callbacks.onNodesChange.mockClear();
+
+    trigger.focus();
+    await user.keyboard("{Enter} ");
+
+    expect(callbacks.openNodeDetails).toHaveBeenCalledTimes(2);
+    expect(callbacks.onNodeClick).not.toHaveBeenCalled();
+    expect(callbacks.onNodesChange).not.toHaveBeenCalled();
+
+    fireEvent.mouseDown(trigger, { button: 0, clientX: 10, clientY: 10 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 50, clientY: 50 });
+    fireEvent.mouseUp(document, { button: 0, clientX: 50, clientY: 50 });
+
+    expect(callbacks.onNodeDragStart).not.toHaveBeenCalled();
+    expect(callbacks.onNodesChange).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["normal", undefined],
+    ["selecting", "selecting" as const],
+  ])(
+    "contains portaled detail-surface events in %s mode",
+    (_mode, selectMode) => {
+      const callbacks = renderInReactFlow(selectMode);
+      const trigger = screen.getByRole("button", {
+        name: /orders.*1 result/i,
+      });
+      callbacks.onNodesChange.mockClear();
+
+      fireEvent.mouseEnter(trigger);
+      const dialog = screen.getByRole("dialog", {
+        name: "orders validation details",
+      });
+
+      fireEvent.pointerDown(dialog);
+      fireEvent.mouseDown(dialog, { button: 0 });
+      fireEvent.click(dialog);
+      fireEvent.doubleClick(dialog);
+
+      expect(callbacks.onNodeClick).not.toHaveBeenCalled();
+      expect(callbacks.onNodeDoubleClick).not.toHaveBeenCalled();
+      expect(callbacks.onNodeDragStart).not.toHaveBeenCalled();
+      expect(callbacks.onNodesChange).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.reactFlow.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.reactFlow.test.tsx
@@ -74,6 +74,7 @@ function renderInReactFlow(selectMode: SelectMode = undefined) {
   const node = createNode();
   const onNodeClick = vi.fn();
   const onNodeDoubleClick = vi.fn();
+  const onNodeContextMenu = vi.fn();
   const onNodeDragStart = vi.fn();
   const onNodesChange = vi.fn();
   const openNodeDetails = vi.fn();
@@ -107,6 +108,7 @@ function renderInReactFlow(selectMode: SelectMode = undefined) {
             nodeTypes={nodeTypes}
             onNodeClick={onNodeClick}
             onNodeDoubleClick={onNodeDoubleClick}
+            onNodeContextMenu={onNodeContextMenu}
             onNodeDragStart={onNodeDragStart}
             onNodesChange={onNodesChange}
             elementsSelectable
@@ -121,6 +123,7 @@ function renderInReactFlow(selectMode: SelectMode = undefined) {
   return {
     onNodeClick,
     onNodeDoubleClick,
+    onNodeContextMenu,
     onNodeDragStart,
     onNodesChange,
     openNodeDetails,
@@ -174,11 +177,19 @@ describe("GraphNode React Flow interaction isolation", () => {
       fireEvent.mouseDown(dialog, { button: 0 });
       fireEvent.click(dialog);
       fireEvent.doubleClick(dialog);
+      const contextMenuEvent = new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+      });
+      fireEvent(dialog, contextMenuEvent);
 
       expect(callbacks.onNodeClick).not.toHaveBeenCalled();
       expect(callbacks.onNodeDoubleClick).not.toHaveBeenCalled();
+      expect(callbacks.onNodeContextMenu).not.toHaveBeenCalled();
       expect(callbacks.onNodeDragStart).not.toHaveBeenCalled();
       expect(callbacks.onNodesChange).not.toHaveBeenCalled();
+      expect(contextMenuEvent.defaultPrevented).toBe(false);
+      expect(dialog).toBeInTheDocument();
     },
   );
 });

--- a/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.test.tsx
@@ -1,14 +1,19 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { vi } from "vitest";
 
-const { mockGraphContext, mockLineageNode, mockViewContext } = vi.hoisted(
-  () => ({
-    mockGraphContext: { current: undefined as unknown },
-    mockLineageNode: vi.fn(),
-    mockViewContext: { current: undefined as unknown },
-  }),
-);
+const {
+  mockGraphContext,
+  mockLineageNode,
+  mockNodeSurfaceClick,
+  mockViewContext,
+} = vi.hoisted(() => ({
+  mockGraphContext: { current: undefined as unknown },
+  mockLineageNode: vi.fn(),
+  mockNodeSurfaceClick: vi.fn(),
+  mockViewContext: { current: undefined as unknown },
+}));
 
 vi.mock("@xyflow/react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@xyflow/react")>();
@@ -42,7 +47,11 @@ vi.mock("../nodes", async (importOriginal) => {
       selectMode?: string;
     }) => {
       mockLineageNode(props);
-      return <div data-testid="lineage-node">{props.runsAggregatedTag}</div>;
+      return (
+        <div data-testid="lineage-node" onClick={mockNodeSurfaceClick}>
+          {props.runsAggregatedTag}
+        </div>
+      );
     },
   };
 });
@@ -55,10 +64,13 @@ import { getSemanticColorTheme } from "../../../theme";
 import { GraphNode, type GraphNodeProps } from "../GraphNodeOss";
 
 function createViewContext(
-  overrides: Partial<LineageViewContextType> = {},
+  overrides: Partial<LineageViewContextType> & {
+    openNodeDetails?: (nodeId: string, view: "analysis") => void;
+  } = {},
 ): LineageViewContextType {
   return {
     interactive: true,
+    openNodeDetails: vi.fn(),
     selectNode: vi.fn(),
     selectMode: "normal",
     focusedNode: undefined,
@@ -80,14 +92,15 @@ function createViewContext(
   } as LineageViewContextType;
 }
 
-function createNodeProps(): GraphNodeProps {
+function createNodeProps(id = "model.test.orders"): GraphNodeProps {
+  const name = id.split(".").at(-1) ?? id;
   const node: LineageGraphNode = {
-    id: "model.test.orders",
+    id,
     type: "lineageGraphNode",
     position: { x: 0, y: 0 },
     data: {
-      id: "model.test.orders",
-      name: "orders",
+      id,
+      name,
       resourceType: "model",
       changeStatus: "modified",
       change: { category: "non_breaking" }, // wire-enum-ok
@@ -107,6 +120,24 @@ function createNodeProps(): GraphNodeProps {
     positionAbsoluteX: 0,
     positionAbsoluteY: 0,
     zIndex: 0,
+  };
+}
+
+type ValidationTypes = NonNullable<
+  NonNullable<
+    import("../../../api").NodeRunsAggregated["validation_summary"]
+  >["types"]
+>;
+
+function validationSummary(
+  resultCount: number,
+  differenceCount: number,
+  types: ValidationTypes,
+) {
+  return {
+    result_count: resultCount,
+    difference_count: differenceCount,
+    types,
   };
 }
 
@@ -196,6 +227,381 @@ describe("GraphNode", () => {
     lineageNodeProps.onSelect?.("model.test.orders");
 
     expect(selectNode).toHaveBeenCalledWith("model.test.orders");
+  });
+
+  it("does not mount the aggregate display when the node has no visible schema, row-count, or validation data", () => {
+    mockViewContext.current = createViewContext();
+    mockGraphContext.current = {
+      runsAggregated: {
+        "model.test.orders": {
+          row_count: { run_id: "row-count", result: { curr: 42 } },
+        },
+      },
+    };
+
+    render(<GraphNode {...createNodeProps()} />);
+
+    expect(mockLineageNode).toHaveBeenLastCalledWith(
+      expect.objectContaining({ runsAggregatedTag: undefined }),
+    );
+    expect(
+      screen.queryByTestId("node-runs-aggregated-display"),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      name: "value diff",
+      summary: validationSummary(1, 1, {
+        value_diff: {
+          result_available: true,
+          latest_run_id: "value-1",
+          difference_count: 1,
+        },
+      }),
+      chip: "1 result · 1 diff",
+      detail: "1 result · 1 diff",
+    },
+    {
+      name: "profile diff",
+      summary: validationSummary(1, 91, {
+        profile_diff: {
+          result_available: true,
+          latest_run_id: "profile-1",
+          result_count: 1,
+        },
+      }),
+      chip: "1 result",
+      detail: "1 result",
+    },
+    {
+      name: "top-k diff",
+      summary: validationSummary(2, 91, {
+        top_k_diff: {
+          result_available: true,
+          latest_run_ids_by_column: { country: "top-k-1", status: "top-k-2" },
+          column_count: 2,
+        },
+      }),
+      chip: "2 results",
+      detail: "2 columns",
+    },
+    {
+      name: "histogram diff",
+      summary: validationSummary(3, 91, {
+        histogram_diff: {
+          result_available: true,
+          latest_run_ids_by_column: {
+            amount: "histogram-1",
+            quantity: "histogram-2",
+            tax: "histogram-3",
+          },
+          column_count: 3,
+        },
+      }),
+      chip: "3 results",
+      detail: "3 columns",
+    },
+  ])(
+    "renders neutral, type-correct counts for a $name summary",
+    ({ name, summary, chip, detail }) => {
+      mockViewContext.current = createViewContext();
+      mockGraphContext.current = {
+        runsAggregated: {
+          "model.test.orders": { validation_summary: summary },
+        },
+      };
+
+      render(<GraphNode {...createNodeProps()} />);
+
+      const trigger = screen.getByRole("button", {
+        name: new RegExp(`orders.*${chip.replace(" · ", ".*")}`, "i"),
+      });
+      expect(trigger).toHaveTextContent(chip);
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+      expect(trigger).toHaveStyle({ minHeight: "24px" });
+      expect(trigger.querySelectorAll(".MuiChip-root")).toHaveLength(1);
+      expect(trigger.querySelector(".MuiChip-root")).toHaveClass(
+        "MuiChip-colorDefault",
+        "MuiChip-outlined",
+      );
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      fireEvent.mouseEnter(trigger);
+
+      const dialog = screen.getByRole("dialog", {
+        name: "orders validation details",
+      });
+      expect(dialog).toBeInTheDocument();
+      expect(
+        within(dialog).getByText(new RegExp(name, "i")),
+      ).toBeInTheDocument();
+      expect(
+        within(dialog).getByText(detail, { exact: true }),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it("renders one mixed-summary chip and readable per-type details", () => {
+    mockViewContext.current = createViewContext();
+    mockGraphContext.current = {
+      runsAggregated: {
+        "model.test.orders": {
+          validation_summary: validationSummary(7, 2, {
+            value_diff: {
+              result_available: true,
+              latest_run_id: "value-1",
+              difference_count: 2,
+            },
+            profile_diff: {
+              result_available: true,
+              latest_run_id: "profile-1",
+              result_count: 1,
+            },
+            top_k_diff: {
+              result_available: true,
+              latest_run_ids_by_column: {
+                country: "top-k-1",
+                status: "top-k-2",
+              },
+              column_count: 2,
+            },
+            histogram_diff: {
+              result_available: true,
+              latest_run_ids_by_column: {
+                amount: "histogram-1",
+                quantity: "histogram-2",
+                tax: "histogram-3",
+              },
+              column_count: 3,
+            },
+          }),
+        },
+      },
+    };
+
+    render(<GraphNode {...createNodeProps()} />);
+
+    const trigger = screen.getByRole("button", {
+      name: /orders.*7 results.*2 diffs/i,
+    });
+    expect(trigger).toHaveTextContent("7 results · 2 diffs");
+    expect(screen.getAllByTestId("validation-summary-chip")).toHaveLength(1);
+
+    fireEvent.mouseEnter(trigger);
+
+    expect(screen.getByText("Value diff")).toBeInTheDocument();
+    expect(screen.getByText("Profile diff")).toBeInTheDocument();
+    expect(screen.getByText("Top-k diff")).toBeInTheDocument();
+    expect(screen.getByText("Histogram diff")).toBeInTheDocument();
+    expect(screen.getByText("1 result · 2 diffs")).toBeInTheDocument();
+    expect(screen.getByText("1 result", { exact: true })).toBeInTheDocument();
+    expect(screen.getAllByText("2 columns")).toHaveLength(1);
+    expect(screen.getAllByText("3 columns")).toHaveLength(1);
+  });
+
+  it("opens Analysis repeatably from keyboard without toggling batch selection or the node surface", async () => {
+    const user = userEvent.setup();
+    const openNodeDetails = vi.fn();
+    const selectNode = vi.fn();
+    mockViewContext.current = createViewContext({
+      openNodeDetails,
+      selectNode,
+    });
+    mockGraphContext.current = {
+      runsAggregated: {
+        "model.test.orders": {
+          validation_summary: validationSummary(1, 0, {
+            value_diff: {
+              result_available: true,
+              latest_run_id: "value-1",
+              difference_count: 0,
+            },
+          }),
+        },
+      },
+    };
+
+    render(<GraphNode {...createNodeProps()} />);
+
+    const trigger = screen.getByRole("button", {
+      name: /orders.*1 result.*0 diffs/i,
+    });
+    await user.tab();
+    expect(trigger).toHaveFocus();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(trigger).toHaveFocus();
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await user.keyboard("{Enter} ");
+
+    expect(openNodeDetails).toHaveBeenNthCalledWith(
+      1,
+      "model.test.orders",
+      "analysis",
+    );
+    expect(openNodeDetails).toHaveBeenNthCalledWith(
+      2,
+      "model.test.orders",
+      "analysis",
+    );
+    expect(selectNode).not.toHaveBeenCalled();
+    expect(mockNodeSurfaceClick).not.toHaveBeenCalled();
+  });
+
+  it("keeps lazy details open while the summary button retains focus", () => {
+    vi.useFakeTimers();
+    try {
+      mockViewContext.current = createViewContext();
+      mockGraphContext.current = {
+        runsAggregated: {
+          "model.test.orders": {
+            validation_summary: validationSummary(1, 0, {
+              profile_diff: {
+                result_available: true,
+                latest_run_id: "profile-1",
+                result_count: 1,
+              },
+            }),
+          },
+        },
+      };
+      render(<GraphNode {...createNodeProps()} />);
+      const trigger = screen.getByRole("button", { name: /orders.*1 result/i });
+
+      act(() => trigger.focus());
+      fireEvent.mouseLeave(trigger);
+      act(() => vi.advanceTimersByTime(101));
+
+      expect(trigger).toHaveFocus();
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("adds and removes the display as aggregate data changes", () => {
+    mockViewContext.current = createViewContext();
+    mockGraphContext.current = { runsAggregated: {} };
+    const initialProps = createNodeProps();
+    const { rerender } = render(<GraphNode {...initialProps} />);
+    expect(
+      screen.queryByTestId("node-runs-aggregated-display"),
+    ).not.toBeInTheDocument();
+
+    mockGraphContext.current = {
+      runsAggregated: {
+        "model.test.orders": {
+          validation_summary: validationSummary(1, 0, {
+            profile_diff: {
+              result_available: true,
+              latest_run_id: "profile-1",
+              result_count: 1,
+            },
+          }),
+        },
+      },
+    };
+    rerender(<GraphNode {...initialProps} selected />);
+    expect(screen.getByText("1 result")).toBeInTheDocument();
+
+    mockGraphContext.current = { runsAggregated: {} };
+    rerender(<GraphNode {...initialProps} selected={false} />);
+    expect(
+      screen.queryByTestId("node-runs-aggregated-display"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("coexists with schema, row-count, and new-CLL presentation inside the fixed node slot", () => {
+    const props = createNodeProps();
+    props.data.change = {
+      category: "partial_breaking", // wire-enum-ok
+      columns: {},
+    };
+    mockViewContext.current = createViewContext({ newCllExperience: true });
+    mockGraphContext.current = {
+      runsAggregated: {
+        "model.test.orders": {
+          row_count_diff: {
+            run_id: "row-count-1",
+            result: { base: 100, curr: 150 },
+          },
+          validation_summary: validationSummary(1234567, 765432, {
+            value_diff: {
+              result_available: true,
+              latest_run_id: "value-1",
+              difference_count: 765432,
+            },
+          }),
+        },
+      },
+    };
+
+    render(<GraphNode {...props} />);
+
+    expect(screen.getByText("↑ +50.0% Rows")).toBeInTheDocument();
+    expect(
+      screen.getByText("1,234,567 results · 765,432 diffs"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Schema (no change)")).toBeInTheDocument();
+    expect(mockLineageNode).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        changeCategory: undefined,
+        showChangeAnalysis: false,
+      }),
+    );
+  });
+
+  it("mounts aggregate displays and popovers in proportion to summarized nodes in a large sparse graph", () => {
+    const summarizedNodeIds = [
+      "model.test.node_7",
+      "model.test.node_503",
+      "model.test.node_997",
+    ];
+    mockViewContext.current = createViewContext();
+    mockGraphContext.current = {
+      runsAggregated: Object.fromEntries(
+        summarizedNodeIds.map((id, index) => [
+          id,
+          {
+            validation_summary: validationSummary(index + 1, 0, {
+              profile_diff: {
+                result_available: true,
+                latest_run_id: `profile-${index}`,
+                result_count: 1,
+              },
+            }),
+          },
+        ]),
+      ),
+    };
+
+    render(
+      <>
+        {Array.from({ length: 1000 }, (_, index) => {
+          const id = `model.test.node_${index}`;
+          return <GraphNode key={id} {...createNodeProps(id)} />;
+        })}
+      </>,
+    );
+
+    expect(screen.getAllByTestId("node-runs-aggregated-display")).toHaveLength(
+      summarizedNodeIds.length,
+    );
+    expect(screen.getAllByTestId("validation-summary-chip")).toHaveLength(
+      summarizedNodeIds.length,
+    );
+    expect(screen.queryAllByRole("dialog")).toHaveLength(0);
+
+    fireEvent.mouseEnter(
+      screen.getByRole("button", { name: /node_503.*2 results/i }),
+    );
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
   });
 
   it.each([

--- a/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/GraphNodeOss.test.tsx
@@ -250,6 +250,64 @@ describe("GraphNode", () => {
   });
 
   it.each([
+    ["zero", 0],
+    ["negative", -1],
+    ["NaN", Number.NaN],
+    ["infinite", Number.POSITIVE_INFINITY],
+  ])(
+    "does not mount an otherwise-empty aggregate display for a %s validation result count",
+    (_label, resultCount) => {
+      mockViewContext.current = createViewContext();
+      mockGraphContext.current = {
+        runsAggregated: {
+          "model.test.orders": {
+            validation_summary: validationSummary(resultCount, 0, {}),
+          },
+        },
+      };
+
+      render(<GraphNode {...createNodeProps()} />);
+
+      expect(mockLineageNode).toHaveBeenLastCalledWith(
+        expect.objectContaining({ runsAggregatedTag: undefined }),
+      );
+      expect(
+        screen.queryByTestId("node-runs-aggregated-display"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("validation-summary-chip")).toBeNull();
+    },
+  );
+
+  it("preserves schema and row-count evidence while hiding a zero-result validation summary", () => {
+    const props = createNodeProps();
+    props.data.change = {
+      category: "non_breaking", // wire-enum-ok
+      columns: { id: "modified" },
+    };
+    mockViewContext.current = createViewContext();
+    mockGraphContext.current = {
+      runsAggregated: {
+        "model.test.orders": {
+          row_count_diff: {
+            run_id: "row-count-1",
+            result: { base: 100, curr: 150 },
+          },
+          validation_summary: validationSummary(0, 0, {}),
+        },
+      },
+    };
+
+    render(<GraphNode {...props} />);
+
+    expect(
+      screen.getByTestId("node-runs-aggregated-display"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Schema (changed)")).toBeInTheDocument();
+    expect(screen.getByText("↑ +50.0% Rows")).toBeInTheDocument();
+    expect(screen.queryByTestId("validation-summary-chip")).toBeNull();
+  });
+
+  it.each([
     {
       name: "value diff",
       summary: validationSummary(1, 1, {

--- a/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
@@ -584,6 +584,32 @@ describe("LineageNode", () => {
       expect(screen.getByTestId("runs-tag")).toBeInTheDocument();
     });
 
+    it("keeps the change label and aggregate evidence in the same fixed 300x60 card", () => {
+      const props = createMockNodeProps(
+        {
+          showChangeAnalysis: true,
+          changeCategory: "non_breaking", // wire-enum-ok
+          runsAggregatedTag: (
+            <span data-testid="runs-tag">
+              1,234,567 results · 765,432 diffs
+            </span>
+          ),
+        },
+        { label: "coexistence" },
+      );
+
+      render(<LineageNode {...props} />);
+
+      expect(screen.getByText("Additive Change")).toBeInTheDocument();
+      expect(screen.getByTestId("runs-tag")).toBeInTheDocument();
+      expect(screen.getByTestId("lineage-node-card")).toHaveStyle({
+        height: "60px",
+      });
+      expect(screen.getByTestId("lineage-node-card").parentElement).toHaveStyle(
+        { width: "300px" },
+      );
+    });
+
     it("does not render runsAggregatedTag in action_result mode", () => {
       const props = createMockNodeProps(
         {

--- a/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageNode.test.tsx
@@ -623,6 +623,23 @@ describe("LineageNode", () => {
 
       expect(screen.queryByTestId("runs-tag")).not.toBeInTheDocument();
     });
+
+    it("keeps the change label in action_result mode when the node has no action tag", () => {
+      const props = createMockNodeProps(
+        {
+          selectMode: "action_result",
+          showChangeAnalysis: true,
+          changeCategory: "non_breaking", // wire-enum-ok
+          runsAggregatedTag: <span data-testid="runs-tag">+10%</span>,
+        },
+        { label: "test" },
+      );
+
+      render(<LineageNode {...props} />);
+
+      expect(screen.getByText("Additive Change")).toBeInTheDocument();
+      expect(screen.queryByTestId("runs-tag")).not.toBeInTheDocument();
+    });
   });
 
   // ==========================================================================

--- a/js/packages/ui/src/components/lineage/__tests__/LineageViewFocus.test.ts
+++ b/js/packages/ui/src/components/lineage/__tests__/LineageViewFocus.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { nextFocusedNodeId } from "../LineageViewOss";
+import {
+  createNodeDetailsOpenRequest,
+  nextFocusedNodeId,
+} from "../LineageViewOss";
 
 describe("nextFocusedNodeId", () => {
   it("focuses a newly clicked node", () => {
@@ -18,5 +21,24 @@ describe("nextFocusedNodeId", () => {
     expect(nextFocusedNodeId("model.test.orders", "model.test.customers")).toBe(
       "model.test.customers",
     );
+  });
+});
+
+describe("createNodeDetailsOpenRequest", () => {
+  it("issues a new token for repeated requests to the same node and view", () => {
+    expect(
+      createNodeDetailsOpenRequest(40, "model.test.orders", "analysis"),
+    ).toEqual({
+      nodeId: "model.test.orders",
+      view: "analysis",
+      requestToken: 41,
+    });
+    expect(
+      createNodeDetailsOpenRequest(41, "model.test.orders", "analysis"),
+    ).toEqual({
+      nodeId: "model.test.orders",
+      view: "analysis",
+      requestToken: 42,
+    });
   });
 });

--- a/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
@@ -9,8 +9,10 @@
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { afterEach, beforeEach, vi } from "vitest";
 import type { NodeColumnData } from "../../../api";
+import type { NodeDetailsOpenRequest } from "../../../contexts";
 import type { NodeViewNodeData } from "../NodeView";
 import { NodeView } from "../NodeView";
 
@@ -300,6 +302,83 @@ describe("NodeView", () => {
         />,
       );
 
+      expect(screen.getByRole("tab", { name: "Analysis" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    test("consumes an Analysis request so remounting cannot replay it while later activations still work", () => {
+      const node = createNode("model", testColumns);
+
+      function RequestHarness() {
+        const [mounted, setMounted] = useState(true);
+        const [nextToken, setNextToken] = useState(1);
+        const [request, setRequest] = useState<
+          NodeDetailsOpenRequest | undefined
+        >({ nodeId: node.id, view: "analysis", requestToken: 1 });
+
+        return (
+          <>
+            <button type="button" onClick={() => setMounted((value) => !value)}>
+              {mounted ? "Unmount details" : "Remount details"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const requestToken = nextToken + 1;
+                setNextToken(requestToken);
+                setRequest({
+                  nodeId: node.id,
+                  view: "analysis",
+                  requestToken,
+                });
+              }}
+            >
+              Request Analysis
+            </button>
+            {mounted && (
+              <NodeView
+                node={node}
+                modelDetail={createModelDetail(testColumns)}
+                onCloseNode={vi.fn()}
+                isSingleEnv={false}
+                SchemaView={MockSchemaView}
+                openRequest={request}
+                onOpenRequestConsumed={(requestToken) =>
+                  setRequest((current) =>
+                    current?.requestToken === requestToken
+                      ? undefined
+                      : current,
+                  )
+                }
+              />
+            )}
+          </>
+        );
+      }
+
+      render(<RequestHarness />);
+      expect(screen.getByRole("tab", { name: "Analysis" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      fireEvent.click(screen.getByRole("tab", { name: "Columns" }));
+      fireEvent.click(screen.getByRole("button", { name: "Unmount details" }));
+      fireEvent.click(screen.getByRole("button", { name: "Remount details" }));
+
+      expect(screen.getByRole("tab", { name: "Columns" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Request Analysis" }));
+      expect(screen.getByRole("tab", { name: "Analysis" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      fireEvent.click(screen.getByRole("tab", { name: "Columns" }));
+      fireEvent.click(screen.getByRole("button", { name: "Request Analysis" }));
       expect(screen.getByRole("tab", { name: "Analysis" })).toHaveAttribute(
         "aria-selected",
         "true",

--- a/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
+++ b/js/packages/ui/src/components/lineage/__tests__/NodeView.test.tsx
@@ -259,6 +259,69 @@ describe("NodeView", () => {
       );
     });
 
+    test("honors repeated explicit Analysis requests for the same focused node", () => {
+      const node = createNode("model", testColumns);
+      const sharedProps = {
+        node,
+        modelDetail: createModelDetail(testColumns),
+        onCloseNode: vi.fn(),
+        isSingleEnv: false,
+        SchemaView: MockSchemaView,
+      };
+      const { rerender } = render(
+        <NodeView
+          {...sharedProps}
+          openRequest={{
+            nodeId: node.id,
+            view: "analysis",
+            requestToken: 1,
+          }}
+        />,
+      );
+
+      expect(screen.getByRole("tab", { name: "Analysis" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      fireEvent.click(screen.getByRole("tab", { name: "Columns" }));
+      expect(screen.getByRole("tab", { name: "Columns" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+
+      rerender(
+        <NodeView
+          {...sharedProps}
+          openRequest={{
+            nodeId: node.id,
+            view: "analysis",
+            requestToken: 2,
+          }}
+        />,
+      );
+
+      expect(screen.getByRole("tab", { name: "Analysis" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    test("ignores an Analysis request addressed to a different node", () => {
+      const node = createNode("model", testColumns);
+      renderNodeView(node, testColumns, {
+        openRequest: {
+          nodeId: "model.test.somewhere_else",
+          view: "analysis",
+          requestToken: 1,
+        },
+      });
+
+      expect(screen.getByRole("tab", { name: "Columns" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
     test.each(["Analysis", "Lineage"])(
       "resets to Columns when focus moves from the %s tab to a source node",
       (selectedTab) => {

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -668,26 +668,42 @@ function LineageNodeComponent({
               visibility: showContent ? "inherit" : "hidden",
             }}
           >
-            <Stack direction="row" spacing={1}>
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{ alignItems: "center", minWidth: 0 }}
+            >
               {actionTag ? (
                 <>
                   <Box sx={{ flexGrow: 1 }} />
                   {actionTag}
                 </>
-              ) : changeCategoryLabel ? (
-                <Typography
-                  sx={{
-                    height: 20,
-                    color: "text.secondary",
-                    fontSize: "9pt",
-                    margin: 0,
-                    fontWeight: 600,
-                  }}
-                >
-                  {changeCategoryLabel}
-                </Typography>
-              ) : selectMode !== "action_result" && runsAggregatedTag ? (
-                runsAggregatedTag
+              ) : selectMode !== "action_result" ? (
+                <>
+                  {changeCategoryLabel && (
+                    <Typography
+                      sx={{
+                        color: "text.secondary",
+                        flex: "0 1 auto",
+                        fontSize: "0.75rem",
+                        fontWeight: 600,
+                        height: 20,
+                        margin: 0,
+                        minWidth: 0,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {changeCategoryLabel}
+                    </Typography>
+                  )}
+                  {runsAggregatedTag && (
+                    <Box sx={{ display: "flex", flex: 1, minWidth: 0 }}>
+                      {runsAggregatedTag}
+                    </Box>
+                  )}
+                </>
               ) : null}
             </Stack>
           </Box>

--- a/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
+++ b/js/packages/ui/src/components/lineage/nodes/LineageNode.tsx
@@ -678,7 +678,7 @@ function LineageNodeComponent({
                   <Box sx={{ flexGrow: 1 }} />
                   {actionTag}
                 </>
-              ) : selectMode !== "action_result" ? (
+              ) : (
                 <>
                   {changeCategoryLabel && (
                     <Typography
@@ -698,13 +698,13 @@ function LineageNodeComponent({
                       {changeCategoryLabel}
                     </Typography>
                   )}
-                  {runsAggregatedTag && (
+                  {selectMode !== "action_result" && runsAggregatedTag && (
                     <Box sx={{ display: "flex", flex: 1, minWidth: 0 }}>
                       {runsAggregatedTag}
                     </Box>
                   )}
                 </>
-              ) : null}
+              )}
             </Stack>
           </Box>
         </Box>

--- a/js/packages/ui/src/contexts-entry.ts
+++ b/js/packages/ui/src/contexts-entry.ts
@@ -59,6 +59,8 @@ export type {
   LineageViewContextType,
   NodeAction,
   NodeColumnSetMap,
+  NodeDetailsOpenRequest,
+  NodeDetailsView,
   SelectMode,
 } from "./contexts/lineage";
 export {

--- a/js/packages/ui/src/contexts/index.ts
+++ b/js/packages/ui/src/contexts/index.ts
@@ -65,6 +65,8 @@ export type {
   LineageViewContextType,
   NodeAction,
   NodeColumnSetMap,
+  NodeDetailsOpenRequest,
+  NodeDetailsView,
   SelectMode,
 } from "./lineage";
 export {

--- a/js/packages/ui/src/contexts/lineage/index.ts
+++ b/js/packages/ui/src/contexts/lineage/index.ts
@@ -28,6 +28,8 @@ export type {
   LineageGraphNodes,
   LineageViewContextType,
   NodeAction,
+  NodeDetailsOpenRequest,
+  NodeDetailsView,
   SelectMode,
 } from "./types";
 

--- a/js/packages/ui/src/contexts/lineage/types.ts
+++ b/js/packages/ui/src/contexts/lineage/types.ts
@@ -186,6 +186,20 @@ export type ActionMode = "per_node" | "multi_nodes";
  */
 export type SelectMode = "selecting" | "action_result" | undefined;
 
+/** A detail-panel destination that a lineage-node affordance can request. */
+export type NodeDetailsView = "analysis";
+
+/**
+ * An explicit request to open one node's detail panel at a specific view.
+ * `requestToken` changes for every activation, including repeated activation
+ * of the same node and view.
+ */
+export interface NodeDetailsOpenRequest {
+  nodeId: string;
+  view: NodeDetailsView;
+  requestToken: number;
+}
+
 /**
  * Action state for individual node operations
  */
@@ -249,6 +263,8 @@ export interface LineageViewContextType {
   selectMode: SelectMode;
   /** Select/deselect a single node */
   selectNode: (nodeId: string) => void;
+  /** Open a node's detail panel without changing batch selection. */
+  openNodeDetails: (nodeId: string, view: NodeDetailsView) => void;
   /** Select all parent nodes up to a degree */
   selectParentNodes: (nodeId: string, degree?: number) => void;
   /** Select all child nodes up to a degree */

--- a/js/packages/ui/src/index.ts
+++ b/js/packages/ui/src/index.ts
@@ -124,6 +124,8 @@ export type {
   LineageViewContextType,
   NodeAction,
   NodeColumnSetMap,
+  NodeDetailsOpenRequest,
+  NodeDetailsView,
   RecceActionContextType,
   RecceActionOptions,
   RecceActionProviderProps,

--- a/js/packages/ui/src/types/index.ts
+++ b/js/packages/ui/src/types/index.ts
@@ -149,6 +149,8 @@ export type { InstanceInfoType } from "../contexts/instance";
 export type {
   LineageGraphContextType,
   LineageGraphProviderProps,
+  NodeDetailsOpenRequest,
+  NodeDetailsView,
 } from "../contexts/lineage";
 // Lineage graph types
 export type {


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Feature

**What this PR does / why we need it**:

- Shows a compact validation-summary chip only on lineage nodes with positive result evidence.
- Lazily exposes readable per-type details with accessible hover, focus, keyboard, and Escape behavior.
- Isolates chip and portal interactions from React Flow dragging, panning, selection, context menus, and keyboard handling.
- Opens the selected node directly on the Analysis tab through a repeatable, acknowledged navigation request.
- Re-exports the new public context types through all package entrypoints.

**Which issue(s) this PR fixes**:

Closes DRC-4261

**Special notes for your reviewer**:

- Stack position: 2 of 2 in the lineage stack.
- Base/parent: `feature/drc-4260-aggregate-compact-validation-summaries-by-lineage-node`
- Parent PR: https://github.com/DataRecce/recce/pull/1539
- GitHub stack: https://github.com/DataRecce/recce/stacks/1541
- Final focused zero-result and React Flow interaction regressions: 29 passed.
- Full frontend suite: 4,369 passed, 5 skipped.
- Frontend lint/type checks, shared UI declaration build, OSS production build, diff checks, and hooks passed.
- Tests exercise the real React Flow wrapper in normal and selecting modes.

**Does this PR introduce a user-facing change?**:

Yes.

```release-note
Lineage nodes now show an accessible validation-summary chip for positive validation evidence, with per-type details and one-step navigation to the Analysis tab.
```
